### PR TITLE
Link-check CI: only list errors

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -44,3 +44,4 @@ jobs:
       with:
         config-file: '.github/workflows/check-md-link-config.json'
         folder-path: '., docs, regtests, regtests/client/python/docs, regtests/client/python'
+        use-quiet-mode: true


### PR DESCRIPTION
The `Check Markdown links` CI job currently lists all checked links, even successful checks. Only listing errors makes it easier to find mistakes.
