### PR TITLE
Add unique ID to TestEnvironment

### DIFF
--- a/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -156,8 +156,8 @@ public class PolarisApplicationIntegrationTest {
         EXT.client()
             .target(
                 String.format(
-                    "http://localhost:%d/api/management/v1/principals/snowman/principal-roles",
-                    EXT.getLocalPort()))
+                    "http://localhost:%d/api/management/v1/principals/%s/principal-roles",
+                    EXT.getLocalPort(), snowmanCredentials.identifier().principalName()))
             .request("application/json")
             .header("Authorization", "Bearer " + PolarisApplicationIntegrationTest.userToken)
             .header(REALM_PROPERTY_KEY, realm)

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -93,7 +93,7 @@ public abstract class PolarisRestCatalogViewIntegrationTest extends ViewCatalogT
         .getTestMethod()
         .ifPresent(
             method -> {
-              String catalogName = method.getName();
+              String catalogName = method.getName() + testEnv.uniqueId();
               try (Response response =
                   testEnv
                       .apiClient()

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -93,7 +93,7 @@ public abstract class PolarisRestCatalogViewIntegrationTest extends ViewCatalogT
         .getTestMethod()
         .ifPresent(
             method -> {
-              String catalogName = method.getName() + testEnv.uniqueId();
+              String catalogName = method.getName() + testEnv.testId();
               try (Response response =
                   testEnv
                       .apiClient()

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
@@ -146,8 +146,10 @@ public class TestUtil {
           client
               .target(
                   String.format(
-                      "%s/api/management/v1/principal-roles/catalog-admin/catalog-roles/%s",
-                      baseUrl, currentCatalogName))
+                      "%s/api/management/v1/principal-roles/%s/catalog-roles/%s",
+                      baseUrl,
+                      snowmanCredentials.identifier().principalRoleName(),
+                      currentCatalogName))
               .request("application/json")
               .header("Authorization", "Bearer " + adminToken.token())
               .header(REALM_PROPERTY_KEY, realm)

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
@@ -46,7 +46,10 @@ public class SnowmanCredentialsExtension
   private static final Logger LOGGER = LoggerFactory.getLogger(SnowmanCredentialsExtension.class);
   private SnowmanCredentials snowmanCredentials;
 
-  public record SnowmanCredentials(String clientId, String clientSecret) {}
+  public record SnowmanIdentifier(String principalName, String principalRoleName) {}
+
+  public record SnowmanCredentials(
+      String clientId, String clientSecret, SnowmanIdentifier identifier) {}
 
   @Override
   public void beforeAll(ExtensionContext extensionContext) throws Exception {
@@ -73,7 +76,8 @@ public class SnowmanCredentialsExtension
             adminSecrets.getMainSecret(),
             realm);
 
-    PrincipalRole principalRole = new PrincipalRole("catalog-admin");
+    SnowmanIdentifier snowmanIdentifier = getSnowmanIdentifier(testEnv);
+    PrincipalRole principalRole = new PrincipalRole(snowmanIdentifier.principalRoleName());
     try (Response createPrResponse =
         testEnv
             .apiClient()
@@ -86,7 +90,7 @@ public class SnowmanCredentialsExtension
           .returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
     }
 
-    Principal principal = new Principal("snowman");
+    Principal principal = new Principal(snowmanIdentifier.principalName);
 
     try (Response createPResponse =
         testEnv
@@ -105,7 +109,8 @@ public class SnowmanCredentialsExtension
               .apiClient()
               .target(
                   String.format(
-                      "%s/api/management/v1/principals/%s/rotate", testEnv.baseUri(), "snowman"))
+                      "%s/api/management/v1/principals/%s/rotate",
+                      testEnv.baseUri(), principal.getName()))
               .request(MediaType.APPLICATION_JSON)
               .header(
                   "Authorization",
@@ -127,14 +132,16 @@ public class SnowmanCredentialsExtension
       snowmanCredentials =
           new SnowmanCredentials(
               snowmanWithCredentials.getCredentials().getClientId(),
-              snowmanWithCredentials.getCredentials().getClientSecret());
+              snowmanWithCredentials.getCredentials().getClientSecret(),
+              snowmanIdentifier);
     }
     try (Response assignPrResponse =
         testEnv
             .apiClient()
             .target(
                 String.format(
-                    "%s/api/management/v1/principals/snowman/principal-roles", testEnv.baseUri()))
+                    "%s/api/management/v1/principals/%s/principal-roles",
+                    testEnv.baseUri(), principal.getName()))
             .request("application/json")
             .header("Authorization", "Bearer " + userToken) // how is token getting used?
             .header(REALM_PROPERTY_KEY, realm)
@@ -169,11 +176,13 @@ public class SnowmanCredentialsExtension
             adminSecrets.getMainSecret(),
             realm);
 
+    SnowmanIdentifier snowmanIdentifier = getSnowmanIdentifier(testEnv);
     testEnv
         .apiClient()
         .target(
             String.format(
-                "%s/api/management/v1/principal-roles/%s", testEnv.baseUri(), "catalog-admin"))
+                "%s/api/management/v1/principal-roles/%s",
+                testEnv.baseUri(), snowmanIdentifier.principalRoleName()))
         .request("application/json")
         .header("Authorization", "Bearer " + userToken)
         .header(REALM_PROPERTY_KEY, realm)
