### PR TITLE
Introduce Immutables library

### DIFF
--- a/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -55,7 +55,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
             store, Mockito.mock(), RealmContext.of("realm"), null, "polaris");
     return new PolarisTestMetaStoreManager(
         new PolarisMetaStoreManagerImpl(),
-        new PolarisCallContext(
+        PolarisCallContext.of(
             session,
             diagServices,
             new PolarisConfigurationStore() {},

--- a/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManagerImpl;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
@@ -51,7 +52,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     PolarisEclipseLinkStore store = new PolarisEclipseLinkStore(diagServices);
     PolarisEclipseLinkMetaStoreSessionImpl session =
         new PolarisEclipseLinkMetaStoreSessionImpl(
-            store, Mockito.mock(), () -> "realm", null, "polaris");
+            store, Mockito.mock(), RealmContext.of("realm"), null, "polaris");
     return new PolarisTestMetaStoreManager(
         new PolarisMetaStoreManagerImpl(),
         new PolarisCallContext(
@@ -72,7 +73,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     try {
       var session =
           new PolarisEclipseLinkMetaStoreSessionImpl(
-              store, Mockito.mock(), () -> "realm", confFile, "polaris");
+              store, Mockito.mock(), RealmContext.of("realm"), confFile, "polaris");
       assertNotNull(session);
       assertTrue(success);
     } catch (Exception e) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@
 [versions]
 hadoop = "3.4.0"
 iceberg = "1.6.1"
+immutables = "2.10.1"
 dropwizard = "4.0.8"
 slf4j = "2.0.13"
 swagger = "1.6.14"
@@ -50,6 +51,9 @@ hadoop-client-api = { module = "org.apache.hadoop:hadoop-client-api", version.re
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.ref = "hadoop" }
 iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
+immutables-builder = { module = "org.immutables:builder", version.ref = "immutables" }
+immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
+immutables-value-processor = { module = "org.immutables:value-processor", version.ref = "immutables" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.17.2" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "3.1.0" }

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.spotbugs.annotations)
 
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
   implementation(libs.hadoop.common) {
     exclude("org.slf4j", "slf4j-reload4j")
     exclude("org.slf4j", "slf4j-log4j12")

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -21,56 +21,39 @@ package org.apache.polaris.core;
 import java.time.Clock;
 import java.time.ZoneId;
 import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
+import org.apache.polaris.immutables.PolarisImmutable;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * The Call context is allocated each time a new REST request is processed. It contains instances of
  * low-level services required to process that request
  */
-public class PolarisCallContext {
+@PolarisImmutable
+public interface PolarisCallContext {
 
-  // meta store which is used to persist Polaris entity metadata
-  private final PolarisMetaStoreSession metaStore;
+  PolarisMetaStoreSession getMetaStore();
 
-  // diag services
-  private final PolarisDiagnostics diagServices;
+  PolarisDiagnostics getDiagServices();
 
-  private final PolarisConfigurationStore configurationStore;
+  PolarisConfigurationStore getConfigurationStore();
 
-  private final Clock clock;
+  Clock getClock();
 
-  public PolarisCallContext(
-      @NotNull PolarisMetaStoreSession metaStore,
+  static PolarisCallContext of(
+      @NotNull PolarisMetaStoreSession metaStoreSession,
       @NotNull PolarisDiagnostics diagServices,
       @NotNull PolarisConfigurationStore configurationStore,
       @NotNull Clock clock) {
-    this.metaStore = metaStore;
-    this.diagServices = diagServices;
-    this.configurationStore = configurationStore;
-    this.clock = clock;
+    return ImmutablePolarisCallContext.of(
+        metaStoreSession, diagServices, configurationStore, clock);
   }
 
-  public PolarisCallContext(
+  static PolarisCallContext of(
       @NotNull PolarisMetaStoreSession metaStore, @NotNull PolarisDiagnostics diagServices) {
-    this.metaStore = metaStore;
-    this.diagServices = diagServices;
-    this.configurationStore = new PolarisConfigurationStore() {};
-    this.clock = Clock.system(ZoneId.systemDefault());
-  }
-
-  public PolarisMetaStoreSession getMetaStore() {
-    return metaStore;
-  }
-
-  public PolarisDiagnostics getDiagServices() {
-    return diagServices;
-  }
-
-  public PolarisConfigurationStore getConfigurationStore() {
-    return configurationStore;
-  }
-
-  public Clock getClock() {
-    return clock;
+    return of(
+        metaStore,
+        diagServices,
+        new PolarisConfigurationStore() {},
+        Clock.system(ZoneId.systemDefault()));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -22,6 +22,7 @@ import java.time.Clock;
 import java.time.ZoneId;
 import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -31,12 +32,16 @@ import org.jetbrains.annotations.NotNull;
 @PolarisImmutable
 public interface PolarisCallContext {
 
+  @Value.Parameter(order = 0)
   PolarisMetaStoreSession getMetaStore();
 
+  @Value.Parameter(order = 1)
   PolarisDiagnostics getDiagServices();
 
+  @Value.Parameter(order = 2)
   PolarisConfigurationStore getConfigurationStore();
 
+  @Value.Parameter(order = 3)
   Clock getClock();
 
   static PolarisCallContext of(

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -38,7 +38,7 @@ public interface PolarisConfiguration<T> {
     return catalogConfig().isPresent();
   }
 
-  @Value.Lazy
+  @Value.NonAttribute
   default String catalogConfigOrThrow() {
     return catalogConfig()
         .orElseThrow(
@@ -47,7 +47,6 @@ public interface PolarisConfiguration<T> {
                     "Attempted to read a catalog config key from a configuration that doesn't have one."));
   }
 
-  @Value.NonAttribute
   default T cast(Object value) {
     @SuppressWarnings("unchecked")
     T cast = (T) defaultValue().getClass().cast(value);

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -19,89 +19,55 @@
 package org.apache.polaris.core;
 
 import java.util.Optional;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
-public class PolarisConfiguration<T> {
+@PolarisImmutable
+public interface PolarisConfiguration<T> {
 
-  public final String key;
-  public final String description;
-  public final T defaultValue;
-  private final Optional<String> catalogConfigImpl;
-  private final Class<T> typ;
+  String key();
 
-  @SuppressWarnings("unchecked")
-  public PolarisConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
-    this.key = key;
-    this.description = description;
-    this.defaultValue = defaultValue;
-    this.catalogConfigImpl = catalogConfig;
-    this.typ = (Class<T>) defaultValue.getClass();
+  String description();
+
+  T defaultValue();
+
+  Optional<String> catalogConfig();
+
+  @Value.Derived
+  default boolean hasCatalogConfig() {
+    return catalogConfig().isPresent();
   }
 
-  public boolean hasCatalogConfig() {
-    return catalogConfigImpl.isPresent();
+  @Value.Lazy
+  default String catalogConfigOrThrow() {
+    return catalogConfig()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Attempted to read a catalog config key from a configuration that doesn't have one."));
   }
 
-  public String catalogConfig() {
-    return catalogConfigImpl.orElseThrow(
-        () ->
-            new IllegalStateException(
-                "Attempted to read a catalog config key from a configuration that doesn't have one."));
+  @Value.Lazy
+  default T cast(Object value) {
+    @SuppressWarnings("unchecked")
+    T cast = (T) defaultValue().getClass().cast(value);
+    return cast;
   }
 
-  T cast(Object value) {
-    return this.typ.cast(value);
+  static <T> ImmutablePolarisConfiguration.Builder<T> builder() {
+    return ImmutablePolarisConfiguration.builder();
   }
 
-  public static class Builder<T> {
-    private String key;
-    private String description;
-    private T defaultValue;
-    private Optional<String> catalogConfig = Optional.empty();
+  PolarisConfiguration<Boolean> ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING =
+      PolarisConfiguration.<Boolean>builder()
+          .key("ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING")
+          .description(
+              "If set to true, require that principals must rotate their credentials before being used "
+                  + "for anything else.")
+          .defaultValue(false)
+          .build();
 
-    public Builder<T> key(String key) {
-      this.key = key;
-      return this;
-    }
-
-    public Builder<T> description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public Builder<T> defaultValue(T defaultValue) {
-      this.defaultValue = defaultValue;
-      return this;
-    }
-
-    public Builder<T> catalogConfig(String catalogConfig) {
-      this.catalogConfig = Optional.of(catalogConfig);
-      return this;
-    }
-
-    public PolarisConfiguration<T> build() {
-      if (key == null || description == null || defaultValue == null) {
-        throw new IllegalArgumentException("key, description, and defaultValue are required");
-      }
-      return new PolarisConfiguration<>(key, description, defaultValue, catalogConfig);
-    }
-  }
-
-  public static <T> Builder<T> builder() {
-    return new Builder<>();
-  }
-
-  public static final PolarisConfiguration<Boolean>
-      ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING =
-          PolarisConfiguration.<Boolean>builder()
-              .key("ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING")
-              .description(
-                  "If set to true, require that principals must rotate their credentials before being used "
-                      + "for anything else.")
-              .defaultValue(false)
-              .build();
-
-  public static final PolarisConfiguration<Boolean> ALLOW_TABLE_LOCATION_OVERLAP =
+  PolarisConfiguration<Boolean> ALLOW_TABLE_LOCATION_OVERLAP =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_TABLE_LOCATION_OVERLAP")
           .catalogConfig("allow.overlapping.table.location")
@@ -111,7 +77,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> ALLOW_NAMESPACE_LOCATION_OVERLAP =
+  PolarisConfiguration<Boolean> ALLOW_NAMESPACE_LOCATION_OVERLAP =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_NAMESPACE_LOCATION_OVERLAP")
           .description(
@@ -120,7 +86,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> ALLOW_EXTERNAL_METADATA_FILE_LOCATION =
+  PolarisConfiguration<Boolean> ALLOW_EXTERNAL_METADATA_FILE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_METADATA_FILE_LOCATION")
           .description(
@@ -128,14 +94,14 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> ALLOW_OVERLAPPING_CATALOG_URLS =
+  PolarisConfiguration<Boolean> ALLOW_OVERLAPPING_CATALOG_URLS =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_OVERLAPPING_CATALOG_URLS")
           .description("If set to true, allows catalog URLs to overlap.")
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> ALLOW_UNSTRUCTURED_TABLE_LOCATION =
+  PolarisConfiguration<Boolean> ALLOW_UNSTRUCTURED_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_UNSTRUCTURED_TABLE_LOCATION")
           .catalogConfig("allow.unstructured.table.location")
@@ -143,7 +109,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
+  PolarisConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_TABLE_LOCATION")
           .catalogConfig("allow.external.table.location")
@@ -152,7 +118,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =
+  PolarisConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_NAMESPACE_DROP")
           .catalogConfig("cleanup.on.namespace.drop")
@@ -160,7 +126,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> CLEANUP_ON_CATALOG_DROP =
+  PolarisConfiguration<Boolean> CLEANUP_ON_CATALOG_DROP =
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_CATALOG_DROP")
           .catalogConfig("cleanup.on.catalog.drop")
@@ -168,7 +134,7 @@ public class PolarisConfiguration<T> {
           .defaultValue(false)
           .build();
 
-  public static final PolarisConfiguration<Boolean> DROP_WITH_PURGE_ENABLED =
+  PolarisConfiguration<Boolean> DROP_WITH_PURGE_ENABLED =
       PolarisConfiguration.<Boolean>builder()
           .key("DROP_WITH_PURGE_ENABLED")
           .catalogConfig("drop-with-purge.enabled")

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -47,7 +47,7 @@ public interface PolarisConfiguration<T> {
                     "Attempted to read a catalog config key from a configuration that doesn't have one."));
   }
 
-  @Value.Lazy
+  @Value.Derived
   default T cast(Object value) {
     @SuppressWarnings("unchecked")
     T cast = (T) defaultValue().getClass().cast(value);

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -47,7 +47,7 @@ public interface PolarisConfiguration<T> {
                     "Attempted to read a catalog config key from a configuration that doesn't have one."));
   }
 
-  @Value.Derived
+  @Value.NonAttribute
   default T cast(Object value) {
     @SuppressWarnings("unchecked")
     T cast = (T) defaultValue().getClass().cast(value);

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -63,10 +63,10 @@ public interface PolarisConfigurationStore {
    */
   private <T> @NotNull T tryCast(PolarisConfiguration<T> config, Object value) {
     if (value == null) {
-      return config.defaultValue;
+      return config.defaultValue();
     }
 
-    if (config.defaultValue instanceof Boolean) {
+    if (config.defaultValue() instanceof Boolean) {
       return config.cast(Boolean.valueOf(String.valueOf(value)));
     } else {
       return config.cast(value);
@@ -82,7 +82,7 @@ public interface PolarisConfigurationStore {
    * @param <T> the type of the configuration value
    */
   default <T> @NotNull T getConfiguration(PolarisCallContext ctx, PolarisConfiguration<T> config) {
-    T result = getConfiguration(ctx, config.key, config.defaultValue);
+    T result = getConfiguration(ctx, config.key(), config.defaultValue());
     return tryCast(config, result);
   }
 
@@ -101,8 +101,8 @@ public interface PolarisConfigurationStore {
       @NotNull CatalogEntity catalogEntity,
       PolarisConfiguration<T> config) {
     if (config.hasCatalogConfig()
-        && catalogEntity.getPropertiesAsMap().containsKey(config.catalogConfig())) {
-      return tryCast(config, catalogEntity.getPropertiesAsMap().get(config.catalogConfig()));
+        && catalogEntity.getPropertiesAsMap().containsKey(config.catalogConfigOrThrow())) {
+      return tryCast(config, catalogEntity.getPropertiesAsMap().get(config.catalogConfigOrThrow()));
     } else {
       return getConfiguration(ctx, config);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthenticatedPolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthenticatedPolarisPrincipal.java
@@ -22,51 +22,40 @@ import java.util.List;
 import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
-import org.jetbrains.annotations.NotNull;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
 /** Holds the results of request authentication. */
-public class AuthenticatedPolarisPrincipal implements java.security.Principal {
-  private final PolarisEntity principalEntity;
-  private final Set<String> activatedPrincipalRoleNames;
-  // only known and set after the above set of principal role names have been resolved. Before
-  // this, this list is null
-  private List<PrincipalRoleEntity> activatedPrincipalRoles;
+@PolarisImmutable
+public interface AuthenticatedPolarisPrincipal extends java.security.Principal {
 
-  public AuthenticatedPolarisPrincipal(
-      @NotNull PolarisEntity principalEntity, @NotNull Set<String> activatedPrincipalRoles) {
-    this.principalEntity = principalEntity;
-    this.activatedPrincipalRoleNames = activatedPrincipalRoles;
-    this.activatedPrincipalRoles = null;
-  }
-
+  @Value.Derived
   @Override
-  public String getName() {
-    return principalEntity.getName();
+  default String getName() {
+    return getPrincipalEntity().getName();
   }
 
-  public PolarisEntity getPrincipalEntity() {
-    return principalEntity;
+  PolarisEntity getPrincipalEntity();
+
+  Set<String> getActivatedPrincipalRoleNames();
+
+  /** Get the activated principal roles. Can be empty if roles weren't fully resolved yet. */
+  List<PrincipalRoleEntity> getActivatedPrincipalRoles();
+
+  AuthenticatedPolarisPrincipal withActivatedPrincipalRoles(
+      Iterable<? extends PrincipalRoleEntity> activatedPrincipalRoles);
+
+  static AuthenticatedPolarisPrincipal of(PolarisEntity principalEntity) {
+    return ImmutableAuthenticatedPolarisPrincipal.builder()
+        .principalEntity(principalEntity)
+        .build();
   }
 
-  public Set<String> getActivatedPrincipalRoleNames() {
-    return activatedPrincipalRoleNames;
-  }
-
-  public List<PrincipalRoleEntity> getActivatedPrincipalRoles() {
-    return activatedPrincipalRoles;
-  }
-
-  public void setActivatedPrincipalRoles(List<PrincipalRoleEntity> activatedPrincipalRoles) {
-    this.activatedPrincipalRoles = activatedPrincipalRoles;
-  }
-
-  @Override
-  public String toString() {
-    return "principalEntity="
-        + getPrincipalEntity()
-        + ";activatedPrincipalRoleNames="
-        + getActivatedPrincipalRoleNames()
-        + ";activatedPrincipalRoles="
-        + getActivatedPrincipalRoles();
+  static AuthenticatedPolarisPrincipal of(
+      PolarisEntity principalEntity, Set<String> activatedPrincipalRoleNames) {
+    return ImmutableAuthenticatedPolarisPrincipal.builder()
+        .principalEntity(principalEntity)
+        .activatedPrincipalRoleNames(activatedPrincipalRoleNames)
+        .build();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.entity;
 
 import static org.apache.polaris.core.admin.model.StorageConfigInfo.StorageTypeEnum.AZURE;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -130,7 +129,6 @@ public class CatalogEntity extends PolarisEntity {
   private StorageConfigInfo getStorageInfo(Map<String, String> internalProperties) {
     if (internalProperties.containsKey(PolarisEntityConstants.getStorageConfigInfoPropertyName())) {
       PolarisStorageConfigurationInfo configInfo = getStorageConfigurationInfo();
-      PolarisStorageConfigurationInfo.StorageType storageType = configInfo.getStorageType();
       if (configInfo instanceof AwsStorageConfigurationInfo) {
         AwsStorageConfigurationInfo awsConfig = (AwsStorageConfigurationInfo) configInfo;
         return AwsStorageConfigInfo.builder()
@@ -241,24 +239,19 @@ public class CatalogEntity extends PolarisEntity {
           case S3:
             AwsStorageConfigInfo awsConfigModel = (AwsStorageConfigInfo) storageConfigModel;
             config =
-                new AwsStorageConfigurationInfo(
-                    PolarisStorageConfigurationInfo.StorageType.S3,
-                    new ArrayList<>(allowedLocations),
-                    awsConfigModel.getRoleArn(),
-                    awsConfigModel.getExternalId());
-            ((AwsStorageConfigurationInfo) config).validateArn(awsConfigModel.getRoleArn());
+                AwsStorageConfigurationInfo.of(
+                    allowedLocations, awsConfigModel.getRoleArn(), awsConfigModel.getExternalId());
             break;
           case AZURE:
             AzureStorageConfigInfo azureConfigModel = (AzureStorageConfigInfo) storageConfigModel;
             config =
-                new AzureStorageConfigurationInfo(
-                    new ArrayList<>(allowedLocations), azureConfigModel.getTenantId());
+                AzureStorageConfigurationInfo.of(allowedLocations, azureConfigModel.getTenantId());
             break;
           case GCS:
-            config = new GcpStorageConfigurationInfo(new ArrayList<>(allowedLocations));
+            config = GcpStorageConfigurationInfo.of(allowedLocations);
             break;
           case FILE:
-            config = new FileStorageConfigurationInfo(new ArrayList<>(allowedLocations));
+            config = FileStorageConfigurationInfo.of(allowedLocations);
             break;
           default:
             throw new IllegalStateException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -80,7 +80,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
     Map<String, PolarisMetaStoreManager.PrincipalSecretsResult> results = new HashMap<>();
 
     for (String realm : realms) {
-      RealmContext realmContext = () -> realm;
+      RealmContext realmContext = RealmContext.of(realm);
       if (!metaStoreManagerMap.containsKey(realmContext.getRealmIdentifier())) {
         initializeForRealm(realmContext);
         PolarisMetaStoreManager.PrincipalSecretsResult secretsResult =
@@ -96,8 +96,9 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
   @Override
   public void purgeRealms(List<String> realms) {
     for (String realm : realms) {
-      PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(() -> realm);
-      PolarisMetaStoreSession session = getOrCreateSessionSupplier(() -> realm).get();
+      RealmContext realmContext = RealmContext.of(realm);
+      PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
+      PolarisMetaStoreSession session = getOrCreateSessionSupplier(realmContext).get();
 
       PolarisCallContext callContext = new PolarisCallContext(session, diagServices);
       metaStoreManager.purge(callContext);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -100,7 +100,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
       PolarisMetaStoreSession session = getOrCreateSessionSupplier(realmContext).get();
 
-      PolarisCallContext callContext = new PolarisCallContext(session, diagServices);
+      PolarisCallContext callContext = PolarisCallContext.of(session, diagServices);
       metaStoreManager.purge(callContext);
 
       storageCredentialCacheMap.remove(realm);
@@ -164,7 +164,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
     // While bootstrapping we need to act as a fake privileged context since the real
     // CallContext hasn't even been resolved yet.
     PolarisCallContext polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
     CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
 
@@ -220,7 +220,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
   private void checkPolarisServiceBootstrappedForRealm(
       RealmContext realmContext, PolarisMetaStoreManager metaStoreManager) {
     PolarisCallContext polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
     CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -55,7 +55,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
 
   private final PolarisEntityManager entityManager;
   private final CallContext callContext;
-  private final AuthenticatedPolarisPrincipal authenticatedPrincipal;
+  private AuthenticatedPolarisPrincipal authenticatedPrincipal;
   private final String catalogName;
   private final Resolver primaryResolver;
   private final PolarisDiagnostics diagnostics;
@@ -147,7 +147,8 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
           primaryResolver.getResolvedCallerPrincipalRoles().stream()
               .map(ce -> PrincipalRoleEntity.of(ce.getEntity()))
               .collect(Collectors.toList());
-      this.authenticatedPrincipal.setActivatedPrincipalRoles(activatedPrincipalRoles);
+      authenticatedPrincipal =
+          authenticatedPrincipal.withActivatedPrincipalRoles(activatedPrincipalRoles);
     }
     return primaryResolverStatus;
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
@@ -18,10 +18,12 @@
  */
 package org.apache.polaris.core.storage;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
 /**
  * Support for file:// URLs in storage configuration. This is pretty-much only used for testing.
@@ -31,6 +33,7 @@ import org.apache.polaris.immutables.PolarisImmutable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableFileStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableFileStorageConfigurationInfo.class)
+@JsonTypeName("FileStorageConfigurationInfo")
 public abstract class FileStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
   public static FileStorageConfigurationInfo of(Iterable<String> allowedLocations) {
@@ -42,11 +45,13 @@ public abstract class FileStorageConfigurationInfo extends PolarisStorageConfigu
   @Override
   public abstract List<String> getAllowedLocations();
 
+  @Value.Default
   @Override
   public StorageType getStorageType() {
     return StorageType.FILE;
   }
 
+  @Value.Default
   @Override
   public String getFileIoImplClassName() {
     return "org.apache.iceberg.hadoop.HadoopFileIO";

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
@@ -18,21 +18,33 @@
  */
 package org.apache.polaris.core.storage;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
+import org.apache.polaris.immutables.PolarisImmutable;
 
 /**
  * Support for file:// URLs in storage configuration. This is pretty-much only used for testing.
  * Supports URLs that start with file:// or /, but also supports wildcard (*) to support certain
  * test cases.
  */
-public class FileStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
+@PolarisImmutable
+@JsonSerialize(as = ImmutableFileStorageConfigurationInfo.class)
+@JsonDeserialize(as = ImmutableFileStorageConfigurationInfo.class)
+public abstract class FileStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
-  public FileStorageConfigurationInfo(
-      @JsonProperty(value = "allowedLocations", required = true) @NotNull
-          List<String> allowedLocations) {
-    super(StorageType.FILE, allowedLocations);
+  public static FileStorageConfigurationInfo of(Iterable<String> allowedLocations) {
+    return ImmutableFileStorageConfigurationInfo.builder()
+        .allowedLocations(allowedLocations)
+        .build();
+  }
+
+  @Override
+  public abstract List<String> getAllowedLocations();
+
+  @Override
+  public StorageType getStorageType() {
+    return StorageType.FILE;
   }
 
   @Override
@@ -41,7 +53,7 @@ public class FileStorageConfigurationInfo extends PolarisStorageConfigurationInf
   }
 
   @Override
-  public void validatePrefixForStorageType(String loc) {
+  protected void validatePrefixForStorageType(String loc) {
     if (!loc.startsWith(getStorageType().getPrefix())
         && !loc.startsWith("file:/")
         && !loc.startsWith("/")

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisConfiguration;
@@ -199,6 +200,11 @@ public abstract class PolarisStorageConfigurationInfo {
   @Check
   protected void validate() {
     getAllowedLocations().forEach(this::validatePrefixForStorageType);
+    getMaxAllowedLocations().ifPresent(this::validateMaxAllowedLocations);
+  }
+
+  protected OptionalInt getMaxAllowedLocations() {
+    return OptionalInt.empty();
   }
 
   /** Validate if the provided allowed locations are valid for the storage type */
@@ -211,7 +217,10 @@ public abstract class PolarisStorageConfigurationInfo {
     }
   }
 
-  /** Validate the number of allowed locations not exceeding the max value. */
+  /**
+   * Validate the number of allowed locations not exceeding the max value. Only called from
+   * subclasses because the number of max allowed locations depends on the subtype.
+   */
   protected void validateMaxAllowedLocations(int maxAllowedLocations) {
     if (getAllowedLocations().size() > maxAllowedLocations) {
       throw new IllegalArgumentException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -44,9 +44,9 @@ import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.TableLikeEntity;
-import org.apache.polaris.core.storage.aws.ImmutableAwsStorageConfigurationInfo;
-import org.apache.polaris.core.storage.azure.ImmutableAzureStorageConfigurationInfo;
-import org.apache.polaris.core.storage.gcp.ImmutableGcpStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
+import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
 import org.immutables.value.Value.Check;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -63,10 +63,10 @@ import org.slf4j.LoggerFactory;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
-  @JsonSubTypes.Type(value = ImmutableAwsStorageConfigurationInfo.class),
-  @JsonSubTypes.Type(value = ImmutableAzureStorageConfigurationInfo.class),
-  @JsonSubTypes.Type(value = ImmutableGcpStorageConfigurationInfo.class),
-  @JsonSubTypes.Type(value = ImmutableFileStorageConfigurationInfo.class),
+  @JsonSubTypes.Type(value = AwsStorageConfigurationInfo.class),
+  @JsonSubTypes.Type(value = AzureStorageConfigurationInfo.class),
+  @JsonSubTypes.Type(value = GcpStorageConfigurationInfo.class),
+  @JsonSubTypes.Type(value = FileStorageConfigurationInfo.class),
 })
 public abstract class PolarisStorageConfigurationInfo {
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigurationOverride.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigurationOverride.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.storage;
 
 import java.util.List;
+import java.util.OptionalInt;
 import org.apache.polaris.immutables.PolarisImmutable;
 
 /**
@@ -60,7 +61,7 @@ public abstract class StorageConfigurationOverride extends PolarisStorageConfigu
   }
 
   @Override
-  public void validateMaxAllowedLocations(int maxAllowedLocations) {
-    parentStorageConfiguration().validateMaxAllowedLocations(maxAllowedLocations);
+  protected OptionalInt getMaxAllowedLocations() {
+    return parentStorageConfiguration().getMaxAllowedLocations();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigurationOverride.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigurationOverride.java
@@ -19,7 +19,7 @@
 package org.apache.polaris.core.storage;
 
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
+import org.apache.polaris.immutables.PolarisImmutable;
 
 /**
  * Allows overriding the allowed locations for specific entities. Only the allowedLocations
@@ -27,31 +27,40 @@ import org.jetbrains.annotations.NotNull;
  * storage configuration. All other storage configuration is inherited from the parent configuration
  * and cannot be overridden.
  */
-public class StorageConfigurationOverride extends PolarisStorageConfigurationInfo {
+@PolarisImmutable
+public abstract class StorageConfigurationOverride extends PolarisStorageConfigurationInfo {
 
-  private final PolarisStorageConfigurationInfo parentStorageConfiguration;
+  public static PolarisStorageConfigurationInfo of(
+      PolarisStorageConfigurationInfo parent, Iterable<String> allowedLocations) {
+    return ImmutableStorageConfigurationOverride.builder()
+        .parentStorageConfiguration(parent)
+        .allowedLocations(allowedLocations)
+        .build();
+  }
 
-  public StorageConfigurationOverride(
-      @NotNull PolarisStorageConfigurationInfo parentStorageConfiguration,
-      List<String> allowedLocations) {
-    super(parentStorageConfiguration.getStorageType(), allowedLocations, false);
-    this.parentStorageConfiguration = parentStorageConfiguration;
-    allowedLocations.forEach(this::validatePrefixForStorageType);
+  protected abstract PolarisStorageConfigurationInfo parentStorageConfiguration();
+
+  @Override
+  public abstract List<String> getAllowedLocations();
+
+  @Override
+  public StorageType getStorageType() {
+    return parentStorageConfiguration().getStorageType();
   }
 
   @Override
   public String getFileIoImplClassName() {
-    return parentStorageConfiguration.getFileIoImplClassName();
+    return parentStorageConfiguration().getFileIoImplClassName();
   }
 
   // delegate to the wrapped class in case they override the parent behavior
   @Override
   protected void validatePrefixForStorageType(String loc) {
-    parentStorageConfiguration.validatePrefixForStorageType(loc);
+    parentStorageConfiguration().validatePrefixForStorageType(loc);
   }
 
   @Override
   public void validateMaxAllowedLocations(int maxAllowedLocations) {
-    parentStorageConfiguration.validateMaxAllowedLocations(maxAllowedLocations);
+    parentStorageConfiguration().validateMaxAllowedLocations(maxAllowedLocations);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -18,64 +18,77 @@
  */
 package org.apache.polaris.core.storage.aws;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
-import org.jetbrains.annotations.NotNull;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.jetbrains.annotations.Nullable;
 
 /** Aws Polaris Storage Configuration information */
-public class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
+@PolarisImmutable
+@JsonSerialize(as = ImmutableAwsStorageConfigurationInfo.class)
+@JsonDeserialize(as = ImmutableAwsStorageConfigurationInfo.class)
+public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
   // 5 is the approximate max allowed locations for the size of AccessPolicy when LIST is required
   // for allowed read and write locations for subscoping creds.
-  @JsonIgnore private static final int MAX_ALLOWED_LOCATIONS = 5;
+  private static final int MAX_ALLOWED_LOCATIONS = 5;
 
   // Technically, it should be ^arn:(aws|aws-cn|aws-us-gov):iam::\d{12}:role/.+$,
-  @JsonIgnore public static final String ROLE_ARN_PATTERN = "^arn:aws:iam::\\d{12}:role/.+$";
+  private static final String ROLE_ARN_PATTERN = "^arn:aws:iam::\\d{12}:role/.+$";
 
-  // AWS role to be assumed
-  private final @NotNull String roleARN;
-
-  // AWS external ID, optional
-  @JsonProperty(value = "externalId", required = false)
-  private @Nullable String externalId = null;
-
-  /** User ARN for the service principal */
-  @JsonProperty(value = "userARN", required = false)
-  private @Nullable String userARN = null;
-
-  @JsonCreator
-  public AwsStorageConfigurationInfo(
-      @JsonProperty(value = "storageType", required = true) @NotNull StorageType storageType,
-      @JsonProperty(value = "allowedLocations", required = true) @NotNull
-          List<String> allowedLocations,
-      @JsonProperty(value = "roleARN", required = true) @NotNull String roleARN) {
-    this(storageType, allowedLocations, roleARN, null);
+  public static AwsStorageConfigurationInfo of(Iterable<String> allowedLocations, String roleARN) {
+    return of(allowedLocations, roleARN, null);
   }
 
-  public AwsStorageConfigurationInfo(
-      @NotNull StorageType storageType,
-      @NotNull List<String> allowedLocations,
-      @NotNull String roleARN,
-      @Nullable String externalId) {
-    super(storageType, allowedLocations);
-    this.roleARN = roleARN;
-    this.externalId = externalId;
-    validateMaxAllowedLocations(MAX_ALLOWED_LOCATIONS);
+  public static AwsStorageConfigurationInfo of(
+      Iterable<String> allowedLocations, String roleARN, @Nullable String externalId) {
+    return ImmutableAwsStorageConfigurationInfo.builder()
+        .allowedLocations(allowedLocations)
+        .roleARN(roleARN)
+        .externalId(externalId)
+        .build();
   }
 
+  @Override
+  public abstract List<String> getAllowedLocations();
+
+  @Override
+  public StorageType getStorageType() {
+    return StorageType.S3;
+  }
+
+  @Value.Default
   @Override
   public String getFileIoImplClassName() {
     return "org.apache.iceberg.aws.s3.S3FileIO";
   }
 
-  public void validateArn(String arn) {
-    if (arn == null || arn.isEmpty()) {
+  /** AWS role to be assumed. */
+  public abstract String getRoleARN();
+
+  /** AWS external ID, optional. */
+  @Nullable
+  public abstract String getExternalId();
+
+  @Nullable
+  public abstract String getUserARN();
+
+  @Check
+  @Override
+  protected void validate() {
+    super.validate();
+    validateMaxAllowedLocations(MAX_ALLOWED_LOCATIONS);
+    validateArn();
+  }
+
+  private void validateArn() {
+    String arn = getRoleARN();
+    if (arn.isEmpty()) {
       throw new IllegalArgumentException("ARN cannot be null or empty");
     }
     // specifically throw errors for China and Gov
@@ -85,37 +98,5 @@ public class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo
     if (!Pattern.matches(ROLE_ARN_PATTERN, arn)) {
       throw new IllegalArgumentException("Invalid role ARN format");
     }
-  }
-
-  public @NotNull String getRoleARN() {
-    return roleARN;
-  }
-
-  public @Nullable String getExternalId() {
-    return externalId;
-  }
-
-  public void setExternalId(String externalId) {
-    this.externalId = externalId;
-  }
-
-  public @Nullable String getUserARN() {
-    return userARN;
-  }
-
-  public void setUserARN(@Nullable String userARN) {
-    this.userARN = userARN;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("storageType", getStorageType())
-        .add("storageType", getStorageType().name())
-        .add("roleARN", roleARN)
-        .add("userARN", userARN)
-        .add("externalId", externalId)
-        .add("allowedLocation", getAllowedLocations())
-        .toString();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.storage.aws;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableAwsStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableAwsStorageConfigurationInfo.class)
+@JsonTypeName("AwsStorageConfigurationInfo")
 public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
   // 5 is the approximate max allowed locations for the size of AccessPolicy when LIST is required
@@ -59,6 +61,7 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
   @Override
   public abstract List<String> getAllowedLocations();
 
+  @Value.Default
   @Override
   public StorageType getStorageType() {
     return StorageType.S3;
@@ -81,7 +84,7 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
   public abstract String getUserARN();
 
   @Value.Default
-  public Set<String> getAllowedArnDomains() {
+  protected Set<String> getAllowedArnDomains() {
     return Set.of("aws");
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.storage.azure;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableAzureStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableAzureStorageConfigurationInfo.class)
+@JsonTypeName("AzureStorageConfigurationInfo")
 public abstract class AzureStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
   // technically there is no limitation since expectation for Azure locations are for the same
@@ -49,6 +51,7 @@ public abstract class AzureStorageConfigurationInfo extends PolarisStorageConfig
   @Override
   public abstract List<String> getAllowedLocations();
 
+  @Value.Default
   @Override
   public StorageType getStorageType() {
     return StorageType.AZURE;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Check;
 import org.jetbrains.annotations.Nullable;
 
 /** Azure storage configuration information. */
@@ -70,11 +70,9 @@ public abstract class AzureStorageConfigurationInfo extends PolarisStorageConfig
   @Nullable
   public abstract String getConsentUrl();
 
-  @Check
   @Override
-  protected void validate() {
-    super.validate();
-    validateMaxAllowedLocations(MAX_ALLOWED_LOCATIONS);
+  protected OptionalInt getMaxAllowedLocations() {
+    return OptionalInt.of(MAX_ALLOWED_LOCATIONS);
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
@@ -21,9 +21,9 @@ package org.apache.polaris.core.storage.gcp;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import java.util.OptionalInt;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.immutables.PolarisImmutable;
-import org.immutables.value.Value.Check;
 import org.jetbrains.annotations.Nullable;
 
 /** Gcp storage storage configuration information. */
@@ -60,10 +60,8 @@ public abstract class GcpStorageConfigurationInfo extends PolarisStorageConfigur
   @Nullable
   public abstract String getGcpServiceAccount();
 
-  @Check
   @Override
-  protected void validate() {
-    super.validate();
-    validateMaxAllowedLocations(MAX_ALLOWED_LOCATIONS);
+  protected OptionalInt getMaxAllowedLocations() {
+    return OptionalInt.of(MAX_ALLOWED_LOCATIONS);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
@@ -18,18 +18,21 @@
  */
 package org.apache.polaris.core.storage.gcp;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.OptionalInt;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 import org.jetbrains.annotations.Nullable;
 
 /** Gcp storage storage configuration information. */
 @PolarisImmutable
 @JsonSerialize(as = ImmutableGcpStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableGcpStorageConfigurationInfo.class)
+@JsonTypeName("GcpStorageConfigurationInfo")
 public abstract class GcpStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 
   // 8 is an experimental result from generating GCP accessBoundaryRules when subscoping creds,
@@ -46,11 +49,13 @@ public abstract class GcpStorageConfigurationInfo extends PolarisStorageConfigur
   @Override
   public abstract List<String> getAllowedLocations();
 
+  @Value.Default
   @Override
   public StorageType getStorageType() {
     return StorageType.GCS;
   }
 
+  @Value.Default
   @Override
   public String getFileIoImplClassName() {
     return "org.apache.iceberg.gcp.gcs.GCSFileIO";

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/EntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/EntityCacheTest.java
@@ -83,7 +83,7 @@ public class EntityCacheTest {
     diagServices = new PolarisDefaultDiagServiceImpl();
     store = new PolarisTreeMapStore(diagServices);
     metaStore = new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock());
-    callCtx = new PolarisCallContext(metaStore, diagServices);
+    callCtx = PolarisCallContext.of(metaStore, diagServices);
     metaStoreManager = new PolarisMetaStoreManagerImpl();
 
     // bootstrap the mata store with our test schema

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
@@ -31,7 +31,7 @@ public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreMana
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
     PolarisTreeMapStore store = new PolarisTreeMapStore(diagServices);
     PolarisCallContext callCtx =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock()),
             diagServices,
             new PolarisConfigurationStore() {},

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -96,7 +96,7 @@ public class ResolverTest {
     diagServices = new PolarisDefaultDiagServiceImpl();
     store = new PolarisTreeMapStore(diagServices);
     metaStore = new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock());
-    callCtx = new PolarisCallContext(metaStore, diagServices);
+    callCtx = PolarisCallContext.of(metaStore, diagServices);
     metaStoreManager = new PolarisMetaStoreManagerImpl();
 
     // bootstrap the mata store with our test schema

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -28,6 +28,7 @@ import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
@@ -90,7 +91,8 @@ class InMemoryStorageIntegrationTest {
             },
             Clock.systemUTC());
     try (CallContext ignored =
-        CallContext.setCurrentContext(CallContext.of(() -> "realm", polarisCallContext))) {
+        CallContext.setCurrentContext(
+            CallContext.of(RealmContext.of("realm"), polarisCallContext))) {
       Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
           storage.validateAccessToLocations(
               new FileStorageConfigurationInfo(List.of("file://", "*")),

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -43,8 +43,7 @@ class InMemoryStorageIntegrationTest {
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration();
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            new AwsStorageConfigurationInfo(
-                PolarisStorageConfigurationInfo.StorageType.S3,
+            AwsStorageConfigurationInfo.of(
                 List.of(
                     "s3://bucket/path/to/warehouse",
                     "s3://bucket/anotherpath/to/warehouse",
@@ -95,7 +94,7 @@ class InMemoryStorageIntegrationTest {
             CallContext.of(RealmContext.of("realm"), polarisCallContext))) {
       Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
           storage.validateAccessToLocations(
-              new FileStorageConfigurationInfo(List.of("file://", "*")),
+              FileStorageConfigurationInfo.of(List.of("file://", "*")),
               Set.of(PolarisStorageActions.READ),
               Set.of(
                   "s3://bucket/path/to/warehouse/namespace/table",
@@ -135,10 +134,7 @@ class InMemoryStorageIntegrationTest {
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration();
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            new AwsStorageConfigurationInfo(
-                PolarisStorageConfigurationInfo.StorageType.S3,
-                List.of(),
-                "arn:aws:iam::012345678901:role/jdoe"),
+            AwsStorageConfigurationInfo.of(List.of(), "arn:aws:iam::012345678901:role/jdoe"),
             Set.of(PolarisStorageActions.READ),
             Set.of(
                 "s3://bucket/path/to/warehouse/namespace/table",
@@ -168,10 +164,8 @@ class InMemoryStorageIntegrationTest {
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration();
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            new AwsStorageConfigurationInfo(
-                PolarisStorageConfigurationInfo.StorageType.S3,
-                List.of("s3://bucket/path/to/warehouse"),
-                "arn:aws:iam::012345678901:role/jdoe"),
+            AwsStorageConfigurationInfo.of(
+                List.of("s3://bucket/path/to/warehouse"), "arn:aws:iam::012345678901:role/jdoe"),
             Set.of(PolarisStorageActions.READ),
             // trying to read a prefix under the allowed location
             Set.of("s3://bucket/path/to"));

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -79,7 +79,7 @@ class InMemoryStorageIntegrationTest {
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration();
     Map<String, Boolean> config = Map.of("ALLOW_WILDCARD_LOCATION", true);
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             Mockito.mock(),
             new PolarisDefaultDiagServiceImpl(),
             new PolarisConfigurationStore() {

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
@@ -16,11 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.core.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -46,7 +44,8 @@ class PolarisStorageConfigurationInfoTest {
                 .roleARN("arn:aws:iam::012345678901:role/jdoe")
                 .externalId("externalId")
                 .userARN("userARN")
-                .build()),
+                .build(),
+            "AwsStorageConfigurationInfo"),
         Arguments.of(
             ImmutableAzureStorageConfigurationInfo.builder()
                 .allowedLocations(
@@ -57,7 +56,8 @@ class PolarisStorageConfigurationInfoTest {
                 .consentUrl("https://login.microsoftonline.com/tenantId/oauth2/authorize")
                 .multiTenantAppName("appName")
                 .tenantId("tenantId")
-                .build()),
+                .build(),
+            "AzureStorageConfigurationInfo"),
         Arguments.of(
             ImmutableGcpStorageConfigurationInfo.builder()
                 .allowedLocations(
@@ -66,14 +66,24 @@ class PolarisStorageConfigurationInfoTest {
                         "gs://bucket/anotherpath/to/warehouse",
                         "gs://bucket2/warehouse/"))
                 .gcpServiceAccount("serviceAccount")
-                .build()));
+                .build(),
+            "GcpStorageConfigurationInfo"),
+        Arguments.of(
+            ImmutableFileStorageConfigurationInfo.builder()
+                .allowedLocations(
+                    List.of(
+                        "file:///path/to/warehouse",
+                        "file:///anotherpath/to/warehouse",
+                        "file:///warehouse/"))
+                .build(),
+            "FileStorageConfigurationInfo"));
   }
 
   @ParameterizedTest
   @MethodSource
-  void serialize(PolarisStorageConfigurationInfo instance) {
+  void serialize(PolarisStorageConfigurationInfo instance, String typeName) {
     String json = instance.serialize();
-    System.out.println(json);
+    assertThat(json).contains("\"@type\":\"" + typeName + "\"");
     PolarisStorageConfigurationInfo deserialized =
         PolarisStorageConfigurationInfo.deserialize(new PolarisDefaultDiagServiceImpl(), json);
     assertThat(deserialized).isEqualTo(instance);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.storage.aws.ImmutableAwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.azure.ImmutableAzureStorageConfigurationInfo;
+import org.apache.polaris.core.storage.gcp.ImmutableGcpStorageConfigurationInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PolarisStorageConfigurationInfoTest {
+
+  public static Stream<Arguments> serialize() {
+    return Stream.of(
+        Arguments.of(
+            ImmutableAwsStorageConfigurationInfo.builder()
+                .allowedLocations(
+                    List.of(
+                        "s3://bucket/path/to/warehouse",
+                        "s3://bucket/anotherpath/to/warehouse",
+                        "s3://bucket2/warehouse/"))
+                .roleARN("arn:aws:iam::012345678901:role/jdoe")
+                .externalId("externalId")
+                .userARN("userARN")
+                .build()),
+        Arguments.of(
+            ImmutableAzureStorageConfigurationInfo.builder()
+                .allowedLocations(
+                    List.of(
+                        "abfs://account@container.com/path/to/warehouse",
+                        "abfs://account@container.com/anotherpath/to/warehouse",
+                        "abfs://account2@container.com/warehouse/"))
+                .consentUrl("https://login.microsoftonline.com/tenantId/oauth2/authorize")
+                .multiTenantAppName("appName")
+                .tenantId("tenantId")
+                .build()),
+        Arguments.of(
+            ImmutableGcpStorageConfigurationInfo.builder()
+                .allowedLocations(
+                    List.of(
+                        "gs://bucket/path/to/warehouse",
+                        "gs://bucket/anotherpath/to/warehouse",
+                        "gs://bucket2/warehouse/"))
+                .gcpServiceAccount("serviceAccount")
+                .build()));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void serialize(PolarisStorageConfigurationInfo instance) {
+    String json = instance.serialize();
+    System.out.println(json);
+    PolarisStorageConfigurationInfo deserialized =
+        PolarisStorageConfigurationInfo.deserialize(new PolarisDefaultDiagServiceImpl(), json);
+    assertThat(deserialized).isEqualTo(instance);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PolarisStorageConfigurationInfoTest {
 
-  public static Stream<Arguments> serialize() {
+  static Stream<Arguments> serialize() {
     return Stream.of(
         Arguments.of(
             ImmutableAwsStorageConfigurationInfo.builder()

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -65,7 +65,7 @@ public class StorageCredentialCacheTest {
     // to interact with the metastore
     PolarisMetaStoreSession metaStore =
         new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock());
-    callCtx = new PolarisCallContext(metaStore, diagServices);
+    callCtx = PolarisCallContext.of(metaStore, diagServices);
     metaStoreManager = Mockito.mock(PolarisMetaStoreManagerImpl.class);
     storageCredentialCache = new StorageCredentialCache();
   }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -28,9 +28,12 @@ import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.ImmutableAwsStorageConfigurationInfo;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.policybuilder.iam.IamAction;
 import software.amazon.awssdk.policybuilder.iam.IamCondition;
@@ -88,116 +91,140 @@ class AwsCredentialsStorageIntegrationTest {
         .containsEntry(PolarisCredentialProperty.AWS_SECRET_KEY, "secretKey");
   }
 
-  @Test
-  public void testGetSubscopedCredsInlinePolicy() {
-    PolarisStorageConfigurationInfo.StorageType storageType =
-        PolarisStorageConfigurationInfo.StorageType.S3;
-    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
-    StsClient stsClient = Mockito.mock(StsClient.class);
-    String externalId = "externalId";
-    String bucket = "bucket";
-    String warehouseKeyPrefix = "path/to/warehouse";
-    String firstPath = warehouseKeyPrefix + "/namespace/table";
-    String secondPath = warehouseKeyPrefix + "/oldnamespace/table";
-    Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
-        .thenAnswer(
-            invocation -> {
-              assertThat(invocation.getArguments()[0])
-                  .isInstanceOf(AssumeRoleRequest.class)
-                  .asInstanceOf(InstanceOfAssertFactories.type(AssumeRoleRequest.class))
-                  .extracting(AssumeRoleRequest::policy)
-                  .extracting(IamPolicy::fromJson)
-                  .satisfies(
-                      policy -> {
-                        assertThat(policy)
-                            .extracting(IamPolicy::statements)
-                            .asInstanceOf(InstanceOfAssertFactories.list(IamStatement.class))
-                            .hasSize(3)
-                            .satisfiesExactly(
-                                statement ->
-                                    assertThat(statement)
-                                        .returns(IamEffect.ALLOW, IamStatement::effect)
-                                        .returns(
-                                            List.of(
-                                                IamResource.create(
-                                                    s3Arn(AWS_PARTITION, bucket, firstPath))),
-                                            IamStatement::resources)
-                                        .returns(
-                                            List.of(
-                                                IamAction.create("s3:PutObject"),
-                                                IamAction.create("s3:DeleteObject")),
-                                            IamStatement::actions),
-                                statement ->
-                                    assertThat(statement)
-                                        .returns(IamEffect.ALLOW, IamStatement::effect)
-                                        .returns(
-                                            List.of(
-                                                IamResource.create(
-                                                    s3Arn(AWS_PARTITION, bucket, null))),
-                                            IamStatement::resources)
-                                        .returns(
-                                            List.of(IamAction.create("s3:ListBucket")),
-                                            IamStatement::actions)
-                                        .returns(
-                                            List.of(
-                                                IamResource.create(
-                                                    s3Arn(AWS_PARTITION, bucket, null))),
-                                            IamStatement::resources)
-                                        .satisfies(
-                                            st ->
-                                                assertThat(st.conditions())
-                                                    .containsExactlyInAnyOrder(
-                                                        IamCondition.builder()
-                                                            .operator(
-                                                                IamConditionOperator.STRING_LIKE)
-                                                            .key("s3:prefix")
-                                                            .value(secondPath + "/*")
-                                                            .build(),
-                                                        IamCondition.builder()
-                                                            .operator(
-                                                                IamConditionOperator.STRING_LIKE)
-                                                            .key("s3:prefix")
-                                                            .value(firstPath + "/*")
-                                                            .build())),
-                                statement ->
-                                    assertThat(statement)
-                                        .returns(IamEffect.ALLOW, IamStatement::effect)
-                                        .satisfies(
-                                            st ->
-                                                assertThat(st.resources())
-                                                    .containsExactlyInAnyOrder(
-                                                        IamResource.create(
-                                                            s3Arn(
-                                                                AWS_PARTITION, bucket, firstPath)),
-                                                        IamResource.create(
-                                                            s3Arn(
-                                                                AWS_PARTITION,
-                                                                bucket,
-                                                                secondPath))))
-                                        .returns(
-                                            List.of(
-                                                IamAction.create("s3:GetObject"),
-                                                IamAction.create("s3:GetObjectVersion")),
-                                            IamStatement::actions));
-                      });
-              return ASSUME_ROLE_RESPONSE;
-            });
-    EnumMap<PolarisCredentialProperty, String> credentials =
-        new AwsCredentialsStorageIntegration(stsClient)
-            .getSubscopedCreds(
-                Mockito.mock(PolarisDiagnostics.class),
-                AwsStorageConfigurationInfo.of(
-                    List.of(s3Path(bucket, warehouseKeyPrefix, storageType)), roleARN, externalId),
-                true,
-                Set.of(
-                    s3Path(bucket, firstPath, storageType),
-                    s3Path(bucket, secondPath, storageType)),
-                Set.of(s3Path(bucket, firstPath, storageType)));
-    assertThat(credentials)
-        .isNotEmpty()
-        .containsEntry(PolarisCredentialProperty.AWS_TOKEN, "sess")
-        .containsEntry(PolarisCredentialProperty.AWS_KEY_ID, "accessKey")
-        .containsEntry(PolarisCredentialProperty.AWS_SECRET_KEY, "secretKey");
+  @ParameterizedTest
+  @ValueSource(strings = {AWS_PARTITION, "aws-cn", "aws-us-gov"})
+  public void testGetSubscopedCredsInlinePolicy(String awsPartition) {
+    System.setProperty("polaris.aws.allowed_arn_domains", "aws,aws-cn,aws-us-gov");
+    try {
+      PolarisStorageConfigurationInfo.StorageType storageType =
+          PolarisStorageConfigurationInfo.StorageType.S3;
+      String roleARN;
+      switch (awsPartition) {
+        case AWS_PARTITION:
+          roleARN = "arn:aws:iam::012345678901:role/jdoe";
+          break;
+        case "aws-cn":
+          roleARN = "arn:aws-cn:iam::012345678901:role/jdoe";
+          break;
+        case "aws-us-gov":
+          roleARN = "arn:aws-us-gov:iam::012345678901:role/jdoe";
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown aws partition: " + awsPartition);
+      }
+
+      StsClient stsClient = Mockito.mock(StsClient.class);
+      String externalId = "externalId";
+      String bucket = "bucket";
+      String warehouseKeyPrefix = "path/to/warehouse";
+      String firstPath = warehouseKeyPrefix + "/namespace/table";
+      String secondPath = warehouseKeyPrefix + "/oldnamespace/table";
+      Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                assertThat(invocation.getArguments()[0])
+                    .isInstanceOf(AssumeRoleRequest.class)
+                    .asInstanceOf(InstanceOfAssertFactories.type(AssumeRoleRequest.class))
+                    .extracting(AssumeRoleRequest::policy)
+                    .extracting(IamPolicy::fromJson)
+                    .satisfies(
+                        policy -> {
+                          assertThat(policy)
+                              .extracting(IamPolicy::statements)
+                              .asInstanceOf(InstanceOfAssertFactories.list(IamStatement.class))
+                              .hasSize(3)
+                              .satisfiesExactly(
+                                  statement ->
+                                      assertThat(statement)
+                                          .returns(IamEffect.ALLOW, IamStatement::effect)
+                                          .returns(
+                                              List.of(
+                                                  IamResource.create(
+                                                      s3Arn(awsPartition, bucket, firstPath))),
+                                              IamStatement::resources)
+                                          .returns(
+                                              List.of(
+                                                  IamAction.create("s3:PutObject"),
+                                                  IamAction.create("s3:DeleteObject")),
+                                              IamStatement::actions),
+                                  statement ->
+                                      assertThat(statement)
+                                          .returns(IamEffect.ALLOW, IamStatement::effect)
+                                          .returns(
+                                              List.of(
+                                                  IamResource.create(
+                                                      s3Arn(awsPartition, bucket, null))),
+                                              IamStatement::resources)
+                                          .returns(
+                                              List.of(IamAction.create("s3:ListBucket")),
+                                              IamStatement::actions)
+                                          .returns(
+                                              List.of(
+                                                  IamResource.create(
+                                                      s3Arn(awsPartition, bucket, null))),
+                                              IamStatement::resources)
+                                          .satisfies(
+                                              st ->
+                                                  assertThat(st.conditions())
+                                                      .containsExactlyInAnyOrder(
+                                                          IamCondition.builder()
+                                                              .operator(
+                                                                  IamConditionOperator.STRING_LIKE)
+                                                              .key("s3:prefix")
+                                                              .value(secondPath + "/*")
+                                                              .build(),
+                                                          IamCondition.builder()
+                                                              .operator(
+                                                                  IamConditionOperator.STRING_LIKE)
+                                                              .key("s3:prefix")
+                                                              .value(firstPath + "/*")
+                                                              .build())),
+                                  statement ->
+                                      assertThat(statement)
+                                          .returns(IamEffect.ALLOW, IamStatement::effect)
+                                          .satisfies(
+                                              st ->
+                                                  assertThat(st.resources())
+                                                      .containsExactlyInAnyOrder(
+                                                          IamResource.create(
+                                                              s3Arn(
+                                                                  awsPartition, bucket, firstPath)),
+                                                          IamResource.create(
+                                                              s3Arn(
+                                                                  awsPartition,
+                                                                  bucket,
+                                                                  secondPath))))
+                                          .returns(
+                                              List.of(
+                                                  IamAction.create("s3:GetObject"),
+                                                  IamAction.create("s3:GetObjectVersion")),
+                                              IamStatement::actions));
+                        });
+                return ASSUME_ROLE_RESPONSE;
+              });
+      EnumMap<PolarisCredentialProperty, String> credentials =
+          new AwsCredentialsStorageIntegration(stsClient)
+              .getSubscopedCreds(
+                  Mockito.mock(PolarisDiagnostics.class),
+                  ImmutableAwsStorageConfigurationInfo.builder()
+                      .allowedLocations(List.of(s3Path(bucket, warehouseKeyPrefix, storageType)))
+                      .roleARN(roleARN)
+                      .externalId(externalId)
+                      .allowedArnDomains(Set.of(awsPartition))
+                      .build(),
+                  true,
+                  Set.of(
+                      s3Path(bucket, firstPath, storageType),
+                      s3Path(bucket, secondPath, storageType)),
+                  Set.of(s3Path(bucket, firstPath, storageType)));
+      assertThat(credentials)
+          .isNotEmpty()
+          .containsEntry(PolarisCredentialProperty.AWS_TOKEN, "sess")
+          .containsEntry(PolarisCredentialProperty.AWS_KEY_ID, "accessKey")
+          .containsEntry(PolarisCredentialProperty.AWS_SECRET_KEY, "secretKey");
+    } finally {
+      System.clearProperty("polaris.aws.forbidden_arn_domains");
+    }
   }
 
   @Test

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -341,7 +341,7 @@ public class AzureCredentialStorageIntegrationTest {
     allowedLoc.addAll(allowedReadLoc);
     allowedLoc.addAll(allowedWriteLoc);
     AzureStorageConfigurationInfo azureConfig =
-        new AzureStorageConfigurationInfo(allowedLoc, tenantId);
+        AzureStorageConfigurationInfo.of(allowedLoc, tenantId);
     AzureCredentialsStorageIntegration azureCredsIntegration =
         new AzureCredentialsStorageIntegration();
     EnumMap<PolarisCredentialProperty, String> credsMap =

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -165,7 +165,7 @@ class GcpCredentialsStorageIntegrationTest {
     List<String> allowedLoc = new ArrayList<>();
     allowedLoc.addAll(allowedReadLoc);
     allowedLoc.addAll(allowedWriteLoc);
-    GcpStorageConfigurationInfo gcpConfig = new GcpStorageConfigurationInfo(allowedLoc);
+    GcpStorageConfigurationInfo gcpConfig = GcpStorageConfigurationInfo.of(allowedLoc);
     GcpCredentialsStorageIntegration gcpCredsIntegration =
         new GcpCredentialsStorageIntegration(
             GoogleCredentials.getApplicationDefault(),

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -104,7 +105,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   void testCreateEntities() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
     try (CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext)) {
+        CallContext.of(
+            RealmContext.of("testRealm"), polarisTestMetaStoreManager.polarisCallContext)) {
       if (CallContext.getCurrentContext() == null) {
         CallContext.setCurrentContext(callCtx);
       }
@@ -155,7 +157,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   void testCreateEntitiesAlreadyExisting() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
     try (CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext)) {
+        CallContext.of(
+            RealmContext.of("testRealm"), polarisTestMetaStoreManager.polarisCallContext)) {
       if (CallContext.getCurrentContext() == null) {
         CallContext.setCurrentContext(callCtx);
       }
@@ -199,7 +202,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   void testCreateEntitiesWithConflict() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
     try (CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext)) {
+        CallContext.of(
+            RealmContext.of("testRealm"), polarisTestMetaStoreManager.polarisCallContext)) {
       if (CallContext.getCurrentContext() == null) {
         CallContext.setCurrentContext(callCtx);
       }

--- a/polaris-immutables/build.gradle.kts
+++ b/polaris-immutables/build.gradle.kts
@@ -16,21 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.core.context;
 
-import org.apache.polaris.immutables.PolarisImmutable;
+plugins {
+  id("java-library")
+  id("polaris-client")
+}
 
-/**
- * Represents the elements of a REST request associated with routing to independent and isolated
- * "universes". This may include properties such as region, deployment environment (e.g. dev, qa,
- * prod), and/or account.
- */
-@PolarisImmutable
-public interface RealmContext {
+val processor: Configuration by configurations.creating
 
-  String getRealmIdentifier();
+processor.extendsFrom(configurations.api.get())
 
-  static RealmContext of(String realmIdentifier) {
-    return ImmutableRealmContext.builder().realmIdentifier(realmIdentifier).build();
-  }
+dependencies {
+  api(libs.immutables.builder)
+  api(libs.immutables.value.annotations)
+
+  processor(libs.immutables.value.processor)
+  processor(project)
 }

--- a/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
+++ b/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
@@ -25,14 +25,13 @@ import org.immutables.value.Value;
 
 /**
  * A <a href="http://immutables.github.io/style.html#custom-immutable-annotation">Custom
- * {@code @Value.Immutable}</a> using {@code allParameters=true, lazyhash=true,
- * forceJacksonPropertyNames = false, clearBuilder = true}.
+ * {@code @Value.Immutable}</a> using {@code lazyhash=true, forceJacksonPropertyNames = false,
+ * clearBuilder = true, depluralize = true, and JavaBeans-style getters}.
  */
 @Documented
 @Target(ElementType.TYPE)
 @Value.Style(
     defaults = @Value.Immutable(lazyhash = true),
-    allParameters = true,
     forceJacksonPropertyNames = false,
     clearBuilder = true,
     depluralize = true,

--- a/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
+++ b/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
@@ -16,21 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.core.context;
+package org.apache.polaris.immutables;
 
-import org.apache.polaris.immutables.PolarisImmutable;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
 
 /**
- * Represents the elements of a REST request associated with routing to independent and isolated
- * "universes". This may include properties such as region, deployment environment (e.g. dev, qa,
- * prod), and/or account.
+ * A <a href="http://immutables.github.io/style.html#custom-immutable-annotation">Custom
+ * {@code @Value.Immutable}</a> using {@code allParameters=true, lazyhash=true,
+ * forceJacksonPropertyNames = false, clearBuilder = true}.
  */
-@PolarisImmutable
-public interface RealmContext {
-
-  String getRealmIdentifier();
-
-  static RealmContext of(String realmIdentifier) {
-    return ImmutableRealmContext.builder().realmIdentifier(realmIdentifier).build();
-  }
-}
+@Documented
+@Target(ElementType.TYPE)
+@Value.Style(
+    defaults = @Value.Immutable(lazyhash = true),
+    allParameters = true,
+    forceJacksonPropertyNames = false,
+    clearBuilder = true,
+    depluralize = true,
+    get = {"get*", "is*"})
+public @interface PolarisImmutable {}

--- a/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
+++ b/polaris-immutables/src/main/java/org/apache/polaris/immutables/PolarisImmutable.java
@@ -25,15 +25,26 @@ import org.immutables.value.Value;
 
 /**
  * A <a href="http://immutables.github.io/style.html#custom-immutable-annotation">Custom
- * {@code @Value.Immutable}</a> using {@code lazyhash=true, forceJacksonPropertyNames = false,
- * clearBuilder = true, depluralize = true, and JavaBeans-style getters}.
+ * {@code @Value.Immutable}</a> with the following defaults:
+ *
+ * <ul>
+ *   <li><b>lazyhash</b> - Set to {@code true} to generate hash code lazily for performance
+ *       benefits.
+ *   <li><b>clearBuilder</b> - Set to {@code true} to be able to reuse builder instances.
+ *   <li><b>depluralize</b> - Set to {@code true} to use singular names for collections and arrays
+ *       in JavaBeans-style accessors and builder methods.
+ *   <li><b>get</b> - Accessor prefixes set to {@code get*} and {@code is*} to emulate
+ *       JavaBeans-style getters.
+ *   <li><b>forceJacksonPropertyNames</b> - Set to {@code false} since we use JavaBeans-style
+ *       getters, and for better compatibility with custom naming strategies.
+ * </ul>
  */
 @Documented
 @Target(ElementType.TYPE)
 @Value.Style(
     defaults = @Value.Immutable(lazyhash = true),
-    forceJacksonPropertyNames = false,
     clearBuilder = true,
     depluralize = true,
-    get = {"get*", "is*"})
+    get = {"get*", "is*"},
+    forceJacksonPropertyNames = false)
 public @interface PolarisImmutable {}

--- a/polaris-immutables/src/main/resources/META-INF/annotations/org.immutables.value.immutable
+++ b/polaris-immutables/src/main/resources/META-INF/annotations/org.immutables.value.immutable
@@ -16,10 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-#
 
-polaris-core=polaris-core
-polaris-immutables=polaris-immutables
-polaris-service=polaris-service
-polaris-eclipselink=extension/persistence/eclipselink
-aggregated-license-report=aggregated-license-report
+org.apache.polaris.immutables.PolarisImmutable

--- a/polaris-service/src/main/java/org/apache/polaris/service/PolarisApplication.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/PolarisApplication.java
@@ -302,7 +302,8 @@ public class PolarisApplication extends Application<PolarisApplicationConfig> {
     // different processes
     // and in-memory state will be lost b/w invocation of bootstrap command and running a server
     if (metaStoreManagerFactory instanceof InMemoryPolarisMetaStoreManagerFactory) {
-      metaStoreManagerFactory.getOrCreateMetaStoreManager(configuration::getDefaultRealm);
+      metaStoreManagerFactory.getOrCreateMetaStoreManager(
+          RealmContext.of(configuration.getDefaultRealm()));
     }
 
     LOGGER.info("Server started successfully.");

--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -1846,8 +1846,8 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
                 "Unable to purge entity: %s. To enable this feature, set the Polaris configuration %s "
                     + "or the catalog configuration %s",
                 identifier.name(),
-                PolarisConfiguration.DROP_WITH_PURGE_ENABLED.key,
-                PolarisConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig()));
+                PolarisConfiguration.DROP_WITH_PURGE_ENABLED.key(),
+                PolarisConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfigOrThrow()));
       }
     }
 

--- a/polaris-service/src/main/java/org/apache/polaris/service/context/DefaultContextResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/context/DefaultContextResolver.java
@@ -131,7 +131,7 @@ public class DefaultContextResolver
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
     PolarisMetaStoreSession metaStoreSession = entityManager.newMetaStoreSession();
     PolarisCallContext polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreSession,
             diagServices,
             configurationStore,

--- a/polaris-service/src/main/java/org/apache/polaris/service/context/DefaultContextResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/context/DefaultContextResolver.java
@@ -97,7 +97,7 @@ public class DefaultContextResolver
           REALM_PROPERTY_DEFAULT_VALUE);
       parsedProperties.put(REALM_PROPERTY_KEY, REALM_PROPERTY_DEFAULT_VALUE);
     }
-    return () -> parsedProperties.get(REALM_PROPERTY_KEY);
+    return RealmContext.of(parsedProperties.get(REALM_PROPERTY_KEY));
   }
 
   @Override

--- a/polaris-service/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
@@ -82,8 +82,6 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
             taskExecutor,
             fileIOFactory);
 
-    context.contextVariables().put(CallContext.REQUEST_PATH_CATALOG_INSTANCE_KEY, catalogInstance);
-
     CatalogEntity catalog = CatalogEntity.of(baseCatalogEntity);
     Map<String, String> catalogProperties = new HashMap<>(catalog.getPropertiesAsMap());
     String defaultBaseLocation = catalog.getDefaultBaseLocation();

--- a/polaris-service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -68,7 +68,7 @@ public class TaskExecutorImpl implements TaskExecutor {
    */
   @Override
   public void addTaskHandlerContext(long taskEntityId, CallContext callContext) {
-    CallContext clone = CallContext.copyOf(callContext);
+    CallContext clone = CallContext.copyWithoutCloaseables(callContext);
     tryHandleTask(taskEntityId, clone, null, 1);
   }
 
@@ -80,7 +80,8 @@ public class TaskExecutorImpl implements TaskExecutor {
     return CompletableFuture.runAsync(
             () -> {
               // set the call context INSIDE the async task
-              try (CallContext ctx = CallContext.setCurrentContext(CallContext.copyOf(clone))) {
+              try (CallContext ctx =
+                  CallContext.setCurrentContext(CallContext.copyWithoutCloaseables(clone))) {
                 PolarisMetaStoreManager metaStoreManager =
                     metaStoreManagerFactory.getOrCreateMetaStoreManager(ctx.getRealmContext());
                 PolarisBaseEntity taskEntity =

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
@@ -42,7 +42,7 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
 
   private PolarisAdminService newTestAdminService(Set<String> activatedPrincipalRoles) {
     final AuthenticatedPolarisPrincipal authenticatedPrincipal =
-        new AuthenticatedPolarisPrincipal(principalEntity, activatedPrincipalRoles);
+        AuthenticatedPolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
     return new PolarisAdminService(
         callContext, entityManager, authenticatedPrincipal, polarisAuthorizer);
   }

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -149,7 +149,7 @@ public abstract class PolarisAuthzTestBase {
         new InMemoryPolarisMetaStoreManagerFactory();
     managerFactory.setStorageIntegrationProvider(
         new PolarisStorageIntegrationProviderImpl(Mockito::mock));
-    RealmContext realmContext = () -> "realm";
+    RealmContext realmContext = RealmContext.of("realm");
     PolarisMetaStoreManager metaStoreManager =
         managerFactory.getOrCreateMetaStoreManager(realmContext);
 
@@ -171,15 +171,7 @@ public abstract class PolarisAuthzTestBase {
         new PolarisEntityManager(
             metaStoreManager, polarisContext::getMetaStore, new StorageCredentialCache());
 
-    callContext =
-        CallContext.of(
-            new RealmContext() {
-              @Override
-              public String getRealmIdentifier() {
-                return "test-realm";
-              }
-            },
-            polarisContext);
+    callContext = CallContext.of(RealmContext.of("test-realm"), polarisContext);
     CallContext.setCurrentContext(callContext);
 
     PrincipalEntity rootEntity =
@@ -195,7 +187,7 @@ public abstract class PolarisAuthzTestBase {
                         "root")
                     .getEntity()));
 
-    this.authenticatedRoot = new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    this.authenticatedRoot = AuthenticatedPolarisPrincipal.of(rootEntity);
 
     this.adminService =
         new PolarisAdminService(callContext, entityManager, authenticatedRoot, polarisAuthorizer);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -157,7 +157,7 @@ public abstract class PolarisAuthzTestBase {
         Map.of(
             "ALLOW_SPECIFYING_FILE_IO_IMPL", true, "ALLOW_EXTERNAL_METADATA_FILE_LOCATION", true);
     PolarisCallContext polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             new PolarisConfigurationStore() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -130,7 +130,8 @@ public abstract class PolarisAuthzTestBase {
       new PolarisAuthorizer(
           new DefaultConfigurationStore(
               Map.of(
-                  PolarisConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING.key,
+                  PolarisConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING
+                      .key(),
                   true)));
 
   protected BasePolarisCatalog baseCatalog;

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -151,10 +151,10 @@ public class PolarisOverlappingTableTest {
         if (!c.equals(defaultCatalog)) {
           propertiesBuilder
               .addProperty(
-                  PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
+                  PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
                   String.valueOf(c.equals(laxCatalog)))
               .addProperty(
-                  PolarisConfiguration.ALLOW_TABLE_LOCATION_OVERLAP.catalogConfig(),
+                  PolarisConfiguration.ALLOW_TABLE_LOCATION_OVERLAP.catalogConfigOrThrow(),
                   String.valueOf(c.equals(laxCatalog)));
         }
         StorageConfigInfo config =

--- a/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.ImmutableCallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -80,22 +81,11 @@ public class JWTRSAKeyPairTest {
 
   public CallContext getTestCallContext(PolarisCallContext polarisCallContext) {
     return CallContext.setCurrentContext(
-        new CallContext() {
-          @Override
-          public RealmContext getRealmContext() {
-            return null;
-          }
-
-          @Override
-          public PolarisCallContext getPolarisCallContext() {
-            return polarisCallContext;
-          }
-
-          @Override
-          public Map<String, Object> contextVariables() {
-            return Map.of("token", "me");
-          }
-        });
+        ImmutableCallContext.builder()
+            .realmContext(RealmContext.of("realm"))
+            .polarisCallContext(polarisCallContext)
+            .putContextVariable("token", "me")
+            .build());
   }
 
   @Test

--- a/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
@@ -32,10 +32,12 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Clock;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.ImmutableCallContext;
 import org.apache.polaris.core.context.RealmContext;
@@ -45,6 +47,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.service.config.DefaultConfigurationStore;
 import org.junit.jupiter.api.Test;
@@ -103,7 +106,11 @@ public class JWTRSAKeyPairTest {
     config.put("LOCAL_PUBLIC_LOCATION_KEY", publicFileLocation);
 
     DefaultConfigurationStore store = new DefaultConfigurationStore(config);
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, store, null);
+
+    PolarisMetaStoreSession metaStoreSession = Mockito.mock(PolarisMetaStoreSession.class);
+    PolarisDiagnostics diagServices = Mockito.mock(PolarisDiagnostics.class);
+    PolarisCallContext polarisCallContext =
+        PolarisCallContext.of(metaStoreSession, diagServices, store, Clock.systemUTC());
     CallContext.setCurrentContext(getTestCallContext(polarisCallContext));
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "client-secret";

--- a/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
@@ -24,7 +24,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
@@ -44,23 +43,7 @@ public class JWTSymmetricKeyGeneratorTest {
   @Test
   public void testJWTSymmetricKeyGenerator() {
     PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null, null);
-    CallContext.setCurrentContext(
-        new CallContext() {
-          @Override
-          public RealmContext getRealmContext() {
-            return () -> "realm";
-          }
-
-          @Override
-          public PolarisCallContext getPolarisCallContext() {
-            return polarisCallContext;
-          }
-
-          @Override
-          public Map<String, Object> contextVariables() {
-            return Map.of();
-          }
-        });
+    CallContext.setCurrentContext(CallContext.of(RealmContext.of("realm"), polarisCallContext));
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "test_secret";
     String clientId = "test_client_id";

--- a/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
@@ -25,6 +25,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -33,6 +34,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,7 +44,9 @@ public class JWTSymmetricKeyGeneratorTest {
   /** Sanity test to verify that we can generate a token */
   @Test
   public void testJWTSymmetricKeyGenerator() {
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null, null);
+    PolarisMetaStoreSession metaStoreSession = Mockito.mock(PolarisMetaStoreSession.class);
+    PolarisDiagnostics diagServices = Mockito.mock(PolarisDiagnostics.class);
+    PolarisCallContext polarisCallContext = PolarisCallContext.of(metaStoreSession, diagServices);
     CallContext.setCurrentContext(CallContext.of(RealmContext.of("realm"), polarisCallContext));
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "test_secret";

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
@@ -130,7 +130,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
   @SuppressWarnings("unchecked")
   public void before() {
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
-    RealmContext realmContext = () -> "realm";
+    RealmContext realmContext = RealmContext.of("realm");
     PolarisStorageIntegrationProvider storageIntegrationProvider = Mockito.mock();
     InMemoryPolarisMetaStoreManagerFactory managerFactory =
         new InMemoryPolarisMetaStoreManagerFactory();
@@ -170,7 +170,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
                         "root")
                     .getEntity()));
 
-    authenticatedRoot = new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    authenticatedRoot = AuthenticatedPolarisPrincipal.of(rootEntity);
 
     adminService =
         new PolarisAdminService(
@@ -1235,7 +1235,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             .addProperty(PolarisConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "false")
             .setStorageConfigurationInfo(noPurgeStorageConfigModel, storageLocation)
             .build());
-    RealmContext realmContext = () -> "realm";
+    RealmContext realmContext = RealmContext.of("realm");
     CallContext callContext = CallContext.of(realmContext, polarisContext);
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
@@ -1315,7 +1315,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
 
   @Test
   public void testFileIOWrapper() {
-    RealmContext realmContext = () -> "realm";
+    RealmContext realmContext = RealmContext.of("realm");
     CallContext callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);
     PolarisPassthroughResolutionView passthroughView =

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
@@ -140,7 +140,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     configMap.put("ALLOW_SPECIFYING_FILE_IO_IMPL", true);
     configMap.put("INITIALIZE_DEFAULT_CATALOG_FILEIO_FOR_TEST", true);
     polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             new PolarisConfigurationStore() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
@@ -194,9 +194,11 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
                 .setDefaultBaseLocation(storageLocation)
                 .setReplaceNewLocationPrefixWithCatalogDefault("file:")
                 .addProperty(
-                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "true")
                 .addProperty(
-                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
+                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "true")
                 .setStorageConfigurationInfo(storageConfigModel, storageLocation)
                 .build());
 
@@ -465,9 +467,11 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             List.of(PolarisEntity.toCore(catalogEntity)),
             new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
                 .addProperty(
-                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
+                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "false")
                 .addProperty(
-                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
+                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "true")
                 .build());
     BasePolarisCatalog catalog = catalog();
     TableMetadata tableMetadata =
@@ -524,9 +528,11 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             List.of(PolarisEntity.toCore(catalogEntity)),
             new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
                 .addProperty(
-                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
+                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "false")
                 .addProperty(
-                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
+                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "true")
                 .build());
     BasePolarisCatalog catalog = catalog();
     TableMetadata tableMetadata =
@@ -580,9 +586,11 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             List.of(PolarisEntity.toCore(catalogEntity)),
             new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
                 .addProperty(
-                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
+                    PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "false")
                 .addProperty(
-                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
+                    PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                    "true")
                 .build());
     BasePolarisCatalog catalog = catalog();
     InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
@@ -1229,10 +1237,13 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             .setName(noPurgeCatalogName)
             .setDefaultBaseLocation(storageLocation)
             .setReplaceNewLocationPrefixWithCatalogDefault("file:")
-            .addProperty(PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
             .addProperty(
-                PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-            .addProperty(PolarisConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "false")
+                PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(), "true")
+            .addProperty(
+                PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                "true")
+            .addProperty(
+                PolarisConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfigOrThrow(), "false")
             .setStorageConfigurationInfo(noPurgeStorageConfigModel, storageLocation)
             .build());
     RealmContext realmContext = RealmContext.of("realm");
@@ -1270,7 +1281,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     // Attempt to drop the table:
     Assertions.assertThatThrownBy(() -> noPurgeCatalog.dropTable(TABLE, true))
         .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining(PolarisConfiguration.DROP_WITH_PURGE_ENABLED.key);
+        .hasMessageContaining(PolarisConfiguration.DROP_WITH_PURGE_ENABLED.key());
   }
 
   private TableMetadata createSampleTableMetadata(String tableLocation) {

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
@@ -71,7 +71,7 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
     configMap.put("ALLOW_WILDCARD_LOCATION", true);
     configMap.put("ALLOW_SPECIFYING_FILE_IO_IMPL", true);
     PolarisCallContext polarisContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             new PolarisConfigurationStore() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
@@ -112,9 +112,11 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
     adminService.createCatalog(
         new CatalogEntity.Builder()
             .setName(CATALOG_NAME)
-            .addProperty(PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
             .addProperty(
-                PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
+                PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(), "true")
+            .addProperty(
+                PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(),
+                "true")
             .setDefaultBaseLocation("file://tmp")
             .setStorageConfigurationInfo(
                 new FileStorageConfigInfo(

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogViewTest.java
@@ -23,7 +23,6 @@ import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.view.ViewCatalogTests;
@@ -61,7 +60,7 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
   @SuppressWarnings("unchecked")
   public void before() {
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
-    RealmContext realmContext = () -> "realm";
+    RealmContext realmContext = RealmContext.of("realm");
     InMemoryPolarisMetaStoreManagerFactory managerFactory =
         new InMemoryPolarisMetaStoreManagerFactory();
     managerFactory.setStorageIntegrationProvider(
@@ -87,7 +86,7 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
         new PolarisEntityManager(
             metaStoreManager, polarisContext::getMetaStore, new StorageCredentialCache());
 
-    CallContext callContext = CallContext.of(null, polarisContext);
+    CallContext callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);
 
     PrincipalEntity rootEntity =
@@ -102,8 +101,7 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
                         PolarisEntitySubType.NULL_SUBTYPE,
                         "root")
                     .getEntity()));
-    AuthenticatedPolarisPrincipal authenticatedRoot =
-        new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    AuthenticatedPolarisPrincipal authenticatedRoot = AuthenticatedPolarisPrincipal.of(rootEntity);
 
     PolarisAdminService adminService =
         new PolarisAdminService(

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
@@ -85,7 +85,7 @@ public class PolarisCatalogHandlerWrapperAuthzTest extends PolarisAuthzTestBase 
       String catalogName,
       PolarisCallContextCatalogFactory factory) {
     final AuthenticatedPolarisPrincipal authenticatedPrincipal =
-        new AuthenticatedPolarisPrincipal(principalEntity, activatedPrincipalRoles);
+        AuthenticatedPolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
     return new PolarisCatalogHandlerWrapper(
         callContext,
         entityManager,
@@ -221,8 +221,7 @@ public class PolarisCatalogHandlerWrapperAuthzTest extends PolarisAuthzTestBase 
     adminService.assignPrincipalRole(principalName, PRINCIPAL_ROLE2);
 
     final AuthenticatedPolarisPrincipal authenticatedPrincipal =
-        new AuthenticatedPolarisPrincipal(
-            PrincipalEntity.of(newPrincipal.getPrincipal()), Set.of());
+        AuthenticatedPolarisPrincipal.of(PrincipalEntity.of(newPrincipal.getPrincipal()));
     PolarisCatalogHandlerWrapper wrapper =
         new PolarisCatalogHandlerWrapper(
             callContext,
@@ -255,7 +254,7 @@ public class PolarisCatalogHandlerWrapperAuthzTest extends PolarisAuthzTestBase 
             credentials,
             callContext.getPolarisCallContext());
     final AuthenticatedPolarisPrincipal authenticatedPrincipal1 =
-        new AuthenticatedPolarisPrincipal(PrincipalEntity.of(refreshPrincipal), Set.of());
+        AuthenticatedPolarisPrincipal.of(PrincipalEntity.of(refreshPrincipal));
     PolarisCatalogHandlerWrapper refreshedWrapper =
         new PolarisCatalogHandlerWrapper(
             callContext,

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -163,10 +163,11 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
               org.apache.polaris.core.admin.model.CatalogProperties.Builder catalogPropsBuilder =
                   org.apache.polaris.core.admin.model.CatalogProperties.builder(catalogBaseLocation)
                       .addProperty(
-                          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
+                          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION
+                              .catalogConfigOrThrow(),
                           "true")
                       .addProperty(
-                          PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(),
+                          PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
                           "true");
               if (!S3_BUCKET_BASE.startsWith("file:/")) {
                 catalogPropsBuilder.addProperty(
@@ -581,7 +582,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       Catalog catalog = response.readEntity(Catalog.class);
       Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
       catalogProps.put(
-          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
+          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(), "false");
       try (Response updateResponse =
           EXT.client()
               .target(
@@ -638,7 +639,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       Catalog catalog = response.readEntity(Catalog.class);
       Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
       catalogProps.put(
-          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
+          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(), "false");
       try (Response updateResponse =
           EXT.client()
               .target(
@@ -704,7 +705,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       Catalog catalog = response.readEntity(Catalog.class);
       Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
       catalogProps.put(
-          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
+          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfigOrThrow(), "false");
       try (Response updateResponse =
           EXT.client()
               .target(

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -140,10 +140,11 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
                           CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY,
                           "file:")
                       .addProperty(
-                          PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(),
+                          PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfigOrThrow(),
                           "true")
                       .addProperty(
-                          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
+                          PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION
+                              .catalogConfigOrThrow(),
                           "true")
                       .build();
               Catalog catalog =

--- a/polaris-service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -204,19 +204,12 @@ public class CatalogEntityTest {
             .setProperties(prop)
             .setStorageConfigInfo(awsStorageConfigModel)
             .build();
-    String expectedMessage = "";
-    switch (roleArn) {
-      case "":
-        expectedMessage = "ARN cannot be null or empty";
-        break;
-      case "aws-cn":
-      case "aws-us-gov":
-        expectedMessage = "AWS China or Gov Cloud are temporarily not supported";
-        break;
-      default:
-        expectedMessage = "Invalid role ARN format";
-    }
-    ;
+    String expectedMessage =
+        switch (roleArn) {
+          case "" -> "ARN cannot be null or empty";
+          case "aws-cn", "aws-us-gov" -> "ARN domain temporarily not supported: " + roleArn;
+          default -> "Invalid role ARN format";
+        };
     Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);

--- a/polaris-service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -204,12 +204,19 @@ public class CatalogEntityTest {
             .setProperties(prop)
             .setStorageConfigInfo(awsStorageConfigModel)
             .build();
-    String expectedMessage =
-        switch (roleArn) {
-          case "" -> "ARN cannot be null or empty";
-          case "aws-cn", "aws-us-gov" -> "ARN domain temporarily not supported: " + roleArn;
-          default -> "Invalid role ARN format";
-        };
+    String expectedMessage = "";
+    switch (roleArn) {
+      case "":
+        expectedMessage = "ARN cannot be null or empty";
+        break;
+      case "aws-cn":
+      case "aws-us-gov":
+        expectedMessage = "AWS China or Gov Cloud are temporarily not supported";
+        break;
+      default:
+        expectedMessage = "Invalid role ARN format";
+    }
+    ;
     Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);

--- a/polaris-service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
@@ -59,7 +59,7 @@ class ManifestFileCleanupTaskHandlerTest {
   @Test
   public void testCleanupFileNotExists() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -90,7 +90,7 @@ class ManifestFileCleanupTaskHandlerTest {
   @Test
   public void testCleanupFileManifestExistsDataFilesDontExist() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -120,7 +120,7 @@ class ManifestFileCleanupTaskHandlerTest {
   @Test
   public void testCleanupFiles() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -167,7 +167,7 @@ class ManifestFileCleanupTaskHandlerTest {
   @Test
   public void testCleanupFilesWithRetries() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {

--- a/polaris-service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
@@ -53,7 +53,7 @@ class ManifestFileCleanupTaskHandlerTest {
   @BeforeEach
   void setUp() {
     metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
-    realmContext = () -> "realmName";
+    realmContext = RealmContext.of("realmName");
   }
 
   @Test

--- a/polaris-service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -59,7 +59,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanup() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -119,7 +119,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupHandlesAlreadyDeletedMetadata() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -178,7 +178,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupDuplicatesTasksIfFileStillExists() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {
@@ -270,7 +270,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupMultipleSnapshots() throws IOException {
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
+        PolarisCallContext.of(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
     try (CallContext callCtx = CallContext.of(realmContext, polarisCallContext)) {

--- a/polaris-service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -53,7 +53,7 @@ class TableCleanupTaskHandlerTest {
   @BeforeEach
   void setUp() {
     metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
-    realmContext = () -> "realmName";
+    realmContext = RealmContext.of("realmName");
   }
 
   @Test


### PR DESCRIPTION
This PR introduces the Immutables library:

https://immutables.github.io/

This library is widely used in Iceberg and many other projects. The ability to define immutable components in an easy way, without struggling with the nitty-gritty details (getters, builders, equals, hashCode, toString, etc.) is a nice productivity boost and improves code correctness by enforcing immutability by default.

This PR only adds the library and converts a few components that were good candidates for immutability. If the change is accepted, there are probably more components that could be progressively converted into immutables.