### PR TITLE
Reduce duplicate md link check

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -41,5 +41,5 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/check-md-link-config.json'
-        folder-path: 'regtests, regtests/client/python/docs, regtests/client/python, .github, build-logic, polaris-core, polaris-service, extension, spec, k8, getting-started'
-        file-path: 'CHAT_BYLAWS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, README.md SECURITY.md'
+        folder-path: 'regtests, .github, build-logic, polaris-core, polaris-service, extension, spec, k8, getting-started, helm'
+        file-path: 'CHAT_BYLAWS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, README.md, SECURITY.md'


### PR DESCRIPTION
# Description

We are using gaurav-nelson/github-action-markdown-link-check@v1 to perform md link check. According to https://github.com/gaurav-nelson/github-action-markdown-link-check/tree/v1, the max depth by default is set to -1 which  means check all levels. Thus, when a duplicate dir levels are provided, it will actually cause duplicate check on the same files multiple times.

Here is the current behavior:
```
# current logic 
➜  find regtests regtests/client/python/docs regtests/client/python .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' -exec markdown-link-check '{}' --config .github/workflows/check-md-link-config.json -q ';'

# current file count after removed the exec part
➜  find regtests regtests/client/python/docs regtests/client/python .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' | wc -l
     515

# Current file count after removed duplicate files
➜ find regtests regtests/client/python/docs regtests/client/python .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' | sort | uniq | wc -l
     206
``` 

Here is the fixed one:
```
# new command without the exec part
➜ find regtests .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' | wc -l
     206
# show no diff in the file captured
➜ find regtests regtests/client/python/docs regtests/client/python .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' | sort | uniq > 1
➜ find regtests .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' | sort | uniq > 2
➜ diff 1 2
➜ 
```

Also, I added `helm` as another directory to check (not necessary as `file-path` already checked for `README.md`. However, looking at `folder-path`, we are specifying all dirs except the one which we want to skipped (e.g. `site` used by hugo), it may be consistent for this.

Lastly, there is a missing separate for `file-path` for the last element 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested this locally via `ack`:
```
➜ act -j markdown-link-check
...
| Using markdown-link-check configuration file: .github/workflows/check-md-link-config.json
| USE_QUIET_MODE: yes
| USE_VERBOSE_MODE: no
| FOLDER_PATH: regtests, .github, build-logic, polaris-core, polaris-service, extension, spec, k8, getting-started
| MAX_DEPTH: -1
| CHECK_MODIFIED_FILES: no
| FILE_EXTENSION: .md
| FILE_PATH: CHAT_BYLAWS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, README.md, SECURITY.md
| + find regtests .github build-logic polaris-core polaris-service extension spec k8 getting-started -name '*.md' -not -path './node_modules/*' -exec markdown-link-check '{}' --config .github/workflows/check-md-link-config.json -q ';'
| + set +x
| + find . -type f '(' -wholename CHAT_BYLAWS.md -o -wholename CODE_OF_CONDUCT.md -o -wholename CONTRIBUTING.md -o -wholename README.md -o -wholename SECURITY.md ')' -not -path './node_modules/*' -exec markdown-link-check '{}' --config .github/workflows/check-md-link-config.json -q ';'
| + set +x
| =========================> MARKDOWN LINK CHECK <=========================
|
| [✔] All links are good!
|
| =========================================================================
[Check Markdown links/markdown-link-check]   ✅  Success - Main gaurav-nelson/github-action-markdown-link-check@v1
[Check Markdown links/markdown-link-check] Cleaning up container for job markdown-link-check
[Check Markdown links/markdown-link-check] 🏁  Job succeeded
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
