### PR TITLE
Exclude "logs/**" from Rat license check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,7 @@ tasks.named<RatTask>("rat").configure {
 
   excludes.add("gradle/wrapper/gradle-wrapper*.jar*")
 
+  excludes.add("logs/**")
   excludes.add("polaris-service/src/**/banner.txt")
   excludes.add("polaris-service/logs")
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Exclude "logs/**" from license check. When you run `java -jar polaris-service/build/libs/polaris-service-999-SNAPSHOT.jar server `, logs are generated in logs/ folder and the build would fail.

Fixes #299 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `gradlew build` 
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
