### PR TITLE
Add unit tests for helm chart

### DIFF
--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
     metadata:
       {{- if .Values.podAnnotations }}
       annotations:
-          {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
+        {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "polaris.selectorLabels" . | nindent 8 }}

--- a/helm/polaris/templates/ingress.yaml
+++ b/helm/polaris/templates/ingress.yaml
@@ -17,10 +17,9 @@
   under the License.
 */}}
 
-# {{- $kubeVersion := .Capabilities.KubeVersion.Version -}}
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "polaris.fullname" . -}}
-{{- $svcPort := index .Values.service.ports "polaris-service" -}}
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "polaris.fullname" . }}
+{{- $svcPort := index .Values.service.ports "polaris-service" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,10 +27,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
+  {{- if .Values.ingress.annotations }}
   annotations:
-    {{- if .Values.ingress.annotations }}
-      {{- tpl (toYaml .Values.ingress.annotations) . | nindent 4 }}
-    {{- end }}
+    {{- tpl (toYaml .Values.ingress.annotations) . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}

--- a/helm/polaris/templates/job.yaml
+++ b/helm/polaris/templates/job.yaml
@@ -33,10 +33,10 @@ metadata:
 spec:
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
       annotations:
-        {{- if .Values.podAnnotations }}
-          {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
-        {{- end }}
+        {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "polaris.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}
@@ -63,12 +63,16 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ include "polaris.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext}}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext}}
           securityContext:
             {{- tpl (toYaml .Values.securityContext) . | nindent 12 }}
+          {{- end }}
           image: "{{ tpl .Values.image.repository . }}:{{ tpl .Values.image.tag . | default .Chart.Version }}"
           imagePullPolicy: {{ tpl .Values.image.pullPolicy . }}
           command: ["/app/bin/polaris-service"]
@@ -81,8 +85,10 @@ spec:
             - name: eclipselink-config-volume
               mountPath: /eclipselink-config
             {{- end }}
+          {{- if .Values.resources }}
           resources:
             {{- tpl (toYaml .Values.resources) . | nindent 12 }}
+          {{- end }}
       restartPolicy: Never
       volumes:
         - name: config-volume

--- a/helm/polaris/templates/service.yaml
+++ b/helm/polaris/templates/service.yaml
@@ -24,10 +24,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
   annotations:
-    {{- if .Values.service.annotations }}
-      {{- tpl (toYaml .Values.service.annotations) . | nindent 4 }}
-    {{- end }}
+    {{- tpl (toYaml .Values.service.annotations) . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/helm/polaris/templates/serviceaccount.yaml
+++ b/helm/polaris/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
   under the License.
 */}}
 
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,8 +25,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
   annotations:
-    {{- if .Values.serviceAccount.annotations }}
-      {{- tpl (toYaml .Values.serviceAccount.annotations) . | nindent 4 }}
-    {{- end }}
+    {{- tpl (toYaml .Values.serviceAccount.annotations) . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/polaris/tests/configmap_test.yaml
+++ b/helm/polaris/tests/configmap_test.yaml
@@ -1,0 +1,296 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+chart:
+  version: 1.2.3
+  appVersion: 4.5.6
+
+release:
+  name: polaris-release
+  namespace: polaris-ns
+
+templates:
+  - configmap.yaml
+
+tests:
+
+  # metadata.name
+  - it: should set config map name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release
+  - it: should set config map name with override
+    set:
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release-polaris-override
+  - it: should set config map name with full override
+    set:
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+
+  # metadata.namespace
+  - it: should set config map namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: polaris-ns
+
+  # metadata.labels
+  - it: should set config map default labels
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+            app.kubernetes.io/version: 4.5.6
+            app.kubernetes.io/managed-by: Helm
+            helm.sh/chart: polaris-1.2.3
+  - it: should set include podLabels in deployment labels
+    set:
+      configMapLabels:
+        app.kubernetes.io/component: polaris
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/component: polaris
+
+  # data
+  ## there is an auto newline for logFormat in the config map
+  ## auto newline of long string is reported in https://github.com/helm/helm/issues/5568 and due to https://github.com/go-yaml/yaml/issues/166
+  - it: should set config map default data
+    asserts:
+      - equal:
+          path: data
+          value:
+            polaris-server.yml: |-
+              authenticator:
+                class: org.apache.polaris.service.auth.TestInlineBearerTokenPolarisAuthenticator
+              callContextResolver:
+                type: default
+              cors:
+                allowed-credentials: true
+                allowed-headers:
+                - '*'
+                allowed-methods:
+                - PATCH
+                - POST
+                - DELETE
+                - GET
+                - PUT
+                allowed-origins:
+                - http://localhost:8080
+                allowed-timing-origins:
+                - http://localhost:8080
+                exposed-headers:
+                - '*'
+                preflight-max-age: 600
+              defaultRealms:
+              - default-realm
+              featureConfiguration:
+                ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
+                SUPPORTED_CATALOG_STORAGE_TYPES:
+                - S3
+                - GCS
+                - AZURE
+                - FILE
+              io:
+                factoryType: default
+              logging:
+                appenders:
+                - logFormat: '%-5p [%d{ISO8601} - %-6r] [%t] [%X{aid}%X{sid}%X{tid}%X{wid}%X{oid}%X{srv}%X{job}%X{rid}]
+                    %c{30}: %m %kvp%n%ex'
+                  threshold: ALL
+                  type: console
+                level: INFO
+                loggers:
+                  org.apache.iceberg.rest: DEBUG
+                  org.apache.polaris: DEBUG
+              maxRequestBodyBytes: -1
+              metaStoreManager:
+                type: in-memory
+              oauth2:
+                type: test
+              rateLimiter:
+                type: no-op
+              realmContextResolver:
+                type: default
+              server:
+                adminConnectors:
+                - port: 8182
+                  type: http
+                applicationConnectors:
+                - port: 8181
+                  type: http
+                maxThreads: 200
+                minThreads: 10
+                requestLog:
+                  appenders:
+                  - type: console
+  - it: should set config map data (auto sorted)
+    set:
+      polarisServerConfig:
+        server:
+          maxThreads: 200
+          minThreads: 10
+          applicationConnectors:
+          - type: http
+            port: 8181
+          adminConnectors:
+          - type: http
+            port: 8182
+          requestLog:
+            appenders:
+            - type: console
+        featureConfiguration:
+          ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
+          SUPPORTED_CATALOG_STORAGE_TYPES:
+          - S3
+        callContextResolver:
+          type: default
+        realmContextResolver:
+          type: default
+        defaultRealms:
+        - default-realm
+        metaStoreManager:
+          type: eclipse-link
+          persistence-unit: polaris
+          conf-file: /eclipselink-config/conf.jar!/persistence.xml
+        io:
+          factoryType: default
+        oauth2:
+          type: default
+          tokenBroker:
+            type: symmetric-key
+            secret: polaris
+        authenticator:
+          class: org.apache.polaris.service.auth.DefaultPolarisAuthenticator
+          tokenBroker:
+            type: symmetric-key
+            secret: polaris
+        cors:
+          allowed-origins:
+          - http://localhost:8080
+          allowed-timing-origins:
+          - http://localhost:8080
+          allowed-methods:
+          - PATCH
+          - POST
+          - DELETE
+          - GET
+          - PUT
+          allowed-headers:
+          - "*"
+          exposed-headers:
+          - "*"
+          preflight-max-age: 600
+          allowed-credentials: true
+        logging:
+          level: INFO
+          loggers:
+            org.apache.iceberg.rest: INFO
+            org.apache.polaris: INFO
+          appenders:
+          - type: console
+            threshold: ALL
+            logFormat: "%-5p [%d{ISO8601} - %-6r] [%t] [%X{aid}%X{sid}%X{tid}%X{wid}%X{oid}%X{srv}%X{job}%X{rid}] %c{30}: %m %kvp%n%ex"
+        maxRequestBodyBytes: -1
+        rateLimiter:
+          type: no-op
+    asserts:
+      - equal:
+          path: data
+          value:
+            polaris-server.yml: |-
+              authenticator:
+                class: org.apache.polaris.service.auth.DefaultPolarisAuthenticator
+                tokenBroker:
+                  secret: polaris
+                  type: symmetric-key
+              callContextResolver:
+                type: default
+              cors:
+                allowed-credentials: true
+                allowed-headers:
+                - '*'
+                allowed-methods:
+                - PATCH
+                - POST
+                - DELETE
+                - GET
+                - PUT
+                allowed-origins:
+                - http://localhost:8080
+                allowed-timing-origins:
+                - http://localhost:8080
+                exposed-headers:
+                - '*'
+                preflight-max-age: 600
+              defaultRealms:
+              - default-realm
+              featureConfiguration:
+                ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
+                SUPPORTED_CATALOG_STORAGE_TYPES:
+                - S3
+              io:
+                factoryType: default
+              logging:
+                appenders:
+                - logFormat: '%-5p [%d{ISO8601} - %-6r] [%t] [%X{aid}%X{sid}%X{tid}%X{wid}%X{oid}%X{srv}%X{job}%X{rid}]
+                    %c{30}: %m %kvp%n%ex'
+                  threshold: ALL
+                  type: console
+                level: INFO
+                loggers:
+                  org.apache.iceberg.rest: INFO
+                  org.apache.polaris: INFO
+              maxRequestBodyBytes: -1
+              metaStoreManager:
+                conf-file: /eclipselink-config/conf.jar!/persistence.xml
+                persistence-unit: polaris
+                type: eclipse-link
+              oauth2:
+                tokenBroker:
+                  secret: polaris
+                  type: symmetric-key
+                type: default
+              rateLimiter:
+                type: no-op
+              realmContextResolver:
+                type: default
+              server:
+                adminConnectors:
+                - port: 8182
+                  type: http
+                applicationConnectors:
+                - port: 8181
+                  type: http
+                maxThreads: 200
+                minThreads: 10
+                requestLog:
+                  appenders:
+                  - type: console

--- a/helm/polaris/tests/hpa_test.yaml
+++ b/helm/polaris/tests/hpa_test.yaml
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+chart:
+  version: 1.2.3
+  appVersion: 4.5.6
+
+release:
+  name: polaris-release
+  namespace: polaris-ns
+
+templates:
+  - hpa.yaml
+
+tests:
+
+  # kind
+  - it: should not create HPA by default
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+        not: true
+  - it: should create HPA when enabled
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+
+  # metadata.name (with with autoscaling enabled)
+  - it: should set HPA name
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release
+  - it: should set HPA name with override
+    set:
+      autoscaling.enabled: true
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release-polaris-override
+  - it: should set HPA name with full override
+    set:
+      autoscaling.enabled: true
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+
+  # metadata.namespace (with autoscaling enabled)
+  - it: should set HPA namespace
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: polaris-ns
+
+  # metadata.labels (with autoscaling enabled)
+  - it: should set HPA default labels
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+            app.kubernetes.io/version: 4.5.6
+            app.kubernetes.io/managed-by: Helm
+            helm.sh/chart: polaris-1.2.3
+
+  # spec.scaleTargetRef.name (with autoscaling enabled)
+  - it: should set target deployment name
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: polaris-release
+  - it: should set target deployment name with override
+    set:
+      autoscaling.enabled: true
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: polaris-release-polaris-override
+  - it: should set target deployment name with full override
+    set:
+      autoscaling.enabled: true
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: polaris-override
+
+  # spec.maxReplicas (with autoscaling enabled)
+  - it: should set default min replicas
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+  - it: should set min replicas
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+
+  # spec.maxReplicas (with autoscaling enabled)
+  - it: should set default max replicas
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.maxReplicas
+          value: 3
+  - it: should set max replicas
+    set:
+      autoscaling.enabled: true
+      autoscaling.maxReplicas: 4
+    asserts:
+      - equal:
+          path: spec.maxReplicas
+          value: 4
+
+  # spec.metrics (with autoscaling enabled)
+  - it: should set default CPU utilization percentage
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+  - it: should set CPU utilization percentage
+    set:
+      autoscaling.enabled: true
+      autoscaling.targetCPUUtilizationPercentage: 90
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 90   
+  - it: should not set default memory utilization percentage
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - notContains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization:
+  - it: should set memory utilization percentage
+    set:
+      autoscaling.enabled: true
+      autoscaling.targetMemoryUtilizationPercentage: 80
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80

--- a/helm/polaris/tests/ingress_test.yaml
+++ b/helm/polaris/tests/ingress_test.yaml
@@ -1,0 +1,176 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+chart:
+  version: 1.2.3
+  appVersion: 4.5.6
+
+release:
+  name: polaris-release
+  namespace: polaris-ns
+
+templates:
+  - ingress.yaml
+
+tests:
+
+  # kind
+  - it: should not create ingress by default
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+        not: true
+  - it: should create ingress with enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+
+  # metadata.name (with with ingress enabled)
+  - it: should set ingress name
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release
+  - it: should set ingress name with override
+    set:
+      ingress.enabled: true
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release-polaris-override
+  - it: should set ingress name with full override
+    set:
+      ingress.enabled: true
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+
+  # metadata.namespace (with ingress enabled)
+  - it: should set ingress namespace
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: polaris-ns
+
+  # metadata.labels (with ingress enabled)
+  - it: should set ingress default labels
+    set:
+      ingress.enabled: true
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+            app.kubernetes.io/version: 4.5.6
+            app.kubernetes.io/managed-by: Helm
+            helm.sh/chart: polaris-1.2.3
+
+  # metadata.annotations (with ingress enabled)
+  - it: should not set ingress annotations by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should set ingress annotations
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/upstream-hash-by: "$binary_remote_addr"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            nginx.ingress.kubernetes.io/upstream-hash-by: "$binary_remote_addr"
+
+  # spec.ingressClassName (with ingress enabled)
+  - it: should not set ingress class by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+  - it: should set ingress class
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  # spec.tls (with ingress enabled)
+  - it: should not set ingress TLS by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: spec.tls
+  - it: should set ingress TLS
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - hosts:
+            - chart-example1.local
+            - chart-example2.local
+          secretName: secret1
+    asserts:
+      - equal:
+          path: spec.tls
+          value:
+            - hosts:
+                - "chart-example1.local"
+                - "chart-example2.local"
+              secretName: secret1
+
+  # spec.rules (with ingress enabled)
+  - it: should set ingress TLS
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: chart-example.local
+          paths:
+            - path: /
+              pathType:  Prefix
+    asserts:
+      - equal:
+          path: spec.rules
+          value:
+            - host: chart-example.local
+              http:
+                paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: polaris-release
+                        port:
+                          number: 8181

--- a/helm/polaris/tests/job_test.yaml
+++ b/helm/polaris/tests/job_test.yaml
@@ -26,40 +26,63 @@ release:
   namespace: polaris-ns
 
 templates:
-  - deployment.yaml
+  - job.yaml
 
 tests:
 
-  # metadata.name
-  - it: should set deployment name
+  # kind
+  - it: should not create job by default
+    asserts:
+      - containsDocument:
+          kind: Job
+          apiVersion: batch/v1
+        not: true
+  - it: should create job when enabled
+    set:
+      bootstrapMetastoreManager: true
+    asserts:
+      - containsDocument:
+          kind: Job
+          apiVersion: batch/v1
+
+  # metadata.name (with bootstrapMetastoreManager enabled)
+  - it: should set job name
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - equal:
           path: metadata.name
           value: polaris-release
-  - it: should set deployment name with override
+  - it: should set job name with override
     set:
+      bootstrapMetastoreManager: true
       nameOverride: polaris-override
     asserts:
       - equal:
           path: metadata.name
           value: polaris-release-polaris-override
-  - it: should set deployment name with full override
+  - it: should set job name with full override
     set:
+      bootstrapMetastoreManager: true
       fullnameOverride: polaris-override
     asserts:
       - equal:
           path: metadata.name
           value: polaris-override
 
-  # metadata.namespace
-  - it: should set deployment namespace
+  # metadata.namespace (with bootstrapMetastoreManager enabled)
+  - it: should set job namespace
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - equal:
           path: metadata.namespace
           value: polaris-ns
 
-  # metadata.labels
-  - it: should set deployment default labels
+  # metadata.labels (with bootstrapMetastoreManager enabled)
+  - it: should set job default labels
+    set:
+      bootstrapMetastoreManager: true  
     asserts:
       - isSubset:
           path: metadata.labels
@@ -69,8 +92,9 @@ tests:
             app.kubernetes.io/version: 4.5.6
             app.kubernetes.io/managed-by: Helm
             helm.sh/chart: polaris-1.2.3
-  - it: should set podLabels in deployment labels
+  - it: should set podLabels in job labels
     set:
+      bootstrapMetastoreManager: true
       podLabels:
         app.kubernetes.io/component: polaris
     asserts:
@@ -79,62 +103,26 @@ tests:
           content:
             app.kubernetes.io/component: polaris
 
-  # spec.replicas
-  - it: should set default replicas
+  # metadata.annotations (with bootstrapMetastoreManager enabled)
+  - it: should set job annotations
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - equal:
-          path: spec.replicas
-          value: 1
-  - it: should set replicas
-    set:
-      replicaCount: 3
-    asserts:
-      - equal:
-          path: spec.replicas
-          value: 3
-  - it: should not set replicas if autoscaling is enabled
-    set:
-      replicaCount: 3
-      autoscaling:
-        enabled: true
-    asserts:
-      - notExists:
-          path: spec.replicas
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": post-install
 
-  # spec.selector.matchLabels + spec.template.metadata.labels
-  - it: should set deployment selector labels
-    asserts:
-      - isSubset:
-          path: spec.selector.matchLabels
-          content:
-            app.kubernetes.io/name: polaris
-            app.kubernetes.io/instance: polaris-release
-      - isSubset:
-          path: spec.template.metadata.labels
-          content:
-            app.kubernetes.io/name: polaris
-            app.kubernetes.io/instance: polaris-release
-  - it: should include podLabels in spec.template.metadata.labels only
-    set:
-      podLabels:
-        app.kubernetes.io/component: polaris
-    asserts:
-      - isNotSubset:
-          path: spec.selector.matchLabels
-          content:
-              app.kubernetes.io/component: polaris
-      - isSubset:
-          path: spec.template.metadata.labels
-          content:
-            app.kubernetes.io/component: polaris
-
-  # spec.template.metadata.annotations
+  # spec.template.metadata.annotations (with bootstrapMetastoreManager enabled)
   - it: should not set pod annotations by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.metadata.annotations
   - it: should set pod annotations
     set:
+      bootstrapMetastoreManager: true
       podAnnotations:
         foo: bar
     asserts:
@@ -143,13 +131,37 @@ tests:
           content:
             foo: bar
 
-  # spec.template.spec.initContainers
+  # spec.template.metadata.labels (with bootstrapMetastoreManager enabled)
+  - it: should set pod labels
+    set:
+      bootstrapMetastoreManager: true
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+  - it: should set podLabels in pod labels
+    set:
+      bootstrapMetastoreManager: true
+      podLabels:
+        app.kubernetes.io/component: polaris
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            app.kubernetes.io/component: polaris
+
+  # spec.template.spec.initContainers (with bootstrapMetastoreManager enabled)
   - it: should not set initContainers by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.initContainers
   - it: should set initContainers if persistence is enabled
     set:
+      bootstrapMetastoreManager: true
       persistenceConfigSecret: polaris-persistence-secret
       polarisServerConfig:
         metaStoreManager:
@@ -174,13 +186,16 @@ tests:
               - name: secret-volume
                 mountPath: /secret
 
-  # spec.template.spec.imagePullSecrets
+  # spec.template.spec.imagePullSecrets (with bootstrapMetastoreManager enabled)
   - it: should not set imagePullSecrets by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.imagePullSecrets
   - it: should set imagePullSecrets
     set:
+      bootstrapMetastoreManager: true
       imagePullSecrets:
         - test-secret
     asserts:
@@ -189,14 +204,17 @@ tests:
           content:
             name: test-secret
 
-  # spec.template.spec.serviceAccountName
+  # spec.template.spec.serviceAccountName (with bootstrapMetastoreManager enabled)
   - it: should set default service account name
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: polaris-release
   - it: should set service account name when serviceAccount.create is true
     set:
+      bootstrapMetastoreManager: true
       serviceAccount:
         create: true
     asserts:
@@ -205,6 +223,7 @@ tests:
           value: polaris-release
   - it: should set custom service account name when serviceAccount.create is true
     set:
+      bootstrapMetastoreManager: true
       serviceAccount:
         create: true
         name: polaris-sa
@@ -214,6 +233,7 @@ tests:
           value: polaris-sa
   - it: should set service account name to default when serviceAccount.create is false
     set:
+      bootstrapMetastoreManager: true
       serviceAccount:
         create: false
     asserts:
@@ -222,6 +242,7 @@ tests:
           value: default
   - it: should set custom service account name when serviceAccount.create is false
     set:
+      bootstrapMetastoreManager: true
       serviceAccount:
         create: false
         name: polaris-sa
@@ -230,13 +251,16 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: polaris-sa
 
-  # spec.template.spec.securityContext
+  # spec.template.spec.securityContext (with bootstrapMetastoreManager enabled)
   - it: should not set securityContext by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.securityContext
   - it: should set securityContext
     set:
+      bootstrapMetastoreManager: true
       podSecurityContext:
         runAsUser: 1000
     asserts:
@@ -245,20 +269,25 @@ tests:
           content:
             runAsUser: 1000
 
-  # spec.template.spec.containers
+  # spec.template.spec.containers (with bootstrapMetastoreManager enabled)
   - it: should set container name
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
           value: polaris
 
-  # spec.template.spec.containers[0].securityContext
+  # spec.template.spec.containers[0].securityContext (with bootstrapMetastoreManager enabled)
   - it: should not set container securityContext by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].securityContext
   - it: should set container securityContext
     set:
+      bootstrapMetastoreManager: true    
       securityContext:
         runAsUser: 1000
     asserts:
@@ -267,9 +296,10 @@ tests:
           content:
             runAsUser: 1000
 
-  # spec.template.spec.containers[0].image
+  # spec.template.spec.containers[0].image (with bootstrapMetastoreManager enabled)
   - it: should set container image
     set:
+      bootstrapMetastoreManager: true
       image:
         repository: test-repo
         tag: test-tag
@@ -279,6 +309,7 @@ tests:
           value: test-repo:test-tag
   - it: should set container image with template
     set:
+      bootstrapMetastoreManager: true
       image:
         repository: test-repo-{{ .Chart.Version }}
         tag: test-tag-{{ .Release.Name }}
@@ -288,6 +319,7 @@ tests:
           value: test-repo-1.2.3:test-tag-polaris-release
   - it: should set container image with chart version if no tag provided
     set:
+      bootstrapMetastoreManager: true    
       image:
         repository: test-repo
         tag: ""
@@ -296,9 +328,10 @@ tests:
           path: spec.template.spec.containers[0].image
           value: test-repo:1.2.3
 
-  # spec.template.spec.containers[0].imagePullPolicy
+  # spec.template.spec.containers[0].imagePullPolicy (with bootstrapMetastoreManager enabled)
   - it: should set container pull policy
     set:
+      bootstrapMetastoreManager: true    
       image:
         pullPolicy: Always
     asserts:
@@ -306,25 +339,10 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  # spec.template.spec.containers[0].env
-  - it: should not set container env by default
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].env
-  - it: should set container env
-    set:
-      extraEnv:
-        - name: foo
-          value: bar
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: foo
-            value: bar
-
-  # spec.template.spec.containers[0].volumeMounts + spec.template.spec.volumes
+  # spec.template.spec.containers[0].volumeMounts + spec.template.spec.volumes (with bootstrapMetastoreManager enabled)
   - it: should not set persistence volumes by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - lengthEqual:
           path: spec.template.spec.volumes
@@ -340,6 +358,7 @@ tests:
             subPath: polaris-server.yml
   - it: should set persistence volumes if persistence is enabled
     set:
+      bootstrapMetastoreManager: true
       persistenceConfigSecret: polaris-persistence-secret
       polarisServerConfig:
         metaStoreManager:
@@ -368,70 +387,16 @@ tests:
             name: eclipselink-config-volume
             mountPath: /eclipselink-config
 
-  # spec.template.spec.containers[0].ports
-  - it: should set container ports by default
-    asserts:
-      - lengthEqual:
-          path: spec.template.spec.containers[0].ports
-          count: 2
-      - contains:
-          path: spec.template.spec.containers[0].ports
-          content:
-            name: polaris-service
-            containerPort: 8181
-            protocol: TCP
-      - contains:
-          path: spec.template.spec.containers[0].ports
-          content:
-            name: polaris-metrics
-            containerPort: 8182
-            protocol: TCP
-
-  # spec.template.spec.containers[0].livenessProbe
-  - it: should set container livenessProbe by default
-    set:
-      livenessProbe:
-        initialDelaySeconds: 11
-        periodSeconds: 22
-        successThreshold: 33
-        failureThreshold: 44
-        timeoutSeconds: 55
-    asserts:
-      - isSubset:
-          path: spec.template.spec.containers[0].livenessProbe
-          content:
-            initialDelaySeconds: 11
-            periodSeconds: 22
-            successThreshold: 33
-            failureThreshold: 44
-            timeoutSeconds: 55
-
-  # spec.template.spec.containers[0].readinessProbe
-  - it: should set container readinessProbe by default
-    set:
-      readinessProbe:
-        initialDelaySeconds: 11
-        periodSeconds: 22
-        successThreshold: 33
-        failureThreshold: 44
-        timeoutSeconds: 55
-    asserts:
-      - isSubset:
-          path: spec.template.spec.containers[0].readinessProbe
-          content:
-            initialDelaySeconds: 11
-            periodSeconds: 22
-            successThreshold: 33
-            failureThreshold: 44
-            timeoutSeconds: 55
-
-  # spec.template.spec.containers[0].resources
+  # spec.template.spec.containers[0].resources (with bootstrapMetastoreManager enabled)
   - it: should not set container resources by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].resources
   - it: should set container resources
     set:
+      bootstrapMetastoreManager: true
       resources:
         requests:
           cpu: 100m
@@ -450,13 +415,16 @@ tests:
               cpu: 200m
               memory: 256Mi
 
-  # spec.template.spec.nodeSelector
+  # spec.template.spec.nodeSelector (with bootstrapMetastoreManager enabled)
   - it: should not set nodeSelector by default
+    set:
+      bootstrapMetastoreManager: true  
     asserts:
       - notExists:
           path: spec.template.spec.nodeSelector
   - it: should set nodeSelector
     set:
+      bootstrapMetastoreManager: true
       nodeSelector:
         disktype: ssd
     asserts:
@@ -465,13 +433,16 @@ tests:
           value:
             disktype: ssd
 
-  # spec.template.spec.affinity
+  # spec.template.spec.affinity (with bootstrapMetastoreManager enabled)
   - it: should not set affinity by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.affinity
   - it: should set affinity
     set:
+      bootstrapMetastoreManager: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -496,13 +467,16 @@ tests:
                           - zone1
                           - zone2
 
-  # spec.template.spec.tolerations
+  # spec.template.spec.tolerations (with bootstrapMetastoreManager enabled)
   - it: should not set tolerations by default
+    set:
+      bootstrapMetastoreManager: true
     asserts:
       - notExists:
           path: spec.template.spec.tolerations
   - it: should set tolerations
     set:
+      bootstrapMetastoreManager: true
       tolerations:
         - key: "key"
           operator: "Equal"

--- a/helm/polaris/tests/service_test.yaml
+++ b/helm/polaris/tests/service_test.yaml
@@ -1,0 +1,158 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+chart:
+  version: 1.2.3
+  appVersion: 4.5.6
+
+release:
+  name: polaris-release
+  namespace: polaris-ns
+
+templates:
+  - service.yaml
+
+tests:
+
+  # metadata.name
+  - it: should set service name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release
+  - it: should set service name with override
+    set:
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release-polaris-override
+  - it: should set service name with full override
+    set:
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+
+  # metadata.namespace
+  - it: should set service namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: polaris-ns
+
+  # metadata.labels
+  - it: should set service default labels
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+            app.kubernetes.io/version: 4.5.6
+            app.kubernetes.io/managed-by: Helm
+            helm.sh/chart: polaris-1.2.3
+
+  # metadata.annotations
+  - it: should not set service annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should set service annotations
+    set:
+      service.annotations:
+        foo: bar
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+
+  # spec.type
+  - it: should set service default type
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+  - it: should set service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  # spec.selector
+  - it: should set service default selector
+    asserts:
+      - isSubset:
+          path: spec.selector
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+
+  # spec.ports
+  - it: should set service default ports
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - port: 8182
+              targetPort: 8182
+              protocol: TCP
+              name: polaris-metrics
+            - port: 8181
+              targetPort: 8181
+              protocol: TCP
+              name: polaris-service
+  - it: should set service ports
+    set:
+      service:
+        ports:
+          polaris-service: 18181
+          polaris-metrics: 18182
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - port: 18182
+              targetPort: 18182
+              protocol: TCP
+              name: polaris-metrics
+            - port: 18181
+              targetPort: 18181
+              protocol: TCP
+              name: polaris-service
+
+  # spec.sessionAffinity
+  - it: should set service default session affinity
+    asserts:
+      - equal:
+          path: spec.sessionAffinity
+          value:
+            None
+  - it: should set service session affinity
+    set:
+      service.sessionAffinity: ClientIP
+    asserts:
+      - equal:
+          path: spec.sessionAffinity
+          value:
+            ClientIP

--- a/helm/polaris/tests/serviceaccount_test.yaml
+++ b/helm/polaris/tests/serviceaccount_test.yaml
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+chart:
+  version: 1.2.3
+  appVersion: 4.5.6
+
+release:
+  name: polaris-release
+  namespace: polaris-ns
+
+templates:
+  - serviceaccount.yaml
+
+tests:
+
+  # Kind
+  - it: should create service account by default
+    asserts:
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+  - it: should not create service account when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+        not: true
+
+  # metadata.name
+  - it: should set service account name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release
+  - it: should set service account name with override
+    set:
+      nameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-release-polaris-override
+  - it: should set service account name with full override
+    set:
+      fullnameOverride: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+  - it: should set service account name with defined name
+    set:
+      serviceAccount.name: polaris-override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: polaris-override
+
+  # metadata.namespace
+  - it: should set service account namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: polaris-ns
+
+  # metadata.labels
+  - it: should set service account default labels
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: polaris
+            app.kubernetes.io/instance: polaris-release
+            app.kubernetes.io/version: 4.5.6
+            app.kubernetes.io/managed-by: Helm
+            helm.sh/chart: polaris-1.2.3
+
+  # metadata.annotations
+  - it: should not set service account annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should set service account annotations
+    set:
+      serviceAccount.annotations:
+        foo: bar
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar


### PR DESCRIPTION
# Description

As https://github.com/apache/polaris/pull/387 add a helm unit test to the CI pipeline for deployment manifest. This PR add the unit test for the remaining six manifests. This had being discussed in https://github.com/apache/polaris/pull/386 with @adutra.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


```sh
xxxx@DESKTOP:~/k8s/polaris(helm_unit_test)$ helm unittest helm/polaris/ 2>&1 | grep -v 'symbolic link'

### Chart [ polaris ] helm/polaris/

 PASS   helm/polaris/tests/configmap_test.yaml
 PASS   helm/polaris/tests/deployment_test.yaml
 PASS   helm/polaris/tests/hpa_test.yaml
 PASS   helm/polaris/tests/ingress_test.yaml
 PASS   helm/polaris/tests/job_test.yaml
 PASS   helm/polaris/tests/service_test.yaml
 PASS   helm/polaris/tests/serviceaccount_test.yaml

Charts:      1 passed, 1 total
Test Suites: 7 passed, 7 total
Tests:       151 passed, 151 total
Snapshot:    0 passed, 0 total
Time:        399.43489ms
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
