### PR TITLE
Bump up the default integration-test requests-per-second to 9999 vs 10

### DIFF
--- a/polaris-service/src/test/resources/polaris-server-integrationtest.yml
+++ b/polaris-service/src/test/resources/polaris-server-integrationtest.yml
@@ -156,5 +156,5 @@ maxRequestBodyBytes: 1000000
 # Limits the request rate per realm
 rateLimiter:
   type: realm-token-bucket
-  requestsPerSecond: 100
+  requestsPerSecond: 9999
   windowSeconds: 10

--- a/polaris-service/src/test/resources/polaris-server-integrationtest.yml
+++ b/polaris-service/src/test/resources/polaris-server-integrationtest.yml
@@ -156,5 +156,5 @@ maxRequestBodyBytes: 1000000
 # Limits the request rate per realm
 rateLimiter:
   type: realm-token-bucket
-  requestsPerSecond: 10
+  requestsPerSecond: 100
   windowSeconds: 10


### PR DESCRIPTION
# Description

At 10 per second, PolarisRestCatalogIntegrationTest takes about 2m50s. At 20 per second, it takes about 1m25s.
At 50 per second, it takes about 30s.
At 100 per second it takes about 19s.
At 200 per second it takes about 19s.

## Type of change

Please delete options that are not relevant.

- [x] Test only

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
