### PR TITLE
Fix Polaris version by adding incubating in preparation for the release

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-0.9.0-SNAPSHOT
+0.9.0-incubating-SNAPSHOT


### PR DESCRIPTION
As ASF incubator project, Polaris version has to contain `-incubating`.