### PR TITLE
Resolve type id 'eclipse-link' as a subtype of MetaStoreManagerFactory

### DIFF
--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
 dependencies {
   implementation(project(":polaris-core"))
+  implementation(project(":polaris-eclipselink"))
 
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")


### PR DESCRIPTION
# Description

Resolve type id 'eclipse-link' as a subtype of MetaStoreManagerFactory. Right now with the main branch as it is when we try to configure  and run polaris server for production use case with eclipse link as metaStoreManager and postgres as db, it fails with following error 

 Failed to parse configuration at: metaStoreManager; Could not resolve type id 'eclipse-link' as a subtype of `org.apache.polaris.core.persistence.MetaStoreManagerFactory`: known type ids = [in-memory] (for POJO property 'metaStoreManager')
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.apache.polaris.service.config.PolarisApplicationConfig["metaStoreManager"])

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] able to start server locally with eclipse link as metastore manager and hit requests to create catalog etc

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
