### PR TITLE
Use `assumeThat` to GCP/Azure ITs that need secrets

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -67,7 +67,7 @@ public class AzureCredentialStorageIntegrationTest {
   private final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
   private final String tenantId = "d479c7c9-2632-445a-b22d-7c19e68774f6";
 
-  private void checkEnvNullVariables() {
+  private void assumeEnvVariablesNotNull() {
     Assumptions.assumeThat(Strings.isNullOrEmpty(clientId) || Strings.isNullOrEmpty(clientSecret))
         .describedAs("Null Azure testing environment variables!")
         .isFalse();
@@ -109,7 +109,7 @@ public class AzureCredentialStorageIntegrationTest {
   @TestWithAzureArgs
   public void testGetSubscopedTokenList(boolean allowListAction, String service) {
 
-    checkEnvNullVariables();
+    assumeEnvVariablesNotNull();
 
     boolean isBlobService = service.equals("blob");
     List<String> allowedLoc =
@@ -179,7 +179,7 @@ public class AzureCredentialStorageIntegrationTest {
   @TestWithAzureArgs
   public void testGetSubscopedTokenRead(
       @SuppressWarnings("unused") boolean allowListAction, String service) {
-    checkEnvNullVariables();
+    assumeEnvVariablesNotNull();
 
     String allowedPrefix = "polaris-test";
     String blockedPrefix = "blocked-prefix";
@@ -248,7 +248,7 @@ public class AzureCredentialStorageIntegrationTest {
   @TestWithAzureArgs
   public void testGetSubscopedTokenWrite(
       @SuppressWarnings("unused") boolean allowListAction, String service) {
-    checkEnvNullVariables();
+    assumeEnvVariablesNotNull();
 
     boolean isBlobService = service.equals("blob");
     String allowedPrefix = "polaris-test/scopedcreds/";

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -52,6 +52,7 @@ import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.assertj.core.util.Strings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -59,24 +60,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AzureCredentialStorageIntegrationTest {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(AzureCredentialStorageIntegrationTest.class);
 
   private final String clientId = System.getenv("AZURE_CLIENT_ID");
   private final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
   private final String tenantId = "d479c7c9-2632-445a-b22d-7c19e68774f6";
 
-  private boolean checkEnvNullVariables() {
-    if (Strings.isNullOrEmpty(clientId) || Strings.isNullOrEmpty(clientSecret)) {
-      LOGGER.debug("Null Azure testing environment variables! Skip {}", this.getClass().getName());
-      return true;
-    }
-    return false;
+  private void checkEnvNullVariables() {
+    Assumptions.assumeThat(Strings.isNullOrEmpty(clientId) || Strings.isNullOrEmpty(clientSecret))
+        .describedAs("Null Azure testing environment variables!")
+        .isFalse();
   }
 
   @Test
@@ -115,9 +109,8 @@ public class AzureCredentialStorageIntegrationTest {
   @TestWithAzureArgs
   public void testGetSubscopedTokenList(boolean allowListAction, String service) {
 
-    if (checkEnvNullVariables()) {
-      return;
-    }
+    checkEnvNullVariables();
+
     boolean isBlobService = service.equals("blob");
     List<String> allowedLoc =
         Arrays.asList(
@@ -184,10 +177,10 @@ public class AzureCredentialStorageIntegrationTest {
   }
 
   @TestWithAzureArgs
-  public void testGetSubscopedTokenRead(boolean allowListAction, String service) {
-    if (checkEnvNullVariables()) {
-      return;
-    }
+  public void testGetSubscopedTokenRead(
+      @SuppressWarnings("unused") boolean allowListAction, String service) {
+    checkEnvNullVariables();
+
     String allowedPrefix = "polaris-test";
     String blockedPrefix = "blocked-prefix";
     List<String> allowedLoc =
@@ -253,10 +246,10 @@ public class AzureCredentialStorageIntegrationTest {
   }
 
   @TestWithAzureArgs
-  public void testGetSubscopedTokenWrite(boolean allowListAction, String service) {
-    if (checkEnvNullVariables()) {
-      return;
-    }
+  public void testGetSubscopedTokenWrite(
+      @SuppressWarnings("unused") boolean allowListAction, String service) {
+    checkEnvNullVariables();
+
     boolean isBlobService = service.equals("blob");
     String allowedPrefix = "polaris-test/scopedcreds/";
     String blockedPrefix = "blocked-prefix";

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -53,31 +53,25 @@ import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
-import org.assertj.core.util.Strings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class GcpCredentialsStorageIntegrationTest {
 
   private final String gcsServiceKeyJsonFileLocation =
       System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(GcpCredentialsStorageIntegrationTest.class);
-
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testSubscope(boolean allowedListAction) throws IOException {
-    if (Strings.isNullOrEmpty(gcsServiceKeyJsonFileLocation)) {
-      LOGGER.debug(
-          "Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits, skip test {}",
-          getClass().getName());
-      return;
-    }
+  public void testSubscope(boolean allowedListAction) throws Exception {
+    Assumptions.assumeThat(gcsServiceKeyJsonFileLocation)
+        .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
+        .isNotNull()
+        .isNotEmpty();
+
     List<String> allowedRead =
         Arrays.asList(
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/read1/",


### PR DESCRIPTION
This change lets the tests that require secrets not pass but mark those as "skipped".

Also a nit-ish change (suppress-warning).
