### PR TITLE
Update Polaris Community Sync invite

### DIFF
--- a/site/content/community/meetings/_index.adoc
+++ b/site/content/community/meetings/_index.adoc
@@ -29,7 +29,7 @@ cascade:
 
 We have bi-weekly community meeting using Google Meet.
 
-Join the https://groups.google.com/u/1/g/polaris-community-sync[polaris-community-sync Google Group].
+Join https://calendar.app.google/SWqjQJHs38M6wVALA[Polaris Community Sync invite].
 
 == Scheduled Meetings
 


### PR DESCRIPTION
In order to be able to record the meeting, we created a new Google Meet invite.

This PR updates website with the new Polaris Community Sync invite.