### PR TITLE
Clarify setting credentials for root principals when bootstrapping

### DIFF
--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -72,11 +72,11 @@ To use EclipseLink for metastore management, specify the configuration `metaStor
 
 Before using Polaris when using a metastore manager other than `in-memory`, you must **bootstrap** the metastore manager. This is a manual operation that must be performed **only once** in order to prepare the metastore manager to integrate with Polaris. When the metastore manager is bootstrapped, any existing Polaris entities in the metastore manager may be **purged**.
 
-By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the following envrionment variables for realm name `polaris`:
+By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the following envrionment variables for realm name `my_realm`:
 
 ```
-export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID=my-client-id
-export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_SECRET=my-client-secret
+export POLARIS_BOOTSTRAP_MY_REALM_ROOT_CLIENT_ID=my-client-id
+export POLARIS_BOOTSTRAP_MY_REALM_ROOT_CLIENT_SECRET=my-client-secret
 ```
 
 **IMPORTANT**: In case you use `default-realm` for metastore backend database, you won't be able to use `export` command. Use this instead:

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -72,16 +72,46 @@ To use EclipseLink for metastore management, specify the configuration `metaStor
 
 Before using Polaris when using a metastore manager other than `in-memory`, you must **bootstrap** the metastore manager. This is a manual operation that must be performed **only once** in order to prepare the metastore manager to integrate with Polaris. When the metastore manager is bootstrapped, any existing Polaris entities in the metastore manager may be **purged**.
 
-To bootstrap Polaris, run:
+By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the following envrionment variables:
+
+```
+export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID=my-client-id
+export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_SECRET=my-client-secret
+```
+
+Now, to bootstrap Polaris, run:
 
 ```bash
 java -jar /path/to/jar/polaris-service-all.jar bootstrap polaris-server.yml
+```
+
+or in a container:
+
+```bash
+bin/polaris-service bootstrap config/polaris-server.yml
 ```
 
 Afterward, Polaris can be launched normally:
 
 ```bash
 java -jar /path/to/jar/polaris-service-all.jar server polaris-server.yml
+```
+
+You can verify the setup by attempting a token issue for the `root` principal:
+
+```bash
+curl -X POST http://localhost:8181/api/catalog/v1/oauth/tokens -d "grant_type=client_credentials&client_id=my-client-id&client_secret=my-client-secret&scope=PRINCIPAL_ROLE:ALL"
+```
+
+which should return:
+
+```json
+{"access_token":"...","token_type":"bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}
+```
+
+Note that if you used non-default realm name, for example, `iceberg` instead of `default-realm` in your `polaris-server.yml`, then you should add an appropriate request header:
+```bash
+curl -X POST -H 'realm: polaris' http://localhost:8181/api/catalog/v1/oauth/tokens -d "grant_type=client_credentials&client_id=my-client-id&client_secret=my-client-secret&scope=PRINCIPAL_ROLE:ALL"
 ```
 
 ## Other Configurations

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -79,6 +79,12 @@ export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID=my-client-id
 export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_SECRET=my-client-secret
 ```
 
+**IMPORTANT**: In case you use `default-realm` for metastore backend database, you won't be able to use `export` command. Use this instead:
+
+```bash
+env POLARIS_BOOTSTRAP_DEFAULT-REALM_ROOT_CLIENT_ID=my-client-id POLARIS_BOOTSTRAP_DEFAULT-REALM_ROOT_CLIENT_SECRET=my-client-secret <bootstrap command> 
+```
+
 Now, to bootstrap Polaris, run:
 
 ```bash

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -111,7 +111,7 @@ which should return:
 
 Note that if you used non-default realm name, for example, `iceberg` instead of `default-realm` in your `polaris-server.yml`, then you should add an appropriate request header:
 ```bash
-curl -X POST -H 'realm: polaris' http://localhost:8181/api/catalog/v1/oauth/tokens -d "grant_type=client_credentials&client_id=my-client-id&client_secret=my-client-secret&scope=PRINCIPAL_ROLE:ALL"
+curl -X POST -H 'realm: iceberg' http://localhost:8181/api/catalog/v1/oauth/tokens -d "grant_type=client_credentials&client_id=my-client-id&client_secret=my-client-secret&scope=PRINCIPAL_ROLE:ALL"
 ```
 
 ## Other Configurations

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -72,7 +72,7 @@ To use EclipseLink for metastore management, specify the configuration `metaStor
 
 Before using Polaris when using a metastore manager other than `in-memory`, you must **bootstrap** the metastore manager. This is a manual operation that must be performed **only once** in order to prepare the metastore manager to integrate with Polaris. When the metastore manager is bootstrapped, any existing Polaris entities in the metastore manager may be **purged**.
 
-By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the following envrionment variables:
+By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the following envrionment variables for realm name `polaris`:
 
 ```
 export POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID=my-client-id


### PR DESCRIPTION
Current documentation site doesn't say anything about where to get creds for root principal when using production (Postgres) metastore backend. Which leads to a successful bootstrap w/o an ability to use the server.

I've spent a couple hours figuring out how to control root principal credentials at bootstrap stage and finally found [this](https://github.com/apache/polaris/blob/50ef1bca3a2f32d79829fda313e71f62e8f2633a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PrincipalSecretsGenerator.java#L69-L85) code piece, which answered my question, but let's update the docs as well!

NB: this is a documentation-only change.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
