### PR TITLE
Move secret validation logic and authN-loadPrincipal into `PolarisSecretsManager`

### DIFF
--- a/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -2355,7 +2355,10 @@ public class PolarisServiceImplIntegrationTest {
   @Test
   public void testTokenInvalidPrincipalId() {
     String newToken =
-        defaultJwt().withClaim(CLAIM_KEY_PRINCIPAL_ID, 0).sign(Algorithm.HMAC256("polaris"));
+        defaultJwt()
+            .withClaim(CLAIM_KEY_PRINCIPAL_ID, 0)
+            .withClaim(CLAIM_KEY_CLIENT_ID, "foo")
+            .sign(Algorithm.HMAC256("polaris"));
     try (Response response =
         newRequest("http://localhost:%d/api/management/v1/principals", newToken).get()) {
       assertThat(response)

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
@@ -36,13 +36,12 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
+import org.apache.polaris.core.auth.PolarisSecretsManager;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.service.config.DefaultConfigurationStore;
 import org.junit.jupiter.api.Test;
@@ -116,10 +115,6 @@ public class JWTRSAKeyPairTest {
     CallContext.setCurrentContext(getTestCallContext(polarisCallContext));
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "client-secret";
-    PolarisPrincipalSecrets principalSecrets =
-        new PolarisPrincipalSecrets(1L, clientId, mainSecret, "otherSecret");
-    Mockito.when(metastoreManager.loadPrincipalSecrets(polarisCallContext, clientId))
-        .thenReturn(new PrincipalSecretsResult(principalSecrets));
     PolarisBaseEntity principal =
         new PolarisBaseEntity(
             0L,
@@ -128,8 +123,8 @@ public class JWTRSAKeyPairTest {
             PolarisEntitySubType.NULL_SUBTYPE,
             0L,
             "principal");
-    Mockito.when(metastoreManager.loadEntity(polarisCallContext, 0L, 1L))
-        .thenReturn(new PolarisMetaStoreManager.EntityResult(principal));
+    Mockito.when(metastoreManager.validateSecret(polarisCallContext, clientId, mainSecret))
+        .thenReturn(new PolarisSecretsManager.SecretValidationResult(principal));
     TokenBroker tokenBroker = new JWTRSAKeyPair(metastoreManager, 420);
     TokenResponse token =
         tokenBroker.generateFromClientSecrets(

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
@@ -26,13 +26,12 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
+import org.apache.polaris.core.auth.PolarisSecretsManager;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -63,10 +62,6 @@ public class JWTSymmetricKeyGeneratorTest {
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "test_secret";
     String clientId = "test_client_id";
-    PolarisPrincipalSecrets principalSecrets =
-        new PolarisPrincipalSecrets(1L, clientId, mainSecret, "otherSecret");
-    Mockito.when(metastoreManager.loadPrincipalSecrets(polarisCallContext, clientId))
-        .thenReturn(new PrincipalSecretsResult(principalSecrets));
     PolarisBaseEntity principal =
         new PolarisBaseEntity(
             0L,
@@ -75,8 +70,8 @@ public class JWTSymmetricKeyGeneratorTest {
             PolarisEntitySubType.NULL_SUBTYPE,
             0L,
             "principal");
-    Mockito.when(metastoreManager.loadEntity(polarisCallContext, 0L, 1L))
-        .thenReturn(new PolarisMetaStoreManager.EntityResult(principal));
+    Mockito.when(metastoreManager.validateSecret(polarisCallContext, clientId, mainSecret))
+        .thenReturn(new PolarisSecretsManager.SecretValidationResult(principal));
     TokenBroker generator = new JWTSymmetricKeyBroker(metastoreManager, 666, () -> "polaris");
     TokenResponse token =
         generator.generateFromClientSecrets(

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BaseResult;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager.EntityResult;
 
 /** Manages secrets for Polaris principals. */
 public interface PolarisSecretsManager {
@@ -38,6 +40,17 @@ public interface PolarisSecretsManager {
   @Nonnull
   PrincipalSecretsResult loadPrincipalSecrets(
       @Nonnull PolarisCallContext callCtx, @Nonnull String clientId);
+
+  @Nonnull
+  SecretValidationResult validateSecret(
+      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId, @Nonnull String clientSecret);
+
+  @Nonnull
+  EntityResult loadPrincipal(
+      @Nonnull PolarisCallContext callCtx,
+      @Nullable String roleName,
+      @Nullable String clientId,
+      @Nullable Long principalId);
 
   /**
    * Rotate secrets
@@ -98,6 +111,36 @@ public interface PolarisSecretsManager {
 
     public PolarisPrincipalSecrets getPrincipalSecrets() {
       return principalSecrets;
+    }
+  }
+
+  /** the result of load/rotate principal secrets */
+  class SecretValidationResult extends BaseResult {
+
+    private final PolarisBaseEntity principal;
+
+    public SecretValidationResult(
+        @Nonnull BaseResult.ReturnStatus errorCode, @Nullable String extraInformation) {
+      super(errorCode, extraInformation);
+      this.principal = null;
+    }
+
+    public SecretValidationResult(@Nonnull PolarisBaseEntity principal) {
+      super(BaseResult.ReturnStatus.SUCCESS);
+      this.principal = principal;
+    }
+
+    @JsonCreator
+    private SecretValidationResult(
+        @JsonProperty("returnStatus") @Nonnull BaseResult.ReturnStatus returnStatus,
+        @JsonProperty("extraInformation") @Nullable String extraInformation,
+        @JsonProperty("principalSecrets") @Nonnull PolarisBaseEntity principal) {
+      super(returnStatus, extraInformation);
+      this.principal = principal;
+    }
+
+    public PolarisBaseEntity getPrincipal() {
+      return principal;
     }
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseResult.java
@@ -111,6 +111,8 @@ public class BaseResult {
 
     // error caught while sub-scoping credentials. Error message will be returned
     SUBSCOPE_CREDS_ERROR(13),
+
+    SECRET_VALIDATION_FAILED(14),
     ;
 
     // code for the enum

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
@@ -70,7 +70,7 @@ public class PolarisEntityManager {
         callContext.getPolarisCallContext(),
         metaStoreManager,
         authenticatedPrincipal.getPrincipalEntity().getId(),
-        null, /* callerPrincipalName */
+        authenticatedPrincipal.getPrincipalEntity().getName(),
         authenticatedPrincipal.getActivatedPrincipalRoleNames().isEmpty()
             ? null
             : authenticatedPrincipal.getActivatedPrincipalRoleNames(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -34,6 +34,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Wraps an existing impl of PolarisMetaStoreManager and delegates expected "read" operations
@@ -126,6 +127,23 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "loadPrincipalSecrets");
+    return null;
+  }
+
+  @Override
+  public @NotNull SecretValidationResult validateSecret(
+      @NotNull PolarisCallContext callCtx, @NotNull String clientId, @NotNull String clientSecret) {
+    callCtx.getDiagServices().fail("illegal_method_in_transaction_workspace", "validateSecret");
+    return null;
+  }
+
+  @Override
+  public @NotNull EntityResult loadPrincipal(
+      @NotNull PolarisCallContext callCtx,
+      @Nullable String roleName,
+      @Nullable String clientId,
+      @Nullable Long principalId) {
+    callCtx.getDiagServices().fail("illegal_method_in_transaction_workspace", "validateSecret");
     return null;
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
@@ -30,8 +30,6 @@ import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -65,17 +63,12 @@ public abstract class BasePolarisAuthenticator
     PolarisEntity principal;
     try {
       principal =
-          tokenInfo.getPrincipalId() > 0
-              ? PolarisEntity.of(
-                  metaStoreManager.loadEntity(
-                      getCurrentPolarisContext(), 0L, tokenInfo.getPrincipalId()))
-              : PolarisEntity.of(
-                  metaStoreManager.readEntityByName(
-                      getCurrentPolarisContext(),
-                      null,
-                      PolarisEntityType.PRINCIPAL,
-                      PolarisEntitySubType.NULL_SUBTYPE,
-                      tokenInfo.getSub()));
+          PolarisEntity.of(
+              metaStoreManager.loadPrincipal(
+                  getCurrentPolarisContext(),
+                  tokenInfo.getSub(),
+                  tokenInfo.getClientId(),
+                  tokenInfo.getPrincipalId()));
     } catch (Exception e) {
       LOGGER
           .atError()


### PR DESCRIPTION
The logic _how_ a principal and/or principal secret's are persisted should be transparent to the calling code. Relying on the persistence internals for principals and secrets management makes it impossible to factor out secrets management / make principal management possible.

This change moves the secret validation and retrieval of a principal by client-ID behind an implementation of `PolarisSecretsManager`.
