### PR TITLE
WasbTranslatingFileIO to preserve endpoint on translation

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
@@ -50,10 +50,11 @@ public class WasbTranslatingFileIO implements FileIO {
           scheme = scheme.replaceFirst(WASB_SCHEME, ABFS_SCHEME);
         }
         return String.format(
-            "%s://%s@%s.dfs.core.windows.net/%s",
+            "%s://%s@%s.%s/%s",
             scheme,
             azureLocation.getContainer(),
             azureLocation.getStorageAccount(),
+            azureLocation.getEndpoint(),
             azureLocation.getFilePath());
       } else {
         return path;


### PR DESCRIPTION
# Description

Azure SAS tokens are tied to a specific endpoint type (dfs/blob), so the fileIO shouldn't force every path to be translated to `dfs.core.windows.net`, otherwise if a user provides a blob endpoint and Polaris acquires a token for that, the fileIO that tries to read/write with the dfs endpoint would fail to authenticate with the token.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
