### PR TITLE
Add python aux files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,9 @@ regtests/metastore_db
 regtests/output/
 
 # Python stuff
-poetry.lock
-polaris-venv/
-pyproject.toml
+/poetry.lock
+/polaris-venv/
+/pyproject.toml
 
 # Notebooks
 notebooks/.ipynb_checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ regtests/derby.log
 regtests/metastore_db
 regtests/output/
 
+# Python stuff
+poetry.lock
+polaris-venv/
+pyproject.toml
+
 # Notebooks
 notebooks/.ipynb_checkpoints/
 


### PR DESCRIPTION
After running `./polaris ...`:

```
$ git st
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	poetry.lock
	polaris-venv/
	pyproject.toml
```

# Description

Excluding python-related auxiliary files from source control. 
