### PR TITLE
Fix 403 error message hints

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -2104,16 +2103,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   private static boolean isAccessDenied(String errorMsg) {
     // Corresponding error messages for storage providers Aws/Azure/Gcp
     boolean isAccessDenied =
-        errorMsg != null
-            && (errorMsg
-                    .toLowerCase(Locale.ENGLISH)
-                    .contains(IcebergExceptionMapper.AWS_ACCESS_DENIED_HINT)
-                || errorMsg
-                    .toLowerCase(Locale.ENGLISH)
-                    .contains(IcebergExceptionMapper.AZURE_ACCESS_DENIED_HINT)
-                || errorMsg
-                    .toLowerCase(Locale.ENGLISH)
-                    .contains(IcebergExceptionMapper.GCP_ACCESS_DENIED_HINT));
+        errorMsg != null && IcebergExceptionMapper.containsAnyAccessDeniedHint(errorMsg);
     if (isAccessDenied) {
       LOGGER.debug("Access Denied or Forbidden error: {}", errorMsg);
       return true;

--- a/polaris-service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -20,7 +20,7 @@ package org.apache.polaris.service.exception;
 
 import com.azure.core.exception.AzureException;
 import com.google.cloud.storage.StorageException;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -28,6 +28,7 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Set;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
@@ -62,9 +63,8 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
   // to lack of permissions
   // We may want to consider a change to Iceberg Core to wrap cloud provider IO exceptions to
   // Iceberg ForbiddenException
-  private static final String[] ACCESS_DENIED_HINTS = {
-    "access denied", "not authorized", "forbidden"
-  };
+  private static final Set<String> ACCESS_DENIED_HINTS =
+      Set.of("access denied", "not authorized", "forbidden");
 
   public IcebergExceptionMapper() {}
 
@@ -135,11 +135,11 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
 
   public static boolean containsAnyAccessDeniedHint(String message) {
     String messageLower = message.toLowerCase(Locale.ENGLISH);
-    return Arrays.stream(ACCESS_DENIED_HINTS).anyMatch(messageLower::contains);
+    return ACCESS_DENIED_HINTS.stream().anyMatch(messageLower::contains);
   }
 
   @VisibleForTesting
   public static Collection<String> getAccessDeniedHints() {
-    return ImmutableList.copyOf(ACCESS_DENIED_HINTS);
+    return ImmutableSet.copyOf(ACCESS_DENIED_HINTS);
   }
 }

--- a/polaris-service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -137,6 +138,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
     return Arrays.stream(ACCESS_DENIED_HINTS).anyMatch(messageLower::contains);
   }
 
+  @VisibleForTesting
   public static Collection<String> getAccessDeniedHints() {
     return ImmutableList.copyOf(ACCESS_DENIED_HINTS);
   }

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/BasePolarisCatalogTest.java
@@ -25,11 +25,13 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,6 +90,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.TestFileIOFactory;
+import org.apache.polaris.service.exception.IcebergExceptionMapper;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.apache.polaris.service.task.TableCleanupTaskHandler;
 import org.apache.polaris.service.task.TaskExecutor;
@@ -1449,9 +1452,11 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
 
   @Test
   public void testRetriableException() {
-    RuntimeException s3Exception = new RuntimeException(AWS_ACCESS_DENIED_HINT);
-    RuntimeException azureBlobStorageException = new RuntimeException(AZURE_ACCESS_DENIED_HINT);
-    RuntimeException gcsException = new RuntimeException(GCP_ACCESS_DENIED_HINT);
+    Iterator<String> accessDeniedHint =
+        Iterators.cycle(IcebergExceptionMapper.getAccessDeniedHints());
+    RuntimeException s3Exception = new RuntimeException(accessDeniedHint.next());
+    RuntimeException azureBlobStorageException = new RuntimeException(accessDeniedHint.next());
+    RuntimeException gcsException = new RuntimeException(accessDeniedHint.next());
     RuntimeException otherException = new RuntimeException(new IOException("Connection reset"));
     Assertions.assertThat(BasePolarisCatalog.SHOULD_RETRY_REFRESH_PREDICATE.test(s3Exception))
         .isFalse();

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
@@ -24,11 +24,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.azure.core.exception.AzureException;
 import com.google.cloud.storage.StorageException;
+import com.google.common.collect.Iterators;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,6 +162,8 @@ public class FileIOIntegrationTest {
   }
 
   private static Stream<Arguments> getIOExceptionTypeTestConfigs() {
+    Iterator<String> accessDeniedHint =
+        Iterators.cycle(IcebergExceptionMapper.getAccessDeniedHints());
     List<IOExceptionTypeTestConfig<?>> configs =
         Stream.of(
                 IOExceptionTypeTestConfig.allVariants(
@@ -167,32 +171,32 @@ public class FileIOIntegrationTest {
                     () ->
                         S3Exception.builder()
                             .statusCode(403)
-                            .message(IcebergExceptionMapper.AWS_ACCESS_DENIED_HINT)
+                            .message(accessDeniedHint.next())
                             .build(),
                     FileIOIntegrationTest::workloadCreateTable),
                 IOExceptionTypeTestConfig.allVariants(
                     ForbiddenException.class,
-                    () -> new AzureException(IcebergExceptionMapper.AZURE_ACCESS_DENIED_HINT),
+                    () -> new AzureException(accessDeniedHint.next()),
                     FileIOIntegrationTest::workloadCreateTable),
                 IOExceptionTypeTestConfig.allVariants(
                     ForbiddenException.class,
-                    () -> new StorageException(403, IcebergExceptionMapper.GCP_ACCESS_DENIED_HINT),
+                    () -> new StorageException(403, accessDeniedHint.next()),
                     FileIOIntegrationTest::workloadCreateTable),
                 IOExceptionTypeTestConfig.allVariants(
                     ForbiddenException.class,
                     () ->
                         S3Exception.builder()
                             .statusCode(403)
-                            .message(IcebergExceptionMapper.AWS_ACCESS_DENIED_HINT)
+                            .message(accessDeniedHint.next())
                             .build(),
                     FileIOIntegrationTest::workloadUpdateTableProperties),
                 IOExceptionTypeTestConfig.allVariants(
                     ForbiddenException.class,
-                    () -> new AzureException(IcebergExceptionMapper.AZURE_ACCESS_DENIED_HINT),
+                    () -> new AzureException(accessDeniedHint.next()),
                     FileIOIntegrationTest::workloadUpdateTableProperties),
                 IOExceptionTypeTestConfig.allVariants(
                     ForbiddenException.class,
-                    () -> new StorageException(403, IcebergExceptionMapper.GCP_ACCESS_DENIED_HINT),
+                    () -> new StorageException(403, accessDeniedHint.next()),
                     FileIOIntegrationTest::workloadUpdateTableProperties))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());


### PR DESCRIPTION
# Description

In a previous change I took a stab at transforming some cloud-provider-specific 403s into Polaris 403s. I don't think the hints were fully accurate as I'm seeing AWS errors that don't mention "access denied". Rather than trying to chase down the exact error messages per cloud provider, I went with reasonable catch-alls. We still only apply this to cloud-provider-specific exception types such as S3Exception so this should be fine.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Existing unit tests

# Checklist:

- [X] I have performed a self-review of my code
- [X I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
