### PR TITLE
Setting repositoriesMode back to its default

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -22,7 +22,6 @@ dependencyResolutionManagement {
 }
 
 dependencyResolutionManagement {
-  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
   repositories {
     mavenCentral()
     gradlePluginPortal()


### PR DESCRIPTION
# Description

Addressing #265 by reverting to the default mode of `PREFER_PROJECT`

Fixes #265 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Full build and test


**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [X] I have performed a self-review of my code
