### PR TITLE
Adding support for the assumed role (in AWS) to have get-bucket-locat…

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -133,7 +133,7 @@ class AwsCredentialsStorageIntegrationTest {
                         assertThat(policy)
                             .extracting(IamPolicy::statements)
                             .asInstanceOf(InstanceOfAssertFactories.list(IamStatement.class))
-                            .hasSize(3)
+                            .hasSize(4)
                             .satisfiesExactly(
                                 statement ->
                                     assertThat(statement)
@@ -180,6 +180,18 @@ class AwsCredentialsStorageIntegrationTest {
                                                             .key("s3:prefix")
                                                             .value(firstPath + "/*")
                                                             .build())),
+                                statement ->
+                                    assertThat(statement)
+                                        .returns(IamEffect.ALLOW, IamStatement::effect)
+                                        .satisfies(
+                                            st ->
+                                                assertThat(st.resources())
+                                                    .contains(
+                                                        IamResource.create(
+                                                            s3Arn(awsPartition, bucket, null))))
+                                        .returns(
+                                            List.of(IamAction.create("s3:GetBucketLocation")),
+                                            IamStatement::actions),
                                 statement ->
                                     assertThat(statement)
                                         .returns(IamEffect.ALLOW, IamStatement::effect)
@@ -243,7 +255,7 @@ class AwsCredentialsStorageIntegrationTest {
                         assertThat(policy)
                             .extracting(IamPolicy::statements)
                             .asInstanceOf(InstanceOfAssertFactories.list(IamStatement.class))
-                            .hasSize(2)
+                            .hasSize(3)
                             .satisfiesExactly(
                                 statement ->
                                     assertThat(statement)
@@ -257,6 +269,18 @@ class AwsCredentialsStorageIntegrationTest {
                                             List.of(
                                                 IamAction.create("s3:PutObject"),
                                                 IamAction.create("s3:DeleteObject")),
+                                            IamStatement::actions),
+                                statement ->
+                                    assertThat(statement)
+                                        .returns(IamEffect.ALLOW, IamStatement::effect)
+                                        .satisfies(
+                                            st ->
+                                                assertThat(st.resources())
+                                                    .contains(
+                                                        IamResource.create(
+                                                            s3Arn(AWS_PARTITION, bucket, null))))
+                                        .returns(
+                                            List.of(IamAction.create("s3:GetBucketLocation")),
                                             IamStatement::actions),
                                 statement ->
                                     assertThat(statement)
@@ -326,7 +350,7 @@ class AwsCredentialsStorageIntegrationTest {
                         assertThat(policy)
                             .extracting(IamPolicy::statements)
                             .asInstanceOf(InstanceOfAssertFactories.list(IamStatement.class))
-                            .hasSize(2)
+                            .hasSize(3)
                             .satisfiesExactly(
                                 statement ->
                                     assertThat(statement)
@@ -338,6 +362,18 @@ class AwsCredentialsStorageIntegrationTest {
                                             IamStatement::resources)
                                         .returns(
                                             List.of(IamAction.create("s3:ListBucket")),
+                                            IamStatement::actions),
+                                statement ->
+                                    assertThat(statement)
+                                        .returns(IamEffect.ALLOW, IamStatement::effect)
+                                        .satisfies(
+                                            st ->
+                                                assertThat(st.resources())
+                                                    .contains(
+                                                        IamResource.create(
+                                                            s3Arn(AWS_PARTITION, bucket, null))))
+                                        .returns(
+                                            List.of(IamAction.create("s3:GetBucketLocation")),
                                             IamStatement::actions),
                                 statement ->
                                     assertThat(statement)


### PR DESCRIPTION
…ion ability on any buckets that make up the table's storage locations.

# Description

Reference - [Supporting region attribute in vended credentials for AWS](https://lists.apache.org/thread/dvfo4wzjg2ybdot70c7nlwntcxbvwlrt) proposal

This PR adds support for the _assumed role_ to have `s3:GetBucketLocation`. This is the first step for the proposal above. A followup PR will leverage this functionality to infer `client.region` and include it in vended credentials for AWS. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added unit tests. Tested by manually starting and testing the service.

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
