### PR TITLE
Remove map of parameters from `CallContextResolver` and `RealmContextResolver`

### DIFF
--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/PolarisApplication.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/PolarisApplication.java
@@ -502,18 +502,12 @@ public class PolarisApplication extends Application<PolarisApplicationConfig> {
               httpRequest.getRequestURL().toString(),
               httpRequest.getMethod(),
               httpRequest.getRequestURI().substring(1),
-              request.getParameterMap().entrySet().stream()
-                  .collect(
-                      Collectors.toMap(Map.Entry::getKey, (e) -> ((String[]) e.getValue())[0])),
               headers);
       CallContext currentCallContext =
           callContextResolver.resolveCallContext(
               currentRealmContext,
               httpRequest.getMethod(),
               httpRequest.getRequestURI().substring(1),
-              request.getParameterMap().entrySet().stream()
-                  .collect(
-                      Collectors.toMap(Map.Entry::getKey, (e) -> ((String[]) e.getValue())[0])),
               headers);
       CallContext.setCurrentContext(currentCallContext);
       try (MDC.MDCCloseable ignored1 =

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/test/PolarisConnectionExtension.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/test/PolarisConnectionExtension.java
@@ -99,12 +99,11 @@ public class PolarisConnectionExtension
                   String.format("%s://%s", testEnvUri.getScheme(), testEnvUri.getHost()),
                   "GET",
                   path,
-                  Map.of(),
                   Map.of(REALM_PROPERTY_KEY, realm));
       CallContext ctx =
           config
               .findService(CallContextResolver.class)
-              .resolveCallContext(realmContext, "GET", path, Map.of(), Map.of());
+              .resolveCallContext(realmContext, "GET", path, Map.of());
       CallContext.setCurrentContext(ctx);
       PolarisMetaStoreManager metaStoreManager =
           metaStoreManagerFactory.getOrCreateMetaStoreManager(ctx.getRealmContext());

--- a/service/common/src/main/java/org/apache/polaris/service/context/CallContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/CallContextResolver.java
@@ -25,9 +25,5 @@ import org.apache.polaris.core.context.RealmContext;
 /** Uses the resolved RealmContext to further resolve elements of the CallContext. */
 public interface CallContextResolver {
   CallContext resolveCallContext(
-      RealmContext realmContext,
-      String method,
-      String path,
-      Map<String, String> queryParams,
-      Map<String, String> headers);
+      RealmContext realmContext, String method, String path, Map<String, String> headers);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
@@ -49,17 +49,12 @@ public class DefaultCallContextResolver implements CallContextResolver {
 
   @Override
   public CallContext resolveCallContext(
-      final RealmContext realmContext,
-      String method,
-      String path,
-      Map<String, String> queryParams,
-      Map<String, String> headers) {
+      final RealmContext realmContext, String method, String path, Map<String, String> headers) {
     LOGGER
         .atDebug()
         .addKeyValue("realmContext", realmContext.getRealmIdentifier())
         .addKeyValue("method", method)
         .addKeyValue("path", path)
-        .addKeyValue("queryParams", queryParams)
         .addKeyValue("headers", headers)
         .log("Resolving CallContext");
 

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmContextResolver.java
@@ -42,20 +42,12 @@ public class DefaultRealmContextResolver implements RealmContextResolver {
 
   @Override
   public RealmContext resolveRealmContext(
-      String requestURL,
-      String method,
-      String path,
-      Map<String, String> queryParams,
-      Map<String, String> headers) {
+      String requestURL, String method, String path, Map<String, String> headers) {
     // Since this default resolver is strictly for use in test/dev environments, we'll consider
     // it safe to log all contents. Any "real" resolver used in a prod environment should make
     // sure to only log non-sensitive contents.
     LOGGER.debug(
-        "Resolving RealmContext for method: {}, path: {}, queryParams: {}, headers: {}",
-        method,
-        path,
-        queryParams,
-        headers);
+        "Resolving RealmContext for method: {}, path: {}, headers: {}", method, path, headers);
     final Map<String, String> parsedProperties = parseBearerTokenAsKvPairs(headers);
 
     if (!parsedProperties.containsKey(REALM_PROPERTY_KEY)

--- a/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
@@ -24,11 +24,7 @@ import org.apache.polaris.core.context.RealmContext;
 public interface RealmContextResolver {
 
   RealmContext resolveRealmContext(
-      String requestURL,
-      String method,
-      String path,
-      Map<String, String> queryParams,
-      Map<String, String> headers);
+      String requestURL, String method, String path, Map<String, String> headers);
 
   void setDefaultRealm(String defaultRealm);
 


### PR DESCRIPTION
No implementation uses the `queryParams` `Map`, the code to build this parameter is also wrong, see #616

Fixes #616

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
