### PR TITLE
Remove dropwizard-jackson dep from core

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/DiscoverableMetaStoreManagerFactory.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/DiscoverableMetaStoreManagerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.extension.persistence.impl.eclipselink;
+
+import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+
+/**
+ * Discoverability aid for Dropwizard. Leaf classes cannot implement {@link Discoverable} directly,
+ * they have to implement another interface, which implements {@link Discoverable}.
+ *
+ * @see DiscoverableSubtypeResolver
+ */
+public interface DiscoverableMetaStoreManagerFactory extends Discoverable {}

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -34,7 +34,8 @@ import org.jetbrains.annotations.NotNull;
  */
 @JsonTypeName("eclipse-link")
 public class EclipseLinkPolarisMetaStoreManagerFactory
-    extends LocalPolarisMetaStoreManagerFactory<PolarisEclipseLinkStore> {
+    extends LocalPolarisMetaStoreManagerFactory<PolarisEclipseLinkStore>
+    implements DiscoverableMetaStoreManagerFactory {
   @JsonProperty("conf-file")
   private String confFile;
 

--- a/extension/persistence/eclipselink/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/extension/persistence/eclipselink/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -17,5 +17,4 @@
 # under the License.
 #
 
-org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory
-org.apache.polaris.extension.persistence.impl.eclipselink.EclipseLinkPolarisMetaStoreManagerFactory
+org.apache.polaris.extension.persistence.impl.eclipselink.DiscoverableMetaStoreManagerFactory

--- a/extension/persistence/eclipselink/src/main/resources/META-INF/services/org.apache.polaris.extension.persistence.impl.eclipselink.DiscoverableMetaStoreManagerFactory
+++ b/extension/persistence/eclipselink/src/main/resources/META-INF/services/org.apache.polaris.extension.persistence.impl.eclipselink.DiscoverableMetaStoreManagerFactory
@@ -17,11 +17,4 @@
 # under the License.
 #
 
-org.apache.polaris.service.auth.DiscoverableAuthenticator
-org.apache.polaris.service.persistence.DiscoverableMetaStoreManagerFactory
-org.apache.polaris.service.config.OAuth2ApiService
-org.apache.polaris.service.context.RealmContextResolver
-org.apache.polaris.service.context.CallContextResolver
-org.apache.polaris.service.auth.TokenBrokerFactory
-org.apache.polaris.service.catalog.io.FileIOFactory
-org.apache.polaris.service.ratelimiter.RateLimiter
+org.apache.polaris.extension.persistence.impl.eclipselink.EclipseLinkPolarisMetaStoreManagerFactory

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -33,10 +33,6 @@ dependencies {
   constraints {
     implementation("io.airlift:aircompressor:0.27") { because("Vulnerability detected in 0.25") }
   }
-  // TODO - this is only here for the Discoverable interface
-  // We should use a different mechanism to discover the plugin implementations
-  implementation(platform(libs.dropwizard.bom))
-  implementation("io.dropwizard:dropwizard-jackson")
 
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-annotations")

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.core.persistence;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.dropwizard.jackson.Discoverable;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -33,7 +32,7 @@ import org.apache.polaris.core.storage.cache.StorageCredentialCache;
  * configuration
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public interface MetaStoreManagerFactory extends Discoverable {
+public interface MetaStoreManagerFactory {
 
   PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmContext realmContext);
 

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -119,7 +119,7 @@ dependencies {
   testImplementation(libs.mockito.core)
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-  testRuntimeOnly(project(":polaris-eclipselink"))
+  testImplementation(project(":polaris-eclipselink"))
 }
 
 if (project.properties.get("eclipseLink") == "true") {

--- a/polaris-service/src/main/java/org/apache/polaris/service/persistence/DiscoverableMetaStoreManagerFactory.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/persistence/DiscoverableMetaStoreManagerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.persistence;
+
+import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+
+/**
+ * Discoverability aid for Dropwizard. Leaf classes cannot implement {@link Discoverable} directly,
+ * they have to implement another interface, which implements {@link Discoverable}.
+ *
+ * @see DiscoverableSubtypeResolver
+ */
+public interface DiscoverableMetaStoreManagerFactory extends Discoverable {}

--- a/polaris-service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -35,7 +35,8 @@ import org.jetbrains.annotations.NotNull;
 
 @JsonTypeName("in-memory")
 public class InMemoryPolarisMetaStoreManagerFactory
-    extends LocalPolarisMetaStoreManagerFactory<PolarisTreeMapStore> {
+    extends LocalPolarisMetaStoreManagerFactory<PolarisTreeMapStore>
+    implements DiscoverableMetaStoreManagerFactory {
   final Set<String> bootstrappedRealms = new HashSet<>();
 
   @Override

--- a/polaris-service/src/main/resources/META-INF/services/org.apache.polaris.service.persistence.DiscoverableMetaStoreManagerFactory
+++ b/polaris-service/src/main/resources/META-INF/services/org.apache.polaris.service.persistence.DiscoverableMetaStoreManagerFactory
@@ -17,11 +17,4 @@
 # under the License.
 #
 
-org.apache.polaris.service.auth.DiscoverableAuthenticator
-org.apache.polaris.service.persistence.DiscoverableMetaStoreManagerFactory
-org.apache.polaris.service.config.OAuth2ApiService
-org.apache.polaris.service.context.RealmContextResolver
-org.apache.polaris.service.context.CallContextResolver
-org.apache.polaris.service.auth.TokenBrokerFactory
-org.apache.polaris.service.catalog.io.FileIOFactory
-org.apache.polaris.service.ratelimiter.RateLimiter
+org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationConfigurationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationConfigurationTest.java
@@ -24,6 +24,7 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.apache.polaris.extension.persistence.impl.eclipselink.EclipseLinkPolarisMetaStoreManagerFactory;
 import org.apache.polaris.service.config.PolarisApplicationConfig;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.junit.jupiter.api.Nested;
@@ -62,14 +63,16 @@ public class PolarisApplicationConfigurationTest {
             CONFIG_PATH,
             RANDOM_APP_PORT,
             RANDOM_ADMIN_PORT,
-            ConfigOverride.config("metaStoreManager.type", "eclipse-link"));
+            ConfigOverride.config("metaStoreManager.type", "eclipse-link"),
+            ConfigOverride.config("metaStoreManager.persistence-unit", "test-unit"),
+            ConfigOverride.config("metaStoreManager.conf-file", "/test-conf-file"));
 
     @Test
     void testMetastoreType() {
       assertThat(app.getConfiguration().getMetaStoreManagerFactory())
-          .extracting(Object::getClass)
-          .extracting(Class::getSimpleName)
-          .isEqualTo("EclipseLinkPolarisMetaStoreManagerFactory");
+          .isInstanceOf(EclipseLinkPolarisMetaStoreManagerFactory.class)
+          .extracting("persistenceUnitName", "confFile")
+          .containsExactly("test-unit", "/test-conf-file");
     }
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationConfigurationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.apache.polaris.service.config.PolarisApplicationConfig;
+import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class PolarisApplicationConfigurationTest {
+
+  public static final String CONFIG_PATH =
+      ResourceHelpers.resourceFilePath("polaris-server-integrationtest.yml");
+  // Bind to random ports to support parallelism
+  public static final ConfigOverride RANDOM_APP_PORT =
+      ConfigOverride.config("server.applicationConnectors[0].port", "0");
+  public static final ConfigOverride RANDOM_ADMIN_PORT =
+      ConfigOverride.config("server.adminConnectors[0].port", "0");
+
+  @Nested
+  class DefaultMetastore {
+    private final DropwizardAppExtension<PolarisApplicationConfig> app =
+        new DropwizardAppExtension<>(
+            PolarisApplication.class, CONFIG_PATH, RANDOM_APP_PORT, RANDOM_ADMIN_PORT);
+
+    @Test
+    void testMetastoreType() {
+      assertThat(app.getConfiguration().getMetaStoreManagerFactory())
+          .isInstanceOf(InMemoryPolarisMetaStoreManagerFactory.class);
+    }
+  }
+
+  @Nested
+  class EclipseLinkMetastore {
+    private final DropwizardAppExtension<PolarisApplicationConfig> app =
+        new DropwizardAppExtension<>(
+            PolarisApplication.class,
+            CONFIG_PATH,
+            RANDOM_APP_PORT,
+            RANDOM_ADMIN_PORT,
+            ConfigOverride.config("metaStoreManager.type", "eclipse-link"));
+
+    @Test
+    void testMetastoreType() {
+      assertThat(app.getConfiguration().getMetaStoreManagerFactory())
+          .extracting(Object::getClass)
+          .extracting(Class::getSimpleName)
+          .isEqualTo("EclipseLinkPolarisMetaStoreManagerFactory");
+    }
+  }
+}


### PR DESCRIPTION
This is a simplification / cleanup. The dependency does not appear to be required in `polaris-core`

### How Has This Been Tested?

Manual `bootstrap` execution with EclipseLink and PostgreSQL.