### PR TITLE
CI/Gradle-check: add `--continue` to let Gradle continue and fail at the end

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,7 @@ jobs:
           validate-wrappers: false
 
       - name: Code style checks and tests
-        run: ./gradlew check
+        run: ./gradlew --continue check
 
       - name: Check Maven publication
         run: ./gradlew publishToMavenLocal sourceTarball


### PR DESCRIPTION
This way, Gradle will exercise all check tasks and not fail early, for example not skip tests, if spotless complains.
