### PR TITLE
Clean the openapi-code-generation target

### DIFF
--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -145,6 +145,8 @@ tasks.register<GenerateTask>("generatePolarisService").configure {
   additionalProperties.put("apiNameSuffix", "Api")
   additionalProperties.put("metricsPrefix", "polaris")
   serverVariables = mapOf("basePath" to "api/v1")
+
+  doFirst { delete(outputDir.get()) }
 }
 
 tasks.named("compileJava").configure { dependsOn("generatePolarisService") }

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -192,6 +192,8 @@ tasks.register<GenerateTask>("generatePolarisService").configure {
   additionalProperties.put("apiNameSuffix", "Api")
   additionalProperties.put("metricsPrefix", "polaris")
   serverVariables.put("basePath", "api/v1")
+
+  doFirst { delete(outputDir.get()) }
 }
 
 tasks.named("compileJava").configure { dependsOn("openApiGenerate", "generatePolarisService") }


### PR DESCRIPTION
The `GenerateTask` doesn't clean the output before it runs. This change deletes the output directory before the generation actually starts.
