### PR TITLE
Remove non-existent feature configuration in FileIOIntegrationTest

### DIFF
--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/io/FileIOIntegrationTest.java
@@ -83,7 +83,6 @@ public class FileIOIntegrationTest {
               "server.applicationConnectors[0].port",
               "0"), // Bind to random port to support parallelism
           ConfigOverride.config("server.adminConnectors[0].port", "0"),
-          ConfigOverride.config("featureConfiguration.MAX_FILE_IO_READ_BYTES", "10"),
           ConfigOverride.config("io.factoryType", "test"));
 
   private static final String catalogBaseLocation = "file:/tmp/buckets/my-bucket/path/to/data";


### PR DESCRIPTION
The feature configuration `MAX_FILE_IO_READ_BYTES` does not seem to exist.