### PR TITLE
Update GitHub templates + remove checkbox from bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -19,25 +19,16 @@
 
 name: Bug report
 description: Create a report to help us improve.
-title: "[BUG]"
+title: "[BUG] (provide short, concise summary)"
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/apache/polaris/issues), use the `Filter` field to narrow down your search.
-
-        Please provide a title above with a short, concise summary - don't leave it "empty".
-
-        Do **NOT** share any sensitive information like password, security tokens, private URLs etc.
-
-  - type: checkboxes
-    attributes:
-      label: "Is this a possible security vulnerability?"
-      description: "If yes, then STOP here and contact security@apache.org instead!"
-      options:
-        - label: "This is NOT a possible security vulnerability"
-          required: true
+        * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/apache/polaris/issues), use the `Filter` field to narrow down your search.
+        * **Possible security vulnerabilities**: STOP here and contact `security@apache.org` instead!
+        * _**Please provide a title above with a short, concise summary**_ - don't leave it "empty".
+        * Do **NOT** share any sensitive information like password, security tokens, private URLs etc.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -19,7 +19,6 @@
 
 name: Bug report
 description: Create a report to help us improve.
-title: "[BUG] (provide short, concise summary)"
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -19,17 +19,15 @@
 
 name: Feature request
 description: Suggest an idea for this project
-title: "[FEATURE REQUEST]"
-labels: enhancement
+title: "[FEATURE REQUEST] (provide short, concise summary)"
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Verify that the feature request is not already reported, looking at the [currently open issues](https://github.com/apache/polaris/issues), use the `Filter` field to narrow down your search.
-
-        Please provide a title above with a short, concise summary - don't leave it "empty".
-
-        Do **NOT** share any sensitive information like password, security tokens, private URLs etc.
+        * Verify that the feature request is not already reported, looking at the [currently open issues](https://github.com/apache/polaris/issues), use the `Filter` field to narrow down your search.
+        * _**Please provide a title above with a short, concise summary**_ - don't leave it "empty".
+        * Do **NOT** share any sensitive information like password, security tokens, private URLs etc.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -19,7 +19,6 @@
 
 name: Feature request
 description: Suggest an idea for this project
-title: "[FEATURE REQUEST] (provide short, concise summary)"
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,24 @@
-# Description
+<!--
+    Possible security vulnerabilities: STOP here and contact security@apache.org instead!
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
+    Please update this summary field:
 
-Fixes # (issue)
+    The summary should cover these topics, if applicable:
+    * the motivation for the change
+    * a description of the status quo, for example the current behavior
+    * the desired behavior
+    * etc
 
-## Type of change
+    PR checklist:
+    - Do a self-review of your code before opening a pull request
+    - Make sure that there's good test coverage for the changes included in this PR
+    - Run tests locally before pushing a PR (./gradlew check)
+    - Code should have comments where applicable. Particularly hard-to-understand
+      areas deserve good in-line documentation.
+    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
+    - For Work In Progress Pull Requests, please use the Draft PR feature.
 
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] Documentation update
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-# How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Test A
-- [ ] Test B
-
-**Test Configuration**:
-* Hardware:
-* Toolchain:
-* SDK:
-
-# Checklist:
-
-Please delete options that are not relevant.
-
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
+    Make sure to add the information BELOW this comment.
+    Everything in this comment will NOT be added to the PR description.
+-->


### PR DESCRIPTION
The current PR template contains a lot of overly detailed textual information. This change moves the relevant parts into a _comment_ which does not "leak" into PR descriptions, leaving the whole description field for developer-provided information.

Also removes the "security issue" checkbox, but highlight the fact.