### PR TITLE
CI/Build: Add Gradle Build Scans

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,10 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      # https://docs.gradle.com/develocity/gradle-plugin/current/#via_environment_variable
+      DEVELOCITY_ACCESS_KEY: ${{secrets.GE_ACCESS_TOKEN}}
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,3 +73,70 @@ dependencyResolutionManagement {
 }
 
 gradle.beforeProject { version = baseVersion }
+
+plugins { id("com.gradle.develocity") version ("3.18.2") }
+
+// Use Apache's Gradle Enterprise instance only in CI and only if the access-key is present
+// See
+// https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=263426153#ProjectOnboardingInstructionsforDevelocity-GitHubActions
+// https://docs.gradle.com/develocity/gradle-plugin/current/#via_environment_variable
+val hasDevelocityAccessKey =
+  System.getenv("DEVELOCITY_ACCESS_KEY") != null &&
+    System.getenv("DEVELOCITY_ACCESS_KEY").isNotBlank()
+val isCI = System.getenv("CI") != null
+
+if (isCI) {
+  logger.lifecycle(
+    "Running build in CI ${if (hasDevelocityAccessKey) "with" else "without"} Develocity access"
+  )
+}
+
+// Publish a build-scan automatically in CI, else only on demand.
+develocity {
+  if (isCI) {
+    if (hasDevelocityAccessKey) {
+      // The GE instance for Apache rejects unauthenticated build scan uploads, so we publish those
+      // to Gradle's public one. This means, that CI runs without secrets, aka all PR CI runs, get
+      // the build scans published at Gradle's infra, while other CI runs publish to Apache's infra.
+      server = "https://ge.apache.org"
+    }
+    buildScan {
+      termsOfUseUrl = "https://gradle.com/terms-of-service"
+      termsOfUseAgree = "yes"
+      // Add some potentially interesting information from the environment
+      listOf(
+          "GITHUB_ACTION_REPOSITORY",
+          "GITHUB_ACTOR",
+          "GITHUB_BASE_REF",
+          "GITHUB_HEAD_REF",
+          "GITHUB_JOB",
+          "GITHUB_REF",
+          "GITHUB_REPOSITORY",
+          "GITHUB_RUN_ID",
+          "GITHUB_RUN_NUMBER",
+          "GITHUB_SHA",
+          "GITHUB_WORKFLOW"
+        )
+        .forEach { e ->
+          val v = System.getenv(e)
+          if (v != null) {
+            value(e, v)
+          }
+        }
+      val ghUrl = System.getenv("GITHUB_SERVER_URL")
+      if (ghUrl != null) {
+        val ghRepo = System.getenv("GITHUB_REPOSITORY")
+        val ghRunId = System.getenv("GITHUB_RUN_ID")
+        link("Summary", "$ghUrl/$ghRepo/actions/runs/$ghRunId")
+        link("PRs", "$ghUrl/$ghRepo/pulls")
+      }
+      obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+    }
+  } else {
+    val isBuildScan = gradle.startParameter.isBuildScan
+    buildScan {
+      publishing { onlyIf { isBuildScan } }
+      obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+    }
+  }
+}


### PR DESCRIPTION
Gradle Build Scans, free of use, collect a lot of information about a Gradle build, including the actual output of failed test. This becomes quite convenient when inspecting test failures in CI and a lot of other information about Gradle builds.

[Example build scan](https://scans.gradle.com/s/jpuykotf4hac6)
