### PR TITLE
Upgrade to Gradle 8.10.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,8 +20,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # See https://gradle.org/release-checksums/ for valid checksums
-distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionSha256Sum=1541fa36599e12857140465f3c91a97409b4512501c26f9631fb113e392c5bd1
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 8.10.1 brings:
- support JDK23
- faster configuration cache
- better configuration cache reports

For more details see https://docs.gradle.org/8.10.1/release-notes.html