### PR TITLE
Fix a slight usability issue with TestFileIO

### DIFF
--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.catalog.io;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.azure.core.exception.AzureException;
 import com.google.cloud.storage.StorageException;
@@ -40,6 +41,8 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -54,6 +57,7 @@ import org.apache.polaris.service.test.PolarisConnectionExtension;
 import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -121,13 +125,34 @@ public class FileIOIntegrationTest {
             .create();
   }
 
+  @Test
+  void testGetLengthExceptionSupplier() {
+    InMemoryFileIO inMemoryFileIO = new InMemoryFileIO();
+
+    String path = "x/y/z";
+    inMemoryFileIO.addFile(path, new byte[0]);
+
+    String errorMsg = "getLength not available";
+    FileIO io =
+        new TestFileIO(
+            inMemoryFileIO,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(() -> new RuntimeException(errorMsg)));
+
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> io.newInputFile(path).getLength());
+    assertTrue(
+        exception.getMessage().contains(errorMsg),
+        String.format("expected '%s' to contain '%s'", exception.getMessage(), errorMsg));
+  }
+
   @ParameterizedTest
   @MethodSource("getIOExceptionTypeTestConfigs")
   void testIOExceptionExceptionTypes(int uniqueId, IOExceptionTypeTestConfig<?> config) {
     ioFactory.loadFileIOExceptionSupplier = config.loadFileIOExceptionSupplier;
     ioFactory.newInputFileExceptionSupplier = config.newInputFileExceptionSupplier;
     ioFactory.newOutputFileExceptionSupplier = config.newOutputFileExceptionSupplier;
-    ioFactory.getLengthExceptionSupplier = config.getLengthExceptionSupplier;
 
     assertThrows(config.expectedException, () -> config.workload.run(uniqueId));
   }
@@ -196,7 +221,6 @@ public class FileIOIntegrationTest {
       Optional<Supplier<RuntimeException>> loadFileIOExceptionSupplier,
       Optional<Supplier<RuntimeException>> newInputFileExceptionSupplier,
       Optional<Supplier<RuntimeException>> newOutputFileExceptionSupplier,
-      Optional<Supplier<RuntimeException>> getLengthExceptionSupplier,
       Workload workload) {
 
     interface Workload {
@@ -215,25 +239,15 @@ public class FileIOIntegrationTest {
               Optional.of(exceptionSupplier),
               Optional.empty(),
               Optional.empty(),
-              Optional.empty(),
               workload),
           new IOExceptionTypeTestConfig<>(
               exceptionType,
               Optional.empty(),
               Optional.of(exceptionSupplier),
               Optional.empty(),
-              Optional.empty(),
               workload),
           new IOExceptionTypeTestConfig<>(
               exceptionType,
-              Optional.empty(),
-              Optional.empty(),
-              Optional.of(exceptionSupplier),
-              Optional.empty(),
-              workload),
-          new IOExceptionTypeTestConfig<>(
-              exceptionType,
-              Optional.empty(),
               Optional.empty(),
               Optional.empty(),
               Optional.of(exceptionSupplier),

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/TestFileIO.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/TestFileIO.java
@@ -73,9 +73,9 @@ public class TestFileIO implements FileIO {
           throw s.get();
         });
 
-    InputFile wrapped = new TestInputFile(inner, getLengthExceptionSupplier);
-    inputBytes += wrapped.getLength();
-    return wrapped;
+    // Use the inner's length in case the TestInputFile throws a getLength exception
+    inputBytes += inner.getLength();
+    return new TestInputFile(inner, getLengthExceptionSupplier);
   }
 
   @Override


### PR DESCRIPTION
# Description

TestFileIOs could be forced to throw an exception when calling getLength. Unfortunately this is hard to use because TestFileIOs also contain functionality for measuring file sizes. This meant that any supplied getLength exception would result in the construction of an InputFile to immediately fail instead of the exception being deferred to later.

This PR makes the TestFileIO use the non-exception-throwing-InputFile for measurement. Unfortunately the previous tests were relying on getLength being called at some point during the workloads but Iceberg seems to rarely call getLength, thus I just wrote a separate test to validate the functionality.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Existing tests

# Checklist:

Please delete options that are not relevant.

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
