### PR TITLE
chore: Fix deprecation warnings (in build and IDE)

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/monitor/PolarisMetricRegistry.java
@@ -53,14 +53,14 @@ public class PolarisMetricRegistry {
   /**
    * @deprecated See class Javadoc.
    */
-  public static final String TAG_REALM_DEPRECATED = "REALM_ID";
+  @Deprecated public static final String TAG_REALM_DEPRECATED = "REALM_ID";
 
   public static final String TAG_REALM = "realm_id";
 
   /**
    * @deprecated See class Javadoc.
    */
-  public static final String TAG_RESP_CODE_DEPRECATED = "HTTP_RESPONSE_CODE";
+  @Deprecated public static final String TAG_RESP_CODE_DEPRECATED = "HTTP_RESPONSE_CODE";
 
   public static final String TAG_RESP_CODE = "http_response_code";
 

--- a/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -140,28 +140,25 @@ public class TimedApplicationEventListenerTest {
         EXT, API_ANNOTATION + SUFFIX_COUNTER, Collections.emptyList());
   }
 
+  @SuppressWarnings("deprecation")
   private double getPerApiRealmMetricCount() {
     return TestMetricsUtil.getTotalCounter(
         EXT,
         API_ANNOTATION + SUFFIX_COUNTER + SUFFIX_REALM,
-        List.of(
-            Tag.of(TAG_REALM, realm),
-            // spotless:off
-            Tag.of(TAG_REALM_DEPRECATED, realm)));
-            // spotless:on
+        List.of(Tag.of(TAG_REALM, realm), Tag.of(TAG_REALM_DEPRECATED, realm)));
   }
 
+  @SuppressWarnings("deprecation")
   private double getPerApiMetricErrorCount() {
     return TestMetricsUtil.getTotalCounter(
         EXT,
         API_ANNOTATION + SUFFIX_ERROR,
         List.of(
             Tag.of(TAG_RESP_CODE, String.valueOf(ERROR_CODE)),
-            // spotless:off
             Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
-            // spotless:on
   }
 
+  @SuppressWarnings("deprecation")
   private double getPerApiRealmMetricErrorCount() {
     return TestMetricsUtil.getTotalCounter(
         EXT,
@@ -169,10 +166,8 @@ public class TimedApplicationEventListenerTest {
         List.of(
             Tag.of(TAG_REALM, realm),
             Tag.of(TAG_RESP_CODE, String.valueOf(ERROR_CODE)),
-            // spotless:off
             Tag.of(TAG_REALM_DEPRECATED, realm),
             Tag.of(TAG_RESP_CODE_DEPRECATED, String.valueOf(ERROR_CODE))));
-            // spotless:on
   }
 
   private double getCommonMetricCount() {


### PR DESCRIPTION
* Add `@Deprecated` to `PolarisMetricRegistry` to fix `warning: [dep-ann] deprecated item is not annotated with @Deprecated`

* Suppress warnings on usage of those deprecated fields in test classes via `@SuppressWarnings`
