### PR TITLE
Add a faster way to try Polaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ create database db1;
 show databases;
 create table db1.table1 (id int, name string);
 insert into db1.table1 values (1, 'a');
-<<<<<<< HEAD
 select * from db1.table1;
-=======
->>>>>>> c2baec9 (Update README.md)
 ```
 
 ### More build and run options

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew test` - To run unit tests and integration tests.
 - `./gradlew runApp` - To run the Polaris server locally on localhost:8181. 
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
-```SPARQL
+```sql
 create database db1;
 show databases;
 create table db1.table1 (id int, name string);

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew test` - To run unit tests and integration tests.
 - `./gradlew runApp` - To run the Polaris server locally on localhost:8181. 
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
-```sql
+```SPARQL
 create database db1;
 show databases;
 create table db1.table1 (id int, name string);

--- a/README.md
+++ b/README.md
@@ -44,14 +44,18 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew test` - To run unit tests and integration tests.
 - `./gradlew runApp` - To run the Polaris server locally on localhost:8181. 
-  - The server starts with the in-memory mode, and it prints the auto-generated credentials to STDOUT in a message like this `realm: default-realm root principal credentials: <id>:<secret>`
-  - These credentials can be used as "Client ID" and "Client Secret" in OAuth2 requests (e.g. the `curl` command below).
-- `./regtests/run.sh` - To run regression tests or end-to-end tests in another terminal.
+- `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
+```sql
+create database db1;
+show databases;
+create table db1.table1 (id int, name string);
+insert into db1.table1 values (1, 'a');
+select * from db1.table1;
+```
 
 Running in Docker
 - `docker build -t localhost:5001/polaris:latest .` - To build the image.
 - `docker run -p 8181:8181 localhost:5001/polaris:latest` - To run the image in standalone mode.
-- `docker compose up --build --exit-code-from regtest` - To run regression tests in a Docker environment.
 
 Running in Kubernetes
 - `./run.sh` - To run Polaris as a mini-deployment locally. This will create one pod that bind itself to ports `8181` and `8182`.
@@ -63,6 +67,10 @@ Running in Kubernetes
 - `kubectl get deployment -n polaris` - To check the status of the deployment.
 - `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.
 
+Running regression tests
+- `./regtests/run.sh` - To run regression tests or end-to-end tests in another terminal.
+- `docker compose up --build --exit-code-from regtest` - To run regression tests in a Docker environment.
+
 Building docs
 - Docs are generated using [Redocly](https://redocly.com/docs/cli/installation). To regenerate them, run the following
 commands from the project root directory.
@@ -70,24 +78,6 @@ commands from the project root directory.
 docker run -p 8080:80 -v ${PWD}:/spec docker.io/redocly/cli join spec/docs.yaml spec/polaris-management-service.yml spec/rest-catalog-open-api.yaml -o spec/index.yaml --prefix-components-with-info-prop title
 docker run -p 8080:80 -v ${PWD}:/spec docker.io/redocly/cli build-docs spec/index.yaml --output=docs/index.html --config=spec/redocly.yaml
 ```
-
-## Connecting from an Engine
-To connect from an engine like Spark, first create a catalog with these steps:
-```bash
-# Generate a token for the root principal, replacing <CLIENT_ID> and <CLIENT_SECRET> with
-# the values from the Polaris server output.
-export PRINCIPAL_TOKEN=$(curl -X POST http://localhost:8181/api/catalog/v1/oauth/tokens \
-  -d 'grant_type=client_credentials&client_id=<CLIENT_ID>&client_secret=<CLIENT_SECRET>&scope=PRINCIPAL_ROLE:ALL' \
-   | jq -r '.access_token')
-   
-# Create a catalog named `polaris`
-curl -i -X POST -H "Authorization: Bearer $PRINCIPAL_TOKEN" -H 'Accept: application/json' -H 'Content-Type: application/json' \
-  http://localhost:8181/api/management/v1/catalogs \
-  -d '{"name": "polaris", "id": 100, "type": "INTERNAL", "readOnly": false, "storageConfigInfo": {"storageType": "FILE"}, "properties": {"default-base-location": "file:///tmp/polaris"}}'
-```
-
-From here, you can use Spark to create namespaces, tables, etc. More details can be found in the
-[Quick Start Guide](https://polaris.apache.org/#section/Quick-Start/Using-Iceberg-and-Polaris).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ create database db1;
 show databases;
 create table db1.table1 (id int, name string);
 insert into db1.table1 values (1, 'a');
+<<<<<<< HEAD
 select * from db1.table1;
+=======
+>>>>>>> c2baec9 (Update README.md)
 ```
 
 Running in Docker
@@ -68,7 +71,7 @@ Running in Kubernetes
 - `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.
 
 Running regression tests
-- `./regtests/run.sh` - To run regression tests or end-to-end tests in another terminal.
+- `./regtests/run.sh` - To run regression tests in another terminal.
 - `docker compose up --build --exit-code-from regtest` - To run regression tests in a Docker environment.
 
 Building docs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ select * from db1.table1;
 >>>>>>> c2baec9 (Update README.md)
 ```
 
+### More build and run options
 Running in Docker
 - `docker build -t localhost:5001/polaris:latest .` - To build the image.
 - `docker run -p 8181:8181 localhost:5001/polaris:latest` - To run the image in standalone mode.


### PR DESCRIPTION
# Description

`run_spark_sql.sh` should be the fastest way for any first-timer to try Polaris with a familiar tool like Spark sql. Any beginner can get start with Polaris + Spark SQL in 5 mins. We should promote it in the front page. 

## Type of change

- [x] Doc changes

# How Has This Been Tested?
Test  the run_spark_sql.sh locally, which passed.

# Checklist:
- [x] I have performed a self-review of my code

Here is the screenshot:
<img width="691" alt="Screenshot 2024-08-22 at 10 01 48 AM" src="https://github.com/user-attachments/assets/7bf47a9e-8b9c-40b3-834f-19a8c665efab">

