### PR TITLE
Dynamic Config Resolver

### DIFF
--- a/polaris-server.yml
+++ b/polaris-server.yml
@@ -73,7 +73,8 @@ featureConfiguration:
     - AZURE
     - FILE
 
-dynamicFeatureConfigResolver: no-op
+dynamicFeatureConfigResolver:
+  type: no-op
 
 callContextResolver:
   type: default

--- a/polaris-server.yml
+++ b/polaris-server.yml
@@ -73,6 +73,8 @@ featureConfiguration:
     - AZURE
     - FILE
 
+dynamicFeatureConfigResolver: no-op
+
 callContextResolver:
   type: default
 

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
 import java.util.Optional;
 
@@ -25,6 +26,7 @@ import java.util.Optional;
  * DynamicFeatureConfigResolvers dynamically resolve featureConfigurations. This is useful for
  * integration with feature flag systems which are intended for fetching configs at runtime.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface DynamicFeatureConfigResolver extends Discoverable {
   /**
    * Resolves a dynamic config by its key name.

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+import io.dropwizard.jackson.Discoverable;
+import java.util.Optional;
+
+public interface DynamicFeatureConfigResolver extends Discoverable {
+  Optional<Object> resolve(String key);
+}

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/DynamicFeatureConfigResolver.java
@@ -21,6 +21,17 @@ package org.apache.polaris.service.config;
 import io.dropwizard.jackson.Discoverable;
 import java.util.Optional;
 
+/**
+ * DynamicFeatureConfigResolvers dynamically resolve featureConfigurations. This is useful for
+ * integration with feature flag systems which are intended for fetching configs at runtime.
+ */
 public interface DynamicFeatureConfigResolver extends Discoverable {
+  /**
+   * Resolves a dynamic config by its key name.
+   *
+   * @param key
+   * @return The config value or Optional.empty() if the config should not be dynamically resolved.
+   *     If it's not dynamically resolved, it will be deferred to the application config.
+   */
   Optional<Object> resolve(String key);
 }

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
@@ -19,11 +19,11 @@
 package org.apache.polaris.service.config;
 
 import java.util.Optional;
-import org.apache.polaris.core.PolarisConfiguration;
 
+/** An empty dynamic config resolver. */
 public class NoOpDynamicFeatureConfigResolver implements DynamicFeatureConfigResolver {
   @Override
-  public <T> Optional<T> resolve(PolarisConfiguration<T> key) {
+  public Optional<Object> resolve(String key) {
     return Optional.empty();
   }
 }

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+import java.util.Optional;
+import org.apache.polaris.core.PolarisConfiguration;
+
+public class NoOpDynamicFeatureConfigResolver implements DynamicFeatureConfigResolver {
+  @Override
+  public <T> Optional<T> resolve(PolarisConfiguration<T> key) {
+    return Optional.empty();
+  }
+}

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/NoOpDynamicFeatureConfigResolver.java
@@ -18,9 +18,11 @@
  */
 package org.apache.polaris.service.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Optional;
 
 /** An empty dynamic config resolver. */
+@JsonTypeName("no-op")
 public class NoOpDynamicFeatureConfigResolver implements DynamicFeatureConfigResolver {
   @Override
   public Optional<Object> resolve(String key) {

--- a/polaris-service/src/main/java/org/apache/polaris/service/config/PolarisApplicationConfig.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/config/PolarisApplicationConfig.java
@@ -63,6 +63,7 @@ public class PolarisApplicationConfig extends Configuration {
   private String awsSecretKey;
   private FileIOFactory fileIOFactory;
   private RateLimiter rateLimiter;
+  private DynamicFeatureConfigResolver dynamicFeatureConfigResolver;
 
   private AccessToken gcpAccessToken;
 
@@ -87,6 +88,17 @@ public class PolarisApplicationConfig extends Configuration {
   @JsonProperty("io")
   public FileIOFactory getFileIOFactory() {
     return fileIOFactory;
+  }
+
+  @JsonProperty("dynamicFeatureConfigResolver")
+  public void setDynamicFeatureConfigResolver(
+      DynamicFeatureConfigResolver dynamicFeatureConfigResolver) {
+    this.dynamicFeatureConfigResolver = dynamicFeatureConfigResolver;
+  }
+
+  @JsonProperty("dynamicFeatureConfigResolver")
+  public DynamicFeatureConfigResolver getDynamicFeatureConfigResolver() {
+    return dynamicFeatureConfigResolver;
   }
 
   @JsonProperty("authenticator")
@@ -194,7 +206,8 @@ public class PolarisApplicationConfig extends Configuration {
   }
 
   public PolarisConfigurationStore getConfigurationStore() {
-    return new DefaultConfigurationStore(globalFeatureConfiguration, realmConfiguration);
+    return new DefaultConfigurationStore(
+        globalFeatureConfiguration, realmConfiguration, dynamicFeatureConfigResolver);
   }
 
   public List<String> getDefaultRealms() {

--- a/polaris-service/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/polaris-service/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -19,6 +19,7 @@
 
 org.apache.polaris.service.auth.DiscoverableAuthenticator
 org.apache.polaris.core.persistence.MetaStoreManagerFactory
+org.apache.polaris.service.config.DynamicFeatureConfigResolver
 org.apache.polaris.service.config.OAuth2ApiService
 org.apache.polaris.service.context.RealmContextResolver
 org.apache.polaris.service.context.CallContextResolver

--- a/polaris-service/src/main/resources/META-INF/services/org.apache.polaris.service.config.DynamicFeatureConfigResolver
+++ b/polaris-service/src/main/resources/META-INF/services/org.apache.polaris.service.config.DynamicFeatureConfigResolver
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.apache.polaris.service.config.NoOpDynamicFeatureConfigResolver

--- a/polaris-service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
@@ -65,7 +65,8 @@ public class DefaultConfigurationStoreTest {
                 "realm1",
                 Map.of("key1", realm1KeyOneValue),
                 "realm2",
-                Map.of("key1", realm2KeyOneValue, "key2", realm2KeyTwoValue)));
+                Map.of("key1", realm2KeyOneValue, "key2", realm2KeyTwoValue)),
+            new NoOpDynamicFeatureConfigResolver());
     InMemoryPolarisMetaStoreManagerFactory metastoreFactory =
         new InMemoryPolarisMetaStoreManagerFactory();
 

--- a/polaris-service/src/test/resources/polaris-server-integrationtest.yml
+++ b/polaris-service/src/test/resources/polaris-server-integrationtest.yml
@@ -79,7 +79,8 @@ featureConfiguration:
     - GCS
     - AZURE
 
-dynamicFeatureConfigResolver: no-op
+dynamicFeatureConfigResolver:
+  type: no-op
 
 metaStoreManager:
   type: in-memory

--- a/polaris-service/src/test/resources/polaris-server-integrationtest.yml
+++ b/polaris-service/src/test/resources/polaris-server-integrationtest.yml
@@ -79,6 +79,8 @@ featureConfiguration:
     - GCS
     - AZURE
 
+dynamicFeatureConfigResolver: no-op
+
 metaStoreManager:
   type: in-memory
 


### PR DESCRIPTION
# Description

Introduces the notion of a `DynamicFeatureConfigResolver`, which can be used to dynamically resolve `featureConfiguration` values at runtime. This is intended for integration with feature flag systems (Statsig, LaunchDarkly, etc) but this PR does not provide the implementations, rather just a hook to make it possible.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


- [X] Unit tests
- [X] Tested end-to-end with a sample implementation

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
