### PR TITLE
Prevent the bootstrap command from leaving root credentials unrecoverable

### DIFF
--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -57,6 +57,11 @@ public class BootstrapCommand extends BaseCommand {
           description =
               "Root principal credentials to bootstrap. Must be of the form 'realm,clientId,clientSecret'.")
       List<String> credentials;
+
+      @CommandLine.Option(
+          names = {"-p", "--print-credentials"},
+          description = "Print root credentials to stdout")
+      boolean printCredentials;
     }
 
     static class FileInputOptions {
@@ -85,6 +90,17 @@ public class BootstrapCommand extends BaseCommand {
                     || inputOptions.stdinOptions.credentials.isEmpty()
                 ? RootCredentialsSet.EMPTY
                 : RootCredentialsSet.fromList(inputOptions.stdinOptions.credentials);
+        if (inputOptions.stdinOptions.credentials == null
+            || inputOptions.stdinOptions.credentials.isEmpty()) {
+          if (!inputOptions.stdinOptions.printCredentials) {
+            spec.commandLine()
+                .getErr()
+                .println(
+                    "Specify either `--credentials` or `--print-credentials` to ensure"
+                        + " the root user is accessible after bootstrapping.");
+            return EXIT_CODE_BOOTSTRAP_ERROR;
+          }
+        }
       }
 
       // Execute the bootstrap
@@ -97,6 +113,15 @@ public class BootstrapCommand extends BaseCommand {
         if (result.getValue().isSuccess()) {
           String realm = result.getKey();
           spec.commandLine().getOut().printf("Realm '%s' successfully bootstrapped.%n", realm);
+          if (inputOptions.stdinOptions != null && inputOptions.stdinOptions.printCredentials) {
+            String msg =
+                String.format(
+                    "realm: %1s root principal credentials: %2s:%3s",
+                    result.getKey(),
+                    result.getValue().getPrincipalSecrets().getPrincipalClientId(),
+                    result.getValue().getPrincipalSecrets().getMainSecret());
+            spec.commandLine().getOut().println(msg);
+          }
         } else {
           String realm = result.getKey();
           spec.commandLine()

--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -99,7 +99,7 @@ class BootstrapCommandTest {
   public void testBootstrapInvalidArguments(LaunchResult result) {
     assertThat(result.getErrorOutput())
         .contains(
-            "Error: (-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]...) "
+            "Error: (-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]) "
                 + "and -f=<file> are mutually exclusive (specify only one)");
   }
 
@@ -130,6 +130,62 @@ class BootstrapCommandTest {
     assertThat(result.getErrorOutput())
         .contains("Failed to read credentials file: file:/non/existing/file")
         .contains("Bootstrap encountered errors during operation.");
+  }
+
+  @Test
+  @Launch(
+      value = {
+          "bootstrap",
+          "-r",
+          "realm1",
+          "-c",
+          "realm1,client1d,s3cr3t",
+          "--print-credentials"
+      })
+  public void testPrintCredentials(LaunchResult result) {
+    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
+    assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: client1d:");
+  }
+
+  @Test
+  @Launch(
+      value = {
+          "bootstrap",
+          "-r",
+          "realm1",
+          "--print-credentials"
+      })
+  public void testPrintCredentialsSystemGenerated(LaunchResult result) {
+    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
+    assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: ");
+  }
+
+  @Test
+  @Launch(
+      value = {
+          "bootstrap",
+          "-r",
+          "realm1"
+      },
+      exitCode = EXIT_CODE_BOOTSTRAP_ERROR)
+  public void testNoPrintCredentialsSystemGenerated(LaunchResult result) {
+    assertThat(result.getErrorOutput()).contains("--credentials");
+    assertThat(result.getErrorOutput()).contains("--print-credentials");
+  }
+
+  @Test
+  @Launch(
+      value = {
+          "bootstrap",
+          "-r",
+          "realm1",
+          "--not-real-arg",
+      },
+      exitCode = EXIT_CODE_USAGE)
+  public void testBootstrapInvalidArg(LaunchResult result) {
+    assertThat(result.getErrorOutput())
+        .contains("Unknown option: '--not-real-arg'")
+        .contains("Usage:");
   }
 
   private static Path copyResource(Path temp, String resource) throws IOException {

--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -134,27 +134,14 @@ class BootstrapCommandTest {
 
   @Test
   @Launch(
-      value = {
-          "bootstrap",
-          "-r",
-          "realm1",
-          "-c",
-          "realm1,client1d,s3cr3t",
-          "--print-credentials"
-      })
+      value = {"bootstrap", "-r", "realm1", "-c", "realm1,client1d,s3cr3t", "--print-credentials"})
   public void testPrintCredentials(LaunchResult result) {
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
     assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: client1d:");
   }
 
   @Test
-  @Launch(
-      value = {
-          "bootstrap",
-          "-r",
-          "realm1",
-          "--print-credentials"
-      })
+  @Launch(value = {"bootstrap", "-r", "realm1", "--print-credentials"})
   public void testPrintCredentialsSystemGenerated(LaunchResult result) {
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
     assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: ");
@@ -162,11 +149,7 @@ class BootstrapCommandTest {
 
   @Test
   @Launch(
-      value = {
-          "bootstrap",
-          "-r",
-          "realm1"
-      },
+      value = {"bootstrap", "-r", "realm1"},
       exitCode = EXIT_CODE_BOOTSTRAP_ERROR)
   public void testNoPrintCredentialsSystemGenerated(LaunchResult result) {
     assertThat(result.getErrorOutput()).contains("--credentials");
@@ -176,10 +159,10 @@ class BootstrapCommandTest {
   @Test
   @Launch(
       value = {
-          "bootstrap",
-          "-r",
-          "realm1",
-          "--not-real-arg",
+        "bootstrap",
+        "-r",
+        "realm1",
+        "--not-real-arg",
       },
       exitCode = EXIT_CODE_USAGE)
   public void testBootstrapInvalidArg(LaunchResult result) {


### PR DESCRIPTION
# Description

This alters the bootstrap command to require either explicit credentials or a new flag `--print-credentials`.

Fixes #219 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Credentials are now printed during bootstrap when it's enabled:
```
realm: default-realm root principal credentials: 2b98107557bcce20:f74281319ac8519ef30cbced6563223b
```