### PR TITLE
Create a new singleton metric with an API_NAME tag

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -80,6 +80,7 @@ spotless {
     licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
     endWithNewline()
     custom("disallowWildcardImports", disallowWildcardImports)
+    toggleOffOn()
   }
   kotlinGradle {
     ktfmt().googleStyle()

--- a/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.polaris.core.resource.TimedApi;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * Wrapper around the Micrometer {@link MeterRegistry} providing additional metric management
@@ -46,8 +47,8 @@ public class PolarisMetricRegistry {
   private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
   private static final String TAG_REALM = "REALM_ID";
   private static final String TAG_RESP_CODE = "HTTP_RESPONSE_CODE";
-  private static final String SUFFIX_COUNTER = ".count";
-  private static final String SUFFIX_ERROR = ".error";
+  public static final String SUFFIX_COUNTER = ".count";
+  public static final String SUFFIX_ERROR = ".error";
   private static final String SUFFIX_REALM = ".realm";
 
   public PolarisMetricRegistry(MeterRegistry meterRegistry) {
@@ -61,6 +62,12 @@ public class PolarisMetricRegistry {
 
   public MeterRegistry getMeterRegistry() {
     return meterRegistry;
+  }
+
+  @VisibleForTesting
+  public void clear() {
+    meterRegistry.clear();
+    counters.clear();
   }
 
   public void init(Class<?>... classes) {

--- a/polaris-service/src/main/java/org/apache/polaris/service/TimedApplicationEventListener.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/TimedApplicationEventListener.java
@@ -30,6 +30,7 @@ import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * An ApplicationEventListener that supports timing and error counting of Jersey resource methods
@@ -39,14 +40,19 @@ import org.glassfish.jersey.server.monitoring.RequestEventListener;
 @Provider
 public class TimedApplicationEventListener implements ApplicationEventListener {
 
-  private static final String METRIC_NAME = "polaris.TimedApi";
-  private static final String TAG_API_NAME = "API_NAME";
+  public static final String METRIC_NAME = "polaris.TimedApi";
+  public static final String TAG_API_NAME = "API_NAME";
 
   // The PolarisMetricRegistry instance used for recording metrics and error counters.
   private final PolarisMetricRegistry polarisMetricRegistry;
 
   public TimedApplicationEventListener(PolarisMetricRegistry polarisMetricRegistry) {
     this.polarisMetricRegistry = polarisMetricRegistry;
+  }
+
+  @VisibleForTesting
+  public PolarisMetricRegistry getMetricRegistry() {
+    return polarisMetricRegistry;
   }
 
   @Override

--- a/polaris-service/src/main/java/org/apache/polaris/service/TimedApplicationEventListener.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/TimedApplicationEventListener.java
@@ -18,9 +18,12 @@
  */
 package org.apache.polaris.service;
 
+import static org.apache.polaris.core.monitor.PolarisMetricRegistry.TAG_RESP_CODE;
+
 import com.google.common.base.Stopwatch;
 import io.micrometer.core.instrument.Tag;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.ext.Provider;
 import org.apache.polaris.core.context.CallContext;
@@ -44,9 +47,9 @@ public class TimedApplicationEventListener implements ApplicationEventListener {
    * Each API will increment a common counter (SINGLETON_METRIC_NAME) but have its API name tagged
    * (TAG_API_NAME).
    */
-  public static final String SINGLETON_METRIC_NAME = "polaris.TimedApi";
+  public static final String SINGLETON_METRIC_NAME = "polaris.api";
 
-  public static final String TAG_API_NAME = "API_NAME";
+  public static final String TAG_API_NAME = "api_name";
 
   // The PolarisMetricRegistry instance used for recording metrics and error counters.
   private final PolarisMetricRegistry polarisMetricRegistry;
@@ -105,7 +108,10 @@ public class TimedApplicationEventListener implements ApplicationEventListener {
           // Increment both the counter with the API name in the metric name and a common metric
           polarisMetricRegistry.incrementErrorCounter(metric, statusCode, realmId);
           polarisMetricRegistry.incrementErrorCounter(
-              SINGLETON_METRIC_NAME, realmId, Tag.of(TAG_API_NAME, metric));
+              SINGLETON_METRIC_NAME,
+              realmId,
+              List.of(
+                  Tag.of(TAG_API_NAME, metric), Tag.of(TAG_RESP_CODE, String.valueOf(statusCode))));
         }
       }
     }

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -140,7 +140,9 @@ public class TimedApplicationEventListenerTest {
     return TestMetricsUtil.getTotalCounter(
         EXT,
         API_ANNOTATION + SUFFIX_COUNTER + SUFFIX_REALM,
+        // spotless:off
         List.of(Tag.of(TAG_REALM, realm), Tag.of(TAG_REALM_DEPRECATED, realm)));
+        // spotless:on
   }
 
   private double getPerApiMetricErrorCount() {
@@ -149,7 +151,9 @@ public class TimedApplicationEventListenerTest {
         API_ANNOTATION + SUFFIX_ERROR,
         List.of(
             Tag.of(TAG_RESP_CODE, String.valueOf(ERROR_CODE)),
+            // spotless:off
             Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
+            // spotless:on
   }
 
   private double getPerApiRealmMetricErrorCount() {
@@ -158,9 +162,11 @@ public class TimedApplicationEventListenerTest {
         API_ANNOTATION + SUFFIX_ERROR + SUFFIX_REALM,
         List.of(
             Tag.of(TAG_REALM, realm),
-            Tag.of(TAG_REALM_DEPRECATED, realm),
             Tag.of(TAG_RESP_CODE, String.valueOf(ERROR_CODE)),
+            // spotless:off
+            Tag.of(TAG_REALM_DEPRECATED, realm),
             Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
+            // spotless:on
   }
 
   private double getCommonMetricCount() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -20,7 +20,7 @@ package org.apache.polaris.service;
 
 import static org.apache.polaris.core.monitor.PolarisMetricRegistry.SUFFIX_COUNTER;
 import static org.apache.polaris.core.monitor.PolarisMetricRegistry.SUFFIX_ERROR;
-import static org.apache.polaris.service.TimedApplicationEventListener.METRIC_NAME;
+import static org.apache.polaris.service.TimedApplicationEventListener.SINGLETON_METRIC_NAME;
 import static org.apache.polaris.service.TimedApplicationEventListener.TAG_API_NAME;
 import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
 
@@ -135,14 +135,14 @@ public class TimedApplicationEventListenerTest {
   private double getCommonMetricCount() {
     return TestMetricsUtil.getTotalCounter(
         EXT,
-        METRIC_NAME + SUFFIX_COUNTER,
+        SINGLETON_METRIC_NAME + SUFFIX_COUNTER,
         Collections.singleton(Tag.of(TAG_API_NAME, API_ANNOTATION)));
   }
 
   private double getCommonMetricErrorCount() {
     return TestMetricsUtil.getTotalCounter(
         EXT,
-        METRIC_NAME + SUFFIX_ERROR,
+        SINGLETON_METRIC_NAME + SUFFIX_ERROR,
         Collections.singleton(Tag.of(TAG_API_NAME, API_ANNOTATION)));
   }
 

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service;
+
+import static org.apache.polaris.core.monitor.PolarisMetricRegistry.SUFFIX_COUNTER;
+import static org.apache.polaris.core.monitor.PolarisMetricRegistry.SUFFIX_ERROR;
+import static org.apache.polaris.service.TimedApplicationEventListener.METRIC_NAME;
+import static org.apache.polaris.service.TimedApplicationEventListener.TAG_API_NAME;
+import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.micrometer.core.instrument.Tag;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.polaris.core.monitor.PolarisMetricRegistry;
+import org.apache.polaris.core.resource.TimedApi;
+import org.apache.polaris.service.admin.api.PolarisPrincipalsApi;
+import org.apache.polaris.service.config.PolarisApplicationConfig;
+import org.apache.polaris.service.test.PolarisConnectionExtension;
+import org.apache.polaris.service.test.PolarisRealm;
+import org.apache.polaris.service.test.SnowmanCredentialsExtension;
+import org.apache.polaris.service.test.TestEnvironmentExtension;
+import org.apache.polaris.service.test.TestMetricsUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({
+  DropwizardExtensionsSupport.class,
+  TestEnvironmentExtension.class,
+  PolarisConnectionExtension.class,
+  SnowmanCredentialsExtension.class
+})
+public class TimedApplicationEventListenerTest {
+  private static final DropwizardAppExtension<PolarisApplicationConfig> EXT =
+      new DropwizardAppExtension<>(
+          PolarisApplication.class,
+          ResourceHelpers.resourceFilePath("polaris-server-integrationtest.yml"),
+          ConfigOverride.config(
+              "server.applicationConnectors[0].port",
+              "0"), // Bind to random port to support parallelism
+          ConfigOverride.config(
+              "server.adminConnectors[0].port", "0")); // Bind to random port to support parallelism
+
+  private static final String ENDPOINT = "api/management/v1/principals";
+  private static final String API_ANNOTATION =
+      Arrays.stream(PolarisPrincipalsApi.class.getMethods())
+          .filter(m -> m.getName().contains("getPrincipal"))
+          .findFirst()
+          .orElseThrow()
+          .getAnnotation(TimedApi.class)
+          .value();
+
+  private static PolarisConnectionExtension.PolarisToken userToken;
+  private static String realm;
+
+  @BeforeAll
+  public static void setup(
+      PolarisConnectionExtension.PolarisToken userToken, @PolarisRealm String realm)
+      throws IOException {
+    TimedApplicationEventListenerTest.userToken = userToken;
+    TimedApplicationEventListenerTest.realm = realm;
+  }
+
+  @BeforeEach
+  public void clearMetrics() {
+    getPolarisMetricRegistry().clear();
+  }
+
+  @Test
+  public void testMetricsEmittedOnSuccessfulRequest() {
+    sendSuccessfulRequest();
+    Assertions.assertTrue(getPerApiMetricCount() > 0);
+    Assertions.assertTrue(getCommonMetricCount() > 0);
+    Assertions.assertEquals(0, getPerApiMetricErrorCount());
+    Assertions.assertEquals(0, getCommonMetricErrorCount());
+  }
+
+  @Test
+  public void testMetricsEmittedOnFailedRequest() {
+    sendFailingRequest();
+    Assertions.assertTrue(getPerApiMetricCount() > 0);
+    Assertions.assertTrue(getCommonMetricCount() > 0);
+    Assertions.assertTrue(getPerApiMetricErrorCount() > 0);
+    Assertions.assertTrue(getCommonMetricErrorCount() > 0);
+  }
+
+  private PolarisMetricRegistry getPolarisMetricRegistry() {
+    TimedApplicationEventListener listener =
+        (TimedApplicationEventListener)
+            EXT.getEnvironment().jersey().getResourceConfig().getSingletons().stream()
+                .filter(
+                    s ->
+                        TimedApplicationEventListener.class
+                            .getName()
+                            .equals(s.getClass().getName()))
+                .findAny()
+                .orElseThrow();
+    return listener.getMetricRegistry();
+  }
+
+  private double getPerApiMetricCount() {
+    return TestMetricsUtil.getTotalCounter(
+        EXT, API_ANNOTATION + SUFFIX_COUNTER, Collections.emptyList());
+  }
+
+  private double getPerApiMetricErrorCount() {
+    return TestMetricsUtil.getTotalCounter(
+        EXT, API_ANNOTATION + SUFFIX_ERROR, Collections.emptyList());
+  }
+
+  private double getCommonMetricCount() {
+    return TestMetricsUtil.getTotalCounter(
+        EXT,
+        METRIC_NAME + SUFFIX_COUNTER,
+        Collections.singleton(Tag.of(TAG_API_NAME, API_ANNOTATION)));
+  }
+
+  private double getCommonMetricErrorCount() {
+    return TestMetricsUtil.getTotalCounter(
+        EXT,
+        METRIC_NAME + SUFFIX_ERROR,
+        Collections.singleton(Tag.of(TAG_API_NAME, API_ANNOTATION)));
+  }
+
+  private int sendRequest(String principalName) {
+    try (Response response =
+        EXT.client()
+            .target(
+                String.format(
+                    "http://localhost:%d/%s/%s", EXT.getLocalPort(), ENDPOINT, principalName))
+            .request("application/json")
+            .header("Authorization", "Bearer " + userToken.token())
+            .header(REALM_PROPERTY_KEY, realm)
+            .get()) {
+      return response.getStatus();
+    }
+  }
+
+  private void sendSuccessfulRequest() {
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), sendRequest("snowman"));
+  }
+
+  private void sendFailingRequest() {
+    Assertions.assertNotEquals(
+        Response.Status.NOT_FOUND.getStatusCode(), sendRequest("notarealprincipal"));
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -76,13 +76,17 @@ public class TimedApplicationEventListenerTest {
           .value();
 
   private static PolarisConnectionExtension.PolarisToken userToken;
+  private static SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials;
   private static String realm;
 
   @BeforeAll
   public static void setup(
-      PolarisConnectionExtension.PolarisToken userToken, @PolarisRealm String realm)
+      PolarisConnectionExtension.PolarisToken userToken,
+      SnowmanCredentialsExtension.SnowmanCredentials snowmanCredentials,
+      @PolarisRealm String realm)
       throws IOException {
     TimedApplicationEventListenerTest.userToken = userToken;
+    TimedApplicationEventListenerTest.snowmanCredentials = snowmanCredentials;
     TimedApplicationEventListenerTest.realm = realm;
   }
 
@@ -219,7 +223,9 @@ public class TimedApplicationEventListenerTest {
   }
 
   private void sendSuccessfulRequest() {
-    Assertions.assertEquals(Response.Status.OK.getStatusCode(), sendRequest("snowman"));
+    Assertions.assertEquals(
+        Response.Status.OK.getStatusCode(),
+        sendRequest(snowmanCredentials.identifier().principalName()));
   }
 
   private void sendFailingRequest() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -140,9 +140,11 @@ public class TimedApplicationEventListenerTest {
     return TestMetricsUtil.getTotalCounter(
         EXT,
         API_ANNOTATION + SUFFIX_COUNTER + SUFFIX_REALM,
-        // spotless:off
-        List.of(Tag.of(TAG_REALM, realm), Tag.of(TAG_REALM_DEPRECATED, realm)));
-        // spotless:on
+        List.of(
+            Tag.of(TAG_REALM, realm),
+            // spotless:off
+            Tag.of(TAG_REALM_DEPRECATED, realm)));
+            // spotless:on
   }
 
   private double getPerApiMetricErrorCount() {

--- a/polaris-service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
@@ -18,15 +18,19 @@
  */
 package org.apache.polaris.service.ratelimiter;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.polaris.core.monitor.PolarisMetricRegistry.*;
+import static org.apache.polaris.service.TimedApplicationEventListener.SINGLETON_METRIC_NAME;
+import static org.apache.polaris.service.TimedApplicationEventListener.TAG_API_NAME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.micrometer.core.instrument.Tag;
 import jakarta.ws.rs.core.Response;
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Consumer;
 import org.apache.polaris.service.PolarisApplication;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
@@ -34,6 +38,7 @@ import org.apache.polaris.service.test.PolarisConnectionExtension;
 import org.apache.polaris.service.test.PolarisRealm;
 import org.apache.polaris.service.test.SnowmanCredentialsExtension;
 import org.apache.polaris.service.test.TestEnvironmentExtension;
+import org.apache.polaris.service.test.TestMetricsUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,24 +114,14 @@ public class RateLimiterFilterTest {
     requestAsserter.accept(Response.Status.TOO_MANY_REQUESTS);
 
     assertTrue(
-        getCounter(
-                "polaris_principal_roles_listPrincipalRoles_error_total{HTTP_RESPONSE_CODE=\"429\"}")
+        TestMetricsUtil.getTotalCounter(
+                EXT,
+                SINGLETON_METRIC_NAME + SUFFIX_ERROR,
+                List.of(
+                    Tag.of(TAG_API_NAME, "polaris.principal-roles.listPrincipalRoles"),
+                    Tag.of(
+                        TAG_RESP_CODE,
+                        String.valueOf(Response.Status.TOO_MANY_REQUESTS.getStatusCode()))))
             > 0);
-  }
-
-  private double getCounter(String metricName) {
-    Response response =
-        EXT.client()
-            .target(String.format("http://localhost:%d/metrics", EXT.getAdminPort()))
-            .request()
-            .get();
-    assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
-    String[] responseLines = response.readEntity(String.class).split("\n");
-    for (String line : responseLines) {
-      if (line.startsWith(metricName)) {
-        return Double.parseDouble(line.split(" ")[1]);
-      }
-    }
-    return 0;
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.Tag;
 import jakarta.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 
 /** Utils for working with metrics in tests */
@@ -56,7 +57,12 @@ public class TestMetricsUtil {
     assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
     String[] responseLines = response.readEntity(String.class).split("\n");
     for (String line : responseLines) {
-      if (line.startsWith(metricName) && tagFilters.stream().allMatch(line::contains)) {
+      System.out.println("ANDREW line: " + line);
+      int numTags =
+          StringUtils.countMatches(line, '='); // Assumes the tag values don't contain an '='
+      if (line.startsWith(metricName)
+          && tagFilters.stream().allMatch(line::contains)
+          && numTags == tagFilters.size()) {
         return Double.parseDouble(line.split(" ")[1]);
       }
     }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
@@ -29,11 +29,11 @@ import org.apache.polaris.service.config.PolarisApplicationConfig;
 
 /** Utils for working with metrics in tests */
 public class TestMetricsUtil {
-  public static final String SUFFIX_TOTAL = ".total";
+  private static final String SUFFIX_TOTAL = ".total";
 
-  /** Gets a counter by calling the Prometheus metrics endpoint */
+  /** Gets a total counter by calling the Prometheus metrics endpoint */
   public static double getTotalCounter(
-      DropwizardAppExtension<PolarisApplicationConfig> EXT,
+      DropwizardAppExtension<PolarisApplicationConfig> dropwizardAppExtension,
       String metricName,
       Collection<Tag> tags) {
 
@@ -47,8 +47,10 @@ public class TestMetricsUtil {
         tags.stream().map(tag -> String.format("%s=\"%s\"", tag.getKey(), tag.getValue())).toList();
 
     Response response =
-        EXT.client()
-            .target(String.format("http://localhost:%d/metrics", EXT.getAdminPort()))
+        dropwizardAppExtension
+            .client()
+            .target(
+                String.format("http://localhost:%d/metrics", dropwizardAppExtension.getAdminPort()))
             .request()
             .get();
     assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.micrometer.core.instrument.Tag;
+import jakarta.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.List;
+import org.apache.polaris.service.config.PolarisApplicationConfig;
+
+/** Utils for working with metrics in tests */
+public class TestMetricsUtil {
+  public static final String SUFFIX_TOTAL = ".total";
+
+  /** Gets a counter by calling the Prometheus metrics endpoint */
+  public static double getTotalCounter(
+      DropwizardAppExtension<PolarisApplicationConfig> EXT,
+      String metricName,
+      Collection<Tag> tags) {
+
+    metricName += SUFFIX_TOTAL;
+    metricName = metricName.replace('.', '_').replace('-', '_');
+
+    // Example of a line from the metrics endpoint:
+    // polaris_TimedApi_count_realm_total{API_NAME="polaris.principals.getPrincipal",REALM_ID="org_apache_polaris_service_TimedApplicationEventListenerTest"} 1.0
+    // This method assumes that tag ordering isn't guaranteed
+    List<String> tagFilters =
+        tags.stream().map(tag -> String.format("%s=\"%s\"", tag.getKey(), tag.getValue())).toList();
+
+    Response response =
+        EXT.client()
+            .target(String.format("http://localhost:%d/metrics", EXT.getAdminPort()))
+            .request()
+            .get();
+    assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+    String[] responseLines = response.readEntity(String.class).split("\n");
+    for (String line : responseLines) {
+      if (line.startsWith(metricName) && tagFilters.stream().allMatch(line::contains)) {
+        return Double.parseDouble(line.split(" ")[1]);
+      }
+    }
+    return 0;
+  }
+}

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestMetricsUtil.java
@@ -57,7 +57,6 @@ public class TestMetricsUtil {
     assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
     String[] responseLines = response.readEntity(String.class).split("\n");
     for (String line : responseLines) {
-      System.out.println("ANDREW line: " + line);
       int numTags =
           StringUtils.countMatches(line, '='); // Assumes the tag values don't contain an '='
       if (line.startsWith(metricName)


### PR DESCRIPTION
# Description

Currently we emit metrics with the API name in the metric name, for example `polaris.principals.getPrincipal`. This is difficult to query in i.e. Grafana; metric names are not intended to be "dynamic".

This PR adds a new equivalent metric `polaris.TimedApi` with the `API_NAME` tag.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Created a test for TimedApplicationEventListener

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
