### PR TITLE
Fix matching file prefixes for FILE based catalogs

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -42,7 +42,7 @@ public class StorageLocation {
       this.location = null;
     } else if (location.startsWith("file:/") && !location.startsWith(LOCAL_PATH_PREFIX)) {
       this.location = URI.create(location.replaceFirst("file:/+", LOCAL_PATH_PREFIX)).toString();
-    } else if (location.startsWith("/")){
+    } else if (location.startsWith("/")) {
       this.location = URI.create(location.replaceFirst("/+", LOCAL_PATH_PREFIX)).toString();
     } else {
       this.location = URI.create(location).toString();

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -25,6 +25,7 @@ import org.apache.polaris.core.storage.azure.AzureLocation;
 /** An abstraction over a storage location */
 public class StorageLocation {
   private final String location;
+  public static final String LOCAL_PATH_PREFIX = "file:///";
 
   /** Create a StorageLocation from a String path */
   public static StorageLocation of(String location) {
@@ -39,8 +40,8 @@ public class StorageLocation {
   protected StorageLocation(@Nonnull String location) {
     if (location == null) {
       this.location = null;
-    } else if (location.startsWith("file:/") && !location.startsWith("file:///")) {
-      this.location = URI.create(location.replaceFirst("file:/+", "file:///")).toString();
+    } else if (location.startsWith("file:/") && !location.startsWith(LOCAL_PATH_PREFIX)) {
+      this.location = URI.create(location.replaceFirst("file:/+", LOCAL_PATH_PREFIX)).toString();
     } else {
       this.location = URI.create(location).toString();
     }
@@ -84,7 +85,7 @@ public class StorageLocation {
   }
 
   /**
-   * Returns true if this StorageLocation's location string starts with the other StorageLocation's 
+   * Returns true if this StorageLocation's location string starts with the other StorageLocation's
    * location string
    */
   public boolean isChildOf(StorageLocation potentialParent) {
@@ -93,8 +94,9 @@ public class StorageLocation {
     } else {
       String slashTerminatedLocation = ensureTrailingSlash(this.location);
       String slashTerminatedParentLocation = ensureTrailingSlash(potentialParent.location);
-      if (slashTerminatedLocation.startsWith("/") && slashTerminatedParentLocation.startsWith("file:///")) {
-        slashTerminatedLocation = "file://" + slashTerminatedLocation;
+      if (slashTerminatedLocation.startsWith("/")
+          && slashTerminatedParentLocation.startsWith(LOCAL_PATH_PREFIX)) {
+        slashTerminatedLocation = slashTerminatedLocation.replaceFirst("/+", LOCAL_PATH_PREFIX);
       }
       return slashTerminatedLocation.startsWith(slashTerminatedParentLocation);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -84,7 +84,7 @@ public class StorageLocation {
   }
 
   /**
-   * Returns true if this StorageLocation's location string starts with the other StorageLocation's
+   * Returns true if this StorageLocation's location string starts with the other StorageLocation's 
    * location string
    */
   public boolean isChildOf(StorageLocation potentialParent) {
@@ -93,6 +93,9 @@ public class StorageLocation {
     } else {
       String slashTerminatedLocation = ensureTrailingSlash(this.location);
       String slashTerminatedParentLocation = ensureTrailingSlash(potentialParent.location);
+      if (slashTerminatedLocation.startsWith("/") && slashTerminatedParentLocation.startsWith("file:///")) {
+        slashTerminatedLocation = "file://" + slashTerminatedLocation;
+      }
       return slashTerminatedLocation.startsWith(slashTerminatedParentLocation);
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -42,6 +42,8 @@ public class StorageLocation {
       this.location = null;
     } else if (location.startsWith("file:/") && !location.startsWith(LOCAL_PATH_PREFIX)) {
       this.location = URI.create(location.replaceFirst("file:/+", LOCAL_PATH_PREFIX)).toString();
+    } else if (location.startsWith("/")){
+      this.location = URI.create(location.replaceFirst("/+", LOCAL_PATH_PREFIX)).toString();
     } else {
       this.location = URI.create(location).toString();
     }
@@ -94,10 +96,6 @@ public class StorageLocation {
     } else {
       String slashTerminatedLocation = ensureTrailingSlash(this.location);
       String slashTerminatedParentLocation = ensureTrailingSlash(potentialParent.location);
-      if (slashTerminatedLocation.startsWith("/")
-          && slashTerminatedParentLocation.startsWith(LOCAL_PATH_PREFIX)) {
-        slashTerminatedLocation = slashTerminatedLocation.replaceFirst("/+", LOCAL_PATH_PREFIX);
-      }
       return slashTerminatedLocation.startsWith(slashTerminatedParentLocation);
     }
   }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/StorageLocationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/StorageLocationTest.java
@@ -25,18 +25,11 @@ import org.junit.jupiter.api.Test;
 public class StorageLocationTest {
 
   @Test
-  public void testIsChildOfMatchingPrefixes() {
-    StorageLocation parentLocation = StorageLocation.of("file:///path/to/file");
-    StorageLocation childLocation = StorageLocation.of("file:///path/to/file/child");
-    Assertions.assertThat(childLocation.isChildOf(parentLocation)).isTrue();
-  }
-
-  @Test
-  public void testIsChildOfDifferentPrefixes() {
-    StorageLocation parentLocation = StorageLocation.of("file:///path/to/file");
-    StorageLocation childLocationLeadingSlash = StorageLocation.of("/path/to/file/child");
-    StorageLocation childLocationSingleSlashFile = StorageLocation.of("file:/path/to/file/child");
-    Assertions.assertThat(childLocationLeadingSlash.isChildOf(parentLocation)).isTrue();
-    Assertions.assertThat(childLocationSingleSlashFile.isChildOf(parentLocation)).isTrue();
+  public void testOfDifferentPrefixes() {
+    StorageLocation StandardLocation = StorageLocation.of("file:///path/to/file");
+    StorageLocation slashLeadingLocation = StorageLocation.of("/path/to/file");
+    StorageLocation fileSingleSlashLocation = StorageLocation.of("file:/path/to/file");
+    Assertions.assertThat(slashLeadingLocation.equals(StandardLocation)).isTrue();
+    Assertions.assertThat(fileSingleSlashLocation.equals(StandardLocation)).isTrue();
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/StorageLocationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/StorageLocationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage;
+
+import org.apache.polaris.core.storage.StorageLocation;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageLocationTest {
+
+  @Test
+  public void testIsChildOfMatchingPrefixes() {
+    StorageLocation parentLocation = StorageLocation.of("file:///path/to/file");
+    StorageLocation childLocation = StorageLocation.of("file:///path/to/file/child");
+    Assertions.assertThat(childLocation.isChildOf(parentLocation)).isTrue();
+  }
+
+  @Test
+  public void testIsChildOfDifferentPrefixes() {
+    StorageLocation parentLocation = StorageLocation.of("file:///path/to/file");
+    StorageLocation childLocationLeadingSlash = StorageLocation.of("/path/to/file/child");
+    StorageLocation childLocationSingleSlashFile = StorageLocation.of("file:/path/to/file/child");
+    Assertions.assertThat(childLocationLeadingSlash.isChildOf(parentLocation)).isTrue();
+    Assertions.assertThat(childLocationSingleSlashFile.isChildOf(parentLocation)).isTrue();
+  }
+}


### PR DESCRIPTION
Ensure matching file prefixes when using polaris instance with FILE based storage.

# Description

We encountered a bug when attempting to register tables to a file-based instance of Polaris for testing. Through logging, we discovered an inconsistent file naming convention when comparing file:/// to /. This inconsistency caused the system to fail to recognize paths that were actually children as child paths, resulting in the isChildOf method failing every time.

This change ensures that when comparing file paths in the isChildOf method, we use a consistent prefix. Additionally, this change enhances the robustness of the method by ensuring that comparisons are made between paths with similar prefixes, whether they start with / or file:///.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- This test has been manually verified by registering tables and creating namespaces using the new method. The method ensures that namespaces and tables are only created and registered if they are part of the child directory, while also ensuring that comparisons are made between similar prefixes.

**Test Configuration**:
* Hardware: Macbook M3 Pro
* Toolchain: 
* SDK: Java 21

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
