### PR TITLE
Dockerfile: Add build arg for eclipselink dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@
 # subject to aggressive request rate limiting and bandwidth shaping.
 FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as build
 ARG ECLIPSELINK=false
+ARG ECLIPSELINK_DEPS
 
 # Copy the REST catalog into the container
 COPY --chown=default:root . /app
@@ -31,7 +32,7 @@ WORKDIR /app
 RUN rm -rf build
 
 # Build the rest catalog
-RUN ./gradlew --no-daemon --info -PeclipseLink=$ECLIPSELINK clean prepareDockerDist
+RUN ./gradlew --no-daemon --info ${ECLIPSELINK_DEPS+"-PeclipseLinkDeps=$ECLIPSELINK_DEPS"} -PeclipseLink=$ECLIPSELINK clean prepareDockerDist
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1721752928
 WORKDIR /app


### PR DESCRIPTION
# Description

https://github.com/apache/polaris/pull/285 adds support for passing EclipseLink dependencies to gradle.

This PR builds on that enhancement to allow passing such dependencies via the Dockerfile

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Test A

```
$ docker build -t polaris  .
```

- [ ] Test B

```
$ docker build -t polaris --build-arg ECLIPSELINK=true  .
```

- [ ] Test C

```
$ docker build -t polaris --build-arg ECLIPSELINK=true --build-arg ECLIPSELINK_DEPS=org.postgresql:postgresql:42.7.4 .
```


Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
