### PR TITLE
Notification API reject out of order notifications

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/TableLikeEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/TableLikeEntity.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTUtil;
+import org.jetbrains.annotations.Nullable;
 
 public class TableLikeEntity extends PolarisEntity {
   // For applicable types, this key on the "internalProperties" map will return the location
@@ -30,6 +31,8 @@ public class TableLikeEntity extends PolarisEntity {
 
   public static final String USER_SPECIFIED_WRITE_DATA_LOCATION_KEY = "write.data.path";
   public static final String USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY = "write.metadata.path";
+
+  public static final String LAST_NOTIFICATION_TIMESTAMP_KEY = "last-notification-timestamp";
 
   public TableLikeEntity(PolarisBaseEntity sourceEntity) {
     super(sourceEntity);
@@ -61,6 +64,14 @@ public class TableLikeEntity extends PolarisEntity {
   @JsonIgnore
   public String getMetadataLocation() {
     return getInternalPropertiesAsMap().get(METADATA_LOCATION_KEY);
+  }
+
+  @JsonIgnore
+  public @Nullable Long getLastNotificationTimestamp() {
+    if (!getInternalPropertiesAsMap().containsKey(LAST_NOTIFICATION_TIMESTAMP_KEY)) {
+      return null;
+    }
+    return Long.parseLong(getInternalPropertiesAsMap().get(LAST_NOTIFICATION_TIMESTAMP_KEY));
   }
 
   @JsonIgnore
@@ -107,6 +118,11 @@ public class TableLikeEntity extends PolarisEntity {
 
     public Builder setMetadataLocation(String location) {
       internalProperties.put(METADATA_LOCATION_KEY, location);
+      return this;
+    }
+
+    public Builder setLastNotificationTimestamp(long timestamp) {
+      internalProperties.put(LAST_NOTIFICATION_TIMESTAMP_KEY, String.valueOf(timestamp));
       return this;
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/TableLikeEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/TableLikeEntity.java
@@ -19,10 +19,10 @@
 package org.apache.polaris.core.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Optional;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTUtil;
-import org.jetbrains.annotations.Nullable;
 
 public class TableLikeEntity extends PolarisEntity {
   // For applicable types, this key on the "internalProperties" map will return the location
@@ -32,7 +32,8 @@ public class TableLikeEntity extends PolarisEntity {
   public static final String USER_SPECIFIED_WRITE_DATA_LOCATION_KEY = "write.data.path";
   public static final String USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY = "write.metadata.path";
 
-  public static final String LAST_NOTIFICATION_TIMESTAMP_KEY = "last-notification-timestamp";
+  public static final String LAST_ADMITTED_NOTIFICATION_TIMESTAMP_KEY =
+      "last-notification-timestamp";
 
   public TableLikeEntity(PolarisBaseEntity sourceEntity) {
     super(sourceEntity);
@@ -67,11 +68,10 @@ public class TableLikeEntity extends PolarisEntity {
   }
 
   @JsonIgnore
-  public @Nullable Long getLastNotificationTimestamp() {
-    if (!getInternalPropertiesAsMap().containsKey(LAST_NOTIFICATION_TIMESTAMP_KEY)) {
-      return null;
-    }
-    return Long.parseLong(getInternalPropertiesAsMap().get(LAST_NOTIFICATION_TIMESTAMP_KEY));
+  public Optional<Long> getLastAdmittedNotificationTimestamp() {
+    return Optional.ofNullable(
+            getInternalPropertiesAsMap().get(LAST_ADMITTED_NOTIFICATION_TIMESTAMP_KEY))
+        .map(Long::parseLong);
   }
 
   @JsonIgnore
@@ -122,7 +122,7 @@ public class TableLikeEntity extends PolarisEntity {
     }
 
     public Builder setLastNotificationTimestamp(long timestamp) {
-      internalProperties.put(LAST_NOTIFICATION_TIMESTAMP_KEY, String.valueOf(timestamp));
+      internalProperties.put(LAST_ADMITTED_NOTIFICATION_TIMESTAMP_KEY, String.valueOf(timestamp));
       return this;
     }
   }

--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -1882,7 +1882,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
             && request.getPayload().getTimestamp()
                 <= entity.getLastAdmittedNotificationTimestamp().get()) {
           throw new AlreadyExistsException(
-              "A notification with a newer timestamp has been admitted for table %s",
+              "A notification with a newer timestamp has been processed for table %s",
               tableIdentifier);
         }
         existingLocation = entity.getMetadataLocation();

--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -1877,11 +1877,13 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
                 .setLastNotificationTimestamp(request.getPayload().getTimestamp())
                 .build();
       } else {
-        // If the notification timestamp is outdated, we should not update the table
-        if (entity.getLastNotificationTimestamp() != null
-            && request.getPayload().getTimestamp() <= entity.getLastNotificationTimestamp()) {
-          throw new CommitFailedException(
-              "Notification timestamp is outdated for table %s", tableIdentifier);
+        // If the notification timestamp is out-of-order, we should not update the table
+        if (entity.getLastAdmittedNotificationTimestamp().isPresent()
+            && request.getPayload().getTimestamp()
+                <= entity.getLastAdmittedNotificationTimestamp().get()) {
+          throw new AlreadyExistsException(
+              "A notification with a newer timestamp has been admitted for table %s",
+              tableIdentifier);
         }
         existingLocation = entity.getMetadataLocation();
         entity =

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
@@ -623,7 +624,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setMetadataLocation(maliciousMetadataFile);
     update.setTableName(table.name());
     update.setTableUuid(UUID.randomUUID().toString());
-    update.setTimestamp(230950845L);
+    update.setTimestamp(230950849L);
     updateRequest.setPayload(update);
 
     Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, updateRequest))
@@ -911,6 +912,70 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Invalid location");
+  }
+
+  @Test
+  public void testUpdateNotificationRejectOutOfOrderTimestamp() {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+    Assumptions.assumeTrue(
+        supportsNestedNamespaces(), "Only applicable if nested namespaces are supported");
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    final String tableLocation = "s3://externally-owned-bucket/table/";
+    final String tableMetadataLocation = tableLocation + "metadata/v1.metadata.json";
+    BasePolarisCatalog catalog = catalog();
+
+    Namespace namespace = Namespace.of("parent", "child1");
+    TableIdentifier table = TableIdentifier.of(namespace, "table");
+
+    long timestamp = 230950845L;
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.CREATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(tableMetadataLocation);
+    update.setTableName(table.name());
+    update.setTableUuid(UUID.randomUUID().toString());
+    update.setTimestamp(timestamp);
+    request.setPayload(update);
+
+    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+
+    fileIO.addFile(
+        tableMetadataLocation,
+        TableMetadataParser.toJson(createSampleTableMetadata(tableLocation)).getBytes());
+
+    catalog.sendNotification(table, request);
+
+    // Send a notification with a timestamp same as that of the previous notification, should fail
+    NotificationRequest request2 = new NotificationRequest();
+    request2.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification update2 = new TableUpdateNotification();
+    update2.setMetadataLocation(tableLocation + "metadata/v2.metadata.json");
+    update2.setTableName(table.name());
+    update2.setTableUuid(UUID.randomUUID().toString());
+    update2.setTimestamp(timestamp);
+    request2.setPayload(update2);
+
+    Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request2))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Notification timestamp is outdated for table parent.child1.table");
+
+    // Verify that DROP notification won't be rejected due to timestamp
+    NotificationRequest request3 = new NotificationRequest();
+    request3.setNotificationType(NotificationType.DROP);
+    TableUpdateNotification update3 = new TableUpdateNotification();
+    update3.setMetadataLocation(tableLocation + "metadata/v2.metadata.json");
+    update3.setTableName(table.name());
+    update3.setTableUuid(UUID.randomUUID().toString());
+    update3.setTimestamp(timestamp);
+    request3.setPayload(update3);
+
+    Assertions.assertThat(catalog.sendNotification(table, request3))
+        .as("Drop notification should not fail despite timestamp being outdated")
+        .isTrue();
   }
 
   @Test

--- a/spec/rest-catalog-open-api.yaml
+++ b/spec/rest-catalog-open-api.yaml
@@ -1010,7 +1010,7 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         409:
           description:
-            Conflict - The timestamp of the notification being sent is older than or equal to the 
+            Conflict - The timestamp of the received notification is older than or equal to the 
             most recent timestamp Polaris has already processed for the specified table.
           content:
             application/json:
@@ -3230,6 +3230,7 @@ components:
     NotificationRequest:
       required:
         - notification-type
+        - payload
       properties:
         notification-type:
           $ref: '#/components/schemas/NotificationType'
@@ -4149,7 +4150,7 @@ components:
 
     OutOfOrderNotificationError:
       summary:
-        The timestamp of the notification being sent is older than or equal to the most recent timestamp 
+        The timestamp of the received notification is older than or equal to the most recent timestamp 
         Polaris has already processed for the specified table.
       value: {
         "error": {

--- a/spec/rest-catalog-open-api.yaml
+++ b/spec/rest-catalog-open-api.yaml
@@ -1001,6 +1001,14 @@ paths:
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
+        409:
+          description: Conflict - Polaris has processed a newer notification timestamp for the table.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              example:
+                $ref: '#/components/examples/OutOfOrderNotificationError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -4128,6 +4136,16 @@ components:
       value: {
         "removals": ["foo", "bar"],
         "updates": {"owner": "Raoul"}
+      }
+
+    OutOfOrderNotificationError:
+      summary: The notification timestamp is older than the latest timestamp which Polaris has processed for the table.
+      value: {
+        "error": {
+          "message": "Notification timestamp is outdated for table",
+          "type": "CommitFailedException",
+          "code": 409
+        }
       }
 
   securitySchemes:

--- a/spec/rest-catalog-open-api.yaml
+++ b/spec/rest-catalog-open-api.yaml
@@ -976,7 +976,14 @@ paths:
       summary: Sends a notification to the table
       operationId: sendNotification
       requestBody:
-        description: The request containing the notification to be sent
+        description:
+          The request containing the notification to be sent.
+        
+          For each table, Polaris will reject any notification where the timestamp in the request body
+          is older than or equal to the most recent time Polaris has already processed for the table.
+          The responsibility of ensuring the correct order of timestamps for a sequence of notifications 
+          lies with the caller of the API. This includes managing potential clock skew or inconsistencies 
+          when notifications are sent from multiple sources.
         content:
           application/json:
             schema:
@@ -1002,7 +1009,9 @@ paths:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         409:
-          description: Conflict - Polaris has processed a newer notification timestamp for the table.
+          description:
+            Conflict - The timestamp of the notification being sent is older than or equal to the 
+            most recent timestamp Polaris has already processed for the specified table.
           content:
             application/json:
               schema:
@@ -4139,11 +4148,13 @@ components:
       }
 
     OutOfOrderNotificationError:
-      summary: The notification timestamp is older than the latest timestamp which Polaris has processed for the table.
+      summary:
+        The timestamp of the notification being sent is older than or equal to the most recent timestamp 
+        Polaris has already processed for the specified table.
       value: {
         "error": {
-          "message": "Notification timestamp is outdated for table",
-          "type": "CommitFailedException",
+          "message": "A notification with a newer timestamp has been admitted for table",
+          "type": "AlreadyExistsException",
           "code": 409
         }
       }


### PR DESCRIPTION
# Description

UPDATE/CREATE notifications will be rejected if the timestamp is older than the latest processed for the table.
DROP notifications won't be affected since messing up the order of DROPs is acceptable as they are idempotent.

Update the notification API spec to clarify that the API caller should ensure the correct order of timestamps for a sequence of notifications. Also added the description for 409 conflict error.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] BasePolarisCatalogTest::testUpdateNotificationRejectOutOfOrderTimestamp

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
