### PR TITLE
Helm: add `bootstrapExtraEnv` for bootstrapping job

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -74,6 +74,7 @@ $ helm uninstall --namespace polaris polaris
 | autoscaling.minReplicas | int | `1` | The minimum number of replicas to maintain. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Optional; set to zero or empty to disable. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Optional; set to zero or empty to disable. |
+| bootstrapExtraEnv | list | `[]` | Extra environment variables to add to the bootstrap metastore manager job (see `extraEnv` for an example) |
 | bootstrapMetastoreManager | bool | `false` | Configures whether to enable the bootstrap metastore manager job |
 | configMapLabels | object | `{}` | Additional Labels to apply to polaris configmap. |
 | extraEnv | list | `[]` | Advanced configuration via Environment Variables. Extra environment variables to add to the Polaris server container. You can pass here any valid EnvVar object: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core This can be useful to get configuration values from Kubernetes secrets or config maps. |

--- a/helm/polaris/templates/job.yaml
+++ b/helm/polaris/templates/job.yaml
@@ -77,6 +77,10 @@ spec:
           imagePullPolicy: {{ tpl .Values.image.pullPolicy . }}
           command: ["/app/bin/polaris-service"]
           args: ["bootstrap", "/app/config/polaris-server.yml"]
+          {{- if .Values.bootstrapExtraEnv }}
+          env:
+            {{- tpl (toYaml .Values.bootstrapExtraEnv) . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /app/config/polaris-server.yml

--- a/helm/polaris/tests/job_test.yaml
+++ b/helm/polaris/tests/job_test.yaml
@@ -415,6 +415,26 @@ tests:
               cpu: 200m
               memory: 256Mi
 
+  # spec.template.spec.containers[0].env (with bootstrapMetastoreManager enabled)
+  - it: should not set container env by default
+    set:
+      bootstrapMetastoreManager: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env
+  - it: should set container env
+    set:
+      bootstrapMetastoreManager: true
+      bootstrapExtraEnv:
+        - name: foo
+          value: bar
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: foo
+            value: bar
+
   # spec.template.spec.nodeSelector (with bootstrapMetastoreManager enabled)
   - it: should not set nodeSelector by default
     set:

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -236,6 +236,9 @@ extraEnv:
 # -- Configures whether to enable the bootstrap metastore manager job
 bootstrapMetastoreManager: false
 
+# -- Extra environment variables to add to the bootstrap metastore manager job (see `extraEnv` for an example)
+bootstrapExtraEnv: []
+
 # -- The secret name to pull persistence.xml from (ensure the key name is 'persistence.xml')
 persistenceConfigSecret: ~
 


### PR DESCRIPTION
This passes down the `extraEnv` values to the bootstrapping job as well. This is needed in order to set initial bootstrapping credentials via `POLARIS_BOOTSTRAP_DEFAULT-REALM_ROOT_CLIENT_ID` and `POLARIS_BOOTSTRAP_DEFAULT-REALM_ROOT_CLIENT_SECRET`. In contrast to the ad-hoc bootstrapping of the application (when in in-memory mode), the initial credentials are not printed to stdout, so they cannot be used if not explicitly set via these variables.