### PR TITLE
Not requiring the PR to be up to date before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,9 +43,11 @@ github:
 
       required_linear_history: true
 
+      del_branch_on_merge: true
+
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
-        strict: true
+        strict: false
         # Contexts are the names of checks that must pass. This is the value
         # of the job's `name` property if it's present.
         contexts:


### PR DESCRIPTION
Currently, we require a PR to be up to date with `main` before merging. This is annoying as it's impossible to merge if the PR is not up to date and we keep on clicking on "Update branch".

This change "relax" this.