### PR TITLE
Refactor PolarisRestCatalogViewIntegrationTest into per cloud provider tests

### DIFF
--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewAwsIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewAwsIntegrationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.assertj.core.util.Strings;
+
+/** Runs PolarisRestCatalogViewIntegrationTest on AWS. */
+public class PolarisRestCatalogViewAwsIntegrationTest
+    extends PolarisRestCatalogViewIntegrationTest {
+  public static final String ROLE_ARN =
+      Optional.ofNullable(System.getenv("INTEGRATION_TEST_ROLE_ARN")) // Backward compatibility
+          .orElse(System.getenv("INTEGRATION_TEST_S3_ROLE_ARN"));
+  public static final String BASE_LOCATION = System.getenv("INTEGRATION_TEST_S3_PATH");
+
+  @Override
+  protected StorageConfigInfo getStorageConfigInfo() {
+    return AwsStorageConfigInfo.builder()
+        .setRoleArn(ROLE_ARN)
+        .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+        .setAllowedLocations(List.of(BASE_LOCATION))
+        .build();
+  }
+
+  @Override
+  protected boolean shouldSkip() {
+    return Stream.of(BASE_LOCATION, ROLE_ARN).anyMatch(Strings::isNullOrEmpty);
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewAzureIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewAzureIntegrationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.assertj.core.util.Strings;
+
+/** Runs PolarisRestCatalogViewIntegrationTest on Azure. */
+public class PolarisRestCatalogViewAzureIntegrationTest
+    extends PolarisRestCatalogViewIntegrationTest {
+  public static final String TENANT_ID = System.getenv("INTEGRATION_TEST_AZURE_TENANT_ID");
+  public static final String BASE_LOCATION = System.getenv("INTEGRATION_TEST_AZURE_PATH");
+
+  @Override
+  protected StorageConfigInfo getStorageConfigInfo() {
+    return AzureStorageConfigInfo.builder()
+        .setTenantId(TENANT_ID)
+        .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
+        .setAllowedLocations(List.of(BASE_LOCATION))
+        .build();
+  }
+
+  @Override
+  protected boolean shouldSkip() {
+    return Stream.of(BASE_LOCATION, TENANT_ID).anyMatch(Strings::isNullOrEmpty);
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewFileIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewFileIntegrationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog;
+
+import java.util.List;
+import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+
+/** Runs PolarisRestCatalogViewIntegrationTest on the local filesystem. */
+public class PolarisRestCatalogViewFileIntegrationTest
+    extends PolarisRestCatalogViewIntegrationTest {
+  public static final String BASE_LOCATION = "file:///tmp/buckets/my-bucket";
+
+  @Override
+  protected StorageConfigInfo getStorageConfigInfo() {
+    return FileStorageConfigInfo.builder()
+        .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
+        .setAllowedLocations(List.of(BASE_LOCATION))
+        .build();
+  }
+
+  @Override
+  protected boolean shouldSkip() {
+    return false;
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewGcpIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewGcpIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.assertj.core.util.Strings;
+
+/** Runs PolarisRestCatalogViewIntegrationTest on GCP. */
+public class PolarisRestCatalogViewGcpIntegrationTest
+    extends PolarisRestCatalogViewIntegrationTest {
+  public static final String SERVICE_ACCOUNT =
+      System.getenv("INTEGRATION_TEST_GCS_SERVICE_ACCOUNT");
+  public static final String BASE_LOCATION = System.getenv("INTEGRATION_TEST_GCS_PATH");
+
+  @Override
+  protected StorageConfigInfo getStorageConfigInfo() {
+    return GcpStorageConfigInfo.builder()
+        .setGcsServiceAccount(SERVICE_ACCOUNT)
+        .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
+        .setAllowedLocations(List.of(BASE_LOCATION))
+        .build();
+  }
+
+  @Override
+  protected boolean shouldSkip() {
+    return Stream.of(BASE_LOCATION, SERVICE_ACCOUNT).anyMatch(Strings::isNullOrEmpty);
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -59,12 +59,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<RESTCatalog> {
   public static final String IDENTITY =
       Optional.ofNullable(System.getenv("INTEGRATION_TEST_ROLE_ARN")) // Backward compatability
-              .orElse(Optional.ofNullable(System.getenv("INTEGRATION_TEST_IDENTITY"))
-                      .orElse("arn:aws:iam::123456789012:role/my-role"));
+          .orElse(
+              Optional.ofNullable(System.getenv("INTEGRATION_TEST_IDENTITY"))
+                  .orElse("arn:aws:iam::123456789012:role/my-role"));
   public static final String BASE_LOCATION =
       Optional.ofNullable(System.getenv("INTEGRATION_TEST_S3_PATH")) // Backward compatability
-              .orElse(Optional.ofNullable(System.getenv("INTEGRATION_TEST_BASE_LOCATION"))
-          .orElse("file:///tmp/buckets/my-bucket"));
+          .orElse(
+              Optional.ofNullable(System.getenv("INTEGRATION_TEST_BASE_LOCATION"))
+                  .orElse("file:///tmp/buckets/my-bucket"));
   private static final DropwizardAppExtension<PolarisApplicationConfig> EXT =
       new DropwizardAppExtension<>(
           PolarisApplication.class,
@@ -113,11 +115,12 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
                 }
               }
 
-              String defaultBaseLocation = BASE_LOCATION + "/" + System.getenv("USER") + "/path/to/data";
-              StorageConfigInfo storageConfig = TestUtil.buildStorageInfo(defaultBaseLocation, IDENTITY);
+              String defaultBaseLocation =
+                  BASE_LOCATION + "/" + System.getenv("USER") + "/path/to/data";
+              StorageConfigInfo storageConfig =
+                  TestUtil.buildStorageInfo(defaultBaseLocation, IDENTITY);
               org.apache.polaris.core.admin.model.CatalogProperties props =
-                  org.apache.polaris.core.admin.model.CatalogProperties.builder(
-                          defaultBaseLocation)
+                  org.apache.polaris.core.admin.model.CatalogProperties.builder(defaultBaseLocation)
                       .addProperty(
                           CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY,
                           "file:")
@@ -133,8 +136,7 @@ public class PolarisRestCatalogViewIntegrationTest extends ViewCatalogTests<REST
                       .setType(Catalog.TypeEnum.INTERNAL)
                       .setName(catalogName)
                       .setProperties(props)
-                      .setStorageConfigInfo(
-                          storageConfig)
+                      .setStorageConfigInfo(storageConfig)
                       .build();
               restCatalog =
                   TestUtil.createSnowmanManagedCatalog(

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
@@ -26,7 +26,6 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -189,34 +188,41 @@ public class TestUtil {
 
   /**
    * Builds a cloud-specific or local StorageConfigInfo based on the provided location and identity.
-   * The storage provider is inferred by the location prefix, such as s3://, file://, and so on.
-   * The identity maps to an S3 role arn, GCS service account, or Azure tenant ID. It's unused for the local file provider.
+   * The storage provider is inferred by the location prefix, such as s3://, file://, and so on. The
+   * identity maps to an S3 role arn, GCS service account, or Azure tenant ID. It's unused for the
+   * local file provider.
    */
   public static StorageConfigInfo buildStorageInfo(String location, String identity) {
-    PolarisStorageConfigurationInfo.StorageType storageType = Arrays.stream(PolarisStorageConfigurationInfo.StorageType.values()).filter(type ->
-            type.getPrefixes().stream().anyMatch(location::startsWith)
-    ).findAny().orElseThrow();
+    PolarisStorageConfigurationInfo.StorageType storageType =
+        Arrays.stream(PolarisStorageConfigurationInfo.StorageType.values())
+            .filter(type -> type.getPrefixes().stream().anyMatch(location::startsWith))
+            .findAny()
+            .orElseThrow();
 
-    return switch(storageType) {
-      case S3 -> AwsStorageConfigInfo.builder()
+    return switch (storageType) {
+      case S3 ->
+          AwsStorageConfigInfo.builder()
               .setRoleArn(identity)
               .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
               .setAllowedLocations(List.of(location))
               .build();
-        case GCS -> GcpStorageConfigInfo.builder()
-                .setGcsServiceAccount(identity)
-                .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
-                .setAllowedLocations(List.of(location))
-                .build();
-        case AZURE -> AzureStorageConfigInfo.builder()
-                .setTenantId(identity)
-                .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
-                .setAllowedLocations(List.of(location))
-                .build();
-        case FILE -> FileStorageConfigInfo.builder()
-                .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
-                .setAllowedLocations(List.of(location))
-                .build();
+      case GCS ->
+          GcpStorageConfigInfo.builder()
+              .setGcsServiceAccount(identity)
+              .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
+              .setAllowedLocations(List.of(location))
+              .build();
+      case AZURE ->
+          AzureStorageConfigInfo.builder()
+              .setTenantId(identity)
+              .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
+              .setAllowedLocations(List.of(location))
+              .build();
+      case FILE ->
+          FileStorageConfigInfo.builder()
+              .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
+              .setAllowedLocations(List.of(location))
+              .build();
     };
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
@@ -26,17 +26,26 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
+import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogGrant;
 import org.apache.polaris.core.admin.model.CatalogPrivilege;
 import org.apache.polaris.core.admin.model.CatalogRole;
+import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
+import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.GrantResource;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.service.auth.BasePolarisAuthenticator;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
@@ -176,5 +185,38 @@ public class TestUtil {
             .putAll(extraProperties);
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());
     return restCatalog;
+  }
+
+  /**
+   * Builds a cloud-specific or local StorageConfigInfo based on the provided location and identity.
+   * The storage provider is inferred by the location prefix, such as s3://, file://, and so on.
+   * The identity maps to an S3 role arn, GCS service account, or Azure tenant ID. It's unused for the local file provider.
+   */
+  public static StorageConfigInfo buildStorageInfo(String location, String identity) {
+    PolarisStorageConfigurationInfo.StorageType storageType = Arrays.stream(PolarisStorageConfigurationInfo.StorageType.values()).filter(type ->
+            type.getPrefixes().stream().anyMatch(location::startsWith)
+    ).findAny().orElseThrow();
+
+    return switch(storageType) {
+      case S3 -> AwsStorageConfigInfo.builder()
+              .setRoleArn(identity)
+              .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+              .setAllowedLocations(List.of(location))
+              .build();
+        case GCS -> GcpStorageConfigInfo.builder()
+                .setGcsServiceAccount(identity)
+                .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
+                .setAllowedLocations(List.of(location))
+                .build();
+        case AZURE -> AzureStorageConfigInfo.builder()
+                .setTenantId(identity)
+                .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
+                .setAllowedLocations(List.of(location))
+                .build();
+        case FILE -> FileStorageConfigInfo.builder()
+                .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
+                .setAllowedLocations(List.of(location))
+                .build();
+    };
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
@@ -26,25 +26,17 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
-import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
-import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogGrant;
 import org.apache.polaris.core.admin.model.CatalogPrivilege;
 import org.apache.polaris.core.admin.model.CatalogRole;
-import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
-import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.GrantResource;
-import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.service.auth.BasePolarisAuthenticator;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.test.PolarisConnectionExtension;
@@ -184,45 +176,5 @@ public class TestUtil {
             .putAll(extraProperties);
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());
     return restCatalog;
-  }
-
-  /**
-   * Builds a cloud-specific or local StorageConfigInfo based on the provided location and identity.
-   * The storage provider is inferred by the location prefix, such as s3://, file://, and so on. The
-   * identity maps to an S3 role arn, GCS service account, or Azure tenant ID. It's unused for the
-   * local file provider.
-   */
-  public static StorageConfigInfo buildStorageInfo(String location, String identity) {
-    PolarisStorageConfigurationInfo.StorageType storageType =
-        Arrays.stream(PolarisStorageConfigurationInfo.StorageType.values())
-            .filter(type -> type.getPrefixes().stream().anyMatch(location::startsWith))
-            .findAny()
-            .orElseThrow();
-
-    return switch (storageType) {
-      case S3 ->
-          AwsStorageConfigInfo.builder()
-              .setRoleArn(identity)
-              .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
-              .setAllowedLocations(List.of(location))
-              .build();
-      case GCS ->
-          GcpStorageConfigInfo.builder()
-              .setGcsServiceAccount(identity)
-              .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
-              .setAllowedLocations(List.of(location))
-              .build();
-      case AZURE ->
-          AzureStorageConfigInfo.builder()
-              .setTenantId(identity)
-              .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
-              .setAllowedLocations(List.of(location))
-              .build();
-      case FILE ->
-          FileStorageConfigInfo.builder()
-              .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
-              .setAllowedLocations(List.of(location))
-              .build();
-    };
   }
 }


### PR DESCRIPTION
# Description

Test-only change that refactors the PolarisRestCatalogViewIntegrationTest, which runs the Iceberg REST Catalog test suite, into 1 test per cloud provider. There doesn't seem to be a way to do this in 1 file because we inherit the test methods from a superclass. 

I'm also interested in doing this for other tests but would like to first gather feedback on this one.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] The tests

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings