### PR TITLE
Don't fail IntelliJ import for Polaris logo download

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,16 +42,11 @@ if (System.getProperty("idea.sync.active").toBoolean()) {
 
   val icon = ideaDir.file("icon.png").asFile
   if (!icon.exists()) {
-    val img =
-      java.net
-        .URI(
-          "https://raw.githubusercontent.com/apache/polaris/main/docs/img/logos/polaris-brandmark.png"
-        )
-        .toURL()
-        .openConnection()
-        .getInputStream()
-        .use { inp -> inp.readAllBytes() }
-    ideaDir.file("icon.png").asFile.outputStream().use { out -> out.write(img) }
+    copy {
+      from("docs/img/logos/polaris-brandmark.png")
+      into(ideaDir)
+      rename { _ -> "icon.png" }
+    }
   }
 }
 


### PR DESCRIPTION
When working without network/internet access, the logo download might fail the whole build. This change makes the logo download rather optional and don't even attempt, if Gradle's used in "offline" mode.

Tested locally in some variations.