### PR TITLE
Feature configuration to modify storage credential lifetime

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -204,8 +204,8 @@ public class PolarisConfiguration<T> {
       PolarisConfiguration.<Integer>builder()
           .key("STORAGE_CREDENTIAL_DURATION_SECONDS")
           .description(
-              "The duration of time that vended storage credentials are valid for. Support for" +
-                  " longer (or shorter) durations is dependent on the storage provider.")
+              "The duration of time that vended storage credentials are valid for. Support for"
+                  + " longer (or shorter) durations is dependent on the storage provider.")
           .defaultValue(60 * 60) // 1 hour
           .build();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -199,4 +199,13 @@ public class PolarisConfiguration<T> {
               "If set to true, allows tables to be dropped with the purge parameter set to true.")
           .defaultValue(true)
           .build();
+
+  public static final PolarisConfiguration<Integer> STORAGE_CREDENTIAL_DURATION_SECONDS =
+      PolarisConfiguration.<Integer>builder()
+          .key("STORAGE_CREDENTIAL_DURATION_SECONDS")
+          .description(
+              "The duration of time that vended storage credentials are valid for. Support for" +
+                  " longer (or shorter) durations is dependent on the storage provider.")
+          .defaultValue(60 * 60) // 1 hour
+          .build();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -217,15 +217,15 @@ public abstract class PolarisStorageConfigurationInfo {
     return Optional.empty();
   }
 
-  /** Returns the value of `STORAGE_CREDENTIAL_DURATION_SECONDS `*/
+  /** Returns the value of `STORAGE_CREDENTIAL_DURATION_SECONDS ` */
   public static int getVendedCredentialDurationSeconds() {
     var callContext = CallContext.getCurrentContext();
     return callContext
-      .getPolarisCallContext()
-      .getConfigurationStore()
-      .getConfiguration(
-          callContext.getPolarisCallContext(),
-          PolarisConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+        .getPolarisCallContext()
+        .getConfigurationStore()
+        .getConfiguration(
+            callContext.getPolarisCallContext(),
+            PolarisConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
   }
 
   /** Subclasses must provide the Iceberg FileIO impl associated with their type in this method. */

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -217,6 +217,17 @@ public abstract class PolarisStorageConfigurationInfo {
     return Optional.empty();
   }
 
+  /** Returns the value of `STORAGE_CREDENTIAL_DURATION_SECONDS `*/
+  public static int getVendedCredentialDurationSeconds() {
+    var callContext = CallContext.getCurrentContext();
+    return callContext
+      .getPolarisCallContext()
+      .getConfigurationStore()
+      .getConfiguration(
+          callContext.getPolarisCallContext(),
+          PolarisConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+  }
+
   /** Subclasses must provide the Iceberg FileIO impl associated with their type in this method. */
   public abstract String getFileIoImplClassName();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.policybuilder.iam.IamConditionOperator;
@@ -69,6 +70,7 @@ public class AwsCredentialsStorageIntegration
                             allowedReadLocations,
                             allowedWriteLocations)
                         .toJson())
+                .durationSeconds(PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds())
                 .build());
     EnumMap<PolarisCredentialProperty, String> credentialMap =
         new EnumMap<>(PolarisCredentialProperty.class);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -70,7 +70,8 @@ public class AwsCredentialsStorageIntegration
                             allowedReadLocations,
                             allowedWriteLocations)
                         .toJson())
-                .durationSeconds(PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds())
+                .durationSeconds(
+                    PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds())
                 .build());
     EnumMap<PolarisCredentialProperty, String> credentialMap =
         new EnumMap<>(PolarisCredentialProperty.class);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -124,8 +124,7 @@ public class AzureCredentialsStorageIntegration
     // Set the new generated user delegation key expiry to 7 days and minute 1 min
     // Azure strictly requires the end time to be <= 7 days from the current time, -1 min to avoid
     // clock skew between the client and server,
