### PR TITLE
Remove a couple non-applicable VIEW privileges from type-specific enums

### DIFF
--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1160,7 +1160,6 @@ components:
       type: string
       enum:
         - CATALOG_MANAGE_ACCESS
-        - VIEW_CREATE
         - VIEW_DROP
         - VIEW_LIST
         - VIEW_READ_PROPERTIES
@@ -1174,7 +1173,6 @@ components:
         - TABLE_DROP
         - TABLE_LIST
         - TABLE_READ_PROPERTIES
-        - VIEW_READ_PROPERTIES
         - TABLE_WRITE_PROPERTIES
         - TABLE_READ_DATA
         - TABLE_WRITE_DATA


### PR DESCRIPTION
Even though VIEW_CREATE is "about" views, as a privilege it's only applicable to NAMESPACE or CATALOG since views are created under namespaces (and at the catalog-level it means inheriting that for all child namespaces). This will be consistent with how TABLE_CREATE is already declared.

Remove VIEW_READ_PROPERTIES from the TablePrivilege enum; this appears to have been a simple typo.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Cleanup

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
