### PR TITLE
Bump main to 1.0.0-incubating-SNAPSHOT

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-0.9.0-incubating-SNAPSHOT
+1.0.0-incubating-SNAPSHOT


### PR DESCRIPTION
As I created the `0.9.x` branch for the `0.9.0` release, I bump `main` to the next release cycle e.g. `1.0.0`.