### PR TITLE
Exclude .env file from rat checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,4 +105,6 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("**/*.svg")
 
   excludes.add("**/*.lock")
+
+  excludes.add("**/*.env*")
 }


### PR DESCRIPTION
# Description

`.env` files are used to store environment variables for docker and docker-compose runs. A user may have multiple `.env` files to run against different environments, such as `.env.qa` or `.env.prod`. This excludes those files from the rat checks, since they are missing license headers.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the `gradle build` locally with multiple `.env` files present

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
