### PR TITLE
Properly name dependency smallrye-common-annotation

### DIFF
--- a/extension/persistence/eclipselink/build.gradle.kts
+++ b/extension/persistence/eclipselink/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   implementation(libs.eclipselink)
   implementation(platform(libs.dropwizard.bom))
   implementation(libs.jakarta.inject.api)
-  implementation(libs.smallrye)
+  implementation(libs.smallrye.common.annotation)
   implementation("io.dropwizard:dropwizard-jackson")
   val eclipseLinkDeps: String? = project.findProperty("eclipseLinkDeps") as String?
   eclipseLinkDeps?.let {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,12 +67,12 @@ opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semco
 prometheus-metrics-exporter-servlet-jakarta = { module = "io.prometheus:prometheus-metrics-exporter-servlet-jakarta", version = "1.3.0" }
 s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "3.11.0" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+smallrye-common-annotation = { module = "io.smallrye.common:smallrye-common-annotation", version = "2.9.0" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version = "4.8.5" }
 swagger-annotations = { module = "io.swagger:swagger-annotations", version.ref = "swagger" }
 swagger-jaxrs = { module = "io.swagger:swagger-jaxrs", version.ref = "swagger" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.20.3" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
-smallrye = { module = "io.smallrye.config:smallrye-config", version = "3.10.2" }
 
 [plugins]
 openapi-generator = { id = "org.openapi.generator", version = "7.6.0" }

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
   implementation(libs.swagger.jaxrs)
   implementation(libs.jakarta.inject.api)
   implementation(libs.jakarta.validation.api)
-  implementation(libs.smallrye)
+  implementation(libs.smallrye.common.annotation)
 
   implementation("org.apache.iceberg:iceberg-aws")
   implementation(platform(libs.awssdk.bom))

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     exclude("org.apache.zookeeper", "zookeeper")
   }
   implementation(libs.hadoop.hdfs.client)
-  implementation(libs.smallrye)
+  implementation(libs.smallrye.common.annotation)
 
   implementation(platform(libs.dropwizard.bom))
   implementation("io.dropwizard:dropwizard-core")


### PR DESCRIPTION
"Smallrye" is a whole bunch of projects, this change updates the dependency name to match the actual artifact.