### PR TITLE
Enable re-using polaris-service tests

### DIFF
--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -259,10 +259,6 @@ tasks.register<Sync>("prepareDockerDist") {
   doFirst { delete(project.layout.buildDirectory.dir("regtest-dist")) }
 }
 
-tasks.named("build").configure {
-  dependsOn("prepareDockerDist")
-}
+tasks.named("build").configure { dependsOn("prepareDockerDist") }
 
-tasks.named("assemble").configure {
-  dependsOn("testJar")
-}
+tasks.named("assemble").configure { dependsOn("testJar") }

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -234,6 +234,11 @@ tasks.named<Jar>("jar") {
   manifest { attributes["Main-Class"] = "org.apache.polaris.service.PolarisApplication" }
 }
 
+tasks.register<Jar>("testJar") {
+  archiveClassifier.set("tests")
+  from(sourceSets.test.get().output)
+}
+
 val shadowJar =
   tasks.named<ShadowJar>("shadowJar") {
     manifest { attributes["Main-Class"] = "org.apache.polaris.service.PolarisApplication" }
@@ -254,4 +259,7 @@ tasks.register<Sync>("prepareDockerDist") {
   doFirst { delete(project.layout.buildDirectory.dir("regtest-dist")) }
 }
 
-tasks.named("build").configure { dependsOn("prepareDockerDist") }
+tasks.named("build").configure {
+  dependsOn("prepareDockerDist")
+  dependsOn("testJar")
+}

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -261,5 +261,8 @@ tasks.register<Sync>("prepareDockerDist") {
 
 tasks.named("build").configure {
   dependsOn("prepareDockerDist")
+}
+
+tasks.named("assemble").configure {
   dependsOn("testJar")
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -114,7 +114,7 @@ public class PolarisApplicationIntegrationTest {
       PolarisConnectionExtension.PolarisToken userToken,
       SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials)
       throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm(PolarisApplicationIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     testDir = Path.of("build/test_data/iceberg/" + realm);
     FileUtils.deleteQuietly(testDir.toFile());

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -72,6 +72,7 @@ import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.service.auth.BasePolarisAuthenticator;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -111,10 +112,11 @@ public class PolarisApplicationIntegrationTest {
 
   @BeforeAll
   public static void setup(
-      PolarisConnectionExtension.PolarisToken userToken,
-      SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials)
+          PolarisConnectionExtension.PolarisToken userToken,
+          SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials,
+          @PolarisRealm String realm)
       throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm();
+    PolarisApplicationIntegrationTest.realm = realm;
 
     testDir = Path.of("build/test_data/iceberg/" + realm);
     FileUtils.deleteQuietly(testDir.toFile());

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -114,9 +114,9 @@ public class PolarisApplicationIntegrationTest {
   public static void setup(
       PolarisConnectionExtension.PolarisToken userToken,
       SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials,
-      @PolarisRealm String realm)
+      @PolarisRealm String polarisRealm)
       throws IOException {
-    PolarisApplicationIntegrationTest.realm = realm;
+    realm = polarisRealm;
 
     testDir = Path.of("build/test_data/iceberg/" + realm);
     FileUtils.deleteQuietly(testDir.toFile());

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -112,9 +112,9 @@ public class PolarisApplicationIntegrationTest {
 
   @BeforeAll
   public static void setup(
-          PolarisConnectionExtension.PolarisToken userToken,
-          SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials,
-          @PolarisRealm String realm)
+      PolarisConnectionExtension.PolarisToken userToken,
+      SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials,
+      @PolarisRealm String realm)
       throws IOException {
     PolarisApplicationIntegrationTest.realm = realm;
 

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -63,7 +63,7 @@ public class PolarisOverlappingCatalogTest {
   @BeforeAll
   public static void setup(PolarisConnectionExtension.PolarisToken adminToken) throws IOException {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm(PolarisOverlappingCatalogTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     // Set up the database location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -62,7 +62,9 @@ public class PolarisOverlappingCatalogTest {
   private static String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) throws IOException {
+  public static void setup(
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm)
+      throws IOException {
     userToken = adminToken.token();
     PolarisOverlappingCatalogTest.realm = realm;
 

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -41,6 +41,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.PolarisApplication;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,9 +62,9 @@ public class PolarisOverlappingCatalogTest {
   private static String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken adminToken) throws IOException {
+  public static void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) throws IOException {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm();
+    PolarisOverlappingCatalogTest.realm = realm;
 
     // Set up the database location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -63,10 +63,10 @@ public class PolarisOverlappingCatalogTest {
 
   @BeforeAll
   public static void setup(
-      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm)
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String polarisRealm)
       throws IOException {
     userToken = adminToken.token();
-    PolarisOverlappingCatalogTest.realm = realm;
+    realm = polarisRealm;
 
     // Set up the database location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -137,7 +137,7 @@ public class PolarisOverlappingTableTest {
   @BeforeEach
   public void setup(PolarisConnectionExtension.PolarisToken adminToken) {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm(PolarisServiceImplIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
     defaultCatalog.catalog = String.format("default_catalog_%s", UUID.randomUUID().toString());
     laxCatalog.catalog = String.format("lax_catalog_%s", UUID.randomUUID().toString());
     strictCatalog.catalog = String.format("strict_catalog_%s", UUID.randomUUID().toString());

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -137,9 +137,9 @@ public class PolarisOverlappingTableTest {
 
   @BeforeEach
   public void setup(
-      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) {
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String polarisRealm) {
     userToken = adminToken.token();
-    PolarisOverlappingTableTest.realm = realm;
+    realm = polarisRealm;
     defaultCatalog.catalog = String.format("default_catalog_%s", UUID.randomUUID().toString());
     laxCatalog.catalog = String.format("lax_catalog_%s", UUID.randomUUID().toString());
     strictCatalog.catalog = String.format("strict_catalog_%s", UUID.randomUUID().toString());

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -136,7 +136,8 @@ public class PolarisOverlappingTableTest {
   }
 
   @BeforeEach
-  public void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) {
+  public void setup(
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) {
     userToken = adminToken.token();
     PolarisOverlappingTableTest.realm = realm;
     defaultCatalog.catalog = String.format("default_catalog_%s", UUID.randomUUID().toString());

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -44,6 +44,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.PolarisApplication;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -135,9 +136,9 @@ public class PolarisOverlappingTableTest {
   }
 
   @BeforeEach
-  public void setup(PolarisConnectionExtension.PolarisToken adminToken) {
+  public void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm();
+    PolarisOverlappingTableTest.realm = realm;
     defaultCatalog.catalog = String.format("default_catalog_%s", UUID.randomUUID().toString());
     laxCatalog.catalog = String.format("lax_catalog_%s", UUID.randomUUID().toString());
     strictCatalog.catalog = String.format("strict_catalog_%s", UUID.randomUUID().toString());

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -101,7 +101,7 @@ public class PolarisServiceImplIntegrationTest {
   @BeforeAll
   public static void setup(PolarisConnectionExtension.PolarisToken adminToken) throws IOException {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm(PolarisServiceImplIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -101,10 +101,10 @@ public class PolarisServiceImplIntegrationTest {
 
   @BeforeAll
   public static void setup(
-      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm)
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String polarisRealm)
       throws IOException {
     userToken = adminToken.token();
-    PolarisServiceImplIntegrationTest.realm = realm;
+    realm = polarisRealm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -100,7 +100,9 @@ public class PolarisServiceImplIntegrationTest {
   private static String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) throws IOException {
+  public static void setup(
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm)
+      throws IOException {
     userToken = adminToken.token();
     PolarisServiceImplIntegrationTest.realm = realm;
 

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -70,6 +70,7 @@ import org.apache.polaris.service.PolarisApplication;
 import org.apache.polaris.service.auth.TokenUtils;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -99,9 +100,9 @@ public class PolarisServiceImplIntegrationTest {
   private static String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken adminToken) throws IOException {
+  public static void setup(PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String realm) throws IOException {
     userToken = adminToken.token();
-    realm = PolarisConnectionExtension.getTestRealm();
+    PolarisServiceImplIntegrationTest.realm = realm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -76,6 +76,7 @@ import org.apache.polaris.service.auth.TokenUtils;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
 import org.apache.polaris.service.test.PolarisConnectionExtension.PolarisToken;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension.SnowmanCredentials;
 import org.apache.polaris.service.types.NotificationRequest;
@@ -127,8 +128,8 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       S3_BUCKET_BASE + "/" + System.getenv("USER") + "/path/to/data";
 
   @BeforeAll
-  public static void setup() throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm();
+  public static void setup(@PolarisRealm String realm) throws IOException {
+    PolarisRestCatalogIntegrationTest.realm = realm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -128,7 +128,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
 
   @BeforeAll
   public static void setup() throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm(PolarisRestCatalogIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -122,22 +122,24 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
   private RESTCatalog restCatalog;
   private String currentCatalogName;
   private String userToken;
-  private static String realm;
+  private String realm;
 
   private final String catalogBaseLocation =
       S3_BUCKET_BASE + "/" + System.getenv("USER") + "/path/to/data";
 
   @BeforeAll
   public static void setup(@PolarisRealm String realm) throws IOException {
-    PolarisRestCatalogIntegrationTest.realm = realm;
-
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);
   }
 
   @BeforeEach
   public void before(
-      TestInfo testInfo, PolarisToken adminToken, SnowmanCredentials snowmanCredentials) {
+      TestInfo testInfo,
+      PolarisToken adminToken,
+      SnowmanCredentials snowmanCredentials,
+      @PolarisRealm String realm) {
+    this.realm = realm;
     userToken =
         TokenUtils.getTokenFromSecrets(
             EXT.client(),

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -88,19 +88,19 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
               "server.adminConnectors[0].port", "0")); // Bind to random port to support parallelism
 
   private RESTCatalog restCatalog;
-  private static String realm;
 
   @BeforeAll
   public static void setup(@PolarisRealm String realm) throws IOException {
-    PolarisRestCatalogViewIntegrationTest.realm = realm;
-
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);
   }
 
   @BeforeEach
   public void before(
-      TestInfo testInfo, PolarisToken adminToken, SnowmanCredentials snowmanCredentials) {
+      TestInfo testInfo,
+      PolarisToken adminToken,
+      SnowmanCredentials snowmanCredentials,
+      @PolarisRealm String realm) {
     String userToken = adminToken.token();
     testInfo
         .getTestMethod()

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -91,7 +91,7 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
 
   @BeforeAll
   public static void setup() throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm(PolarisRestCatalogViewIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -53,6 +53,7 @@ import org.apache.polaris.service.auth.BasePolarisAuthenticator;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
 import org.apache.polaris.service.test.PolarisConnectionExtension.PolarisToken;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension.SnowmanCredentials;
 import org.junit.jupiter.api.BeforeAll;
@@ -90,8 +91,8 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
   private static String realm;
 
   @BeforeAll
-  public static void setup() throws IOException {
-    realm = PolarisConnectionExtension.getTestRealm();
+  public static void setup(@PolarisRealm String realm) throws IOException {
+    PolarisRestCatalogViewIntegrationTest.realm = realm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
@@ -44,6 +44,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.PolarisApplication;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.types.NotificationRequest;
 import org.apache.polaris.service.types.NotificationType;
 import org.apache.polaris.service.types.TableUpdateNotification;
@@ -80,11 +81,11 @@ public class PolarisSparkIntegrationTest {
   private static String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken polarisToken)
+  public static void setup(PolarisConnectionExtension.PolarisToken polarisToken, @PolarisRealm String realm)
       throws IOException {
     s3Container.start();
     PolarisSparkIntegrationTest.polarisToken = polarisToken;
-    realm = PolarisConnectionExtension.getTestRealm();
+    PolarisSparkIntegrationTest.realm = realm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
@@ -78,14 +78,14 @@ public class PolarisSparkIntegrationTest {
       new S3MockContainer("3.9.1").withInitialBuckets("my-bucket,my-old-bucket");
   private static PolarisConnectionExtension.PolarisToken polarisToken;
   private static SparkSession spark;
-  private static String realm;
+  private String realm;
 
   @BeforeAll
-  public static void setup(PolarisConnectionExtension.PolarisToken polarisToken, @PolarisRealm String realm)
+  public static void setup(
+      PolarisConnectionExtension.PolarisToken polarisToken, @PolarisRealm String realm)
       throws IOException {
     s3Container.start();
     PolarisSparkIntegrationTest.polarisToken = polarisToken;
-    PolarisSparkIntegrationTest.realm = realm;
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);
@@ -97,7 +97,8 @@ public class PolarisSparkIntegrationTest {
   }
 
   @BeforeEach
-  public void before() {
+  public void before(@PolarisRealm String realm) {
+    this.realm = realm;
     AwsStorageConfigInfo awsConfigModel =
         AwsStorageConfigInfo.builder()
             .setRoleArn("arn:aws:iam::123456789012:role/my-role")

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
@@ -84,7 +84,7 @@ public class PolarisSparkIntegrationTest {
       throws IOException {
     s3Container.start();
     PolarisSparkIntegrationTest.polarisToken = polarisToken;
-    realm = PolarisConnectionExtension.getTestRealm(PolarisSparkIntegrationTest.class);
+    realm = PolarisConnectionExtension.getTestRealm();
 
     // Set up test location
     PolarisConnectionExtension.createTestDir(realm);

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
@@ -180,7 +180,8 @@ public class PolarisConnectionExtension
             .equals(PolarisConnectionExtension.PolarisToken.class)
         || parameterContext.getParameter().getType().equals(MetaStoreManagerFactory.class)
         || parameterContext.getParameter().getType().equals(PolarisPrincipalSecrets.class)
-            || (parameterContext.getParameter().getType().equals(String.class) && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class));
+        || (parameterContext.getParameter().getType().equals(String.class)
+            && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class));
   }
 
   @Override
@@ -196,7 +197,8 @@ public class PolarisConnectionExtension
               adminSecrets.getMainSecret(),
               realm);
       return new PolarisToken(token);
-    } else if (parameterContext.getParameter().getType().equals(String.class) && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class)) {
+    } else if (parameterContext.getParameter().getType().equals(String.class)
+        && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class)) {
       return realm;
     } else {
       return metaStoreManagerFactory;

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
@@ -127,10 +127,6 @@ public class PolarisConnectionExtension
     }
   }
 
-  public static String getTestRealm() {
-    return realm;
-  }
-
   public static void createTestDir(String realm) throws IOException {
     // Set up the database location
     Path testDir = Path.of("build/test_data/polaris/" + realm);
@@ -183,7 +179,8 @@ public class PolarisConnectionExtension
             .getType()
             .equals(PolarisConnectionExtension.PolarisToken.class)
         || parameterContext.getParameter().getType().equals(MetaStoreManagerFactory.class)
-        || parameterContext.getParameter().getType().equals(PolarisPrincipalSecrets.class);
+        || parameterContext.getParameter().getType().equals(PolarisPrincipalSecrets.class)
+            || (parameterContext.getParameter().getType().equals(String.class) && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class));
   }
 
   @Override
@@ -199,6 +196,8 @@ public class PolarisConnectionExtension
               adminSecrets.getMainSecret(),
               realm);
       return new PolarisToken(token);
+    } else if (parameterContext.getParameter().getType().equals(String.class) && parameterContext.getParameter().isAnnotationPresent(PolarisRealm.class)) {
+      return realm;
     } else {
       return metaStoreManagerFactory;
     }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
@@ -77,7 +77,7 @@ public class PolarisConnectionExtension
     }
 
     // Generate unique realm using test name for each test since the tests can run in parallel
-    realm = getTestRealm(extensionContext.getRequiredTestClass());
+    realm = extensionContext.getRequiredTestClass().getName().replace('.', '_');
     extensionContext
         .getStore(Namespace.create(extensionContext.getRequiredTestClass()))
         .put(REALM_PROPERTY_KEY, realm);
@@ -127,8 +127,8 @@ public class PolarisConnectionExtension
     }
   }
 
-  public static String getTestRealm(Class testClassName) {
-    return testClassName.getName().replace('.', '_');
+  public static String getTestRealm() {
+    return realm;
   }
 
   public static void createTestDir(String realm) throws IOException {

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisRealm.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisRealm.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.test;
 
 import java.lang.annotation.ElementType;
@@ -24,8 +23,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Annotation used to specify where to inject the Polaris test realm identifier. This is provided by PolarisConnectionExtension. */
+/**
+ * Annotation used to specify where to inject the Polaris test realm identifier. This is provided by
+ * PolarisConnectionExtension.
+ */
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface PolarisRealm {
-}
+public @interface PolarisRealm {}

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisRealm.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/PolarisRealm.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Annotation used to specify where to inject the Polaris test realm identifier. This is provided by PolarisConnectionExtension. */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PolarisRealm {
+}


### PR DESCRIPTION
# Description

Generates a new build artifact with the test sources. This lets you re-use test utils and extend entire test classes. For example, if you have a project that includes Polaris, you can now write your own lightweight wrapper test to run the Polaris tests with your own config/environment.

When testing this end-to-end with a class that extends a Polaris test, I ran into an issue where PolarisConnectionExtension and the test classes decided on a different realm identifier, which meant that credentials were created in a different realm than the test ran in. This happened because the realm name was derived from the class names but the class name is tricky to fetch when using inheritance. I changed the test classes to just re-use the same realm name from PolarisConnectionExtension.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested the JAR is generated when running `gradle assemble`:
<img width="377" alt="Screenshot 2024-09-12 at 10 42 57 AM" src="https://github.com/user-attachments/assets/4cffb19e-acf4-440e-a901-41769b93d638">

As a smoke test, validated that `gradle build` still works and the server still starts up.

# Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