-    OffsetDateTime startTime =
-        start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
+    OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds =
         PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds();
     OffsetDateTime intendedEndTime =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -137,7 +137,8 @@ public class GcpCredentialsStorageIntegration
     HashSet<String> readBuckets = new HashSet<>();
     HashSet<String> writeBuckets = new HashSet<>();
 
-    int intendedDurationSeconds = PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds();
+    int intendedDurationSeconds =
+        PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds();
     Instant start = Instant.now();
     Instant expiration = start.plusSeconds(intendedDurationSeconds);
     String expirationExpression = String.format("request.time < timestamp('%s')", expiration);
@@ -167,9 +168,9 @@ public class GcpCredentialsStorageIntegration
                 List<String> writeExpressions =
                     writeConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
                 writeExpressions.add(
-                  String.format(
-                      "(resource.name.startsWith('projects/_/buckets/%s/objects/%s') && %s)",
-                      bucket, path, expirationExpression));
+                    String.format(
+                        "(resource.name.startsWith('projects/_/buckets/%s/objects/%s') && %s)",
+                        bucket, path, expirationExpression));
               }
             });
     CredentialAccessBoundary.Builder accessBoundaryBuilder = CredentialAccessBoundary.newBuilder();
@@ -208,7 +209,7 @@ public class GcpCredentialsStorageIntegration
           builder.setAvailablePermissions(List.of("inRole:roles/storage.legacyBucketWriter"));
           accessBoundaryBuilder.addRule(builder.build());
         });
-      return accessBoundaryBuilder.build();
+    return accessBoundaryBuilder.build();
   }
 
   private static String bucketResource(String bucket) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -27,6 +27,7 @@ import com.google.auth.oauth2.DownscopedCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.jetbrains.annotations.NotNull;
@@ -134,6 +136,12 @@ public class GcpCredentialsStorageIntegration
 
     HashSet<String> readBuckets = new HashSet<>();
     HashSet<String> writeBuckets = new HashSet<>();
+
+    int intendedDurationSeconds = PolarisStorageConfigurationInfo.getVendedCredentialDurationSeconds();
+    Instant start = Instant.now();
+    Instant expiration = start.plusSeconds(intendedDurationSeconds);
+    String expirationExpression = String.format("request.time < timestamp('%s')", expiration);
+
     Stream.concat(allowedReadLocations.stream(), allowedWriteLocations.stream())
         .distinct()
         .forEach(
@@ -146,22 +154,22 @@ public class GcpCredentialsStorageIntegration
                   readConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
               resourceExpressions.add(
                   String.format(
-                      "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
-                      bucket, path));
+                      "resource.name.startsWith('projects/_/buckets/%s/objects/%s && %s')",
+                      bucket, path, expirationExpression));
               if (allowListOperation) {
                 resourceExpressions.add(
                     String.format(
-                        "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s')",
-                        path));
+                        "(api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s') && %s)",
+                        path, expirationExpression));
               }
               if (allowedWriteLocations.contains(location)) {
                 writeBuckets.add(bucket);
                 List<String> writeExpressions =
                     writeConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
                 writeExpressions.add(
-                    String.format(
-                        "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
-                        bucket, path));
+                  String.format(
+                      "(resource.name.startsWith('projects/_/buckets/%s/objects/%s') && %s)",
+                      bucket, path, expirationExpression));
               }
             });
     CredentialAccessBoundary.Builder accessBoundaryBuilder = CredentialAccessBoundary.newBuilder();
@@ -200,7 +208,7 @@ public class GcpCredentialsStorageIntegration
           builder.setAvailablePermissions(List.of("inRole:roles/storage.legacyBucketWriter"));
           accessBoundaryBuilder.addRule(builder.build());
         });
-    return accessBoundaryBuilder.build();
+      return accessBoundaryBuilder.build();
   }
 
   private static String bucketResource(String bucket) {


### PR DESCRIPTION
# Description

If users want to extend/shorten the lifetime of vended storage credentials, we can support that with a `PolarisConfiguration`.

I didn't see a way to implement this for `GcpStorageIntegration`, so that is notably missing from this PR for now.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
