### PR TITLE
Fix Azure path comparison when filePath is root ("/")

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -55,6 +55,15 @@ public class StorageLocation {
     }
   }
 
+  /** If a path doesn't start with `/`, this will add one */
+  protected final @NotNull String ensureLeadingSlash(@NotNull String location) {
+    if (location.startsWith("/")) {
+      return location;
+    } else {
+      return "/" + location;
+    }
+  }
+
   @Override
   public int hashCode() {
     return location.hashCode();

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -108,13 +108,22 @@ public class AzureLocation extends StorageLocation {
       AzureLocation potentialAzureParent = (AzureLocation) potentialParent;
       if (this.container.equals(potentialAzureParent.container)) {
         if (this.storageAccount.equals(potentialAzureParent.storageAccount)) {
-          String slashTerminatedFilePath = ensureTrailingSlash(this.filePath);
-          String slashTerminatedParentFilePath = ensureTrailingSlash(potentialAzureParent.filePath);
-          return slashTerminatedFilePath.startsWith(slashTerminatedParentFilePath);
+          String formattedFilePath = ensureLeadingSlash(ensureTrailingSlash(this.filePath));
+          String formattedParentFilePath = ensureLeadingSlash(ensureTrailingSlash(potentialAzureParent.filePath));
+          return formattedFilePath.startsWith(formattedParentFilePath);
         }
       }
     }
     return false;
+  }
+
+  /** If a path doesn't start with `/`, this will add one */
+  private @NotNull String ensureLeadingSlash(@NotNull String location) {
+    if (location.startsWith("/")) {
+      return location;
+    } else {
+      return "/" + location;
+    }
   }
 
   /** Return true if the input location appears to be an Azure path */

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -109,7 +109,8 @@ public class AzureLocation extends StorageLocation {
       if (this.container.equals(potentialAzureParent.container)) {
         if (this.storageAccount.equals(potentialAzureParent.storageAccount)) {
           String formattedFilePath = ensureLeadingSlash(ensureTrailingSlash(this.filePath));
-          String formattedParentFilePath = ensureLeadingSlash(ensureTrailingSlash(potentialAzureParent.filePath));
+          String formattedParentFilePath =
+              ensureLeadingSlash(ensureTrailingSlash(potentialAzureParent.filePath));
           return formattedFilePath.startsWith(formattedParentFilePath);
         }
       }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -117,15 +117,6 @@ public class AzureLocation extends StorageLocation {
     return false;
   }
 
-  /** If a path doesn't start with `/`, this will add one */
-  private @NotNull String ensureLeadingSlash(@NotNull String location) {
-    if (location.startsWith("/")) {
-      return location;
-    } else {
-      return "/" + location;
-    }
-  }
-
   /** Return true if the input location appears to be an Azure path */
   public static boolean isAzureLocation(String location) {
     if (location == null) {

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureLocationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureLocationTest.java
@@ -56,6 +56,22 @@ public class AzureLocationTest {
   }
 
   @Test
+  public void testLocationComparisons() {
+    StorageLocation location =
+        AzureLocation.of("abfss://container-dash@acc.blob.core.windows.net/some_file/metadata");
+    StorageLocation parentLocation =
+        AzureLocation.of("abfss://container-dash@acc.blob.core.windows.net");
+    StorageLocation parentLocationTrailingSlash =
+        AzureLocation.of("abfss://container-dash@acc.blob.core.windows.net/");
+
+    Assertions.assertThat(location).isNotEqualTo(parentLocation);
+    Assertions.assertThat(location).isNotEqualTo(parentLocationTrailingSlash);
+
+    Assertions.assertThat(location.isChildOf(parentLocation)).isTrue();
+    Assertions.assertThat(location.isChildOf(parentLocationTrailingSlash)).isTrue();
+  }
+
+  @Test
   public void testLocation_negative_cases() {
     Assertions.assertThatThrownBy(
             () -> new AzureLocation("abfss://storageaccount.blob.core.windows.net/myfile"))


### PR DESCRIPTION
# Description

The `AzureLocation.isChildOf` method is currently broken if the parent path points to the root of the container (e.g. `abfss://container@acc.blob.core.windows.net` or `abfss://container@acc.blob.core.windows.net/`). The `filePath` of the path in this case would be parsed as `/` since we always add a "trailing slash". Now if the comparing child path looks something like `abfss://container@acc.blob.core.windows.net/some/file/path/metadata`, the `filePath` would be parsed as `some/file/path/metadata/` after applying the trailing slash, leading to the failure of the `childFilePath.startsWith(parentFilePath)` check since the childFilePath doesn't start with a slash.

Fix is to always ensure a leading slash on top of ensuring a trailing slash.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] AzureLocationTest unit test
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
