### PR TITLE
Remove unnecessary catalog warehouse config in setup.sh

### DIFF
--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -105,13 +105,10 @@ spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.2,org.
 spark.hadoop.fs.s3.impl org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.hadoop.fs.AbstractFileSystem.s3.impl org.apache.hadoop.fs.s3a.S3A
 spark.sql.variable.substitute true
-
 spark.driver.extraJavaOptions -Dderby.system.home=/tmp/derby
-
 spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.polaris.type=rest
 spark.sql.catalog.polaris.uri=http://${POLARIS_HOST:-localhost}:8181/api/catalog
-spark.sql.catalog.polaris.warehouse=snowflake
 spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=true
 spark.sql.catalog.polaris.client.region=us-west-2
 EOF

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -105,7 +105,9 @@ spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.2,org.
 spark.hadoop.fs.s3.impl org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.hadoop.fs.AbstractFileSystem.s3.impl org.apache.hadoop.fs.s3a.S3A
 spark.sql.variable.substitute true
+
 spark.driver.extraJavaOptions -Dderby.system.home=/tmp/derby
+
 spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.polaris.type=rest
 spark.sql.catalog.polaris.uri=http://${POLARIS_HOST:-localhost}:8181/api/catalog


### PR DESCRIPTION
# Description

The warehouse name will always be overwritten by individual test cases.

Fixes # (issue)

## Type of change
- [x] Clean up

# How Has This Been Tested?

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
