### PR TITLE
Fix Azure catalog update in CLI by explicitly adding StorageConfigInfo subtype properties

### DIFF
--- a/regtests/client/python/polaris/management/models/aws_storage_config_info.py
+++ b/regtests/client/python/polaris/management/models/aws_storage_config_info.py
@@ -103,9 +103,13 @@ class AwsStorageConfigInfo(StorageConfigInfo):
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
+        # IMPORTANT: The following may require manual repair to add subtype-specific properties
+        # after using the OpenAPI Generator.
         _obj = cls.model_validate({
             "storageType": obj.get("storageType"),
             "allowedLocations": obj.get("allowedLocations"),
-            "roleArn": obj.get("roleArn")
+            "roleArn": obj.get("roleArn"),
+            "externalId": obj.get("externalId"),
+            "userArn": obj.get("userArn")
         })
         return _obj

--- a/regtests/client/python/polaris/management/models/azure_storage_config_info.py
+++ b/regtests/client/python/polaris/management/models/azure_storage_config_info.py
@@ -100,9 +100,14 @@ class AzureStorageConfigInfo(StorageConfigInfo):
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
+        # IMPORTANT: The following may require manual repair to add subtype-specific properties
+        # after using the OpenAPI Generator.
         _obj = cls.model_validate({
             "storageType": obj.get("storageType"),
-            "allowedLocations": obj.get("allowedLocations")
+            "allowedLocations": obj.get("allowedLocations"),
+            "tenantId": obj.get("tenantId"),
+            "multiTenantAppName": obj.get("multiTenantAppName"),
+            "consentUrl": obj.get("consentUrl")
         })
         return _obj
 

--- a/regtests/client/python/polaris/management/models/gcp_storage_config_info.py
+++ b/regtests/client/python/polaris/management/models/gcp_storage_config_info.py
@@ -98,9 +98,12 @@ class GcpStorageConfigInfo(StorageConfigInfo):
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
+        # IMPORTANT: The following may require manual repair to add subtype-specific properties
+        # after using the OpenAPI Generator.
         _obj = cls.model_validate({
             "storageType": obj.get("storageType"),
-            "allowedLocations": obj.get("allowedLocations")
+            "allowedLocations": obj.get("allowedLocations"),
+            "gcsServiceAccount": obj.get("gcsServiceAccount")
         })
         return _obj
 


### PR DESCRIPTION
# Description

Fields like externalId, userArn for AWS, tenantId for Azure, gcsServiceAccount were getting clobbered when parsing a JSON response due to the autogenerated model classes not correctly pulling in subtype properties from the API spec.

This caused types with "required" subfields like Azure's tenantId to completely fail parsing when trying to get or update a catalog.

Less noticeable but also bad was that these subtype properties were effectively invisible.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] t_cli/src/test_cli.py


# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
