### PR TITLE
Introduce renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:base",
+    // Required to not pin dependencies to _exact_ versions (pip)
+    ":preserveSemverRanges",
+    "group:monorepos",
+    "helpers:pinGitHubActionDigests",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":dependencyDashboard",
+  ],
+
+  // Added for posterity how to let Renovate manage version-branches
+  baseBranches: ["main", "/^release\\/.*/"],
+  additionalBranchPrefix: "{{baseBranch}}/",
+  commitMessagePrefix: "{{baseBranch}}: ",
+
+  pip_requirements: {
+    // fileMatch default: (^|/)([\\w-]*)requirements\\.(txt|pip)$
+    "fileMatch": ["(^|/)([\\w-]*)requirements.*\\.txt$"],
+  },
+
+  packageRules: [
+    {
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["major", "minor", "patch", "digest"],
+      automerge: true,
+      platformAutomerge: true,
+    },
+
+    // Check for updates, merge automatically
+    {
+      matchManagers: ["gradle", "gradle-wrapper", "pip_requirements", "pip_setup", "dockerfile", "devcontainer", "docker-compose"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      platformAutomerge: true,
+    },
+
+    // Check for major updates, but do not merge automatically
+    {
+      matchManagers: ["gradle", "gradle-wrapper", "pip_requirements", "pip_setup", "dockerfile", "devcontainer", "docker-compose"],
+      matchUpdateTypes: ["major"],
+      automerge: false,
+    },
+
+    // Reduce awssdk update frequency noise (awssdk has daily releases)
+    {
+      matchManagers: ["gradle"],
+      matchPackagePrefixes: ["software.amazon.awssdk"],
+      extends: ["schedule:weekly"],
+    },
+
+    // Turn off major & minor version updates on version-branches
+    {
+      matchBaseBranches: ["/^release/.*/"],
+      matchUpdateTypes: ["major", "minor"],
+      enabled: false
+    },
+  ],
+
+  // Max 50 PRs in total, 5 per hour
+  prConcurrentLimit: 50,
+  prHourlyLimit: 5,
+}


### PR DESCRIPTION
The configuration is relatively simple: automerge minor+patch updates and all GH action updates as soon as the updates are available. Exception is the awssdk, which has daily releases, so it's limited to "once per week".

For posterity, the config to let Renovate work against version-branches, restricted to patch-version bumps.