### PR TITLE
Reduce RESTSessionCatalog logger verbosity during tests

### DIFF
--- a/polaris-service/src/test/resources/polaris-server-integrationtest.yml
+++ b/polaris-service/src/test/resources/polaris-server-integrationtest.yml
@@ -119,6 +119,8 @@ logging:
   # Logger-specific levels.
   loggers:
     org.apache.polaris: DEBUG
+    # only used to warn about the tokens endpoint being deprecated
+    org.apache.iceberg.rest.RESTSessionCatalog: ERROR
 
   appenders:
 


### PR DESCRIPTION
The `RESTSessionCatalog` logger is only used to warn about the token endpoint being deprecated. Since there isn't much we can do about this in Polaris for now, reducing its verbosity in tests at least avoid printing the deprecation warning hundreds of times.