### PR TITLE
Fix 560

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -138,6 +138,9 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       initializeForRealm(realmContext);
       checkPolarisServiceBootstrappedForRealm(
           realmContext, metaStoreManagerMap.get(realmContext.getRealmIdentifier()));
+    } else {
+      checkPolarisServiceBootstrappedForRealm(
+          realmContext, metaStoreManagerMap.get(realmContext.getRealmIdentifier()));
     }
     return sessionSupplierMap.get(realmContext.getRealmIdentifier());
   }


### PR DESCRIPTION
The issue arises because the second curl command does not return the correct status code due to the behavior of `getOrCreateSessionSupplier`. When a realm is not found, the method triggers realm initialization. However, realm initialization only partially bootstraps the setup (it creates the sequence object with default and populated tables but no data). As a result, when the second curl command is executed, it attempts credential validation instead of the expected check, since the schema for the required tables is created during the realm initialization.

To ensure consistent error handling and avoid premature credential validation, this PR adds an additional check to verify that the realm is fully bootstrapped before proceeding with credential validation.