### PR TITLE
Fix wrong realm context in PolarisAuthzTestBase

### DIFF
--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -176,15 +176,7 @@ public abstract class PolarisAuthzTestBase {
     this.entityManager = new PolarisEntityManager(metaStoreManager, new StorageCredentialCache());
     this.metaStoreManager = metaStoreManager;
 
-    callContext =
-        CallContext.of(
-            new RealmContext() {
-              @Override
-              public String getRealmIdentifier() {
-                return "test-realm";
-              }
-            },
-            polarisContext);
+    callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);
 
     PrincipalEntity rootEntity =


### PR DESCRIPTION
Minor fix: the realm context in `CallContext` does not match the realm context used to create the metastore manager and the entity manager.