### PR TITLE
Temporarily disable external link checking

### DIFF
--- a/.github/workflows/check-md-link-config.json
+++ b/.github/workflows/check-md-link-config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https?://localhost.*"
+      "pattern": "^https?://(localhost|polaris.apache.org).*"
     },
     {
       "_comment": "mvnrepository blocks requests originating from GitHub Actions",


### PR DESCRIPTION
The project web site is not up yet, so disabling link checking for it.