### PR TITLE
Update base/build images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # Base Image
 # Use a non-docker-io registry, because pulling images from docker.io is
 # subject to aggressive request rate limiting and bandwidth shaping.
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as build
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1726695192 as build
 ARG ECLIPSELINK=false
 
 # Copy the REST catalog into the container
@@ -33,7 +33,7 @@ RUN rm -rf build
 # Build the rest catalog
 RUN ./gradlew --no-daemon --info -PeclipseLink=$ECLIPSELINK clean prepareDockerDist
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1721752928
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1726695169
 WORKDIR /app
 COPY --from=build /app/polaris-service/build/docker-dist/bin /app/bin
 COPY --from=build /app/polaris-service/build/docker-dist/lib /app/lib


### PR DESCRIPTION
# Description

Both build and base images have one important vulnerability based on Red Hat Advisory https://access.redhat.com/errata/RHBA-2024:4869.

Here are the detail pages:
- https://catalog.redhat.com/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814?image=669fe17b0d99d1795833139e&architecture=amd64&container-tabs=security
- https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?image=669fdfd786c985fec9c41128&architecture=amd64&container-tabs=security

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Rerun the run.sh to ensure service still function normally after base/build images updated.

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
