### PR TITLE
Add support of setting revisionHistoryLimit

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -34,6 +34,8 @@ A Helm chart for Polaris.
 **Homepage:** <https://polaris.apache.org/>
 
 ## Maintainers
+* [MonkeyCanCode](https://github.com/MonkeyCanCode)
+* [adutra](https://github.com/adutra)
 
 ## Source Code
 
@@ -105,6 +107,7 @@ $ helm uninstall --namespace polaris polaris
 | readinessProbe.timeoutSeconds | int | `10` | Number of seconds after which the probe times out. Minimum value is 1. |
 | replicaCount | int | `1` | The number of replicas to deploy (horizontal scaling). Beware that replicas are stateless; don't set this number > 1 when using in-memory meta store manager. |
 | resources | object | `{}` | Configures the resources requests and limits for polaris pods. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
+| revisionHistoryLimit | string | `nil` | The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10). |
 | securityContext | object | `{}` | Security context for the polaris container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
 | service.annotations | object | `{}` | Annotations to add to the service. |
 | service.ports | object | `{"polaris-metrics":8182,"polaris-service":8181}` | The ports the service will listen on. Two ports are required: one for the Polaris service and one for the metrics API. Note: port names must be unique and no more than 15 characters long. |

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if not (has (quote .Values.revisionHistoryLimit) (list "" (quote ""))) }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "polaris.selectorLabels" . | nindent 6 }}

--- a/helm/polaris/templates/ingress.yaml
+++ b/helm/polaris/templates/ingress.yaml
@@ -17,7 +17,6 @@
   under the License.
 */}}
 
-# {{- $kubeVersion := .Capabilities.KubeVersion.Version -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "polaris.fullname" . -}}
 {{- $svcPort := index .Values.service.ports "polaris-service" -}}

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -65,6 +65,9 @@ podLabels: {}
 # -- Additional Labels to apply to polaris configmap.
 configMapLabels: {}
 
+# -- The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).
+revisionHistoryLimit: ~
+
 # -- Security context for the polaris pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 podSecurityContext:
   {}


### PR DESCRIPTION
# Description

The current Helm chart doesn’t allow customization of the revisionHistoryLimit parameter, which is crucial for controlling the number of ReplicaSets retained for K8S deployment. This PR introduces the ability to set revisionHistoryLimit in the values file, defaulting to the standard value if not specified.

Also, I cleanup one comment in ingress.yaml which is not needed.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

When revisionHistoryLimit is not set:
```sh
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ cat myvalues.yaml | grep revision
revisionHistoryLimit: ~
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ helm template polaris -f myvalues.yaml . | grep revision
walk.go:74: found symbolic link in path: /home/yong/k8s/polaris/helm/polaris/LICENSE resolves to /home/yong/k8s/polaris/LICENSE. Contents of linked file included and used
```
When revisionHistoryLimit is set to 0:
```
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ cat myvalues.yaml | grep revision
revisionHistoryLimit: 0
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ helm template polaris -f myvalues.yaml . | grep revision
walk.go:74: found symbolic link in path: /home/yong/k8s/polaris/helm/polaris/LICENSE resolves to /home/yong/k8s/polaris/LICENSE. Contents of linked file included and used
  revisionHistoryLimit: 0
```
When revisionHistoryLimit is set to 1:
```sh
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ cat myvalues.yaml | grep revision
revisionHistoryLimit: 1
xxx@DESKTOP:~/k8s/polaris/helm/polaris(add_revisionHistoryLimit)$ helm template polaris -f myvalues.yaml . | grep revision
walk.go:74: found symbolic link in path: /home/yong/k8s/polaris/helm/polaris/LICENSE resolves to /home/yong/k8s/polaris/LICENSE. Contents of linked file included and used
  revisionHistoryLimit: 1
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
