### PR TITLE
Fix 399

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -169,12 +168,11 @@ public class PolarisConfiguration<T> {
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
           .catalogConfig("supported.storage.types")
           .description("The list of supported storage types for a catalog")
-          .defaultValue(Collections.unmodifiableList(
-                  new ArrayList<>(List.of(
-                          StorageConfigInfo.StorageTypeEnum.S3.name(),
-                          StorageConfigInfo.StorageTypeEnum.AZURE.name(),
-                          StorageConfigInfo.StorageTypeEnum.GCS.name(),
-                          StorageConfigInfo.StorageTypeEnum.FILE.name()))))
+          .defaultValue(new ArrayList<>(List.of(
+                  StorageConfigInfo.StorageTypeEnum.S3.name(),
+                  StorageConfigInfo.StorageTypeEnum.AZURE.name(),
+                  StorageConfigInfo.StorageTypeEnum.GCS.name(),
+                  StorageConfigInfo.StorageTypeEnum.FILE.name())))
           .build();
 
   public static final PolarisConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -72,8 +72,14 @@ public class PolarisConfiguration<T> {
       return this;
     }
 
+    @SuppressWarnings("unchecked")
     public Builder<T> defaultValue(T defaultValue) {
-      this.defaultValue = defaultValue;
+      if (defaultValue instanceof List<?>) {
+        // Type-safe handling of List
+        this.defaultValue = (T) new ArrayList<>((List<?>) defaultValue);
+      } else {
+        this.defaultValue = defaultValue;
+      }
       return this;
     }
 
@@ -168,11 +174,11 @@ public class PolarisConfiguration<T> {
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
           .catalogConfig("supported.storage.types")
           .description("The list of supported storage types for a catalog")
-          .defaultValue(new ArrayList<>(List.of(
+          .defaultValue(List.of(
                   StorageConfigInfo.StorageTypeEnum.S3.name(),
                   StorageConfigInfo.StorageTypeEnum.AZURE.name(),
                   StorageConfigInfo.StorageTypeEnum.GCS.name(),
-                  StorageConfigInfo.StorageTypeEnum.FILE.name())))
+                  StorageConfigInfo.StorageTypeEnum.FILE.name()))
           .build();
 
   public static final PolarisConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -167,12 +169,12 @@ public class PolarisConfiguration<T> {
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
           .catalogConfig("supported.storage.types")
           .description("The list of supported storage types for a catalog")
-          .defaultValue(
-              List.of(
-                  StorageConfigInfo.StorageTypeEnum.S3.name(),
-                  StorageConfigInfo.StorageTypeEnum.AZURE.name(),
-                  StorageConfigInfo.StorageTypeEnum.GCS.name(),
-                  StorageConfigInfo.StorageTypeEnum.FILE.name()))
+          .defaultValue(Collections.unmodifiableList(
+                  new ArrayList<>(List.of(
+                          StorageConfigInfo.StorageTypeEnum.S3.name(),
+                          StorageConfigInfo.StorageTypeEnum.AZURE.name(),
+                          StorageConfigInfo.StorageTypeEnum.GCS.name(),
+                          StorageConfigInfo.StorageTypeEnum.FILE.name()))))
           .build();
 
   public static final PolarisConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfiguration.java
@@ -174,7 +174,8 @@ public class PolarisConfiguration<T> {
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
           .catalogConfig("supported.storage.types")
           .description("The list of supported storage types for a catalog")
-          .defaultValue(List.of(
+          .defaultValue(
+              List.of(
                   StorageConfigInfo.StorageTypeEnum.S3.name(),
                   StorageConfigInfo.StorageTypeEnum.AZURE.name(),
                   StorageConfigInfo.StorageTypeEnum.GCS.name(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -19,6 +19,9 @@
 package org.apache.polaris.core;
 
 import com.google.common.base.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +79,7 @@ public interface PolarisConfigurationStore {
     } else if (config.defaultValue instanceof Double) {
       return config.cast(Double.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof List<?>) {
-      return config.cast(List.copyOf((List<?>) value));
+      return config.cast(Collections.unmodifiableList(new ArrayList<>((List<?>) value)));
     } else {
       return config.cast(value);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.core;
 
 import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.polaris.core.entity.CatalogEntity;

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core;
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.jetbrains.annotations.NotNull;
@@ -79,7 +78,7 @@ public interface PolarisConfigurationStore {
     } else if (config.defaultValue instanceof Double) {
       return config.cast(Double.valueOf(String.valueOf(value)));
     } else if (config.defaultValue instanceof List<?>) {
-      return config.cast(Collections.unmodifiableList(new ArrayList<>((List<?>) value)));
+      return config.cast(new ArrayList<>((List<?>) value));
     } else {
       return config.cast(value);
     }


### PR DESCRIPTION
# Description

This PR fixed issue where ClassCastException can raise when a change made to SUPPORTED_CATALOG_STORAGE_TYPES in `polaris-server.yml`. The exception is due to `List.of` will be using internal `ImmutableCollections` type which can be `List12` for shorter list and `ListN` for longer list. As `config.cast` expects a specific type, it may be better to not use `List.of`. For this PR, I am switching to use `Arraylist` instead to avoid this unexpected error from happening when an valid change is made to the server config.

Fixes https://github.com/apache/polaris/issues/399

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

General test suit:
```
➜  polaris git:(fix_399) ✗ ./gradlew clean test
Configuration on demand is an incubating feature.

> Task :polaris-service:openApiGenerate
user-defined server variable support is experimental.
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/yong/Desktop/git/polaris/polaris-service/build/generated

BUILD SUCCESSFUL in 4s
35 actionable tasks: 15 executed, 11 from cache, 9 up-to-date
```

happy path:
```
# start app in terminal 1
➜  polaris git:(fix_399) ✗ ./gradlew runApp

# create catalog in terminal 2
➜  polaris git:(fix_399) ✗ export CLIENT_ID=xxxxx
➜  polaris git:(fix_399) ✗ export CLIENT_SECRET=xxxxx
➜  polaris git:(fix_399) ✗ ./polaris catalogs create --storage-type file --default-base-location file:///tmp/test quickstart_catalog
➜  polaris git:(fix_399) ✗ ./polaris catalogs list
{"type": "INTERNAL", "name": "quickstart_catalog", "properties": {"default-base-location": "file:///tmp/test"}, "createTimestamp": 1731291707237, "lastUpdateTimestamp": 1731291707237, "entityVersion": 1, "storageConfigInfo": {"storageType": "FILE", "allowedLocations": ["file:///tmp/test"]}}
```

original reported unhappy path (fixed now...so also happy path):
```
# update featureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES to only keep `FILE`:
featureConfiguration:
  ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
  SUPPORTED_CATALOG_STORAGE_TYPES:
    - FILE

# start app in terminal 1
➜  polaris git:(fix_399) ✗ ./gradlew runApp

# create catalog in terminal 2
➜  polaris git:(fix_399) ✗ export CLIENT_ID=xxxxx
➜  polaris git:(fix_399) ✗ export CLIENT_SECRET=xxxxx
➜  polaris git:(fix_399) ✗ ./polaris catalogs create --storage-type file --default-base-location file:///tmp/test quickstart_catalog
➜  polaris git:(fix_399) ✗ ./polaris catalogs list
{"type": "INTERNAL", "name": "quickstart_catalog", "properties": {"default-base-location": "file:///tmp/test"}, "createTimestamp": 1731291887163, "lastUpdateTimestamp": 1731291887163, "entityVersion": 1, "storageConfigInfo": {"storageType": "FILE", "allowedLocations": ["file:///tmp/test"]}}
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
