### PR TITLE
Move hadoop deps from core to `polaris-service`

### DIFF
--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -50,13 +50,6 @@ dependencies {
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.spotbugs.annotations)
 
-  implementation(libs.hadoop.common) {
-    exclude("org.slf4j", "slf4j-reload4j")
-    exclude("org.slf4j", "slf4j-log4j12")
-    exclude("ch.qos.reload4j", "reload4j")
-    exclude("log4j", "log4j")
-    exclude("org.apache.zookeeper", "zookeeper")
-  }
   constraints {
     implementation("org.xerial.snappy:snappy-java:1.1.10.4") {
       because("Vulnerability detected in 1.1.8.2")
@@ -74,7 +67,6 @@ dependencies {
       because("Vulnerability detected in 9.8.1")
     }
   }
-  implementation(libs.hadoop.hdfs.client)
 
   implementation(libs.javax.inject)
   implementation(libs.swagger.annotations)

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -35,6 +35,14 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-api")
   implementation("org.apache.iceberg:iceberg-core")
   implementation("org.apache.iceberg:iceberg-aws")
+  implementation(libs.hadoop.common) {
+    exclude("org.slf4j", "slf4j-reload4j")
+    exclude("org.slf4j", "slf4j-log4j12")
+    exclude("ch.qos.reload4j", "reload4j")
+    exclude("log4j", "log4j")
+    exclude("org.apache.zookeeper", "zookeeper")
+  }
+  implementation(libs.hadoop.hdfs.client)
 
   implementation(platform(libs.dropwizard.bom))
   implementation("io.dropwizard:dropwizard-core")


### PR DESCRIPTION
Hadoop dependencies are not required in `polaris-core`, but `WasbTranslatingFileIOFactory` still needs them for Iceberg FileIO

### How Has This Been Tested?

Gradle-based tests
