### PR TITLE
Refactor BasePolarisCatalog to use Iceberg's BadRequestException instead of jakarta

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -23,7 +23,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import jakarta.ws.rs.BadRequestException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
@@ -53,6 +52,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
@@ -1403,7 +1403,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       if (!isUnderParentLocation(
           URI.create(metadata.metadataFileLocation()),
           URI.create(metadata.location() + "/metadata").normalize())) {
-        throw new org.apache.iceberg.exceptions.BadRequestException(
+        throw new BadRequestException(
             "Metadata location %s is not allowed outside of table location %s",
             metadata.metadataFileLocation(), metadata.location());
       }
@@ -1708,7 +1708,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
 
           // some entities cannot be renamed
         case PolarisMetaStoreManager.ReturnStatus.ENTITY_CANNOT_BE_RENAMED:
-          throw new BadRequestException("Cannot rename built-in object " + leafEntity.getName());
+          throw new BadRequestException("Cannot rename built-in object %s", leafEntity.getName());
 
           // some entities cannot be renamed
         default:


### PR DESCRIPTION
# Description
It looks like the jakarta flavor inadvertently got added by someone's IDE and now there's a needless mix of jakarta/iceberg BadRequestException


## Type of change

Please delete options that are not relevant.

- [x] Refactor

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
