### PR TITLE
Enable casting config values of most types

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -69,6 +69,16 @@ public interface PolarisConfigurationStore {
 
     if (config.defaultValue instanceof Boolean) {
       return config.cast(Boolean.valueOf(String.valueOf(value)));
+    } else if (config.defaultValue instanceof Short) {
+      return config.cast(Short.valueOf(String.valueOf(value)));
+    } else if (config.defaultValue instanceof Integer) {
+      return config.cast(Integer.valueOf(String.valueOf(value)));
+    } else if (config.defaultValue instanceof Long) {
+      return config.cast(Long.valueOf(String.valueOf(value)));
+    } else if (config.defaultValue instanceof Float) {
+      return config.cast(Float.valueOf(String.valueOf(value)));
+    } else if (config.defaultValue instanceof Double) {
+      return config.cast(Double.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof List<?>) {
       return config.cast(List.copyOf((List<?>) value));
     } else {

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -69,14 +69,10 @@ public interface PolarisConfigurationStore {
 
     if (config.defaultValue instanceof Boolean) {
       return config.cast(Boolean.valueOf(String.valueOf(value)));
-    } else if (config.defaultValue instanceof Short) {
-      return config.cast(Short.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof Integer) {
       return config.cast(Integer.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof Long) {
       return config.cast(Long.valueOf(String.valueOf(value)));
-    } else if (config.defaultValue instanceof Float) {
-      return config.cast(Float.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof Double) {
       return config.cast(Double.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof List<?>) {

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -33,11 +33,9 @@ public class PolarisConfigurationStoreTest {
     List<PolarisConfiguration<?>> configs =
         List.of(
             buildConfig("bool", true),
-            buildConfig("short", (short) 12),
-            buildConfig("int", 34),
-            buildConfig("long", 56L),
-            buildConfig("float", 7.8F),
-            buildConfig("double", 9.1D));
+            buildConfig("int", 12),
+            buildConfig("long", 34L),
+            buildConfig("double", 5.6D));
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
@@ -56,7 +54,7 @@ public class PolarisConfigurationStoreTest {
 
             throw new IllegalStateException(
                 String.format(
-                    "Didn't find config value for %s, the test isn't set up incorrectly",
+                    "Didn't find config value for %s, the test isn't set up correctly",
                     configName));
           }
         };

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -41,6 +41,10 @@ public class PolarisConfigurationStoreTest {
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
+          /**
+           * Ad-hoc configuration store implementation that just returns the stringified version of
+           * the config's default value
+           */
           @SuppressWarnings("unchecked")
           @Override
           public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
@@ -57,6 +61,8 @@ public class PolarisConfigurationStoreTest {
           }
         };
 
+    // Ensure that we can fetch all the configs and that the value is what we expect, which
+    // is the config's default value based on how we've implemented PolarisConfigurationStore above.
     for (PolarisConfiguration<?> c : configs) {
       Assertions.assertEquals(c.defaultValue, store.getConfiguration(null, c));
     }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage;
+
+import java.util.List;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisConfiguration;
+import org.apache.polaris.core.PolarisConfigurationStore;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for the default behaviors of the PolarisConfigurationStore interface. */
+public class PolarisConfigurationStoreTest {
+  @Test
+  public void testConfigsCanBeCastedFromString() {
+    List<PolarisConfiguration<?>> configs =
+        List.of(
+            buildConfig("bool", true),
+            buildConfig("short", (short) 5),
+            buildConfig("int", 5),
+            buildConfig("long", 5L),
+            buildConfig("float", 5F),
+            buildConfig("double", 5D));
+
+    PolarisConfigurationStore store =
+        new PolarisConfigurationStore() {
+          @SuppressWarnings("unchecked")
+          @Override
+          public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
+            for (PolarisConfiguration<?> c : configs) {
+              if (c.key.equals(configName)) {
+                return (T) String.valueOf(c.defaultValue);
+              }
+            }
+
+            throw new IllegalStateException(
+                String.format(
+                    "Didn't find config value for %s, the test isn't set up incorrectly",
+                    configName));
+          }
+        };
+
+    for (PolarisConfiguration<?> c : configs) {
+      Assertions.assertEquals(c.defaultValue, store.getConfiguration(null, c));
+    }
+  }
+
+  private static <T> PolarisConfiguration<T> buildConfig(String key, T defaultValue) {
+    return PolarisConfiguration.<T>builder()
+        .key(key)
+        .description("")
+        .defaultValue(defaultValue)
+        .build();
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -66,6 +66,26 @@ public class PolarisConfigurationStoreTest {
     }
   }
 
+  @Test
+  public void testInvalidCastThrowsException() {
+    // Bool not included because Boolean.valueOf turns non-boolean strings to false
+    List<PolarisConfiguration<?>> configs =
+        List.of(buildConfig("int", 12), buildConfig("long", 34L), buildConfig("double", 5.6D));
+
+    PolarisConfigurationStore store =
+        new PolarisConfigurationStore() {
+          @SuppressWarnings("unchecked")
+          @Override
+          public <T> T getConfiguration(PolarisCallContext ctx, String configName) {
+            return (T) "abc123";
+          }
+        };
+
+    for (PolarisConfiguration<?> c : configs) {
+      Assertions.assertThrows(NumberFormatException.class, () -> store.getConfiguration(null, c));
+    }
+  }
+
   private static <T> PolarisConfiguration<T> buildConfig(String key, T defaultValue) {
     return PolarisConfiguration.<T>builder()
         .key(key)

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -33,11 +33,11 @@ public class PolarisConfigurationStoreTest {
     List<PolarisConfiguration<?>> configs =
         List.of(
             buildConfig("bool", true),
-            buildConfig("short", (short) 5),
-            buildConfig("int", 5),
-            buildConfig("long", 5L),
-            buildConfig("float", 5F),
-            buildConfig("double", 5D));
+            buildConfig("short", (short) 12),
+            buildConfig("int", 34),
+            buildConfig("long", 56L),
+            buildConfig("float", 7.8F),
+            buildConfig("double", 9.1D));
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {


### PR DESCRIPTION
# Description

Implementations of PolarisConfigurationStore may return strings regardless of the config type. In particular, one place where this happens when specifying a ConfigOverride in a test.

Currently, the interface checks the expected type for booleans and Lists and casts them to the correct config type. Whether this is a pattern we should proliferate or not is up for debate, but this PR simply extends the existing logic to work for other types, and it adds tests to ensure the different castings work. Without this PR, the test fails.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] PolarisConfigurationStoreTest. Without this PR, the test fails.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
