### PR TITLE
Site: Let Hugo verify links

### DIFF
--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -33,22 +33,22 @@ cascade:
 | link:https://polaris-catalog.zulipchat.com/[Zulip]
 | Our public chat, open to everybody
 
-| link:./meetings/[Community Meetings]
+| link:{{% ref "meetings" %}}[Community Meetings]
 | Upcoming, live and recorded Community Meetings
 
-| link:./proposals/[Proposals]
+| link:{{% ref "proposals" %}}[Proposals]
 | Proposals about bigger topics
 
 | link:https://github.com/apache/polaris[GitHub]
 | Development takes place here!
 
-| link:./code-of-conduct/[Code of Conduct]
+| link:{{% ref "code-of-conduct" %}}[Code of Conduct]
 | Code of Conduct
 
-| link:./chat-bylaws/[Chat Bylaws]
+| link:{{% ref "chat-bylaws" %}}[Chat Bylaws]
 | A few rules around our public chat as a collaboration tool for the project.
 
-| link:./contributing-guidelines/[Contribution Guidelines]
+| link:{{% ref "contributing-guidelines" %}}[Contribution Guidelines]
 | How to contribute to Apache Polaris
 |===
 {{% /blocks/feature %}}

--- a/site/content/in-dev/unreleased/_index.md
+++ b/site/content/in-dev/unreleased/_index.md
@@ -37,7 +37,7 @@ These pages refer to the current state of the main branch, which is still under 
 Functionalities can be changed, removed or added without prior notice.
 {{< /alert >}}
 
-Checkout the [Quick Start](./quickstart/) page.
+Checkout the [Quick Start]({{% ref "quickstart" %}}) page.
 
 <!--
 Testing the `releaseVersion` shortcode here: version is: {{< releaseVersion >}}

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -802,7 +802,7 @@ polaris namespaces list --catalog my_catalog --parent a.b
 
 ### Privileges
 
-The `privileges` command is used to grant various privileges to a catalog role, or to revoke those privileges. Privileges can be on the level of a catalog, a namespace, a table, or a view. For more information on privileges, please refer to the [docs](entities.mdrivilege).
+The `privileges` command is used to grant various privileges to a catalog role, or to revoke those privileges. Privileges can be on the level of a catalog, a namespace, a table, or a view. For more information on privileges, please refer to the [docs]({{% ref "entities#privilege" %}}).
 
 Note that when using the `privileges` command, the user specifies the relevant catalog and catalog role before selecting a subcommand.
 

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -59,7 +59,7 @@ Be sure to secure your metastore backend since it will be storing credentials an
 
 ### Configuring EclipseLink
 
-To use EclipseLink for metastore management, specify the configuration `metaStoreManager.conf-file` to point to an EclipseLink `persistence.xml` file. This file, local to the Polaris service, contains details of the database used for metastore management and the connection settings. For more information, refer to [metastore documentation](metastores.md) for details.
+To use EclipseLink for metastore management, specify the configuration `metaStoreManager.conf-file` to point to an EclipseLink `persistence.xml` file. This file, local to the Polaris service, contains details of the database used for metastore management and the connection settings. For more information, refer to [metastore documentation]({{% ref "metastores" %}}) for details.
 
 ### Bootstrapping
 

--- a/site/content/in-dev/unreleased/overview.md
+++ b/site/content/in-dev/unreleased/overview.md
@@ -32,7 +32,7 @@ With Polaris, you can provide centralized, secure read and write access to your 
 
 This section introduces key concepts associated with using Apache Polaris (Incubating).
 
