### PR TITLE
Update codeowners to individual handles to prepare for move

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-* @jbonofre @anoopj @RussellSpitzer @adutra @laurentgo @snazy @hivivo @flyrain @dennishuo @takidau @aihuaxu @jackye1995 @collado-mike @dimas-b
+* @jbonofre @ashvina @anoopj @RussellSpitzer @snazy @vvcephei @hivivo @takidau @jackye1995

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-* @polaris-catalog/polaris
+* @jbonofre @anoopj @RussellSpitzer @adutra @laurentgo @snazy @hivivo @flyrain @dennishuo @takidau @aihuaxu @jackye1995 @collado-mike @dimas-b


### PR DESCRIPTION
# Description

Preparing to move this repo into the /apache github org https://issues.apache.org/jira/browse/INFRA-26049 

We will lose our GitHub team from the Polaris-Catalog org, so updating code owners with individual humans. 

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [ ] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
