### PR TITLE
Fix NPE in catalogOverlapsWithExistingCatalog() occurring when a listed catalog could not be loaded correctly

### DIFF
--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
@@ -140,8 +140,6 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .get()) {
-      // Buffer the entity so we can read it multiple times
-      response.bufferEntity();
       assertStatusCodeWithFailMessage(response, Response.Status.OK.getStatusCode());
 
       CatalogRole catalogRole = response.readEntity(CatalogRole.class);
@@ -182,7 +180,17 @@ public class TestUtil {
     return restCatalog;
   }
 
+  /**
+   * Asserts that the response has the expected status code, with a custom fail message. The
+   * response entity is buffered so it can be read multiple times.
+   *
+   * @param response The response to check
+   * @param expectedStatusCode The expected status code
+   */
   private static void assertStatusCodeWithFailMessage(Response response, int expectedStatusCode) {
+    // Buffer the entity so we can read it multiple times
+    response.bufferEntity();
+
     assertThat(response)
         .withFailMessage(
             "Expected status code %s but got %s with message: %s",

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
@@ -84,7 +84,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .post(Entity.json(catalog))) {
-      assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
     }
 
     // Create a new CatalogRole that has CATALOG_MANAGE_CONTENT and CATALOG_MANAGE_ACCESS
@@ -98,7 +98,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .post(Entity.json(newRole))) {
-      assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
     }
     CatalogGrant grantResource =
         new CatalogGrant(CatalogPrivilege.CATALOG_MANAGE_CONTENT, GrantResource.TypeEnum.CATALOG);
@@ -112,7 +112,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .put(Entity.json(grantResource))) {
-      assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
     }
     CatalogGrant grantAccessResource =
         new CatalogGrant(CatalogPrivilege.CATALOG_MANAGE_ACCESS, GrantResource.TypeEnum.CATALOG);
@@ -126,7 +126,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .put(Entity.json(grantAccessResource))) {
-      assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
     }
 
     // Assign this new CatalogRole to the service_admin PrincipalRole
@@ -140,7 +140,10 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .get()) {
-      assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+      // Buffer the entity so we can read it multiple times
+      response.bufferEntity();
+      assertStatusCodeWithFailMessage(response, Response.Status.OK.getStatusCode());
+
       CatalogRole catalogRole = response.readEntity(CatalogRole.class);
       try (Response assignResponse =
           client
@@ -154,8 +157,7 @@ public class TestUtil {
               .header("Authorization", "Bearer " + adminToken.token())
               .header(REALM_PROPERTY_KEY, realm)
               .put(Entity.json(catalogRole))) {
-        assertThat(assignResponse)
-            .returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+        assertStatusCodeWithFailMessage(assignResponse, Response.Status.CREATED.getStatusCode());
       }
     }
 
@@ -178,5 +180,13 @@ public class TestUtil {
             .putAll(extraProperties);
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());
     return restCatalog;
+  }
+
+  private static void assertStatusCodeWithFailMessage(Response response, int expectedStatusCode) {
+    assertThat(response)
+        .withFailMessage(
+            "Expected status code %s but got %s with message: %s",
+            expectedStatusCode, response.getStatus(), response.readEntity(String.class))
+        .returns(expectedStatusCode, Response::getStatus);
   }
 }

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/TestUtil.java
@@ -84,7 +84,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .post(Entity.json(catalog))) {
-      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
+      assertStatusCode(response, Response.Status.CREATED.getStatusCode());
     }
 
     // Create a new CatalogRole that has CATALOG_MANAGE_CONTENT and CATALOG_MANAGE_ACCESS
@@ -98,7 +98,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .post(Entity.json(newRole))) {
-      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
+      assertStatusCode(response, Response.Status.CREATED.getStatusCode());
     }
     CatalogGrant grantResource =
         new CatalogGrant(CatalogPrivilege.CATALOG_MANAGE_CONTENT, GrantResource.TypeEnum.CATALOG);
