### PR TITLE
Downgrade dnsjava to 3.5.3

### DIFF
--- a/dropwizard/service/build.gradle.kts
+++ b/dropwizard/service/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-core")
   implementation("org.apache.iceberg:iceberg-aws")
 
+  // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
+  implementation(platform(libs.dnsjava))
+
   implementation(libs.hadoop.common) {
     exclude("org.slf4j", "slf4j-reload4j")
     exclude("org.slf4j", "slf4j-log4j12")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ errorprone = { module = "com.google.errorprone:error_prone_core", version = "2.2
 google-cloud-storage-bom = { module = "com.google.cloud:google-cloud-storage-bom", version = "2.42.0" }
 guava = { module = "com.google.guava:guava", version = "33.3.0-jre" }
 h2 = { module = "com.h2database:h2", version = "2.3.232" }
+# Strict dnsjava downgrade due to https://github.com/dnsjava/dnsjava/issues/329
+dnsjava = { module = "dnsjava:dnsjava", version = "3.5.3!!" }
 hadoop-client-api = { module = "org.apache.hadoop:hadoop-client-api", version.ref = "hadoop" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.ref = "hadoop" }


### PR DESCRIPTION
This is due to https://github.com/dnsjava/dnsjava/issues/329

That issue is closed as of 18 Dec 2024, but the fix in 3.6.2 does not appear to be effective for java 21.

The DNS lookup error can happen with JDBC persistence like PosgreSQL.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
