### PR TITLE
Add Detected Java version when Java version not match the Polaris bui…

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
         Build aborted...
 
         The Apache Polaris build requires Java 21.
-
+        Detected Java version: ${JavaVersion.current()}
 
         """
   )


### PR DESCRIPTION
…ld requirements.

# Description

When i build using Gradle, it does not show why my java version does not match the requirements for polaris, we need to add the detected java version when java version not math the requirements.


## Type of change

Please delete options that are not relevant.

- [x] Small improvement for build exception.

# How Has This Been Tested?
Tested build with unmatched java, it shows my java version in execption.


# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