@@ -182,7 +191,10 @@ public class SnowmanCredentialsExtension
 
     testEnv
         .apiClient()
-        .target(String.format("%s/api/management/v1/principals/%s", testEnv.baseUri(), "snowman"))
+        .target(
+            String.format(
+                "%s/api/management/v1/principals/%s",
+                testEnv.baseUri(), snowmanIdentifier.principalName()))
         .request("application/json")
         .header("Authorization", "Bearer " + userToken)
         .header(REALM_PROPERTY_KEY, realm)
@@ -207,5 +219,10 @@ public class SnowmanCredentialsExtension
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
     return snowmanCredentials;
+  }
+
+  private static SnowmanIdentifier getSnowmanIdentifier(TestEnvironment testEnv) {
+    return new SnowmanIdentifier(
+        "snowman" + testEnv.uniqueId(), "catalog-admin" + testEnv.uniqueId());
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
@@ -90,7 +90,7 @@ public class SnowmanCredentialsExtension
           .returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
     }
 
-    Principal principal = new Principal(snowmanIdentifier.principalName);
+    Principal principal = new Principal(snowmanIdentifier.principalName());
 
     try (Response createPResponse =
         testEnv

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
@@ -222,7 +222,6 @@ public class SnowmanCredentialsExtension
   }
 
   private static SnowmanIdentifier getSnowmanIdentifier(TestEnvironment testEnv) {
-    return new SnowmanIdentifier(
-        "snowman" + testEnv.uniqueId(), "catalog-admin" + testEnv.uniqueId());
+    return new SnowmanIdentifier("snowman" + testEnv.testId(), "catalog-admin" + testEnv.testId());
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironment.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironment.java
@@ -20,10 +20,18 @@ package org.apache.polaris.service.test;
 
 import jakarta.ws.rs.client.Client;
 import java.net.URI;
+import java.util.UUID;
 
-/** Defines the test environment that a test should run in. */
-public record TestEnvironment(Client apiClient, URI baseUri) {
+/**
+ * Defines the test environment that a test should run in.
+ *
+ * @param apiClient The HTTP client to use when making requests
+ * @param baseUri The base URL that requests should target, for example http://localhost:1234
+ * @param uniqueId An ID unique to this test. This can be used to prefix resource names, such as
+ *     catalog names, to prevent collision.
+ */
+public record TestEnvironment(Client apiClient, URI baseUri, String uniqueId) {
   public TestEnvironment(Client apiClient, String baseUri) {
-    this(apiClient, URI.create(baseUri));
+    this(apiClient, URI.create(baseUri), UUID.randomUUID().toString().replace("-", ""));
   }
 }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironment.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironment.java
@@ -27,10 +27,10 @@ import java.util.UUID;
  *
  * @param apiClient The HTTP client to use when making requests
  * @param baseUri The base URL that requests should target, for example http://localhost:1234
- * @param uniqueId An ID unique to this test. This can be used to prefix resource names, such as
+ * @param testId An ID unique to this test. This can be used to prefix resource names, such as
  *     catalog names, to prevent collision.
  */
-public record TestEnvironment(Client apiClient, URI baseUri, String uniqueId) {
+public record TestEnvironment(Client apiClient, URI baseUri, String testId) {
   public TestEnvironment(Client apiClient, String baseUri) {
     this(apiClient, URI.create(baseUri), UUID.randomUUID().toString().replace("-", ""));
   }

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironmentExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironmentExtension.java
@@ -41,6 +41,7 @@ public class TestEnvironmentExtension implements ParameterResolver {
 
   public static TestEnvironment getEnv(ExtensionContext extensionContext)
       throws IllegalAccessException {
+    // This must be cached because the TestEnvironment has a randomly generated ID
     return extensionContext
         .getStore(ExtensionContext.Namespace.create(extensionContext.getRequiredTestClass()))
         .getOrComputeIfAbsent(

--- a/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironmentExtension.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/test/TestEnvironmentExtension.java
@@ -37,9 +37,16 @@ public class TestEnvironmentExtension implements ParameterResolver {
   public static final String ENV_TEST_ENVIRONMENT_RESOLVER_IMPL =
       "INTEGRATION_TEST_ENVIRONMENT_RESOLVER_IMPL";
 
+  private static final String ENV_PROPERTY_KEY = "testenvironment";
+
   public static TestEnvironment getEnv(ExtensionContext extensionContext)
       throws IllegalAccessException {
-    return getTestEnvironmentResolver().resolveTestEnvironment(extensionContext);
+    return extensionContext
+        .getStore(ExtensionContext.Namespace.create(extensionContext.getRequiredTestClass()))
+        .getOrComputeIfAbsent(
+            ENV_PROPERTY_KEY,
+            (k) -> getTestEnvironmentResolver().resolveTestEnvironment(extensionContext),
+            TestEnvironment.class);
   }
 
   @Override


### PR DESCRIPTION
# Description

Adds a unique ID to the TestEnvironment and uses it for the Snowman Principal/PrincipalRole name and the PolarisRestCatalogViewIntegrationTest catalog name. In subsequent PRs we should use the ID in more places to ensure unique resource names, especially when running tests in parallel and/or against an external Polaris deployment.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Existing tests pass
- [X] Manually tested an end-to-end test against an external Polaris deployment with 2 tests running concurrently 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
