### PR TITLE
correct docker-compose command in docs (missing dash) 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,7 +94,7 @@ To start using Polaris in Docker, launch Polaris while Docker is running:
 
 ```shell
 cd ~/polaris
-docker compose -f docker-compose.yml up --build
+docker-compose -f docker-compose.yml up --build
 ```
 
 Once the `polaris-polaris` container is up, you can continue to [Defining a Catalog](#defining-a-catalog).


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Tried both versions of the command for myself, the bash script assumes, docker-compose to be used, the correct  syntax is "docker-compose" not "docker compose" (mind the dash and absence thereof) 

**Test Configuration**:
* Hardware: Ubuntu latest
* Toolchain: N/A
* SDK: N/A

# Checklist:

Please delete options that are not relevant.

- [ x ] I have performed a self-review of my code
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings