### PR TITLE
Fix 471: add status code test cases

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -151,14 +151,14 @@ public class IcebergCatalogAdapter
       String prefix, String namespace, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     newHandlerWrapper(securityContext, prefix).namespaceExists(ns);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response dropNamespace(String prefix, String namespace, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     newHandlerWrapper(securityContext, prefix).dropNamespace(ns);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -259,7 +259,7 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     newHandlerWrapper(securityContext, prefix).tableExists(tableIdentifier);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -277,7 +277,7 @@ public class IcebergCatalogAdapter
     } else {
       newHandlerWrapper(securityContext, prefix).dropTableWithoutPurge(tableIdentifier);
     }
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -359,7 +359,7 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     newHandlerWrapper(securityContext, prefix).viewExists(tableIdentifier);
-    return Response.ok().build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
@@ -368,14 +368,14 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     newHandlerWrapper(securityContext, prefix).dropView(tableIdentifier);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response renameView(
       String prefix, RenameTableRequest renameTableRequest, SecurityContext securityContext) {
     newHandlerWrapper(securityContext, prefix).renameView(renameTableRequest);
-    return Response.ok(Response.Status.NO_CONTENT).build();
+    return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override

--- a/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -2376,6 +2376,70 @@ public class PolarisServiceImplIntegrationTest {
     }
   }
 
+  @Test
+  public void testNamespaceExistsStatus() {
+    // create a catalog
+    String catalogName = "mytablemanagecatalog";
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(
+                new AwsStorageConfigInfo(
+                    "arn:aws:iam::012345678901:role/jdoe", StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    createCatalog(catalog);
+
+    // create a namespace
+    String namespaceName = "c";
+    createNamespace(catalogName, namespaceName);
+
+    // check if a namespace existed
+    try (Response response =
+        newRequest(
+                "http://localhost:%d/api/catalog/v1/"
+                    + catalogName
+                    + "/namespaces/"
+                    + namespaceName,
+                userToken)
+            .head()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+  }
+
+  @Test
+  public void testDropNamespaceStatus() {
+    // create a catalog
+    String catalogName = "mytablemanagecatalog";
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(
+                new AwsStorageConfigInfo(
+                    "arn:aws:iam::012345678901:role/jdoe", StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    createCatalog(catalog);
+
+    // create a namespace
+    String namespaceName = "c";
+    createNamespace(catalogName, namespaceName);
+
+    // drop a namespace
+    try (Response response =
+        newRequest(
+                "http://localhost:%d/api/catalog/v1/"
+                    + catalogName
+                    + "/namespaces/"
+                    + namespaceName,
+                userToken)
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+  }
+
   public static JWTCreator.Builder defaultJwt() {
     Instant now = Instant.now();
     return JWT.create()


### PR DESCRIPTION
# Description

This is follow up on https://github.com/apache/polaris/pull/472 which fixed https://github.com/apache/polaris/pull/471. This PR added the missing test cases for success status code.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```sh
➜  polaris git:(status_code_test_cases) ./gradlew test
Starting a Gradle Daemon (subsequent builds will be faster)
Configuration on demand is an incubating feature.

> Task :polaris-service:generatePolarisService
user-defined server variable support is experimental.
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/yong/Desktop/git/polaris/polaris-service/build/generated

> Task :polaris-core:generatePolarisService
user-defined server variable support is experimental.
Unexpected allVars for AwsStorageConfigInfo expecting:5 vars. actual:2 vars
Unexpected allVars for AzureStorageConfigInfo expecting:5 vars. actual:2 vars
Unexpected allVars for GcpStorageConfigInfo expecting:3 vars. actual:2 vars
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/yong/Desktop/git/polaris/polaris-core/build/generated

> Task :polaris-service:openApiGenerate
user-defined server variable support is experimental.
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/yong/Desktop/git/polaris/polaris-service/build/generated

> Task :polaris-core:compileJava
/Users/yong/Desktop/git/polaris/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java:56: warning: [dep-ann] deprecated item is not annotated with @Deprecated
  public static final String TAG_REALM_DEPRECATED = "REALM_ID";
                             ^
/Users/yong/Desktop/git/polaris/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java:63: warning: [dep-ann] deprecated item is not annotated with @Deprecated
  public static final String TAG_RESP_CODE_DEPRECATED = "HTTP_RESPONSE_CODE";
                             ^
2 warnings

> Task :polaris-service:compileTestJava
/Users/yong/Desktop/git/polaris/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java:150: warning: [deprecation] TAG_REALM_DEPRECATED in PolarisMetricRegistry has been deprecated
            Tag.of(TAG_REALM_DEPRECATED, realm)));
                   ^
/Users/yong/Desktop/git/polaris/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java:161: warning: [deprecation] TAG_RESP_CODE_DEPRECATED in PolarisMetricRegistry has been deprecated
            Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
                   ^
/Users/yong/Desktop/git/polaris/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java:173: warning: [deprecation] TAG_REALM_DEPRECATED in PolarisMetricRegistry has been deprecated
            Tag.of(TAG_REALM_DEPRECATED, realm),
                   ^
/Users/yong/Desktop/git/polaris/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java:174: warning: [deprecation] TAG_RESP_CODE_DEPRECATED in PolarisMetricRegistry has been deprecated
            Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
                   ^
4 warnings
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
INFO  [2024-11-27 09:19:22,415] org.apache.spark.util.ShutdownHookManager: Shutdown hook called
INFO  [2024-11-27 09:19:22,415] org.apache.spark.util.ShutdownHookManager: Deleting directory /private/var/folders/fl/1gq302cn7dd_w8mx24s7zhq40000gn/T/spark-52754eb8-3b25-4f98-985e-7de15f5decae
[Incubating] Problems report is available at: file:///Users/yong/Desktop/git/polaris/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 1m 23s
30 actionable tasks: 16 executed, 14 up-to-date
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
