### PR TITLE
Allow update of AWS roleArn associated with catalog when the AWS account IDs are same

### DIFF
--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisServiceImplIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisServiceImplIntegrationTest.java
@@ -939,7 +939,8 @@ public class PolarisServiceImplIntegrationTest {
           .startsWith("Cannot modify");
     }
 
-    // Allow update of fields that are support (e.g. new default-base-location and role ARN when AWS
+    // Allow update of fields that are supported (e.g. new default-base-location and role ARN when
+    // AWS
     // account IDs are same)
     StorageConfigInfo validModifiedStorageConfig =
         new AwsStorageConfigInfo(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -82,7 +82,7 @@ public class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo
     return "org.apache.iceberg.aws.s3.S3FileIO";
   }
 
-  public void validateArn(String arn) {
+  public static void validateArn(String arn) {
     if (arn == null || arn.isEmpty()) {
       throw new IllegalArgumentException("ARN cannot be null or empty");
     }
@@ -123,11 +123,12 @@ public class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo
     this.region = region;
   }
 
+  @JsonIgnore
   public String getAwsAccountId() {
     return parseAwsAccountId(roleARN);
   }
 
-  private String parseAwsAccountId(String arn) {
+  private static String parseAwsAccountId(String arn) {
     validateArn(arn);
     Pattern pattern = Pattern.compile(ROLE_ARN_PATTERN);
     Matcher matcher = pattern.matcher(arn);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -75,6 +75,21 @@ class InMemoryStorageIntegrationTest {
   }
 
   @Test
+  public void testAwsAccountIdParsing() {
+    AwsStorageConfigurationInfo awsConfig =
+        new AwsStorageConfigurationInfo(
+            PolarisStorageConfigurationInfo.StorageType.S3,
+            List.of("s3://bucket/path/to/warehouse"),
+            "arn:aws:iam::012345678901:role/jdoe",
+            "us-east-2");
+
+    String expectedAccountId = "012345678901";
+    String actualAccountId = awsConfig.getAwsAccountId();
+
+    Assertions.assertThat(actualAccountId).isEqualTo(expectedAccountId);
+  }
+
+  @Test
   public void testValidateAccessToLocationsWithWildcard() {
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration();
     Map<String, Boolean> config = Map.of("ALLOW_WILDCARD_LOCATION", true);

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -633,8 +633,7 @@ public class PolarisAdminService {
     if (currentStorageConfig instanceof AwsStorageConfigurationInfo currentAwsConfig
         && newStorageConfig instanceof AwsStorageConfigurationInfo newAwsConfig) {
 
-      if (!currentAwsConfig.getRoleARN().equals(newAwsConfig.getRoleARN())
-          || !newAwsConfig.getRoleARN().equals(currentAwsConfig.getRoleARN())) {
+      if (!currentAwsConfig.getAwsAccountId().equals(newAwsConfig.getAwsAccountId())) {
         throw new BadRequestException(
             "Cannot modify Role ARN in storage config from %s to %s",
             currentStorageConfig, newStorageConfig);


### PR DESCRIPTION
Regarding https://github.com/apache/polaris/issues/582, we’re currently unable to update the AWS roleARN associated with a catalog. This is problematic because it prevents users from renaming their AWS role, which is something similar checks don’t restrict in the case of Azure tenant ID and external ID for AWS. It makes sense to block changes when the AWS account ID is also being modified, but if the AWS account ID remains the same, there's no reason we should prevent users from renaming the role.