### PR TITLE
Block the creation of catalog with WASB[S] locations

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -191,4 +191,12 @@ public class PolarisConfiguration<T> {
               "If set to true, allows tables to be dropped with the purge parameter set to true.")
           .defaultValue(true)
           .build();
+
+  public static final PolarisConfiguration<Boolean> SUPPORT_WASB_CATALOG =
+      PolarisConfiguration.<Boolean>builder()
+          .key("SUPPORT_WASB_CATALOG")
+          .description(
+              "If set to true, allows the creation of catalogs with storage locations using Azure WASB prefix.")
+          .defaultValue(false)
+          .build();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -28,8 +28,12 @@ public class AzureLocation extends StorageLocation {
   private static final Pattern URI_PATTERN = Pattern.compile("^(abfss?|wasbs?)://([^/?#]+)(.*)?$");
 
   public static final String ADLS_ENDPOINT = "dfs.core.windows.net";
-
   public static final String BLOB_ENDPOINT = "blob.core.windows.net";
+
+  public static final String ABFS_SCHEME = "abfs://";
+  public static final String ABFSS_SCHEME = "abfss://";
+  public static final String WASB_SCHEME = "wasb://";
+  public static final String WASBS_SCHEME = "wasbs://";
 
   private final String scheme;
   private final String storageAccount;

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceValidationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceValidationTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.admin;
+
+import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
+import org.apache.polaris.core.admin.model.Catalog;
+import org.apache.polaris.core.admin.model.CatalogProperties;
+import org.apache.polaris.core.admin.model.CreateCatalogRequest;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.service.PolarisApplication;
+import org.apache.polaris.service.config.PolarisApplicationConfig;
+import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+/** Tests for the validations performed in {@link PolarisAdminService}. */
+@ExtendWith({DropwizardExtensionsSupport.class, PolarisConnectionExtension.class})
+public class PolarisAdminServiceValidationTest {
+  private static final DropwizardAppExtension<PolarisApplicationConfig> EXT_BLOCK_WASB =
+      initExt(ConfigOverride.config("featureConfiguration.SUPPORT_WASB_CATALOG", "false"));
+  private static final DropwizardAppExtension<PolarisApplicationConfig> EXT_SUPPORT_WASB =
+      initExt(ConfigOverride.config("featureConfiguration.SUPPORT_WASB_CATALOG", "true"));
+
+  private static String userToken;
+  private static String realm;
+
+  private static DropwizardAppExtension<PolarisApplicationConfig> initExt(
+      ConfigOverride... overrides) {
+    return new DropwizardAppExtension<>(
+        PolarisApplication.class,
+        ResourceHelpers.resourceFilePath("polaris-server-integrationtest.yml"),
+        Stream.concat(
+                Stream.of(
+                    // Bind to random port to support parallelism
+                    ConfigOverride.config("server.applicationConnectors[0].port", "0"),
+                    ConfigOverride.config("server.adminConnectors[0].port", "0")),
+                Stream.of(overrides))
+            .toArray(ConfigOverride[]::new));
+  }
+
+  @BeforeAll
+  public static void setup(
+      PolarisConnectionExtension.PolarisToken adminToken, @PolarisRealm String polarisRealm)
+      throws IOException {
+    userToken = adminToken.token();
+    realm = polarisRealm;
+
+    // Set up the database location
+    PolarisConnectionExtension.createTestDir(realm);
+  }
+
+  private static Invocation.Builder request(DropwizardAppExtension<PolarisApplicationConfig> ext) {
+    return ext.client()
+        .target(String.format("http://localhost:%d/api/management/v1/catalogs", ext.getLocalPort()))
+        .request("application/json")
+        .header("Authorization", "Bearer " + userToken)
+        .header(REALM_PROPERTY_KEY, realm);
+  }
+
+  private Response createAzureCatalog(
+      DropwizardAppExtension<PolarisApplicationConfig> ext,
+      String defaultBaseLocation,
+      boolean isExternal,
+      List<String> allowedLocations) {
+    String uuid = UUID.randomUUID().toString();
+    StorageConfigInfo config =
+        AzureStorageConfigInfo.builder()
+            .setTenantId("tenantId")
+            .setConsentUrl("https://consentUrl")
+            .setMultiTenantAppName("multiTenantAppName")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
+            .setAllowedLocations(allowedLocations)
+            .build();
+    Catalog catalog =
+        new Catalog(
+            isExternal ? Catalog.TypeEnum.EXTERNAL : Catalog.TypeEnum.INTERNAL,
+            String.format("overlap_catalog_%s", uuid),
+            new CatalogProperties(defaultBaseLocation),
+            System.currentTimeMillis(),
+            System.currentTimeMillis(),
+            1,
+            config);
+    try (Response response = request(ext).post(Entity.json(new CreateCatalogRequest(catalog)))) {
+      return response;
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(AzurePathArgs.class)
+  public void testWasbCatalogCreationBlocked(String defaultBaseLocation, String allowedLocation) {
+    int expectedStatusCode =
+        (defaultBaseLocation.startsWith("wasbs") || allowedLocation.startsWith("wasbs"))
+            ? Response.Status.BAD_REQUEST.getStatusCode()
+            : Response.Status.CREATED.getStatusCode();
+
+    assertThat(
+            createAzureCatalog(
+                EXT_BLOCK_WASB,
+                defaultBaseLocation,
+                false,
+                Collections.singletonList(allowedLocation)))
+        .returns(expectedStatusCode, Response::getStatus);
+    assertThat(
+            createAzureCatalog(
+                EXT_BLOCK_WASB,
+                defaultBaseLocation,
+                true,
+                Collections.singletonList(allowedLocation)))
+        .returns(expectedStatusCode, Response::getStatus);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(AzurePathArgs.class)
+  public void testWasbCatalogCreationAllowed(String defaultBaseLocation, String allowedLocation) {
+    assertThat(
+            createAzureCatalog(
+                EXT_SUPPORT_WASB,
+                defaultBaseLocation,
+                false,
+                Collections.singletonList(allowedLocation)))
+        .returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+    assertThat(
+            createAzureCatalog(
+                EXT_SUPPORT_WASB,
+                defaultBaseLocation,
+                true,
+                Collections.singletonList(allowedLocation)))
+        .returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+  }
+
+  private static class AzurePathArgs implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+      return Stream.of(createArguments(), createArguments(), createArguments(), createArguments());
+    }
+
+    private Arguments createArguments() {
+      String prefix = UUID.randomUUID().toString();
+      String wasbPath = String.format("wasbs://container@acct.blob.windows.net/%s/wasb", prefix);
+      String abfsPath = String.format("abfss://container@acct.blob.windows.net/%s/abfs", prefix);
+      return Arguments.of(wasbPath, abfsPath);
+    }
+  }
+}

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -903,7 +903,9 @@ components:
 
     AzureStorageConfigInfo:
       type: object
-      description: azure storage configuration info
+      description:
+        azure storage configuration info; base location supports abfs[s] schemes and only supports wasb[s] schemes
+        when featureConfiguration.SUPPORT_WASB_CATALOG is true
       allOf:
         - $ref: '#/components/schemas/StorageConfigInfo'
       properties:


### PR DESCRIPTION
# Description

Polaris supports creating catalogs with the deprecated wasbs:// scheme (as opposed to the newer abfss://). However, the current implementation of Iceberg SDK's default [ResolvingFileIO](https://github.com/apache/iceberg/blob/33b33f3ec835ce69025aa827b5b5ba6e2fbd98dd/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java) would [fallback](https://github.com/apache/iceberg/blob/33b33f3ec835ce69025aa827b5b5ba6e2fbd98dd/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java#L224) to using the HadoopFileIO when it's provided a wasbs:// path, where the fileIO does not support using vended credentials to read/write to Azure location, as opposed to the ADLSFileIO which supports credential vending and is used for abfss:// paths. This results in when external engines (e.g. Spark) are provided by Polaris a wasbs:// path and a token to access the location, the token cannot be accepted by the fallback HadoopFileIO.

In short, despite Polaris being capable of vending credentials for wasbs:// paths, external engines using the Iceberg SDK for fileIO implementation (which generally is the case) couldn't pick up the vended credentials, and users would need to provide the external engines their own credentials to perform I/O on the location.

This holds until the proposed [fix](https://github.com/apache/iceberg/pull/11294) from the Iceberg community is released and users adopt the Iceberg SDK version that contains the fix.

Until then, Polaris would provide a configurable parameter to decide whether to support the creation of wasbs:// pathed catalogs, and the default value would be False (no support).


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] PolarisAdminServiceValidationTest: scenarios on param on/off

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
