### PR TITLE
Split DefaultContextResolver in 2 beans

### DIFF
--- a/dropwizard/service/src/main/resources/META-INF/hk2-locator/default
+++ b/dropwizard/service/src/main/resources/META-INF/hk2-locator/default
@@ -51,8 +51,13 @@ contract={org.apache.polaris.service.auth.TokenBrokerFactory}
 name=rsa-key-pair
 qualifier={io.smallrye.common.annotation.Identifier}
 
-[org.apache.polaris.service.context.DefaultContextResolver]S
-contract={org.apache.polaris.service.context.CallContextResolver,org.apache.polaris.service.context.RealmContextResolver}
+[org.apache.polaris.service.context.DefaultRealmContextResolver]S
+contract={org.apache.polaris.service.context.RealmContextResolver}
+name=default
+qualifier={io.smallrye.common.annotation.Identifier}
+
+[org.apache.polaris.service.context.DefaultCallContextResolver]S
+contract={org.apache.polaris.service.context.CallContextResolver}
 name=default
 qualifier={io.smallrye.common.annotation.Identifier}
 

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/PolarisApplicationIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.apache.polaris.service.dropwizard.throttling.RequestThrottlingErrorResponse.RequestThrottlingErrorType.REQUEST_TOO_LARGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/TimedApplicationEventListenerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.apache.polaris.service.dropwizard.TimedApplicationEventListener.SINGLETON_METRIC_NAME;
 import static org.apache.polaris.service.dropwizard.TimedApplicationEventListener.TAG_API_NAME;
 import static org.apache.polaris.service.dropwizard.monitor.PolarisMetricRegistry.SUFFIX_COUNTER;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.admin;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.ConfigOverride;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingTableTest.java
@@ -19,7 +19,7 @@
 package org.apache.polaris.service.admin;
 
 import static org.apache.polaris.service.admin.PolarisAuthzTestBase.SCHEMA;
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.ConfigOverride;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisRealmEntityCacheTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisRealmEntityCacheTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.admin;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.core.setup.Environment;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplIntegrationTest.java
@@ -19,7 +19,7 @@
 package org.apache.polaris.service.admin;
 
 import static io.dropwizard.jackson.Jackson.newObjectMapper;
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.auth0.jwt.JWT;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/auth/TokenUtils.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/auth/TokenUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.auth;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.client.Client;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogViewIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/PolarisSparkIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/catalog/TestUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/ratelimiter/TestUtil.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/ratelimiter/TestUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.ratelimiter;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.junit5.DropwizardAppExtension;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/test/PolarisConnectionExtension.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.test;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.apache.polaris.service.test.DropwizardTestEnvironmentResolver.findDropwizardExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/test/SnowmanCredentialsExtension.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.test;
 
-import static org.apache.polaris.service.context.DefaultContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.client.Entity;

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.context;
+
+import static org.apache.polaris.service.context.DefaultRealmContextResolver.parseBearerTokenAsKvPairs;
+
+import io.smallrye.common.annotation.Identifier;
+import jakarta.inject.Inject;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.Map;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisConfigurationStore;
+import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * For local/dev testing, this resolver simply expects a custom bearer-token format that is a
+ * semicolon-separated list of colon-separated key/value pairs that constitute the realm properties.
+ *
+ * <p>Example: principal:data-engineer;password:test;realm:acct123
+ */
+@Identifier("default")
+public class DefaultCallContextResolver implements CallContextResolver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCallContextResolver.class);
+
+  public static final String PRINCIPAL_PROPERTY_KEY = "principal";
+  public static final String PRINCIPAL_PROPERTY_DEFAULT_VALUE = "default-principal";
+
+  @Inject private MetaStoreManagerFactory metaStoreManagerFactory;
+  @Inject private PolarisConfigurationStore configurationStore;
+
+  @Override
+  public CallContext resolveCallContext(
+      final RealmContext realmContext,
+      String method,
+      String path,
+      Map<String, String> queryParams,
+      Map<String, String> headers) {
+    LOGGER
+        .atDebug()
+        .addKeyValue("realmContext", realmContext.getRealmIdentifier())
+        .addKeyValue("method", method)
+        .addKeyValue("path", path)
+        .addKeyValue("queryParams", queryParams)
+        .addKeyValue("headers", headers)
+        .log("Resolving CallContext");
+    final Map<String, String> parsedProperties = parseBearerTokenAsKvPairs(headers);
+
+    if (!parsedProperties.containsKey(PRINCIPAL_PROPERTY_KEY)) {
+      LOGGER.warn(
+          "Failed to parse {} from headers ({}); using {}",
+          PRINCIPAL_PROPERTY_KEY,
+          headers,
+          PRINCIPAL_PROPERTY_DEFAULT_VALUE);
+      parsedProperties.put(PRINCIPAL_PROPERTY_KEY, PRINCIPAL_PROPERTY_DEFAULT_VALUE);
+    }
+
+    PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
+    PolarisMetaStoreSession metaStoreSession =
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+    PolarisCallContext polarisContext =
+        new PolarisCallContext(
+            metaStoreSession,
+            diagServices,
+            configurationStore,
+            Clock.system(ZoneId.systemDefault()));
+    return CallContext.of(realmContext, polarisContext);
+  }
+}


### PR DESCRIPTION
This refactoring is a no-op in terms of functionality.

This is required as `RealmContext` and `CallContext` may be treated differently in the future (e.g. different scopes).