### PR TITLE
Nit: fix javadoc error

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketRateLimiter.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketRateLimiter.java
@@ -44,7 +44,7 @@ public class TokenBucketRateLimiter implements RateLimiter {
   /**
    * Tries to acquire and spend 1 token. Doesn't block if a token isn't available.
    *
-   * @return whether a token was successfully acquired & spent
+   * @return whether a token was successfully acquired and spent
    */
   @Override
   public synchronized boolean tryAcquire() {


### PR DESCRIPTION
```
.../polaris-service/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketRateLimiter.java:47: warning: invalid input: '&'
   * @return whether a token was successfully acquired & spent
                                                       ^
```