-In the following diagram, a sample [Apache Polaris (Incubating) structure](overview.md#catalog) with nested [namespaces](overview.md#namespace) is shown for Catalog1. No tables
+In the following diagram, a sample [Apache Polaris (Incubating) structure](#catalog) with nested [namespaces](#namespace) is shown for Catalog1. No tables
 or namespaces have been created yet for Catalog2 or Catalog3.
 
 ![Diagram that shows an example Apache Polaris (Incubating) structure.](/img/sample-catalog-structure.svg "Sample Apache Polaris (Incubating) structure")
@@ -121,18 +121,18 @@ The following table displays example service principals that you might create in
 A service connection represents a REST-compatible engine (such as Apache Spark&trade;, Apache Flink&reg;, or Trino) that can read from and write to Polaris
 Catalog. When creating a new service connection, the Polaris administrator grants the service principal that is created with the new service 
 connection either a new or existing principal role. A principal role is a resource in Polaris that you can use to logically group Polaris 
-service principals together and grant privileges on securable objects. For more information, see [Principal role](access-control.md#principal-role "Principal role"). Polaris uses a role-based access control (RBAC) model to grant service principals access to resources. For more information, 
-see [Access control](access-control.md "Access control"). For a diagram of this model, see [RBAC model](access-control.md#rbac-model "RBAC model").
+service principals together and grant privileges on securable objects. For more information, see [Principal role]({{% ref "access-control#principal-role" %}}). Polaris uses a role-based access control (RBAC) model to grant service principals access to resources. For more information, 
+see [Access control]({{% ref "access-control" %}}). For a diagram of this model, see [RBAC model]({{% ref "access-control#rbac-model" %}}).
 
 If the Polaris administrator grants the service principal for the new service connection a new principal role, the service principal
 doesn't have any privileges granted to it yet. When securing the catalog that the new service connection will connect to, the Polaris
 administrator grants privileges to catalog roles and then grants these catalog roles to the new principal role. As a result, the service
-principal for the new service connection has these privileges. For more information about catalog roles, see [Catalog role](access-control.md#catalog-role "Catalog role").
+principal for the new service connection has these privileges. For more information about catalog roles, see [Catalog role]({{% ref "access-control#catalog-role" %}}).
 
 If the Polaris administrator grants an existing principal role to the service principal for the new service connection, the service principal
 has the same privileges granted to the catalog roles that are granted to the existing principal role. If needed, the Polaris
 administrator can grant additional catalog roles to the existing principal role or remove catalog roles from it to adjust the privileges
-bestowed to the service principal. For an example of how RBAC works in Polaris, see [RBAC example](access-control.md#rbac-example "RBAC example").
+bestowed to the service principal. For an example of how RBAC works in Polaris, see [RBAC example]({{% ref "access-control#rbac-example" %}}).
 
 ### Storage configuration
 
@@ -203,7 +203,7 @@ Polaris RBAC uses two different role types to delegate privileges:
 - **Catalog roles:** Configured with certain privileges on Polaris
   catalog resources and granted to principal roles.
 
-For more information, see [Access control](access-control.md "Access control").
+For more information, see [Access control]({{% ref "access-control" %}}).
 
 ## Legal Notices
 

--- a/site/content/in-dev/unreleased/quickstart.md
+++ b/site/content/in-dev/unreleased/quickstart.md
@@ -124,7 +124,7 @@ At this point, Polaris is running.
 
 ## Bootstrapping Polaris
 
-For this tutorial, we'll launch an instance of Polaris that stores entities only in-memory. This means that any entities that you define will be destroyed when Polaris is shut down. It also means that Polaris will automatically bootstrap itself with root credentials. For more information on how to configure Polaris for production usage, see the [docs](configuring-polaris-for-production.md).
+For this tutorial, we'll launch an instance of Polaris that stores entities only in-memory. This means that any entities that you define will be destroyed when Polaris is shut down. It also means that Polaris will automatically bootstrap itself with root credentials. For more information on how to configure Polaris for production usage, see the [docs]({{% ref "configuring-polaris-for-production" %}}).
 
 When Polaris is launched using in-memory mode the root principal credentials can be found in stdout on initial startup. For example:
 
@@ -141,7 +141,7 @@ export CLIENT_SECRET=<client-secret>
 
 ## Defining a Catalog
 
-In Polaris, the [catalog](entities.md#catalog) is the top-level entity that objects like [tables](entities.md#table) and [views](entities.md#view) are organized under. With a Polaris service running, you can create a catalog like so:
+In Polaris, the [catalog]({{% ref "entities#catalog" %}}) is the top-level entity that objects like [tables]({{% ref "entities#table" %}}) and [views]({{% ref "entities#view" %}}) are organized under. With a Polaris service running, you can create a catalog like so:
 
 ```shell
 cd ~/polaris
@@ -161,14 +161,14 @@ This will create a new catalog called **quickstart_catalog**.
 
 The `DEFAULT_BASE_LOCATION` you provide will be the default location that objects in this catalog should be stored in, and the `ROLE_ARN` you provide should be a [Role ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) with access to read and write data in that location. These credentials will be provided to engines reading data from the catalog once they have authenticated with Polaris using credentials that have access to those resources.
 
-If you’re using a storage type other than S3, such as Azure, you’ll provide a different type of credential than a Role ARN. For more details on supported storage types, see the [docs](entities.md#storage-type).
+If you’re using a storage type other than S3, such as Azure, you’ll provide a different type of credential than a Role ARN. For more details on supported storage types, see the [docs]({{% ref "entities#storage-type" %}}).
 
-Additionally, if Polaris is running somewhere other than `localhost:8181`, you can specify the correct hostname and port by providing `--host` and `--port` flags. For the full set of options supported by the CLI, please refer to the [docs](command-line-interface.md).
+Additionally, if Polaris is running somewhere other than `localhost:8181`, you can specify the correct hostname and port by providing `--host` and `--port` flags. For the full set of options supported by the CLI, please refer to the [docs]({{% ref "command-line-interface" %}}).
 
 
 ### Creating a Principal and Assigning it Privileges
 
-With a catalog created, we can create a [principal](entities.md#principal) that has access to manage that catalog. For details on how to configure the Polaris CLI, see [the section above](#defining-a-catalog) or refer to the [docs](command-line-interface.md).
+With a catalog created, we can create a [principal]({{% ref "entities#principal" %}}) that has access to manage that catalog. For details on how to configure the Polaris CLI, see [the section above](#defining-a-catalog) or refer to the [docs]({{% ref "command-line-interface" %}}).
 
 ```shell
 ./polaris \
@@ -203,7 +203,7 @@ When the `principals create` command completes successfully, it will return the 
 {"clientId": "XXXX", "clientSecret": "YYYY"}
 ```
 
-Now, we grant the principal the [principal role](entities.md#principal-role) we created, and grant the [catalog role](entities.md#catalog-role) the principal role we created. For more information on these entities, please refer to the linked documentation.
+Now, we grant the principal the [principal role]({{% ref "entities#principal-role" %}}) we created, and grant the [catalog role]({{% ref "entities#catalog-role" %}}) the principal role we created. For more information on these entities, please refer to the linked documentation.
 
 ```shell
 ./polaris \
@@ -228,7 +228,7 @@ Now, we’ve linked our principal to the catalog via roles like so:
 
 ![Principal to Catalog](/img/quickstart/privilege-illustration-1.png "Principal to Catalog")
 
-In order to give this principal the ability to interact with the catalog, we must assign some [privileges](entities.md#privilege). For the time being, we will give this principal the ability to fully manage content in our new catalog. We can do this with the CLI like so:
+In order to give this principal the ability to interact with the catalog, we must assign some [privileges]({{% ref "entities#privilege" %}}). For the time being, we will give this principal the ability to fully manage content in our new catalog. We can do this with the CLI like so:
 
 ```shell
 ./polaris \
@@ -242,7 +242,7 @@ In order to give this principal the ability to interact with the catalog, we mus
   CATALOG_MANAGE_CONTENT
 ```
 
-This grants the [catalog privileges](entities.md#privilege) `CATALOG_MANAGE_CONTENT` to our catalog role, linking everything together like so:
+This grants the [catalog privileges]({{% ref "entities#privilege" %}}) `CATALOG_MANAGE_CONTENT` to our catalog role, linking everything together like so:
 
 ![Principal to Catalog with Catalog Role](/img/quickstart/privilege-illustration-2.png "Principal to Catalog with Catalog Role")
 


### PR DESCRIPTION
Using the `ref` or `relref` shortcodes lets Hugo verify links and fail the site build, if the links cannot be resolved.
