### PR TITLE
Add `Implementation-*` attributes to jar manifest

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -66,6 +66,19 @@ tasks.named<Test>("test").configure {
   jvmArgs("-Duser.language=en")
 }
 
+tasks.withType(Jar::class).configureEach {
+  manifest {
+    attributes(
+      // Do not add any (more or less) dynamic information to jars, because that makes Gradle's
+      // caching way less efficient. Note that version and Git information are already added to jar
+      // manifests for release(-like) builds.
+      "Implementation-Title" to "Apache Polaris(TM) (incubating)",
+      "Implementation-Vendor" to "Apache Software Foundation",
+      "Implementation-URL" to "https://polaris.apache.org/"
+    )
+  }
+}
+
 spotless {
   val disallowWildcardImports = { text: String ->
     val regex = "~/import .*\\.\\*;/".toRegex()

--- a/build-logic/src/main/kotlin/publishing/MemoizedGitInfo.kt
+++ b/build-logic/src/main/kotlin/publishing/MemoizedGitInfo.kt
@@ -70,9 +70,11 @@ internal class MemoizedGitInfo {
         val system = execProc(rootProject, "uname", "-a")
         val javaVersion = System.getProperty("java.version")
 
+        val version = rootProject.version.toString()
         val info =
           mapOf(
-            "Apache-Polaris-Version" to rootProject.version.toString(),
+            "Implementation-Version" to version,
+            "Apache-Polaris-Version" to version,
             "Apache-Polaris-Is-Release" to isRelease.toString(),
             "Apache-Polaris-Build-Git-Head" to gitHead,
             "Apache-Polaris-Build-Git-Describe" to gitDescribe,


### PR DESCRIPTION
Adds the following attributes to built jar manifests:
```
Implementation-Title: Apache Polaris(TM) (incubating)
Implementation-Vendor: Apache Software Foundation
Implementation-URL: https://polaris.apache.org/
```

For release builds, if run with `-Prelease` or `-PjarWithGitInfo`, also adds
```
Implementation-Version: <version-string>
```
in addition to the various `Apache-Polaris-*` manifest attributes.

The `Implementation-*` attributes can be retrieved via Java reflection using the `Class.getPackage().getImplementation*()` functions. NB: Only the `Implementation-Title/Vendor/Version` and `Specification-Title/Vendor/Version` attributes are accessible from `Package`, not other manifest attributes.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
