### PR TITLE
OpenApi generation: fix "reference not found" javadoc warnings

### DIFF
--- a/server-templates/api.mustache
+++ b/server-templates/api.mustache
@@ -90,7 +90,7 @@ public class {{classname}}  {
   /**
    * {{^notes}}{{{summary}}}{{/notes}}{{{notes}}}
    *
-   * Response type {@link {{{returnBaseType}}}}
+   * Response type: {@code {{{returnBaseType}}}}.
    *{{#allParams}} @param {{paramName}} {{#required}}Required -{{/required}} {{description}}
    *{{/allParams}}{{#responses}}
    * @return {{{code}}} - {{{message}}}{{/responses}}


### PR DESCRIPTION
This commit fixes javadoc warnings like this:

```
polaris-service/build/generated/src/main/java/org/apache/polaris/service/catalog/api/IcebergRestCatalogApi.java:529: warning: reference not found: LoadViewResult
   * Response type {@link LoadViewResult}
                   ^
```