### PR TITLE
Added The Helm Chart For Installing Polaris

### DIFF
--- a/k8/apache-polaris/.helmignore
+++ b/k8/apache-polaris/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8/apache-polaris/Chart.yaml
+++ b/k8/apache-polaris/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: apache-polaris
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/k8/apache-polaris/templates/_helpers.tpl
+++ b/k8/apache-polaris/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apache-polaris.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apache-polaris.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apache-polaris.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "apache-polaris.labels" -}}
+helm.sh/chart: {{ include "apache-polaris.chart" . }}
+{{ include "apache-polaris.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "apache-polaris.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apache-polaris.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "apache-polaris.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "apache-polaris.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8/apache-polaris/templates/deployment.yaml
+++ b/k8/apache-polaris/templates/deployment.yaml
@@ -1,0 +1,44 @@
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: {{ .Values.deployment.name }}
+#   namespace: {{ .Values.namespace.name }}
+# spec:
+#   replicas: {{ .Values.replicaCount }}
+#   selector:
+#     matchLabels:
+#       app: {{ .Values.app.name }}
+#   template:
+#     metadata:
+#       labels:
+#         app: {{ .Values.app.name }}
+#     spec:
+#       containers:
+#       - name: {{ .Values.app.name }}
+#         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+#         ports:
+#         - containerPort: 8181
+#         - containerPort: 8182
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  namespace: {{ .Values.namespace.name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app.name }}
+    spec:
+      containers:
+      - name: {{ .Values.app.name }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        ports:
+        {{- range .Values.containerPorts }}
+        - containerPort: {{ . }}
+        {{- end }}

--- a/k8/apache-polaris/templates/namespace.yaml
+++ b/k8/apache-polaris/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}

--- a/k8/apache-polaris/templates/service.yaml
+++ b/k8/apache-polaris/templates/service.yaml
@@ -1,0 +1,30 @@
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: {{ .Values.service.name }}
+#   namespace: {{ .Values.namespace.name }}
+# spec:
+#   selector:
+#     app: {{ .Values.app.name }}
+#   ports:
+#   - name: service
+#     port: 8181
+#     targetPort: 8181
+#   - name: metrics
+#     port: 8182
+#     targetPort: 8182
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: {{ .Values.namespace.name }}
+spec:
+  selector:
+    app: {{ .Values.app.name }}
+  ports:
+  {{- range .Values.service.ports }}
+  - name: {{ .name }}
+    port: {{ .port }}
+    targetPort: {{ .targetPort }}
+  {{- end }}

--- a/k8/apache-polaris/templates/tests/test-connection.yaml
+++ b/k8/apache-polaris/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "apache-polaris.fullname" . }}-test-connection"
+  labels:
+    {{- include "apache-polaris.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "apache-polaris.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/k8/apache-polaris/values.yaml
+++ b/k8/apache-polaris/values.yaml
@@ -1,0 +1,28 @@
+namespace:
+  name: polaris
+
+deployment:
+  name: polaris-deployment
+
+app:
+  name: polaris
+
+replicaCount: 1
+
+image:
+  repository: nishanbiswas/polaris
+  tag: latest
+
+service:
+  name: polaris-service
+  ports:
+    - name: service
+      port: 8181
+      targetPort: 8181
+    - name: metrics
+      port: 8182
+      targetPort: 8182
+
+containerPorts:
+  - 8181
+  - 8182


### PR DESCRIPTION
# Description

I added a Helm chart for installing Polaris, which has been tested locally and on a Kubernetes cluster on Cloud. The image used for setting up Polaris was created using Docker and is stored in a public repository on Docker Hub.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The changes were tested by deploying the Helm chart on both a local Kubernetes cluster and an EKS cluster.

- [x] Local Kubernetes cluster
- [x] Kubernetes EKS cluster

**Test Configuration**:
* Hardware: Local machine, EKS cluster
* Toolchain: Helm, Docker
* SDK: Kubernetes

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code