### PR TITLE
Cleanup CODEOWNERS according to the PolarisProposal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-* @jbonofre @ashvina @anoopj @RussellSpitzer @snazy @vvcephei @hivivo @takidau @jackye1995
+* @jbonofre @ashvina @anoopj @RussellSpitzer @snazy @vvcephei @takidau @jackye1995


### PR DESCRIPTION
These's a mistake in the `CODEOWNERS` file: `hivivo` is not in the PPMC list of the proposal.