### PR TITLE
Cleanup "Check md link" config

### DIFF
--- a/.github/workflows/check-md-link-config.json
+++ b/.github/workflows/check-md-link-config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https?://(localhost|polaris.apache.org).*"
+      "pattern": "^https?://localhost.*"
     },
     {
       "_comment": "mvnrepository blocks requests originating from GitHub Actions",

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -26,7 +26,11 @@
 
 name: Check Markdown links
 
-on: push
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -26,17 +26,7 @@
 
 name: Check Markdown links
 
-on:
-  push:
-    paths:
-      - '*.md'  # Top-level .md files
-      - docs/**
-      - regtests/README.md
-      - regtests/client/python/docs/**
-      - regtests/client/python/README.md
-    branches:
-      - 'main'
-  pull_request:
+on: push
 
 jobs:
   markdown-link-check:
@@ -45,6 +35,6 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        use-quiet-mode: 'yes'
         config-file: '.github/workflows/check-md-link-config.json'
-        folder-path: '., docs, regtests, regtests/client/python/docs, regtests/client/python'
-        use-quiet-mode: true
+        folder-path: '.' # checks all md files


### PR DESCRIPTION
# Description

This PR cleans up config for the "Check md link" Github Action
* Revert #178 now that [polaris.apache.org](polaris.apache.org)is active
* Use `use-quiet-mode: 'yes'` as described in [doc](https://github.com/gaurav-nelson/github-action-markdown-link-check?tab=readme-ov-file#custom-variables) (See https://github.com/apache/polaris/pull/181#issuecomment-2304692624)
* Enable check for all MD files in repo (See https://github.com/apache/polaris/pull/141#discussion_r1726148135)
* Run Github Action without filtering on specific paths

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in forked repo https://github.com/kevinjqliu/polaris-catalog/pull/2

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
