### PR TITLE
Unwrap global rule in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,4 @@
 # under the License.
 #
 
-* @jbonofre @ashvina @anoopj @RussellSpitzer @snazy @vvcephei @takidau @jackye1995 @flyrain 
-* @eric-maynard @collado-mike @ebyhr @annafil
+* @jbonofre @ashvina @anoopj @RussellSpitzer @snazy @vvcephei @takidau @jackye1995 @flyrain @eric-maynard @collado-mike @ebyhr @annafil


### PR DESCRIPTION
# Description

Looks like the 1st pattern (`* @jbonofre ...`) is ignored after https://github.com/apache/polaris/pull/314

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