@@ -112,7 +112,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .put(Entity.json(grantResource))) {
-      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
+      assertStatusCode(response, Response.Status.CREATED.getStatusCode());
     }
     CatalogGrant grantAccessResource =
         new CatalogGrant(CatalogPrivilege.CATALOG_MANAGE_ACCESS, GrantResource.TypeEnum.CATALOG);
@@ -126,7 +126,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .put(Entity.json(grantAccessResource))) {
-      assertStatusCodeWithFailMessage(response, Response.Status.CREATED.getStatusCode());
+      assertStatusCode(response, Response.Status.CREATED.getStatusCode());
     }
 
     // Assign this new CatalogRole to the service_admin PrincipalRole
@@ -140,7 +140,7 @@ public class TestUtil {
             .header("Authorization", "Bearer " + adminToken.token())
             .header(REALM_PROPERTY_KEY, realm)
             .get()) {
-      assertStatusCodeWithFailMessage(response, Response.Status.OK.getStatusCode());
+      assertStatusCode(response, Response.Status.OK.getStatusCode());
 
       CatalogRole catalogRole = response.readEntity(CatalogRole.class);
       try (Response assignResponse =
@@ -155,7 +155,7 @@ public class TestUtil {
               .header("Authorization", "Bearer " + adminToken.token())
               .header(REALM_PROPERTY_KEY, realm)
               .put(Entity.json(catalogRole))) {
-        assertStatusCodeWithFailMessage(assignResponse, Response.Status.CREATED.getStatusCode());
+        assertStatusCode(assignResponse, Response.Status.CREATED.getStatusCode());
       }
     }
 
@@ -181,13 +181,13 @@ public class TestUtil {
   }
 
   /**
-   * Asserts that the response has the expected status code, with a custom fail message. The
-   * response entity is buffered so it can be read multiple times.
+   * Asserts that the response has the expected status code, with a fail message if the assertion
+   * fails. The response entity is buffered so it can be read multiple times.
    *
    * @param response The response to check
    * @param expectedStatusCode The expected status code
    */
-  private static void assertStatusCodeWithFailMessage(Response response, int expectedStatusCode) {
+  private static void assertStatusCode(Response response, int expectedStatusCode) {
     // Buffer the entity so we can read it multiple times
     response.bufferEntity();
 

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -518,6 +518,7 @@ public class PolarisAdminService {
 
     Set<String> newCatalogLocations = getCatalogLocations(catalogEntity);
     return listCatalogsUnsafe().stream()
+        .filter(Objects::nonNull)
         .map(CatalogEntity::new)
         .anyMatch(
             existingCatalog -> {

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -728,7 +728,12 @@ public class PolarisAdminService {
     return listCatalogsUnsafe();
   }
 
-  /** List all catalogs without checking for permission */
+  /**
+   * List all catalogs without checking for permission. May contain NULLs due to multiple non-atomic
+   * API calls to the persistence layer. Specifically, this can happen when a PolarisEntity is
+   * returned by listCatalogs, but cannot be loaded afterward because it was purged by another
+   * process before it could be loaded.
+   */
   private List<PolarisEntity> listCatalogsUnsafe() {
     return metaStoreManager
         .listEntities(

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;


### PR DESCRIPTION
1. In `catalogOverlapsWithExistingCatalog`, the `listCatalogsUnsafe` method would first call the persistence layer to list all the catalogs under the current account. It would then load each returned catalog to ensure the catalog has not been purged, etc. If the catalog could not be loaded, that catalog in the catalog list would be replaced with NULL, which would cause the subsequent [.map(CatalogEntity::new)](https://github.com/apache/polaris/blob/b7fa1f47ad9f52055c30a69c09c140cd2ec08417/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java#L521) to throw NPE. This PR adds a filter on the stream to remove NULL entries from the list.
2. Improve debuggability for `TestUtil.createSnowmanManagedCatalog` by printing the response body when response codes don't match as expected.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
