### PR TITLE
Add 2024/12/12 meeting record and Slack workspace

### DIFF
--- a/CHAT_BYLAWS.md
+++ b/CHAT_BYLAWS.md
@@ -23,8 +23,11 @@ Apache Polaris is currently undergoing Incubation at the Apache Software Foundat
 
 ## Motivation
 
-The Polaris project uses a public and open chat service currently provided by Zulip hosted
-at https://polaris-catalog.zulipchat.com/. A few rules shall ensure that the chat conforms to the rules and best
+Apache Polaris uses two public and open chat services:
+* Slack workspace at https://apache-polaris.slack.com/ (join [here](https://join.slack.com/t/apache-polaris/shared_invite/zt-2w1fddyh3-zqCeeJwn7wNvhn3mVT5njQ))
+* Zuplip hosted at https://polaris-catalog.zulipchat.com
+
+A few rules shall ensure that the chat conforms to the rules and best
 practices of the Apache Software Foundation and serves well as a collaboration tool for the project.
 
 Organizations and other open-source projects that contribute continuously and significantly to Polaris are welcome, but
@@ -41,7 +44,7 @@ the Polaris project public chat.
   chat service.
 * Everybody is welcome to join the Polaris project chat. Invites are not needed.
 * All users are automatically promoted to “members” (don’t stay in “guests”).
-* Polaris project (P)PMC members have “owner” privileges on the Zulip chat. Polaris project committers are granted
+* Polaris project (P)PMC members have “owner” privileges on the Zulip and Slack chat. Polaris project committers are granted
   “moderator” or “administrator” privileges for moderation purposes.
 * This bylaws document shall be published on the project’s web site and linked from relevant public channels.
 * Only (P)PMC members are allowed to create new channels. The number of channels shall be limited to #general (user

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,12 @@ When filing an [issue](https://github.com/apache/polaris/issues), make sure to a
 4. What did you expect to see?
 5. What did you see instead?
 
-Troubleshooting questions should be posted on the [public chat](https://polaris-catalog.zulipchat.com/) (no invite needed) or on [dev mailing list](mailto:dev@polaris.apache.org) (you can [subscribe](mailto:dev-subscribe@polaris.apache.org)) instead of the issue tracker. Maintainers and community members will answer your questions there or ask you to file an issue if you’ve encountered a bug. 
+Troubleshooting questions should be posted on: 
+* [Slack](https://apache-polaris.slack.com/)
+* [Zulip](https://polaris-catalog.zulipchat.com/)
+* [dev mailing list](mailto:dev@polaris.apache.org) (you can [subscribe](mailto:dev-subscribe@polaris.apache.org)) instead of the issue tracker. 
 
+Maintainers and community members will answer your questions there or ask you to file an issue if you’ve encountered a bug.
 
 ### How to suggest a feature or enhancement
 

--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -30,8 +30,11 @@ cascade:
 {{% blocks/feature icon="fa-solid fa-graduation-cap" title="Learn, Connect and Collaborate" %}}
 [cols="2,3"]
 |===
+| link:https://apache-polaris.slack.com/[Slack]
+| Public chat, open to everybody
+
 | link:https://polaris-catalog.zulipchat.com/[Zulip]
-| Our public chat, open to everybody
+| Public chat, open to everybody
 
 | link:{{% ref "meetings" %}}[Community Meetings]
 | Upcoming, live and recorded Community Meetings

--- a/site/content/community/meetings/_index.adoc
+++ b/site/content/community/meetings/_index.adoc
@@ -41,18 +41,27 @@ https://meet.google.com/pii-faxn-woh[Google Meet Link]
 |===
 | Date | Time
 
-| 2024-11-14 | 9:00 AM PST
-
-18:00 CET
-| 2024-11-28 | 9:00 AM PST
-
-18:00 CET
-| 2024-12-12 | 9:00 AM PST
-
-18:00 CET
 | 2024-12-26 | 9:00 AM PST
-
 18:00 CET
+
+| 2025-01-09 | 9:00 AM PST
+18:00 CET
+
+| 2025-01-23 | 9:00 AM PST
+18:00 CET
+
+| 2025-02-06 | 9:00 AM PST
+18:00 CET
+
+| 2025-02-20 | 9:00 AM PST
+18:00 CET
+
+| 2025-03-06 | 9:00 AM PST
+18:00 CET
+
+| 2025-03-20 | 9:00 AM PST
+18:00 CET
+
 | ... |
 |===
 
@@ -61,6 +70,10 @@ https://meet.google.com/pii-faxn-woh[Google Meet Link]
 [cols="1,3,3"]
 |===
 | Date | Notes | Recording
+
+| 2024-12-12
+| https://docs.google.com/document/d/1TAAMjCtk4KuWSwfxpCBhhK9vM1k_3n7YE4L28slclXU/edit?tab=t.0#heading=h.kf4agp8flxjb[Meeting Notes]
+| https://drive.google.com/file/d/1OJiOnn9otN36tgibTMk73wSl01wEak9M/view?usp=sharing
 
 | 2024-11-14
 | https://docs.google.com/document/d/1TAAMjCtk4KuWSwfxpCBhhK9vM1k_3n7YE4L28slclXU/edit?tab=t.0#heading=h.kf4agp8flxjb[Meeting Notes]

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -38,6 +38,10 @@ params:
   links:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
+      - name: Slack
+        url: https://apache-polaris.slack.com/
+        icon: fa-regular fa-comment-dots
+        desc: Chat with other project developers
       - name: Zulip
         url: https://polaris-catalog.zulipchat.com/
         icon: fa-regular fa-comment-dots


### PR DESCRIPTION
This PR publish the 2024/12/12 meeting record.

I also added Slack workspace in addition of Zulip for now (to give time to users to switch).