### PR TITLE
Use local build artifacts for docker build

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -33,10 +33,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
+
       - name: fix permissions
         run: mkdir -p regtests/output && chmod 777 regtests/output && chmod 777 regtests/t_*/ref/*
       - name: Regression Test
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-        run: docker compose up --build --exit-code-from regtest
+        run: |
+          ./gradlew dockerBuild --info
+          docker compose up --build --exit-code-from regtest

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ select * from db1.table1;
 
 ### More build and run options
 Running in Docker
-- `docker build -t localhost:5001/polaris:latest .` - To build the image.
-- `docker run -p 8181:8181 localhost:5001/polaris:latest` - To run the image in standalone mode.
+- `./gradlew dockerBuild` - To build the image.
+  - Run `./gradlew dockerBuild --info` - To see docker build output 
+- `docker run -p 8181:8181 polaris:latest` - To run the image in standalone mode.
 
 Running in Kubernetes
 - `./run.sh` - To run Polaris as a mini-deployment locally. This will create one pod that bind itself to ports `8181` and `8182`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@
 
 services:
   polaris:
-    build:
-      context: .
+    image: polaris:latest
     ports:
       - "8181:8181"
       - "8182"

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  alias(libs.plugins.docker)
+}
+
+val dockerImage by configurations.creating
+
+dependencies {
+  dockerImage(project(":polaris-service", "dockerDist"))
+}
+
+docker {
+  images {
+    polarisDocker {
+      imageName = "polaris"
+      imageVersion = "latest"
+      files {
+        from("src/docker")
+        from(dockerImage)
+        from(rootProject.file("polaris-server.yml"))
+      }
+    }
+  }
+}

--- a/docker/src/docker/Dockerfile
+++ b/docker/src/docker/Dockerfile
@@ -17,27 +17,15 @@
 # under the License.
 #
 
-# Base Image
 # Use a non-docker-io registry, because pulling images from docker.io is
 # subject to aggressive request rate limiting and bandwidth shaping.
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as build
-ARG ECLIPSELINK=false
-
-# Copy the REST catalog into the container
-COPY --chown=default:root . /app
-
-# Set the working directory in the container, nuke any existing builds
-WORKDIR /app
-RUN rm -rf build
-
-# Build the rest catalog
-RUN ./gradlew --no-daemon --info -PeclipseLink=$ECLIPSELINK clean prepareDockerDist
-
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1721752928
+
+COPY lib/ /app/lib/
+COPY bin/ /app/bin/
+COPY polaris-server.yml /app
+
 WORKDIR /app
-COPY --from=build /app/polaris-service/build/docker-dist/bin /app/bin
-COPY --from=build /app/polaris-service/build/docker-dist/lib /app/lib
-COPY --from=build /app/polaris-server.yml /app
 
 EXPOSE 8181
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
 
 [plugins]
+docker = { id = "org.jetbrains.gradle.docker", version = "1.6.0-RC.5" }
 openapi-generator = { id = "org.openapi.generator", version = "7.6.0" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -22,3 +22,4 @@ polaris-core=polaris-core
 polaris-service=polaris-service
 polaris-eclipselink=extension/persistence/eclipselink
 aggregated-license-report=aggregated-license-report
+polaris-docker=docker

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -247,11 +247,16 @@ val startScripts =
     classpath = files(provider { shadowJar.get().archiveFileName })
   }
 
-tasks.register<Sync>("prepareDockerDist") {
-  into(project.layout.buildDirectory.dir("docker-dist"))
-  from(startScripts) { into("bin") }
-  from(shadowJar) { into("lib") }
-  doFirst { delete(project.layout.buildDirectory.dir("regtest-dist")) }
-}
+val prepareDockerDist =
+  tasks.register<Sync>("prepareDockerDist") {
+    into(project.layout.buildDirectory.dir("docker-dist"))
+    from(startScripts) { into("bin") }
+    from(shadowJar) { into("lib") }
+    doFirst { delete(project.layout.buildDirectory.dir("regtest-dist")) }
+  }
+
+val dockerDist by configurations.creating
+
+artifacts { add(dockerDist.name, prepareDockerDist) }
 
 tasks.named("build").configure { dependsOn("prepareDockerDist") }

--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,8 @@ sh ./kind-registry.sh
 
 # build and deploy the server image
 echo "Building polaris image..."
-docker build -t localhost:5001/polaris -f Dockerfile .
+./gradlew dockerBuild --info
+docker tag polaris:latest localhost:5001/polaris:latest
 echo "Pushing polaris image..."
 docker push localhost:5001/polaris
 echo "Loading polaris image to kind..."


### PR DESCRIPTION
The docker build will reuse regular gradle artifacts now and rely on gradle to keep them up-to-date.

The Dockerfile is simplified to remove the `build` layers.

This saves downloads and compile time in local builds (at least).

Details:

* Add `gradle` sub-project for docker-related stuff

* Use `org.jetbrains.gradle.docker` plugin to push gradle artifacts into docker build.

* Add `scripts` configuration to `:polaris-service` for reusing scripts across modules.
