### PR TITLE
Refactor Apache project info retrieval to use whimsey

### DIFF
--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -63,20 +63,5 @@ if (System.getProperty("idea.sync.active").toBoolean()) {
 }
 
 extensions.getByType<PublishingHelperExtension>().apply {
-  asfProjectName = "polaris"
-
   mailingLists.addAll("dev", "issues", "commits")
-
-  podlingPpmcAsfIds.addAll(
-    "anoop",
-    "ashvin",
-    "jackye",
-    "jbonofre",
-    "russellspitzer",
-    "snazy",
-    "takidau",
-    "vvcephei"
-  )
-  podlingMentorsAsfIds.addAll("bdelacretaz", "blue", "holden", "jbonofre", "yao")
-  podlingCommitterAsfIds.addAll("adutra", "annafil", "emaynard", "collado", "yufei", "ebyhr")
 }

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -23,7 +23,6 @@ import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
-import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
 
 /**
@@ -36,14 +35,8 @@ import org.gradle.kotlin.dsl.property
 abstract class PublishingHelperExtension
 @Inject
 constructor(objectFactory: ObjectFactory, project: Project) {
-  // optional customization of the pom.xml <name> element
-  val mavenName = objectFactory.property<String>().convention(project.provider { project.name })
-
-  val licenseUrl =
-    objectFactory.property<String>().convention("https://www.apache.org/licenses/LICENSE-2.0.txt")
-
   // the following are only relevant on the root project
-  val asfProjectName = objectFactory.property<String>()
+  val asfProjectName = objectFactory.property<String>().convention(project.name)
   val baseName =
     objectFactory
       .property<String>()
@@ -60,11 +53,6 @@ constructor(objectFactory: ObjectFactory, project: Project) {
       .convention(project.provider { distributionDir.get().file("${baseName.get()}.sha512") })
 
   val mailingLists = objectFactory.listProperty(String::class.java).convention(emptyList())
-
-  // override the list of developers (P)PMC members + committers, necessary for podlings
-  val podlingPpmcAsfIds = objectFactory.setProperty(String::class.java).convention(emptySet())
-  val podlingMentorsAsfIds = objectFactory.setProperty(String::class.java).convention(emptySet())
-  val podlingCommitterAsfIds = objectFactory.setProperty(String::class.java).convention(emptySet())
 
   fun distributionFile(ext: String): File =
     distributionDir.get().file("${baseName.get()}.$ext").asFile

--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -20,7 +20,6 @@
 package publishing
 
 import groovy.util.Node
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -50,15 +49,11 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
 
     pom {
       if (project != project.rootProject) {
-        name.set(e.mavenName.get())
-        description.set(project.description)
-
         // Add the license to every pom to make it easier for downstream project to retrieve the
         // license.
         licenses {
           license {
             name.set("Apache-2.0") // SPDX identifier
-            url.set(e.licenseUrl.get())
           }
         }
 
@@ -77,63 +72,60 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
         val mavenPom = this
 
         task.doFirst {
-          val asfName = e.asfProjectName.get()
-          val (asfPrj, fromPodlings) = fetchAsfProject(asfName)
+          mavenPom.run {
+            val asfName = e.asfProjectName.get()
+            val projectPeople = fetchProjectPeople(asfName)
 
-          val asfProjectName = asfPrj["name"] as String
-
-          mavenPom.name.set(asfProjectName)
-          mavenPom.description.set(asfPrj["description"] as String)
-
-          inceptionYear.set(
-            (asfPrj["created"] ?: asfPrj["started"]!!).toString().replace("(\\d+)-.*", "\\1")
-          )
-          url.set(asfPrj["homepage"] as String)
-          organization {
-            name.set("The Apache Software Foundation")
-            url.set("https://www.apache.org/")
-          }
-          licenses {
-            license {
-              name.set("Apache-2.0") // SPDX identifier
-              url.set(e.licenseUrl.get())
+            organization {
+              name.set("The Apache Software Foundation")
+              url.set("https://www.apache.org/")
             }
-          }
-          mailingLists {
-            e.mailingLists.get().forEach { ml ->
-              mailingList {
-                name.set("${ml.capitalized()} Mailing List")
-                subscribe.set("$ml-subscribe@$asfName.apache.org")
-                unsubscribe.set("$ml-ubsubscribe@$asfName.apache.org")
-                post.set("$ml@$asfName.apache.org")
-                archive.set("https://lists.apache.org/list.html?$ml@$asfName.apache.org")
+            licenses {
+              license {
+                name.set("Apache-2.0") // SPDX identifier
+                url.set(projectPeople.licenseUrl)
               }
             }
-          }
-          scm {
-            val codeRepo: String =
-              if (asfPrj.contains("repository")) {
-                val repos: List<String> = unsafeCast(asfPrj["repository"]) as List<String>
-                repos[0]
-              } else {
-                "https://github.com/apache/$asfName.git"
+            mailingLists {
+              e.mailingLists.get().forEach { ml ->
+                mailingList {
+                  name.set("${ml.capitalized()} Mailing List")
+                  subscribe.set("$ml-subscribe@$asfName.apache.org")
+                  unsubscribe.set("$ml-ubsubscribe@$asfName.apache.org")
+                  post.set("$ml@$asfName.apache.org")
+                  archive.set("https://lists.apache.org/list.html?$ml@$asfName.apache.org")
+                }
               }
-            connection.set("scm:git:$codeRepo")
-            developerConnection.set("scm:git:$codeRepo")
-            url.set("$codeRepo/tree/main")
-            tag.set("main")
-          }
-          issueManagement {
-            url.set(
-              if (asfPrj.contains("repository")) {
-                asfPrj["bug-database"] as String
-              } else {
-                "https://github.com/apache/$asfName/issues"
+            }
+
+            scm {
+              val codeRepo: String = projectPeople.repository
+              connection.set("scm:git:$codeRepo")
+              developerConnection.set("scm:git:$codeRepo")
+              url.set("$codeRepo/tree/main")
+              tag.set("main")
+            }
+            issueManagement { url.set(projectPeople.bugDatabase) }
+
+            name.set(projectPeople.name)
+            description.set(projectPeople.description)
+            url.set(projectPeople.website)
+            inceptionYear.set(projectPeople.inceptionYear.toString())
+
+            developers {
+              projectPeople.people.forEach { person ->
+                developer {
+                  this.id.set(person.apacheId)
+                  this.name.set(person.name)
+                  this.organization.set("Apache Software Foundation")
+                  this.email.set("${person.apacheId}@apache.org")
+                  this.roles.addAll(person.roles)
+                }
               }
-            )
+            }
+
+            addContributorsToPom(mavenPom, asfName, "Apache ${projectPeople.name}")
           }
-          addDevelopersToPom(mavenPom, asfName, e, fromPodlings)
-          addContributorsToPom(mavenPom, asfName, asfProjectName)
         }
       }
     }
@@ -156,76 +148,6 @@ fun addContributorsToPom(mavenPom: MavenPom, asfName: String, asfProjectName: St
               organizationUrl.set("https://github.com/apache/$asfName")
             }
           }
-      }
-    }
-  }
-
-/** Adds Apache (P)PMC members + committers, in `name` order. */
-fun addDevelopersToPom(
-  mavenPom: MavenPom,
-  asfName: String,
-  e: PublishingHelperExtension,
-  fromPodlings: Boolean
-) =
-  mavenPom.run {
-    developers {
-      // Cannot use check the 'groups' for podlings, because the (only) podling's group
-      // references the mentors, not the PPMC members/committers. There seems to be no
-      // way to automatically fetch the committers + PPMC members for a podling, except
-      // maybe
-      val people: Map<String, Map<String, Any>> =
-        parseJson("https://projects.apache.org/json/foundation/people.json")!!
-      val filteredPeople: List<Pair<String, Map<String, Any>>>
-      val pmc: (Pair<String, Map<String, Any>>) -> Boolean
-      val mentor: (Pair<String, Map<String, Any>>) -> Boolean
-      val pmcRole: String
-      if (!fromPodlings) {
-        val asfNamePmc = "$asfName-pmc"
-        filteredPeople =
-          people
-            .filter { entry ->
-              val groups: List<String> = unsafeCast(entry.value["groups"])
-              groups.any { it == asfName || it == asfNamePmc }
-            }
-            .toList()
-        pmc = { (_, info) ->
-          val groups: List<String> = unsafeCast(info["groups"])
-          groups.contains(asfNamePmc)
-        }
-        pmcRole = "PMC Member"
-        mentor = { (_, _) -> false }
-      } else {
-        val podlingPpmc = e.podlingPpmcAsfIds.get()
-        val podlingMentors = e.podlingMentorsAsfIds.get()
-        filteredPeople =
-          (e.podlingCommitterAsfIds.get() + podlingPpmc + podlingMentors).map { id ->
-            val info = people[id]
-            if (info == null) {
-              throw GradleException("Person with ASF id '%s' not found in people.json".format(id))
-            }
-            Pair(id, info)
-          }
-        pmc = { (id, _) -> podlingPpmc.contains(id) || podlingMentors.contains(id) }
-        pmcRole = "PPMC Member"
-        mentor = { (id, _) -> podlingMentors.contains(id) }
-      }
-
-      val sortedPeople = filteredPeople.sortedBy { (id, info) -> "${info["name"] as String}_$id" }
-
-      sortedPeople.forEach { (id, info) ->
-        developer {
-          this.id.set(id)
-          this.name.set(info["name"] as String)
-          this.organization.set("Apache Software Foundation")
-          this.email.set("$id@apache.org")
-          this.roles.add("Committer")
-          if (pmc.invoke(Pair(id, info))) {
-            this.roles.add(pmcRole)
-          }
-          if (mentor.invoke(Pair(id, info))) {
-            this.roles.add("Mentor")
-          }
-        }
       }
     }
   }

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -133,8 +133,7 @@ internal fun configureOnRootProject(project: Project) =
             "NO STAGING REPOSITORY (no build service) !!"
           }
 
