### PR TITLE
Fix JsonMappingException when defaultRealm property is added in polaris-server.yml

### DIFF
--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/PolarisApplicationConfig.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/PolarisApplicationConfig.java
@@ -309,7 +309,6 @@ public class PolarisApplicationConfig extends Configuration {
   @JsonProperty("defaultRealm")
   public void setDefaultRealm(String defaultRealm) {
     this.defaultRealm = defaultRealm;
-    realmContextResolver.setDefaultRealm(defaultRealm);
   }
 
   @JsonProperty("cors")

--- a/polaris-server.yml
+++ b/polaris-server.yml
@@ -76,6 +76,8 @@ featureConfiguration:
 callContextResolver:
   type: default
 
+defaultRealm: default-realm
+
 realmContextResolver:
   type: default
 


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
When the `defaultRealm` property is defined before the `realmContextResolver` property in the polaris-server.yml file, for example:
```yml
defaultRealm: polaris

realmContextResolver:
  type: default
```
the following exception is thrown:
```
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Cannot invoke "org.apache.polaris.service.context.RealmContextResolver.setDefaultRealm(String)" because "this.realmContextResolver" is null (through reference chain: org.apache.polaris.service.dropwizard.config.PolarisApplicationConfig["defaultRealm"])
```
This occurs because of the following line in the `setDefaultRealm` method:
```java
realmContextResolver.setDefaultRealm(defaultRealm);
```
At the time `defaultRealm` is set, `realmContextResolver` has not yet been initialized, causing the exception.