### PR TITLE
Fix shasum format

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -57,7 +57,7 @@ constructor(objectFactory: ObjectFactory, project: Project) {
   val sourceTarballDigest =
     objectFactory
       .fileProperty()
-      .convention(project.provider { distributionDir.get().file("${baseName.get()}.sha512") })
+      .convention(project.provider { distributionDir.get().file("${baseName.get()}.tar.gz.sha512") })
 
   val mailingLists = objectFactory.listProperty(String::class.java).convention(emptyList())
 

--- a/build-logic/src/main/kotlin/publishing/util.kt
+++ b/build-logic/src/main/kotlin/publishing/util.kt
@@ -70,9 +70,9 @@ internal fun generateDigest(input: File, output: File, algorithm: String) {
       if (rd == -1) break
       md.update(buf, 0, rd)
     }
-
     output.writeText(
       md.digest().joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
+      + " " + input.getName()
     )
   }
 }


### PR DESCRIPTION
The shasum file generated by `sourceTarball` task is not correct:
- the file name should include original file extension
- the file content should include the hashed file