### PR TITLE
Fix 471: wrong status code on success

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -151,14 +151,14 @@ public class IcebergCatalogAdapter
       String prefix, String namespace, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     newHandlerWrapper(securityContext, prefix).namespaceExists(ns);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response dropNamespace(String prefix, String namespace, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     newHandlerWrapper(securityContext, prefix).dropNamespace(ns);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -259,7 +259,7 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     newHandlerWrapper(securityContext, prefix).tableExists(tableIdentifier);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -277,7 +277,7 @@ public class IcebergCatalogAdapter
     } else {
       newHandlerWrapper(securityContext, prefix).dropTableWithoutPurge(tableIdentifier);
     }
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -359,7 +359,7 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     newHandlerWrapper(securityContext, prefix).viewExists(tableIdentifier);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -368,14 +368,14 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     newHandlerWrapper(securityContext, prefix).dropView(tableIdentifier);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response renameView(
       String prefix, RenameTableRequest renameTableRequest, SecurityContext securityContext) {
     newHandlerWrapper(securityContext, prefix).renameView(renameTableRequest);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override


### PR DESCRIPTION
# Description

According to https://polaris.apache.org/in-dev/unreleased/polaris-management-service and https://polaris.apache.org/in-dev/unreleased/rest-catalog-open-api, there are couple endpoints where their success status is 204 instead of 200 (not all of them). As reported by https://github.com/apache/polaris/issues/471, check table existed is one of them where the target status code on success should be 204 instead of 200. While going through IcebergCatalogAdapter.java, I noticed we have couple places where we are using the wrong status code. This PR updated those to reflect the right status code.

Also, there are many places where we are using the following to get status code:
```
Response.ok(Response.Status.NO_CONTENT).build();
```

With above, it will always be 200 instead of 204, thus, I changed the code to the following:
```
Response.status(Response.Status.NO_CONTENT).build();
```

Fixes https://github.com/apache/polaris/issues/471

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Other than our standard test suit, I also used the examples ref by 471:
```
(venv) ➜  Desktop python3 bootstrap.py
polaris_setup.PolarisManagementServiceClient - DEBUG - Url: http://localhost:8181/api/management/v1/
polaris_setup.PolarisManagementServiceClient - DEBUG - Headers: Headers({'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.27.2', 'authorization': '[secure]', 'content-type': 'application/json'})
polaris_setup.PolarisManagementServiceClient - DEBUG - POST http://localhost:8181/api/management/v1/catalogs; params None; data {"catalog": {"type": "INTERNAL", "name": "dagster_example_catalog", "properties": {"default-base-location": "file:///tmp/dagster_example_catalog"}, "storageConfigInfo": {"storageType": "FILE"}}}
polaris_setup.PolarisManagementServiceClient - DEBUG - POST http://localhost:8181/api/management/v1/principals; params None; data {"principal": {"name": "dagster"}}
polaris_setup.PolarisManagementServiceClient - DEBUG - POST http://localhost:8181/api/management/v1/principal-roles; params None; data {"principalRole": {"name": "dagster_principal_role"}}
polaris_setup.PolarisManagementServiceClient - DEBUG - POST http://localhost:8181/api/management/v1/catalogs/dagster_example_catalog/catalog-roles; params None; data {"catalogRole": {"name": "orchestration_catalog_role"}}
polaris_setup.PolarisManagementServiceClient - DEBUG - PUT http://localhost:8181/api/management/v1/principals/dagster/principal-roles; params None; data {"principalRole": {"name": "dagster_principal_role"}}
polaris_setup.PolarisManagementServiceClient - DEBUG - PUT http://localhost:8181/api/management/v1/principal-roles/dagster_principal_role/catalog-roles/dagster_example_catalog; params None; data {"catalogRole": {"name": "orchestration_catalog_role"}}
polaris_setup.PolarisManagementServiceClient - DEBUG - PUT http://localhost:8181/api/management/v1/catalogs/dagster_example_catalog/catalog-roles/orchestration_catalog_role/grants; params None; data {"grant": {"type": "catalog", "privilege": "CATALOG_MANAGE_CONTENT"}}
ppolaris_setup - INFO - Connected to catalog dagster_example_catalog
polaris_setup - INFO - Creating namespace air_quality
polaris_setup - INFO - Namespace air_quality created
polaris_setup - INFO - Writing pyiceberg config to /Users/yong/.pyiceberg.yaml
polaris_setup - INFO - Polaris setup complete

(venv) ➜  Desktop python3 table_check.py
204
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
