### PR TITLE
Relax non-owner PR workflow approval

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,7 @@ github:
   protected_branches:
     main:
       required_pull_request_reviews:
+        require_code_owner_reviews: false
         required_approving_review_count: 1
 
       required_linear_history: true


### PR DESCRIPTION
@flyrain as discussed together, this should "relax" the non-owner contributor's PR workflow approval.