### PR TITLE
Configure EclipseLink for automatic schema migration

### DIFF
--- a/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
+++ b/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
@@ -38,10 +38,10 @@
         value="jdbc:h2:file:./build/test_data/polaris/{realm}/db"/>
       <property name="jakarta.persistence.jdbc.user" value="sa"/>
       <property name="jakarta.persistence.jdbc.password" value=""/>
-      <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
       <property name="eclipselink.logging.level.sql" value="FINE"/>
       <property name="eclipselink.logging.parameters" value="true"/>
       <property name="eclipselink.persistence-context.flush-mode" value="auto"/>
+      <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -66,7 +66,7 @@ Polaris creates and connects to a separate database for each realm. Specifically
         value="jdbc:h2:file:tmp/polaris_test/filedb_{realm}"/>
       <property name="jakarta.persistence.jdbc.user" value="sa"/>
       <property name="jakarta.persistence.jdbc.password" value=""/>
-      <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+      <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
     </properties>
 </persistence-unit>
 ```
@@ -99,8 +99,8 @@ The following shows a sample configuration for integrating Polaris with Postgres
               value="jdbc:postgresql://localhost:5432/{realm}"/>
     <property name="jakarta.persistence.jdbc.user" value="postgres"/>
     <property name="jakarta.persistence.jdbc.password" value="postgres"/>
-    <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
     <property name="eclipselink.persistence-context.flush-mode" value="auto"/>
+    <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
   </properties>
 </persistence-unit>
 ```


### PR DESCRIPTION
# Description

After #438 , it was [reported](https://github.com/apache/polaris/issues/450) that users with an existing metastore might not see the new columns get added to the metastore. This PR configures EclipseLink (via the default `persistence.xml`) to automatically add new columns when they should appear in the metastore.

Fixes #450

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With this PR, I have walked through the steps described in #450, and tests are now (mostly) passing:
```bash
git checkout e232b000760da335721e9112f9d52fe041289613
rm -rf extension/persistence/eclipselink/build
./gradlew :polaris-eclipselink:test --rerun
git checkout issue-450
./gradlew :polaris-eclipselink:test --rerun
```