### PR TITLE
Pass RealmContext instance to all API methods

### DIFF
--- a/api/iceberg-service/build.gradle.kts
+++ b/api/iceberg-service/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
 }
 
 dependencies {
+  implementation(project(":polaris-core"))
+
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")
   implementation("org.apache.iceberg:iceberg-core")

--- a/api/management-service/build.gradle.kts
+++ b/api/management-service/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 
 dependencies {
   implementation(project(":polaris-api-management-model"))
+  implementation(project(":polaris-core"))
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/server-templates/api.mustache
+++ b/server-templates/api.mustache
@@ -54,6 +54,8 @@ import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 import {{javaxPackage}}.inject.Inject;
 
+import org.apache.polaris.core.context.RealmContext;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +107,7 @@ public class {{classname}}  {
   @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}{{#hasAuthMethods}}
   {{#authMethods}}{{#isOAuth}}@RolesAllowed({ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }){{/isOAuth}}{{/authMethods}}{{/hasAuthMethods}}
   @Timed("{{metricsPrefix}}.{{baseName}}.{{nickname}}")
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context RealmContext realmContext,@Context SecurityContext securityContext) {
 {{! Don't log form or header params in case there are secrets, e.g., OAuth tokens }}
     LOGGER.atDebug().setMessage("Invoking {{baseName}} with params")
       .addKeyValue("operation", "{{nickname}}"){{#allParams}}{{^isHeaderParam}}{{^isFormParam}}
@@ -113,7 +115,7 @@ public class {{classname}}  {
       .log();
 
     Response ret =
-      service.{{nickname}}({{#isMultipart}}input,{{/isMultipart}}{{#allParams}}{{^isMultipart}}{{paramName}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}securityContext);
+      service.{{nickname}}({{#isMultipart}}input,{{/isMultipart}}{{#allParams}}{{^isMultipart}}{{paramName}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}realmContext,securityContext);
     LOGGER.debug("Completed execution of {{nickname}} API with status code {}", ret.getStatus());
     return ret;
   }

--- a/server-templates/apiService.mustache
+++ b/server-templates/apiService.mustache
@@ -35,6 +35,8 @@ import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.ws.rs.core.Response;
 import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
+import org.apache.polaris.core.context.RealmContext;
+
 {{!
 Note that this template is copied from https://github.com/OpenAPITools/openapi-generator/blob/783e68c7acbbdcbb2282d167d1644b069f12d486/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiService.mustache
 It is here to remove some unsupported imports and to update the default implementation to return a
@@ -52,7 +54,7 @@ It is here to remove some unsupported imports and to update the default implemen
 {{#operations}}
 public interface {{classname}}Service {
   {{#operation}}
-  default Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}SecurityContext securityContext) {
+  default Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmContext realmContext,SecurityContext securityContext) {
     return Response.status(501).build(); // not implemented
   }
   {{/operation}}

--- a/server-templates/apiServiceImpl.mustache
+++ b/server-templates/apiServiceImpl.mustache
@@ -36,6 +36,8 @@ import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.ws.rs.core.Response;
 import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
+import org.apache.polaris.core.context.RealmContext;
+
 {{!
 Note that this template is copied from https://github.com/OpenAPITools/openapi-generator/blob/783e68c7acbbdcbb2282d167d1644b069f12d486/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiServiceImpl.mustache
 It is here to remove some unsupported imports (ApiResponseMessage, openapi.tools.*)
@@ -53,7 +55,7 @@ It is here to remove some unsupported imports (ApiResponseMessage, openapi.tools
 {{#operations}}
 public class {{classname}}ServiceImpl implements {{classname}}Service {
   {{#operation}}
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmContext realmContext,SecurityContext securityContext) {
     return Response.status(501).build(); // not implemented
   }
   {{/operation}}

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -58,6 +58,7 @@ import org.apache.polaris.core.admin.model.ViewGrant;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.PolarisPrivilege;
@@ -93,8 +94,8 @@ public class PolarisServiceImpl
     this.polarisAuthorizer = polarisAuthorizer;
   }
 
-  private PolarisAdminService newAdminService(SecurityContext securityContext) {
-    CallContext callContext = CallContext.getCurrentContext();
+  private PolarisAdminService newAdminService(
+      RealmContext realmContext, SecurityContext securityContext) {
     AuthenticatedPolarisPrincipal authenticatedPrincipal =
         (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
     if (authenticatedPrincipal == null) {
@@ -102,17 +103,23 @@ public class PolarisServiceImpl
     }
 
     PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(callContext.getRealmContext());
+        entityManagerFactory.getOrCreateEntityManager(realmContext);
     PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(callContext.getRealmContext());
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     return new PolarisAdminService(
-        callContext, entityManager, metaStoreManager, authenticatedPrincipal, polarisAuthorizer);
+        // FIXME remove call to CallContext.getCurrentContext()
+        CallContext.getCurrentContext(),
+        entityManager,
+        metaStoreManager,
+        authenticatedPrincipal,
+        polarisAuthorizer);
   }
 
   /** From PolarisCatalogsApiService */
   @Override
-  public Response createCatalog(CreateCatalogRequest request, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response createCatalog(
+      CreateCatalogRequest request, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     Catalog catalog = request.getCatalog();
     validateStorageConfig(catalog.getStorageConfigInfo());
     Catalog newCatalog =
@@ -123,13 +130,13 @@ public class PolarisServiceImpl
   }
 
   private void validateStorageConfig(StorageConfigInfo storageConfigInfo) {
-    CallContext callContext = CallContext.getCurrentContext();
-    PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
+    PolarisCallContext polarisRealmContext =
+        CallContext.getCurrentContext().getPolarisCallContext();
     List<String> allowedStorageTypes =
-        polarisCallContext
+        polarisRealmContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
+                polarisRealmContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
     if (!allowedStorageTypes.contains(storageConfigInfo.getStorageType().name())) {
       LOGGER
           .atWarn()
@@ -142,24 +149,29 @@ public class PolarisServiceImpl
 
   /** From PolarisCatalogsApiService */
   @Override
-  public Response deleteCatalog(String catalogName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response deleteCatalog(
+      String catalogName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.deleteCatalog(catalogName);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   /** From PolarisCatalogsApiService */
   @Override
-  public Response getCatalog(String catalogName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response getCatalog(
+      String catalogName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.getCatalog(catalogName).asCatalog()).build();
   }
 
   /** From PolarisCatalogsApiService */
   @Override
   public Response updateCatalog(
-      String catalogName, UpdateCatalogRequest updateRequest, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      UpdateCatalogRequest updateRequest,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     if (updateRequest.getStorageConfigInfo() != null) {
       validateStorageConfig(updateRequest.getStorageConfigInfo());
     }
@@ -168,8 +180,8 @@ public class PolarisServiceImpl
 
   /** From PolarisCatalogsApiService */
   @Override
-  public Response listCatalogs(SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response listCatalogs(RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<Catalog> catalogList =
         adminService.listCatalogs().stream()
             .map(CatalogEntity::new)
@@ -182,8 +194,9 @@ public class PolarisServiceImpl
 
   /** From PolarisPrincipalsApiService */
   @Override
-  public Response createPrincipal(CreatePrincipalRequest request, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response createPrincipal(
+      CreatePrincipalRequest request, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     PrincipalEntity principal = PrincipalEntity.fromPrincipal(request.getPrincipal());
     if (Boolean.TRUE.equals(request.getCredentialRotationRequired())) {
       principal =
@@ -196,39 +209,45 @@ public class PolarisServiceImpl
 
   /** From PolarisPrincipalsApiService */
   @Override
-  public Response deletePrincipal(String principalName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response deletePrincipal(
+      String principalName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.deletePrincipal(principalName);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   /** From PolarisPrincipalsApiService */
   @Override
-  public Response getPrincipal(String principalName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response getPrincipal(
+      String principalName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.getPrincipal(principalName).asPrincipal()).build();
   }
 
   /** From PolarisPrincipalsApiService */
   @Override
   public Response updatePrincipal(
-      String principalName, UpdatePrincipalRequest updateRequest, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String principalName,
+      UpdatePrincipalRequest updateRequest,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.updatePrincipal(principalName, updateRequest).asPrincipal())
         .build();
   }
 
   /** From PolarisPrincipalsApiService */
   @Override
-  public Response rotateCredentials(String principalName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response rotateCredentials(
+      String principalName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.rotateCredentials(principalName)).build();
   }
 
   /** From PolarisPrincipalsApiService */
   @Override
-  public Response listPrincipals(SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response listPrincipals(RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<Principal> principalList =
         adminService.listPrincipals().stream()
             .map(PrincipalEntity::new)
@@ -242,8 +261,10 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalRolesApiService */
   @Override
   public Response createPrincipalRole(
-      CreatePrincipalRoleRequest request, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      CreatePrincipalRoleRequest request,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     PrincipalRole newPrincipalRole =
         new PrincipalRoleEntity(
                 adminService.createPrincipalRole(
@@ -255,16 +276,18 @@ public class PolarisServiceImpl
 
   /** From PolarisPrincipalRolesApiService */
   @Override
-  public Response deletePrincipalRole(String principalRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response deletePrincipalRole(
+      String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.deletePrincipalRole(principalRoleName);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   /** From PolarisPrincipalRolesApiService */
   @Override
-  public Response getPrincipalRole(String principalRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response getPrincipalRole(
+      String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.getPrincipalRole(principalRoleName).asPrincipalRole()).build();
   }
 
@@ -273,8 +296,9 @@ public class PolarisServiceImpl
   public Response updatePrincipalRole(
       String principalRoleName,
       UpdatePrincipalRoleRequest updateRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(
             adminService.updatePrincipalRole(principalRoleName, updateRequest).asPrincipalRole())
         .build();
@@ -282,8 +306,8 @@ public class PolarisServiceImpl
 
   /** From PolarisPrincipalRolesApiService */
   @Override
-  public Response listPrincipalRoles(SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response listPrincipalRoles(RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<PrincipalRole> principalRoleList =
         adminService.listPrincipalRoles().stream()
             .map(PrincipalRoleEntity::new)
@@ -297,8 +321,11 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response createCatalogRole(
-      String catalogName, CreateCatalogRoleRequest request, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      CreateCatalogRoleRequest request,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     CatalogRole newCatalogRole =
         new CatalogRoleEntity(
                 adminService.createCatalogRole(
@@ -311,8 +338,11 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response deleteCatalogRole(
-      String catalogName, String catalogRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      String catalogRoleName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.deleteCatalogRole(catalogName, catalogRoleName);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -320,8 +350,11 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response getCatalogRole(
-      String catalogName, String catalogRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      String catalogRoleName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(adminService.getCatalogRole(catalogName, catalogRoleName).asCatalogRole())
         .build();
   }
@@ -332,8 +365,9 @@ public class PolarisServiceImpl
       String catalogName,
       String catalogRoleName,
       UpdateCatalogRoleRequest updateRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     return Response.ok(
             adminService
                 .updateCatalogRole(catalogName, catalogRoleName, updateRequest)
@@ -343,8 +377,9 @@ public class PolarisServiceImpl
 
   /** From PolarisCatalogsApiService */
   @Override
-  public Response listCatalogRoles(String catalogName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+  public Response listCatalogRoles(
+      String catalogName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<CatalogRole> catalogRoleList =
         adminService.listCatalogRoles(catalogName).stream()
             .map(CatalogRoleEntity::new)
@@ -358,12 +393,15 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalsApiService */
   @Override
   public Response assignPrincipalRole(
-      String principalName, GrantPrincipalRoleRequest request, SecurityContext securityContext) {
+      String principalName,
+      GrantPrincipalRoleRequest request,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     LOGGER.info(
         "Assigning principalRole {} to principal {}",
         request.getPrincipalRole().getName(),
         principalName);
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.assignPrincipalRole(principalName, request.getPrincipalRole().getName());
     return Response.status(Response.Status.CREATED).build();
   }
@@ -371,9 +409,12 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalsApiService */
   @Override
   public Response revokePrincipalRole(
-      String principalName, String principalRoleName, SecurityContext securityContext) {
+      String principalName,
+      String principalRoleName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     LOGGER.info("Revoking principalRole {} from principal {}", principalRoleName, principalName);
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.revokePrincipalRole(principalName, principalRoleName);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -381,8 +422,8 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalsApiService */
   @Override
   public Response listPrincipalRolesAssigned(
-      String principalName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String principalName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<PrincipalRole> principalRoleList =
         adminService.listPrincipalRolesAssigned(principalName).stream()
             .map(PrincipalRoleEntity::new)
@@ -399,13 +440,14 @@ public class PolarisServiceImpl
       String principalRoleName,
       String catalogName,
       GrantCatalogRoleRequest request,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     LOGGER.info(
         "Assigning catalogRole {} in catalog {} to principalRole {}",
         request.getCatalogRole().getName(),
         catalogName,
         principalRoleName);
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.assignCatalogRoleToPrincipalRole(
         principalRoleName, catalogName, request.getCatalogRole().getName());
     return Response.status(Response.Status.CREATED).build();
@@ -417,13 +459,14 @@ public class PolarisServiceImpl
       String principalRoleName,
       String catalogName,
       String catalogRoleName,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     LOGGER.info(
         "Revoking catalogRole {} in catalog {} from principalRole {}",
         catalogRoleName,
         catalogName,
         principalRoleName);
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     adminService.revokeCatalogRoleFromPrincipalRole(
         principalRoleName, catalogName, catalogRoleName);
     return Response.status(Response.Status.NO_CONTENT).build();
@@ -432,8 +475,8 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalRolesApiService */
   @Override
   public Response listAssigneePrincipalsForPrincipalRole(
-      String principalRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<Principal> principalList =
         adminService.listAssigneePrincipalsForPrincipalRole(principalRoleName).stream()
             .map(PrincipalEntity::new)
@@ -447,8 +490,11 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalRolesApiService */
   @Override
   public Response listCatalogRolesForPrincipalRole(
-      String principalRoleName, String catalogName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String principalRoleName,
+      String catalogName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<CatalogRole> catalogRoleList =
         adminService.listCatalogRolesForPrincipalRole(principalRoleName, catalogName).stream()
             .map(CatalogRoleEntity::new)
@@ -465,13 +511,14 @@ public class PolarisServiceImpl
       String catalogName,
       String catalogRoleName,
       AddGrantRequest grantRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     LOGGER.info(
         "Adding grant {} to catalogRole {} in catalog {}",
         grantRequest,
         catalogRoleName,
         catalogName);
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     switch (grantRequest.getGrant()) {
         // The per-securable-type Privilege enums must be exact String match for a subset of all
         // PolarisPrivilege values.
@@ -535,6 +582,7 @@ public class PolarisServiceImpl
       String catalogRoleName,
       Boolean cascade,
       RevokeGrantRequest grantRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     LOGGER.info(
         "Revoking grant {} from catalogRole {} in catalog {}",
@@ -546,7 +594,7 @@ public class PolarisServiceImpl
       return Response.status(501).build(); // not implemented
     }
 
-    PolarisAdminService adminService = newAdminService(securityContext);
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     switch (grantRequest.getGrant()) {
         // The per-securable-type Privilege enums must be exact String match for a subset of all
         // PolarisPrivilege values.
@@ -606,8 +654,11 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response listAssigneePrincipalRolesForCatalogRole(
-      String catalogName, String catalogRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      String catalogRoleName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<PrincipalRole> principalRoleList =
         adminService.listAssigneePrincipalRolesForCatalogRole(catalogName, catalogRoleName).stream()
             .map(PrincipalRoleEntity::new)
@@ -621,8 +672,11 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response listGrantsForCatalogRole(
-      String catalogName, String catalogRoleName, SecurityContext securityContext) {
-    PolarisAdminService adminService = newAdminService(securityContext);
+      String catalogName,
+      String catalogRoleName,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<GrantResource> grantList =
         adminService.listGrantsForCatalogRole(catalogName, catalogRoleName);
     GrantResources grantResources = new GrantResources(grantList);

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
@@ -28,7 +28,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.hdfs.web.oauth2.OAuth2Constants;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.service.catalog.api.IcebergRestOAuth2ApiService;
 import org.apache.polaris.service.types.TokenType;
 import org.slf4j.Logger;
@@ -58,10 +58,10 @@ public class DefaultOAuth2ApiService implements IcebergRestOAuth2ApiService {
       TokenType subjectTokenType,
       String actorToken,
       TokenType actorTokenType,
+      RealmContext realmContext,
       SecurityContext securityContext) {
 
-    TokenBroker tokenBroker =
-        tokenBrokerFactory.apply(CallContext.getCurrentContext().getRealmContext());
+    TokenBroker tokenBroker = tokenBrokerFactory.apply(realmContext);
     if (!tokenBroker.supportsGrantType(grantType)) {
       return OAuthUtils.getResponseFromError(OAuthTokenErrorResponse.Error.unsupported_grant_type);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/TestOAuth2ApiService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/TestOAuth2ApiService.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -56,9 +57,10 @@ public class TestOAuth2ApiService implements IcebergRestOAuth2ApiService {
       TokenType subjectTokenType,
       String actorToken,
       TokenType actorTokenType,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Map<String, Object> response = new HashMap<>();
-    String principalName = getPrincipalName(clientId);
+    String principalName = getPrincipalName(clientId, realmContext);
     response.put(
         "access_token",
         "principal:"
@@ -66,7 +68,7 @@ public class TestOAuth2ApiService implements IcebergRestOAuth2ApiService {
             + ";password:"
             + clientSecret
             + ";realm:"
-            + CallContext.getCurrentContext().getRealmContext().getRealmIdentifier()
+            + realmContext.getRealmIdentifier()
             + ";role:"
             + scope.replaceAll(BasePolarisAuthenticator.PRINCIPAL_ROLE_PREFIX, ""));
     response.put("token_type", "bearer");
@@ -75,10 +77,10 @@ public class TestOAuth2ApiService implements IcebergRestOAuth2ApiService {
     return Response.ok(response).build();
   }
 
-  private String getPrincipalName(String clientId) {
+  private String getPrincipalName(String clientId, RealmContext realmContext) {
     PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(
-            CallContext.getCurrentContext().getRealmContext());
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+    // FIXME remove call to CallContext.getCurrentContext()
     PolarisCallContext polarisCallContext = CallContext.getCurrentContext().getPolarisCallContext();
     PrincipalSecretsResult secretsResult =
         metaStoreManager.loadPrincipalSecrets(polarisCallContext, clientId);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -263,7 +263,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
             CatalogProperties.FILE_IO_IMPL);
       }
     }
-    CallContext.getCurrentContext().closeables().addCloseable(this);
+    callContext.closeables().addCloseable(this);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
@@ -447,8 +447,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
           "Scheduled cleanup task {} for table {}",
           dropEntityResult.getCleanupTaskId(),
           tableIdentifier);
-      taskExecutor.addTaskHandlerContext(
-          dropEntityResult.getCleanupTaskId(), CallContext.getCurrentContext());
+      taskExecutor.addTaskHandlerContext(dropEntityResult.getCleanupTaskId(), callContext);
     }
 
     return true;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -127,8 +127,7 @@ public class IcebergCatalogAdapter
   }
 
   private PolarisCatalogHandlerWrapper newHandlerWrapper(
-      SecurityContext securityContext, String catalogName) {
-    CallContext callContext = CallContext.getCurrentContext();
+      RealmContext realmContext, SecurityContext securityContext, String catalogName) {
     AuthenticatedPolarisPrincipal authenticatedPrincipal =
         (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
     if (authenticatedPrincipal == null) {
@@ -136,12 +135,13 @@ public class IcebergCatalogAdapter
     }
 
     PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(callContext.getRealmContext());
+        entityManagerFactory.getOrCreateEntityManager(realmContext);
 
     return new PolarisCatalogHandlerWrapper(
-        callContext,
+        // FIXME remove call to CallContext.getCurrentContext()
+        CallContext.getCurrentContext(),
         entityManager,
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(callContext.getRealmContext()),
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
         authenticatedPrincipal,
         catalogFactory,
         catalogName,
@@ -152,9 +152,11 @@ public class IcebergCatalogAdapter
   public Response createNamespace(
       String prefix,
       CreateNamespaceRequest createNamespaceRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     return Response.ok(
-            newHandlerWrapper(securityContext, prefix).createNamespace(createNamespaceRequest))
+            newHandlerWrapper(realmContext, securityContext, prefix)
+                .createNamespace(createNamespaceRequest))
         .build();
   }
 
@@ -164,20 +166,22 @@ public class IcebergCatalogAdapter
       String pageToken,
       Integer pageSize,
       String parent,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Optional<Namespace> namespaceOptional =
         Optional.ofNullable(parent).map(IcebergCatalogAdapter::decodeNamespace);
     return Response.ok(
-            newHandlerWrapper(securityContext, prefix)
+            newHandlerWrapper(realmContext, securityContext, prefix)
                 .listNamespaces(namespaceOptional.orElse(Namespace.of())))
         .build();
   }
 
   @Override
   public Response loadNamespaceMetadata(
-      String prefix, String namespace, SecurityContext securityContext) {
+      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    return Response.ok(newHandlerWrapper(securityContext, prefix).loadNamespaceMetadata(ns))
+    return Response.ok(
+            newHandlerWrapper(realmContext, securityContext, prefix).loadNamespaceMetadata(ns))
         .build();
   }
 
@@ -187,16 +191,17 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response namespaceExists(
-      String prefix, String namespace, SecurityContext securityContext) {
+      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    newHandlerWrapper(securityContext, prefix).namespaceExists(ns);
+    newHandlerWrapper(realmContext, securityContext, prefix).namespaceExists(ns);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
-  public Response dropNamespace(String prefix, String namespace, SecurityContext securityContext) {
+  public Response dropNamespace(
+      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    newHandlerWrapper(securityContext, prefix).dropNamespace(ns);
+    newHandlerWrapper(realmContext, securityContext, prefix).dropNamespace(ns);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
@@ -205,10 +210,11 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return Response.ok(
-            newHandlerWrapper(securityContext, prefix)
+            newHandlerWrapper(realmContext, securityContext, prefix)
                 .updateNamespaceProperties(ns, updateNamespacePropertiesRequest))
         .build();
   }
@@ -229,6 +235,7 @@ public class IcebergCatalogAdapter
       String namespace,
       CreateTableRequest createTableRequest,
       String accessDelegationMode,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
@@ -236,22 +243,23 @@ public class IcebergCatalogAdapter
     if (createTableRequest.stageCreate()) {
       if (delegationModes.isEmpty()) {
         return Response.ok(
-                newHandlerWrapper(securityContext, prefix)
+                newHandlerWrapper(realmContext, securityContext, prefix)
                     .createTableStaged(ns, createTableRequest))
             .build();
       } else {
         return Response.ok(
-                newHandlerWrapper(securityContext, prefix)
+                newHandlerWrapper(realmContext, securityContext, prefix)
                     .createTableStagedWithWriteDelegation(ns, createTableRequest))
             .build();
       }
     } else if (delegationModes.isEmpty()) {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix).createTableDirect(ns, createTableRequest))
+              newHandlerWrapper(realmContext, securityContext, prefix)
+                  .createTableDirect(ns, createTableRequest))
           .build();
     } else {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix)
+              newHandlerWrapper(realmContext, securityContext, prefix)
                   .createTableDirectWithWriteDelegation(ns, createTableRequest))
           .build();
     }
@@ -263,9 +271,11 @@ public class IcebergCatalogAdapter
       String namespace,
       String pageToken,
       Integer pageSize,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    return Response.ok(newHandlerWrapper(securityContext, prefix).listTables(ns)).build();
+    return Response.ok(newHandlerWrapper(realmContext, securityContext, prefix).listTables(ns))
+        .build();
   }
 
   @Override
@@ -275,6 +285,7 @@ public class IcebergCatalogAdapter
       String table,
       String accessDelegationMode,
       String snapshots,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
@@ -282,11 +293,12 @@ public class IcebergCatalogAdapter
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     if (delegationModes.isEmpty()) {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix).loadTable(tableIdentifier, snapshots))
+              newHandlerWrapper(realmContext, securityContext, prefix)
+                  .loadTable(tableIdentifier, snapshots))
           .build();
     } else {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix)
+              newHandlerWrapper(realmContext, securityContext, prefix)
                   .loadTableWithAccessDelegation(tableIdentifier, snapshots))
           .build();
     }
@@ -294,10 +306,14 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response tableExists(
-      String prefix, String namespace, String table, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      String table,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
-    newHandlerWrapper(securityContext, prefix).tableExists(tableIdentifier);
+    newHandlerWrapper(realmContext, securityContext, prefix).tableExists(tableIdentifier);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
@@ -307,14 +323,16 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       Boolean purgeRequested,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
 
     if (purgeRequested != null && purgeRequested) {
-      newHandlerWrapper(securityContext, prefix).dropTableWithPurge(tableIdentifier);
+      newHandlerWrapper(realmContext, securityContext, prefix).dropTableWithPurge(tableIdentifier);
     } else {
-      newHandlerWrapper(securityContext, prefix).dropTableWithoutPurge(tableIdentifier);
+      newHandlerWrapper(realmContext, securityContext, prefix)
+          .dropTableWithoutPurge(tableIdentifier);
     }
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -324,17 +342,22 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       RegisterTableRequest registerTableRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return Response.ok(
-            newHandlerWrapper(securityContext, prefix).registerTable(ns, registerTableRequest))
+            newHandlerWrapper(realmContext, securityContext, prefix)
+                .registerTable(ns, registerTableRequest))
         .build();
   }
 
   @Override
   public Response renameTable(
-      String prefix, RenameTableRequest renameTableRequest, SecurityContext securityContext) {
-    newHandlerWrapper(securityContext, prefix).renameTable(renameTableRequest);
+      String prefix,
+      RenameTableRequest renameTableRequest,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    newHandlerWrapper(realmContext, securityContext, prefix).renameTable(renameTableRequest);
     return Response.ok(javax.ws.rs.core.Response.Status.NO_CONTENT).build();
   }
 
@@ -344,18 +367,19 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       CommitTableRequest commitTableRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
 
     if (PolarisCatalogHandlerWrapper.isCreate(commitTableRequest)) {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix)
+              newHandlerWrapper(realmContext, securityContext, prefix)
                   .updateTableForStagedCreate(tableIdentifier, commitTableRequest))
           .build();
     } else {
       return Response.ok(
-              newHandlerWrapper(securityContext, prefix)
+              newHandlerWrapper(realmContext, securityContext, prefix)
                   .updateTable(tableIdentifier, commitTableRequest))
           .build();
     }
@@ -366,9 +390,12 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       CreateViewRequest createViewRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    return Response.ok(newHandlerWrapper(securityContext, prefix).createView(ns, createViewRequest))
+    return Response.ok(
+            newHandlerWrapper(realmContext, securityContext, prefix)
+                .createView(ns, createViewRequest))
         .build();
   }
 
@@ -378,42 +405,60 @@ public class IcebergCatalogAdapter
       String namespace,
       String pageToken,
       Integer pageSize,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
-    return Response.ok(newHandlerWrapper(securityContext, prefix).listViews(ns)).build();
+    return Response.ok(newHandlerWrapper(realmContext, securityContext, prefix).listViews(ns))
+        .build();
   }
 
   @Override
   public Response loadView(
-      String prefix, String namespace, String view, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      String view,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
-    return Response.ok(newHandlerWrapper(securityContext, prefix).loadView(tableIdentifier))
+    return Response.ok(
+            newHandlerWrapper(realmContext, securityContext, prefix).loadView(tableIdentifier))
         .build();
   }
 
   @Override
   public Response viewExists(
-      String prefix, String namespace, String view, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      String view,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
-    newHandlerWrapper(securityContext, prefix).viewExists(tableIdentifier);
+    newHandlerWrapper(realmContext, securityContext, prefix).viewExists(tableIdentifier);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response dropView(
-      String prefix, String namespace, String view, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      String view,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
-    newHandlerWrapper(securityContext, prefix).dropView(tableIdentifier);
+    newHandlerWrapper(realmContext, securityContext, prefix).dropView(tableIdentifier);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   @Override
   public Response renameView(
-      String prefix, RenameTableRequest renameTableRequest, SecurityContext securityContext) {
-    newHandlerWrapper(securityContext, prefix).renameView(renameTableRequest);
+      String prefix,
+      RenameTableRequest renameTableRequest,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    newHandlerWrapper(realmContext, securityContext, prefix).renameView(renameTableRequest);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
@@ -423,11 +468,12 @@ public class IcebergCatalogAdapter
       String namespace,
       String view,
       CommitViewRequest commitViewRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     return Response.ok(
-            newHandlerWrapper(securityContext, prefix)
+            newHandlerWrapper(realmContext, securityContext, prefix)
                 .replaceView(tableIdentifier, commitViewRequest))
         .build();
   }
@@ -436,8 +482,10 @@ public class IcebergCatalogAdapter
   public Response commitTransaction(
       String prefix,
       CommitTransactionRequest commitTransactionRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
-    newHandlerWrapper(securityContext, prefix).commitTransaction(commitTransactionRequest);
+    newHandlerWrapper(realmContext, securityContext, prefix)
+        .commitTransaction(commitTransactionRequest);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
@@ -447,6 +495,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       ReportMetricsRequest reportMetricsRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -457,17 +506,19 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       NotificationRequest notificationRequest,
+      RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
-    newHandlerWrapper(securityContext, prefix)
+    newHandlerWrapper(realmContext, securityContext, prefix)
         .sendNotification(tableIdentifier, notificationRequest);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
   /** From IcebergRestConfigurationApiService. */
   @Override
-  public Response getConfig(String warehouse, SecurityContext securityContext) {
+  public Response getConfig(
+      String warehouse, RealmContext realmContext, SecurityContext securityContext) {
     // 'warehouse' as an input here is catalogName.
     // 'warehouse' as an output will be treated by the client as a default catalog
     // storage
@@ -480,8 +531,7 @@ public class IcebergCatalogAdapter
     // TODO: Push this down into PolarisCatalogHandlerWrapper for authorizing "any" catalog
     // role in this catalog.
     PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(
-            CallContext.getCurrentContext().getRealmContext());
+        entityManagerFactory.getOrCreateEntityManager(realmContext);
     AuthenticatedPolarisPrincipal authenticatedPrincipal =
         (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
     if (authenticatedPrincipal == null) {
@@ -490,9 +540,10 @@ public class IcebergCatalogAdapter
     if (warehouse == null) {
       throw new BadRequestException("Please specify a warehouse");
     }
+    // FIXME remove call to CallContext.getCurrentContext()
+    CallContext callContext = CallContext.getCurrentContext();
     Resolver resolver =
-        entityManager.prepareResolver(
-            CallContext.getCurrentContext(), authenticatedPrincipal, warehouse);
+        entityManager.prepareResolver(callContext, authenticatedPrincipal, warehouse);
     ResolverStatus resolverStatus = resolver.resolveAll();
     if (!resolverStatus.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
       throw new NotFoundException("Unable to find warehouse %s", warehouse);


### PR DESCRIPTION
This is a first step towards fixing #463. `RealmContext` is now passed as an argument to every API and Service method generated from OpenAPI specs. Passing the `RealmContext` is also a prerequisite for including the realm ID as a custom tag in generated metrics.