### PR TITLE
CI: Make all PR workflow jobs required

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,6 +42,16 @@ github:
 
       required_linear_history: true
 
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+        # contexts are the names of checks that must pass
+        contexts:
+          - markdown-link-check
+          - build
+          - regtest
+          - site
+
   features:
     wiki: false
     issues: true


### PR DESCRIPTION
All current PR workflow jobs become a strict requirement (must pass) before a PR can be merged.
