### PR TITLE
Update Java for CVE-2023-22025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN rm -rf build
 # Build the rest catalog
 RUN ./gradlew --no-daemon --info ${ECLIPSELINK_DEPS+"-PeclipseLinkDeps=$ECLIPSELINK_DEPS"} -PeclipseLink=$ECLIPSELINK clean prepareDockerDist
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1726695169
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1729089285
 WORKDIR /app
 COPY --from=build /app/polaris-service/build/docker-dist/bin /app/bin
 COPY --from=build /app/polaris-service/build/docker-dist/lib /app/lib


### PR DESCRIPTION
# Description

Our current Java seems to be vulnerable to [CVE-2023-22025](https://nvd.nist.gov/vuln/detail/CVE-2023-22025). I pulled the latest version from [here](https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f).