-        val (asfPrj, _) = fetchAsfProject(asfName)
-        val asfProjectName = asfPrj["name"] as String
+        val asfProjectName = fetchAsfProjectName(asfName)
 
         val versionNoRc = version.toString().replace("-rc-?[0-9]+".toRegex(), "")
 

--- a/build-logic/src/main/kotlin/publishing/util.kt
+++ b/build-logic/src/main/kotlin/publishing/util.kt
@@ -27,7 +27,6 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
 import java.security.MessageDigest
-import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.DependencyResult
@@ -77,29 +76,13 @@ internal fun generateDigest(input: File, output: File, algorithm: String) {
   }
 }
 
-internal fun fetchAsfProject(asfName: String): Pair<Map<String, Any>, Boolean> {
-  val tlpPrj: Map<String, Any>? =
-    parseJson("https://projects.apache.org/json/projects/$asfName.json")
-  return if (tlpPrj != null) {
-    Pair(tlpPrj, false)
-  } else {
-    val podlings: Map<String, Map<String, Any>> =
-      parseJson("https://projects.apache.org/json/foundation/podlings.json")!!
-    val podling = podlings[asfName]
-    if (podling == null) {
-      throw GradleException("Neither a project nor a podling for $asfName could be found at Apache")
-    }
-    Pair(podling, true)
-  }
-}
-
 internal fun <T : Any> unsafeCast(o: Any?): T {
   @Suppress("UNCHECKED_CAST") return o as T
 }
 
 internal fun <T : Any> parseJson(url: String): T? {
   try {
-    @Suppress("UNCHECKED_CAST") return JsonSlurper().parse(URI(url).toURL()) as T
+    return unsafeCast(JsonSlurper().parse(URI(url).toURL())) as T
   } catch (e: JsonException) {
     if (e.cause is FileNotFoundException) {
       return null
@@ -107,3 +90,128 @@ internal fun <T : Any> parseJson(url: String): T? {
     throw e
   }
 }
+
+internal fun fetchAsfProjectName(apacheId: String): String {
+  val projectsAll: Map<String, Map<String, Any>> =
+    parseJson("https://whimsy.apache.org/public/public_ldap_projects.json")!!
+  val projects = unsafeCast<Map<String, Map<String, Any>>>(projectsAll["projects"])
+  val project =
+    projects[apacheId]
+      ?: throw IllegalArgumentException(
+        "No project '$apacheId' found in https://whimsy.apache.org/public/public_ldap_projects.json"
+      )
+  return project["name"] as String
+}
+
+internal fun fetchProjectPeople(apacheId: String): ProjectPeople {
+  val projectsAll: Map<String, Map<String, Any>> =
+    parseJson("https://whimsy.apache.org/public/public_ldap_projects.json")!!
+  val projects = unsafeCast<Map<String, Map<String, Any>>>(projectsAll["projects"])
+  val project =
+    projects[apacheId]
+      ?: throw IllegalArgumentException(
+        "No project '$apacheId' found in https://whimsy.apache.org/public/public_ldap_projects.json"
+      )
+  val isPodlingCurrent = project.containsKey("podling") && project["podling"] == "current"
+
+  val inceptionYear = (project["createTimestamp"] as String).subSequence(0, 4).toString().toInt()
+
+  // Committers
+  val peopleProjectRoles: MutableMap<String, MutableList<String>> = mutableMapOf()
+  val members = unsafeCast(project["members"]) as List<String>
+  members.forEach { member -> peopleProjectRoles.put(member, mutableListOf("Committer")) }
+
+  // (P)PMC Members
+  val pmcRoleName = if (isPodlingCurrent) "PPMC member" else "PMC member"
+  val owners = unsafeCast(project["owners"]) as List<String>
+  owners.forEach { member -> peopleProjectRoles[member]!!.add(pmcRoleName) }
+
+  val projectName: String
+  val description: String
+  val website: String
+  val repository: String
+  val licenseUrl: String
+  val bugDatabase: String
+  if (isPodlingCurrent) {
+    val podlingsAll: Map<String, Map<String, Any>> =
+      parseJson("https://whimsy.apache.org/public/public_podlings.json")!!
+    val podlings = unsafeCast<Map<String, Map<String, Any>>>(podlingsAll["podling"])
+    val podling =
+      podlings[apacheId]
+        ?: throw IllegalArgumentException(
+          "No podling '$apacheId' found in https://whimsy.apache.org/public/public_podlings.json"
+        )
+    projectName = podling["name"] as String
+    description = podling["description"] as String
+    val podlingStatus = unsafeCast(podling["podlingStatus"]) as Map<String, Any>
+    website = podlingStatus["website"] as String
+    // No repository for podlings??
+    repository = "https://github.com/apache/$apacheId.git"
+    bugDatabase = "https://github.com/apache/$apacheId/issues"
+    licenseUrl = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+
+    val champion = podling["champion"] as String
+    peopleProjectRoles[champion]!!.add("Champion")
+
+    val mentors = unsafeCast(podling["mentors"]) as List<String>
+    mentors.forEach { member -> peopleProjectRoles[member]!!.add("Mentor") }
+  } else {
+    val tlpPrj: Map<String, Any> =
+      parseJson("https://projects.apache.org/json/projects/$apacheId.json")!!
+    website = tlpPrj["homepage"] as String
+    repository = (unsafeCast(tlpPrj["repository"]) as List<String>)[0]
+    bugDatabase = tlpPrj["bug-database"] as String
+    licenseUrl = tlpPrj["license"] as String
+
+    val committeesAll: Map<String, Map<String, Any>> =
+      parseJson("https://whimsy.apache.org/public/committee-info.json")!!
+    val committees = unsafeCast<Map<String, Map<String, Any>>>(committeesAll["committees"])
+    val committee = unsafeCast<Map<String, Any>>(committees[apacheId])
+    val pmcChair = unsafeCast<Map<String, Map<String, Any>>>(committee["chair"])
+    projectName = committee["display_name"] as String
+    description = committee["description"] as String
+    pmcChair.keys.forEach { chair -> peopleProjectRoles[chair]!!.add("PMC Chair") }
+  }
+
+  val peopleNames: Map<String, Map<String, Any>> =
+    parseJson("https://whimsy.apache.org/public/public_ldap_people.json")!!
+  val people: Map<String, Map<String, Any>> =
+    unsafeCast(peopleNames["people"]) as Map<String, Map<String, Any>>
+  val peopleList =
+    peopleProjectRoles.entries
+      .map { entry ->
+        val person =
+          people[entry.key]
+            ?: throw IllegalStateException(
+              "No person '${entry.key}' found in https://whimsy.apache.org/public/public_ldap_people.json"
+            )
+        ProjectMember(entry.key, person["name"]!! as String, entry.value)
+      }
+      .sortedBy { it.name }
+
+  return ProjectPeople(
+    apacheId,
+    projectName,
+    description,
+    website,
+    repository,
+    licenseUrl,
+    bugDatabase,
+    inceptionYear,
+    peopleList
+  )
+}
+
+internal class ProjectPeople(
+  val apacheId: String,
+  val name: String,
+  val description: String,
+  val website: String,
+  val repository: String,
+  val licenseUrl: String,
+  val bugDatabase: String,
+  val inceptionYear: Int,
+  val people: List<ProjectMember>
+)
+
+internal class ProjectMember(val apacheId: String, val name: String, val roles: List<String>)


### PR DESCRIPTION
Removes usage of `https://projects.apache.org/json/foundation/people.json` in favor of `https://whimsy.apache.org/public/`.

Also remove the need to manually specify people and their roles for podlings, but added the special champion as a role.

Fixes #476
