### PR TITLE
Helm: add `securityContext` to initContainers

### DIFF
--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
           imagePullPolicy: {{ tpl .Values.toolsImage.pullPolicy . }}
           command: ["jar"]
           args: ["-cf", "/eclipselink-config/conf.jar", "-C", "/secret", "persistence.xml"]
+          {{- if .Values.securityContext}}
+          securityContext:
+            {{- tpl (toYaml .Values.securityContext) . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: eclipselink-config-volume
               mountPath: /eclipselink-config

--- a/helm/polaris/templates/job.yaml
+++ b/helm/polaris/templates/job.yaml
@@ -50,6 +50,10 @@ spec:
           imagePullPolicy: {{ tpl .Values.toolsImage.pullPolicy . }}
           command: ["jar"]
           args: ["-cf", "/eclipselink-config/conf.jar", "-C", "/secret", "persistence.xml"]
+          {{- if .Values.securityContext}}
+          securityContext:
+            {{- tpl (toYaml .Values.securityContext) . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: eclipselink-config-volume
               mountPath: /eclipselink-config

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -299,6 +299,30 @@ tests:
           content:
             runAsUser: 1000
 
+  # spec.template.spec.containers[0].securityContext
+  - it: should not set initContainer securityContext by default
+    set:
+      persistenceConfigSecret: polaris-persistence-secret
+      polarisServerConfig:
+        metaStoreManager:
+          conf-file: /eclipselink-config/conf.jar!/persistence.xml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext
+  - it: should set initContainer securityContext
+    set:
+      persistenceConfigSecret: polaris-persistence-secret
+      polarisServerConfig:
+        metaStoreManager:
+          conf-file: /eclipselink-config/conf.jar!/persistence.xml
+      securityContext:
+        runAsUser: 1000
+    asserts:
+      - isSubset:
+          path: spec.template.spec.initContainers[0].securityContext
+          content:
+            runAsUser: 1000
+
   # spec.template.spec.containers[0].image
   - it: should set container image
     set:

--- a/helm/polaris/tests/job_test.yaml
+++ b/helm/polaris/tests/job_test.yaml
@@ -296,6 +296,32 @@ tests:
           content:
             runAsUser: 1000
 
+  # spec.template.spec.containers[0].securityContext (with bootstrapMetastoreManager enabled)
+  - it: should not set initContainer securityContext by default
+    set:
+      bootstrapMetastoreManager: true
+      persistenceConfigSecret: polaris-persistence-secret
+      polarisServerConfig:
+        metaStoreManager:
+          conf-file: /eclipselink-config/conf.jar!/persistence.xml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext
+  - it: should set initContainer securityContext
+    set:
+      bootstrapMetastoreManager: true
+      persistenceConfigSecret: polaris-persistence-secret
+      polarisServerConfig:
+        metaStoreManager:
+          conf-file: /eclipselink-config/conf.jar!/persistence.xml
+      securityContext:
+        runAsUser: 1000
+    asserts:
+      - isSubset:
+          path: spec.template.spec.initContainers[0].securityContext
+          content:
+            runAsUser: 1000
+
   # spec.template.spec.containers[0].image (with bootstrapMetastoreManager enabled)
   - it: should set container image
     set:


### PR DESCRIPTION
Some/most production environments enforce pod and container security contexts via admission controllers. If they are not compliant, the manifests won't be accepted. The current helm chart only sets the security context of the containers, but not the initContainers. This MR uses the same config for the initContainers as for the containers.