### PR TITLE
Make JWT brokers injectable

### DIFF
--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/TokenBrokerConfig.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/TokenBrokerConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.dropwizard.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
+import org.apache.polaris.service.auth.TokenBrokerFactoryConfig;
+
+/**
+ * This object receives the subsection of the server config YAML (`polaris-server.yml`) that is
+ * related to JWT brokers.
+ */
+public class TokenBrokerConfig implements TokenBrokerFactoryConfig {
+  private String type = "none";
+  private int maxTokenGenerationInSeconds = 3600;
+  private String file;
+  private String secret;
+
+  @JsonProperty("type")
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @JsonProperty("file")
+  public void setFile(String file) {
+    this.file = file;
+  }
+
+  @JsonProperty("secret")
+  public void setSecret(String secret) {
+    this.secret = secret;
+  }
+
+  @JsonProperty("maxTokenGenerationInSeconds")
+  public void setMaxTokenGenerationInSeconds(int maxTokenGenerationInSeconds) {
+    this.maxTokenGenerationInSeconds = maxTokenGenerationInSeconds;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public int maxTokenGenerationInSeconds() {
+    return maxTokenGenerationInSeconds;
+  }
+
+  @Nullable
+  @Override
+  public String file() {
+    return file;
+  }
+
+  @Nullable
+  @Override
+  public String secret() {
+    return secret;
+  }
+}

--- a/dropwizard/service/src/main/resources/META-INF/hk2-locator/default
+++ b/dropwizard/service/src/main/resources/META-INF/hk2-locator/default
@@ -51,6 +51,11 @@ contract={org.apache.polaris.service.auth.TokenBrokerFactory}
 name=rsa-key-pair
 qualifier={io.smallrye.common.annotation.Identifier}
 
+[org.apache.polaris.service.auth.NoneTokenBrokerFactory]S
+contract={org.apache.polaris.service.auth.TokenBrokerFactory}
+name=none
+qualifier={io.smallrye.common.annotation.Identifier}
+
 [org.apache.polaris.service.context.DefaultRealmContextResolver]S
 contract={org.apache.polaris.service.context.RealmContextResolver}
 name=default

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
@@ -25,18 +25,21 @@ import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 
 @Identifier("rsa-key-pair")
 public class JWTRSAKeyPairFactory implements TokenBrokerFactory {
-  private int maxTokenGenerationInSeconds = 3600;
 
-  @Inject private MetaStoreManagerFactory metaStoreManagerFactory;
+  private final TokenBrokerFactoryConfig config;
+  private final MetaStoreManagerFactory metaStoreManagerFactory;
 
-  public void setMaxTokenGenerationInSeconds(int maxTokenGenerationInSeconds) {
-    this.maxTokenGenerationInSeconds = maxTokenGenerationInSeconds;
+  @Inject
+  public JWTRSAKeyPairFactory(
+      TokenBrokerFactoryConfig config, MetaStoreManagerFactory metaStoreManagerFactory) {
+    this.config = config;
+    this.metaStoreManagerFactory = metaStoreManagerFactory;
   }
 
   @Override
   public TokenBroker apply(RealmContext realmContext) {
     return new JWTRSAKeyPair(
         metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-        maxTokenGenerationInSeconds);
+        config.maxTokenGenerationInSeconds());
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTSymmetricKeyFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTSymmetricKeyFactory.java
@@ -23,52 +23,44 @@ import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 
 @Identifier("symmetric-key")
 public class JWTSymmetricKeyFactory implements TokenBrokerFactory {
-  @Inject private MetaStoreManagerFactory metaStoreManagerFactory;
-  private int maxTokenGenerationInSeconds = 3600;
-  private String file;
-  private String secret;
+
+  private final MetaStoreManagerFactory metaStoreManagerFactory;
+  private final TokenBrokerFactoryConfig config;
+
+  @Inject
+  public JWTSymmetricKeyFactory(
+      MetaStoreManagerFactory metaStoreManagerFactory, TokenBrokerFactoryConfig config) {
+    this.metaStoreManagerFactory = metaStoreManagerFactory;
+    this.config = config;
+  }
 
   @Override
   public TokenBroker apply(RealmContext realmContext) {
-    if (file == null && secret == null) {
+    String secret = config.secret();
+    if (config.file() == null && secret == null) {
       throw new IllegalStateException("Either file or secret must be set");
     }
     Supplier<String> secretSupplier = secret != null ? () -> secret : readSecretFromDisk();
     return new JWTSymmetricKeyBroker(
         metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-        maxTokenGenerationInSeconds,
+        config.maxTokenGenerationInSeconds(),
         secretSupplier);
   }
 
   private Supplier<String> readSecretFromDisk() {
     return () -> {
       try {
-        return Files.readString(Paths.get(file));
+        return Files.readString(Paths.get(Objects.requireNonNull(config.file())));
       } catch (IOException e) {
-        throw new RuntimeException("Failed to read secret from file: " + file, e);
+        throw new RuntimeException("Failed to read secret from file: " + config.file(), e);
       }
     };
-  }
-
-  public void setMaxTokenGenerationInSeconds(int maxTokenGenerationInSeconds) {
-    this.maxTokenGenerationInSeconds = maxTokenGenerationInSeconds;
-  }
-
-  public void setFile(String file) {
-    this.file = file;
-  }
-
-  public void setSecret(String secret) {
-    this.secret = secret;
-  }
-
-  public void setMetaStoreManagerFactory(MetaStoreManagerFactory metaStoreManagerFactory) {
-    this.metaStoreManagerFactory = metaStoreManagerFactory;
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import io.smallrye.common.annotation.Identifier;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.service.types.TokenType;
+
+/** Default {@link TokenBrokerFactory} that produces token brokers that do not do anything. */
+@Identifier("none")
+public class NoneTokenBrokerFactory implements TokenBrokerFactory {
+  @Override
+  public TokenBroker apply(RealmContext realmContext) {
+    return new TokenBroker() {
+      @Override
+      public boolean supportsGrantType(String grantType) {
+        return false;
+      }
+
+      @Override
+      public boolean supportsRequestedTokenType(TokenType tokenType) {
+        return false;
+      }
+
+      @Override
+      public TokenResponse generateFromClientSecrets(
+          String clientId, String clientSecret, String grantType, String scope) {
+        return null;
+      }
+
+      @Override
+      public TokenResponse generateFromToken(
+          TokenType tokenType, String subjectToken, String grantType, String scope) {
+        return null;
+      }
+
+      @Override
+      public DecodedToken verify(String token) {
+        return null;
+      }
+    };
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/auth/TokenBrokerFactoryConfig.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/TokenBrokerFactoryConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * This is a union of configuration settings of all token brokers.
+ *
+ * @see TokenBrokerFactory
+ */
+public interface TokenBrokerFactoryConfig {
+  @Nullable
+  String file();
+
+  @Nullable
+  String secret();
+
+  int maxTokenGenerationInSeconds();
+}


### PR DESCRIPTION
* Detach `TokenBrokerFactory` sub-classes from Jackson-based config parsing logic.

* Add a new unified `TokenBrokerConfig` under DW to hold JWT config data.

* Resolve JWT factories through HK2 named service lookup, using the type name from `TokenBrokerConfig`

* Add dedicated class `NoneTokenBrokerFactory` for the default do-nothing token broker implementation.

* Yaml config (`polaris-server.yml`) is not affected

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
