### PR TITLE
Fix circular dependency when ECLIPSELINK arg is set to true during build  

### DIFF
--- a/extension/persistence/eclipselink/build.gradle.kts
+++ b/extension/persistence/eclipselink/build.gradle.kts
@@ -24,7 +24,6 @@ plugins {
 
 dependencies {
   implementation(project(":polaris-core"))
-  runtimeOnly(project(":polaris-service"))
   implementation(libs.eclipselink)
   implementation(platform(libs.dropwizard.bom))
   implementation("io.dropwizard:dropwizard-jackson")


### PR DESCRIPTION
# Description

When ECLIPSELINK arg is set to true during build, we will get the following build error:
```
77.81 All projects evaluated.
77.81 
77.81 FAILURE: Build failed with an exception.
77.81 
77.81 * What went wrong:
77.81 10 actionable tasks: 10 executed
77.81 Circular dependency between the following tasks:
77.81 :polaris-service:jar
77.81 \--- :polaris-service:shadowJar
77.81      \--- :polaris-service:jar (*)
77.81 
77.81 (*) - details omitted (listed previously)
77.81 
77.81 
77.81 * Try:
77.81 > Run with --stacktrace option to get the stack trace.
77.81 > Run with --debug option to get more log output.
77.81 > Run with --scan to get full insights.
77.81 > Get more help at https://help.gradle.org.
```

This is introduced as part of https://github.com/apache/polaris/commit/e81a2c40edf37cf78feddd065414adf8c37aa03e#diff-f714fa5f754f0da54abb877f8cf4e3de6341ad321db5f4c697fa602a5da8e4b4.

Upon debugging, this is due to following in `extension/persistence/eclipselink/build.gradle.kts`
```
  runtimeOnly(project(":polaris-service"))
```
This is added earlier where when building polaris-service with eclipse enabled, it was not picking up the dependencies. But as the change introduced above, that is now included but causing circular dependency. 

Fixes [# (280)](https://github.com/apache/polaris/issues/280)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

After removed the line above, I then did 2 tests:

Test 1:
Check jar file to ensure all 3 classes are included in the final jar:
```
org/apache/polaris/extension/
org/apache/polaris/extension/persistence/
org/apache/polaris/extension/persistence/impl/
org/apache/polaris/extension/persistence/impl/eclipselink/
org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.class
org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.class
org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.class
```

Test 2:
Ensure bootstrap still work when using persistent backend:
```
# manually load h2 as dependency in extension/persistence/eclipselink/build.gradle.kts
# `docker run polaris_local_metastore` in terminal 1
# `docker exec -it 150c2c02dffe /bin/bash` in terminal 2
[default@150c2c02dffe app]$ /app/bin/polaris-service bootstrap polaris-server.yml
DEBUG [2024-09-12 03:08:09,390 - 1054  ] [main] [] o.a.p.e.p.i.e.PolarisEclipseLinkMetaStoreSessionImpl: Creating EclipseLink Meta Store Session for realm default-realm
...
DEBUG [2024-09-12 03:08:10,116 - 1780  ] [main] [] o.a.p.e.p.i.e.PolarisEclipseLinkMetaStoreSessionImpl: transaction committed
INFO  [2024-09-12 03:08:10,117 - 1781  ] [main] [] o.a.p.s.BootstrapRealmsCommand: Bootstrap completed successfully.
# verified files created for h2
[default@150c2c02dffe app]$ ls build/test_data/polaris/default-realm/
db.mv.db     db.trace.db
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
