### PR TITLE
Cleanup derby home dir

### DIFF
--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -120,7 +120,6 @@ EOF
 fi
 
 # cleanup derby home if existed
-# Check if the directory exists
 if [ -d "${DERBY_HOME}" ]; then
   echo "Directory ${DERBY_HOME} exists. Deleting it..."
   rm -rf "${DERBY_HOME}"

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -30,6 +30,7 @@ if [ -z "${SPARK_HOME}" ]; then
   SPARK_HOME=$(realpath ~/${SPARK_DISTRIBUTION})
 fi
 SPARK_CONF="${SPARK_HOME}/conf/spark-defaults.conf"
+DERBY_HOME="/tmp/derby"
 export PYTHONPATH="${SPARK_HOME}/python/:${SPARK_HOME}/python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH"
 
 # Ensure binaries are downloaded locally
@@ -106,7 +107,7 @@ spark.hadoop.fs.s3.impl org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.hadoop.fs.AbstractFileSystem.s3.impl org.apache.hadoop.fs.s3a.S3A
 spark.sql.variable.substitute true
 
-spark.driver.extraJavaOptions -Dderby.system.home=/tmp/derby
+spark.driver.extraJavaOptions -Dderby.system.home=${DERBY_HOME}
 
 spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.polaris.type=rest
@@ -118,6 +119,12 @@ EOF
   echo 'Success!'
 fi
 
+# cleanup derby home if existed
+# Check if the directory exists
+if [ -d "${DERBY_HOME}" ]; then
+  echo "Directory ${DERBY_HOME} exists. Deleting it..."
+  rm -rf "${DERBY_HOME}"
+fi
 # setup python venv and install polaris client library and test dependencies
 pushd $SCRIPT_DIR && ./pyspark-setup.sh && popd
 


### PR DESCRIPTION
# Description

This will cleanup derby home dir for `regtest/setup.sh`.

Fixes [217](https://github.com/apache/polaris/issues/217)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually corrupted the derby home dir after a successful run. After derby home got corrupted, user won't be able to rerun the script until derby home is getting cleanup. With this fix, it will cleanup the derby home dir before running the script.

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
