### PR TITLE
Don't let `test` depend on `shadowJar`

### DIFF
--- a/build-logic/src/main/kotlin/polaris-shadow-jar.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-shadow-jar.gradle.kts
@@ -29,12 +29,11 @@ shadowJar.configure {
   mergeServiceFiles()
 }
 
-tasks.named<Jar>("jar").configure {
-  dependsOn(shadowJar)
-  archiveClassifier = "raw"
-}
+tasks.named<Jar>("jar").configure { archiveClassifier = "raw" }
 
 tasks.withType<ShadowJar>().configureEach {
   exclude("META-INF/jandex.idx")
   isZip64 = true
 }
+
+tasks.named("assemble").configure { dependsOn("shadowJar") }

--- a/dropwizard/service/build.gradle.kts
+++ b/dropwizard/service/build.gradle.kts
@@ -160,12 +160,7 @@ tasks.register<Jar>("testJar") {
 
 val shadowJar =
   tasks.named<ShadowJar>("shadowJar") {
-    manifest {
-      attributes["Main-Class"] = "org.apache.polaris.service.dropwizard.PolarisApplication"
-    }
-    mergeServiceFiles()
     append("META-INF/hk2-locator/default")
-    isZip64 = true
     finalizedBy("startScripts")
   }
 


### PR DESCRIPTION
The `test` task for modules producing a `shadowJar` artifact currently depend on the `shadowJar` task. This isn't necessary to run the tests.

This change removes the dependency of `test` on that task (via `jar`), letting tests in affected modules start much faster, because `shadowJar` isn't running.

Also removing related duplicated configurations in `polaris-dropwizard-service`.
