### PR TITLE
Support buckets containing underscore

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -18,10 +18,8 @@
  */
 package org.apache.polaris.core.storage;
 
-import org.apache.hadoop.fs.Path;
-import org.jetbrains.annotations.NotNull;
-
 import java.net.URI;
+import org.jetbrains.annotations.NotNull;
 
 public class StorageUtil {
   /**
@@ -46,6 +44,7 @@ public class StorageUtil {
 
   /**
    * Given a path, extract the bucket (authority).
+   *
    * @param path A path to parse
    * @return The bucket/authority of the path
    */
@@ -56,6 +55,7 @@ public class StorageUtil {
 
   /**
    * Given a URI, extract the bucket (authority).
+   *
    * @param uri A path to parse
    * @return The bucket/authority of the URI
    */

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -18,7 +18,10 @@
  */
 package org.apache.polaris.core.storage;
 
+import org.apache.hadoop.fs.Path;
 import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
 
 public class StorageUtil {
   /**
@@ -39,5 +42,24 @@ public class StorageUtil {
     } else {
       return leftPath + rightPath;
     }
+  }
+
+  /**
+   * Given a path, extract the bucket (authority).
+   * @param path A path to parse
+   * @return The bucket/authority of the path
+   */
+  public static @NotNull String getBucket(String path) {
+    URI uri = URI.create(path);
+    return getBucket(uri);
+  }
+
+  /**
+   * Given a URI, extract the bucket (authority).
+   * @param uri A path to parse
+   * @return The bucket/authority of the URI
+   */
+  public static @NotNull String getBucket(URI uri) {
+    return uri.getAuthority();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -112,7 +112,7 @@ public class AwsCredentialsStorageIntegration
               if (allowList) {
                 bucketListStatmentBuilder
                     .computeIfAbsent(
-                        arnPrefix + uri.getHost(),
+                        arnPrefix + StorageUtil.getBucket(uri),
                         (String key) ->
                             IamStatement.builder()
                                 .effect(IamEffect.ALLOW)
@@ -164,7 +164,7 @@ public class AwsCredentialsStorageIntegration
   }
 
   private static @NotNull String parseS3Path(URI uri) {
-    String bucket = uri.getHost();
+    String bucket = StorageUtil.getBucket(uri);
     String path = trimLeadingSlash(uri.getPath());
     return String.join(
         "/", Stream.of(bucket, path).filter(Objects::nonNull).toArray(String[]::new));

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -41,6 +41,7 @@ import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.StorageUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -139,7 +140,7 @@ public class GcpCredentialsStorageIntegration
         .forEach(
             location -> {
               URI uri = URI.create(location);
-              String bucket = uri.getHost();
+              String bucket = StorageUtil.getBucket(uri);
               readBuckets.add(bucket);
               String path = uri.getPath().substring(1);
               List<String> resourceExpressions =

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.storage;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class StorageUtilTest {
+
+    @Test
+    public void testEmptyString() {
+        Assertions
+            .assertThat(StorageUtil.getBucket(""))
+            .isNull();
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"s3", "gcs", "azure"})
+    public void testAbsolutePaths(String scheme) {
+        Assertions
+            .assertThat(StorageUtil.getBucket(scheme + "://bucket/path/file.txt"))
+            .isEqualTo("bucket");
+        Assertions
+            .assertThat(StorageUtil.getBucket(scheme + "://bucket:with:colon/path/file.txt"))
+            .isEqualTo("bucket:with:colon");
+        Assertions
+            .assertThat(StorageUtil.getBucket(scheme + "://bucket_with_underscore/path/file.txt"))
+            .isEqualTo("bucket_with_underscore");
+        Assertions
+            .assertThat(StorageUtil.getBucket(scheme + "://bucket_with_ユニコード/path/file.txt"))
+            .isEqualTo("bucket_with_ユニコード");
+    }
+
+    @Test
+    public void testRelativePaths() {
+        Assertions
+            .assertThat(StorageUtil.getBucket("bucket/path/file.txt"))
+            .isNull();
+        Assertions
+            .assertThat(StorageUtil.getBucket("path/file.txt"))
+            .isNull();
+    }
+
+    @Test
+    public void testAbsolutePathWithoutScheme() {
+        Assertions
+            .assertThat(StorageUtil.getBucket("/bucket/path/file.txt"))
+            .isNull();
+    }
+
+    @Test
+    public void testInvalidURI() {
+        Assertions
+            .assertThatThrownBy(() -> StorageUtil.getBucket("s3://bucket with space/path/file.txt"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testAuthorityWithPort() {
+        Assertions
+            .assertThat(StorageUtil.getBucket("s3://bucket:8080/path/file.txt"))
+            .isEqualTo("bucket:8080");
+    }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
@@ -31,7 +31,7 @@ public class StorageUtilTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"s3", "gcs", "azure"})
+  @ValueSource(strings = {"s3", "gcs", "abfs", "file"})
   public void testAbsolutePaths(String scheme) {
     Assertions.assertThat(StorageUtil.getBucket(scheme + "://bucket/path/file.txt"))
         .isEqualTo("bucket");

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.core.storage;
 
 import org.assertj.core.api.Assertions;
@@ -26,59 +25,45 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class StorageUtilTest {
 
-    @Test
-    public void testEmptyString() {
-        Assertions
-            .assertThat(StorageUtil.getBucket(""))
-            .isNull();
-    }
+  @Test
+  public void testEmptyString() {
+    Assertions.assertThat(StorageUtil.getBucket("")).isNull();
+  }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gcs", "azure"})
+  public void testAbsolutePaths(String scheme) {
+    Assertions.assertThat(StorageUtil.getBucket(scheme + "://bucket/path/file.txt"))
+        .isEqualTo("bucket");
+    Assertions.assertThat(StorageUtil.getBucket(scheme + "://bucket:with:colon/path/file.txt"))
+        .isEqualTo("bucket:with:colon");
+    Assertions.assertThat(StorageUtil.getBucket(scheme + "://bucket_with_underscore/path/file.txt"))
+        .isEqualTo("bucket_with_underscore");
+    Assertions.assertThat(StorageUtil.getBucket(scheme + "://bucket_with_ユニコード/path/file.txt"))
+        .isEqualTo("bucket_with_ユニコード");
+  }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"s3", "gcs", "azure"})
-    public void testAbsolutePaths(String scheme) {
-        Assertions
-            .assertThat(StorageUtil.getBucket(scheme + "://bucket/path/file.txt"))
-            .isEqualTo("bucket");
-        Assertions
-            .assertThat(StorageUtil.getBucket(scheme + "://bucket:with:colon/path/file.txt"))
-            .isEqualTo("bucket:with:colon");
-        Assertions
-            .assertThat(StorageUtil.getBucket(scheme + "://bucket_with_underscore/path/file.txt"))
-            .isEqualTo("bucket_with_underscore");
-        Assertions
-            .assertThat(StorageUtil.getBucket(scheme + "://bucket_with_ユニコード/path/file.txt"))
-            .isEqualTo("bucket_with_ユニコード");
-    }
+  @Test
+  public void testRelativePaths() {
+    Assertions.assertThat(StorageUtil.getBucket("bucket/path/file.txt")).isNull();
+    Assertions.assertThat(StorageUtil.getBucket("path/file.txt")).isNull();
+  }
 
-    @Test
-    public void testRelativePaths() {
-        Assertions
-            .assertThat(StorageUtil.getBucket("bucket/path/file.txt"))
-            .isNull();
-        Assertions
-            .assertThat(StorageUtil.getBucket("path/file.txt"))
-            .isNull();
-    }
+  @Test
+  public void testAbsolutePathWithoutScheme() {
+    Assertions.assertThat(StorageUtil.getBucket("/bucket/path/file.txt")).isNull();
+  }
 
-    @Test
-    public void testAbsolutePathWithoutScheme() {
-        Assertions
-            .assertThat(StorageUtil.getBucket("/bucket/path/file.txt"))
-            .isNull();
-    }
+  @Test
+  public void testInvalidURI() {
+    Assertions.assertThatThrownBy(
+            () -> StorageUtil.getBucket("s3://bucket with space/path/file.txt"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-    @Test
-    public void testInvalidURI() {
-        Assertions
-            .assertThatThrownBy(() -> StorageUtil.getBucket("s3://bucket with space/path/file.txt"))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void testAuthorityWithPort() {
-        Assertions
-            .assertThat(StorageUtil.getBucket("s3://bucket:8080/path/file.txt"))
-            .isEqualTo("bucket:8080");
-    }
+  @Test
+  public void testAuthorityWithPort() {
+    Assertions.assertThat(StorageUtil.getBucket("s3://bucket:8080/path/file.txt"))
+        .isEqualTo("bucket:8080");
+  }
 }

--- a/polaris-service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -73,7 +73,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
                           HttpTransportFactory.class, NetHttpTransport::new));
         } catch (IOException e) {
           throw new RuntimeException(
-              "Error initializing default google credentials" + e.getMessage());
+              "Error initializing default google credentials. " + e.getMessage());
         }
         break;
       case AZURE:


### PR DESCRIPTION
# Description

Currently, we are using `URI.getHost` to extract the bucket from paths, which can return `null` unexpectedly when the bucket contains an underscore. [This seems to be](https://stackoverflow.com/questions/25993225/uri-gethost-returns-null-why) a [known issue](https://stackoverflow.com/questions/28568188/java-net-uri-get-host-with-underscores).

This PR introduces a thin new utility for extracting the path and adds a test for it.

Fixes #262 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added a new suite, `StorageUtilTest`.

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
