### PR TITLE
Bump shadow plugin to 8.3.0, use new plugin ID

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,4 +67,4 @@ threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
 openapi-generator = { id = "org.openapi.generator", version = "7.6.0" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.0" }


### PR DESCRIPTION
The shadow-plugin repo has been moved, so has the plugin ID. See [release notes](https://github.com/GradleUp/shadow/releases/tag/8.3.0) for reference.
