### PR TITLE
Improve the error message in the exception thrown for credential-vending enablement

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapper.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapper.java
@@ -834,7 +834,10 @@ public class PolarisCatalogHandlerWrapper {
             callContext.getPolarisCallContext(),
             catalogEntity,
             PolarisConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING)) {
-      throw new ForbiddenException("Access Delegation is not supported for this catalog");
+      throw new ForbiddenException(
+          "Access Delegation is not enabled for this catalog. Please consult applicable "
+              + "documentation for the catalog config property '%s' to enable this feature",
+          PolarisConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING.catalogConfig());
     }
 
     // TODO: Find a way for the configuration or caller to better express whether to fail or omit

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -713,7 +713,8 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
         Assertions.assertThatThrownBy(
                 () -> restCatalog.loadTable(TableIdentifier.of(ns1, "my_table")))
             .isInstanceOf(ForbiddenException.class)
-            .hasMessageContaining("Access Delegation is not supported for this catalog");
+            .hasMessageContaining("Access Delegation is not enabled for this catalog")
+            .hasMessageContaining("'enable.credential.vending'");
       } finally {
         resolvingFileIO.deleteFile(fileLocation);
       }

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -714,7 +714,8 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
                 () -> restCatalog.loadTable(TableIdentifier.of(ns1, "my_table")))
             .isInstanceOf(ForbiddenException.class)
             .hasMessageContaining("Access Delegation is not enabled for this catalog")
-            .hasMessageContaining("'enable.credential.vending'");
+            .hasMessageContaining(
+                PolarisConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING.catalogConfig());
       } finally {
         resolvingFileIO.deleteFile(fileLocation);
       }


### PR DESCRIPTION
Instead of "is not supported", phrase it as "is not enabled", and provide the catalog config key the user can look up to decide whether to enable the feature for their catalog.


## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
