### PR TITLE
Change authentication workflow to lookup principal roles using security context

### DIFF
--- a/dropwizard/service/build.gradle.kts
+++ b/dropwizard/service/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   implementation("io.dropwizard:dropwizard-core")
   implementation("io.dropwizard:dropwizard-auth")
   implementation("io.dropwizard:dropwizard-json-logging")
+  implementation("org.glassfish.jersey.inject:jersey-hk2:3.0.16")
 
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")

--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/PolarisApplication.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/PolarisApplication.java
@@ -107,7 +107,9 @@ import org.apache.polaris.service.admin.api.PolarisPrincipalRolesApi;
 import org.apache.polaris.service.admin.api.PolarisPrincipalRolesApiService;
 import org.apache.polaris.service.admin.api.PolarisPrincipalsApi;
 import org.apache.polaris.service.admin.api.PolarisPrincipalsApiService;
+import org.apache.polaris.service.auth.ActiveRolesProvider;
 import org.apache.polaris.service.auth.Authenticator;
+import org.apache.polaris.service.auth.DefaultActiveRolesProvider;
 import org.apache.polaris.service.catalog.IcebergCatalogAdapter;
 import org.apache.polaris.service.catalog.api.IcebergRestCatalogApi;
 import org.apache.polaris.service.catalog.api.IcebergRestCatalogApiService;
@@ -314,6 +316,7 @@ public class PolarisApplication extends Application<PolarisApplicationConfig> {
                     PolarisCatalogsApi.class,
                     PolarisPrincipalsApi.class,
                     PolarisPrincipalRolesApi.class);
+                bind(DefaultActiveRolesProvider.class).to(ActiveRolesProvider.class);
                 bindAsContract(RealmEntityManagerFactory.class).in(Singleton.class);
                 bind(PolarisCallContextCatalogFactory.class)
                     .to(CallContextCatalogFactory.class)

--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalAuthenticator.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalAuthenticator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.dropwizard.auth;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Optional;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.service.auth.Authenticator;
+
+@jakarta.ws.rs.ext.Provider
+@Priority(Priorities.AUTHENTICATION)
+public class PolarisPrincipalAuthenticator implements ContainerRequestFilter {
+  @Inject private Authenticator<String, AuthenticatedPolarisPrincipal> authenticator;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    String authHeader = requestContext.getHeaderString("Authorization");
+    if (authHeader == null) {
+      throw new IOException("Authorization header is missing");
+    }
+    int spaceIdx = authHeader.indexOf(' ');
+    if (spaceIdx <= 0 || !authHeader.substring(0, spaceIdx).equalsIgnoreCase("Bearer")) {
+      throw new IOException("Authorization header is not a Bearer token");
+    }
+    String credential = authHeader.substring(spaceIdx + 1);
+    Optional<AuthenticatedPolarisPrincipal> principal = authenticator.authenticate(credential);
+    if (principal.isEmpty()) {
+      throw new NotAuthorizedException("Unable to authenticate");
+    }
+    SecurityContext securityContext = requestContext.getSecurityContext();
+    requestContext.setSecurityContext(
+        new SecurityContext() {
+          @Override
+          public Principal getUserPrincipal() {
+            return principal.get();
+          }
+
+          @Override
+          public boolean isUserInRole(String role) {
+            return securityContext.isUserInRole(role);
+          }
+
+          @Override
+          public boolean isSecure() {
+            return securityContext.isSecure();
+          }
+
+          @Override
+          public String getAuthenticationScheme() {
+            return securityContext.getAuthenticationScheme();
+          }
+        });
+  }
+}

--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalRoleSecurityContextProvider.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalRoleSecurityContextProvider.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.dropwizard.auth;
 
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -37,13 +36,12 @@ import org.slf4j.LoggerFactory;
 public class PolarisPrincipalRoleSecurityContextProvider implements ContainerRequestFilter {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PolarisPrincipalRoleSecurityContextProvider.class);
-  @Inject Provider<SecurityContext> securityContextProvider;
   @Inject ActiveRolesProvider activeRolesProvider;
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     AuthenticatedPolarisPrincipal polarisPrincipal =
-        (AuthenticatedPolarisPrincipal) securityContextProvider.get().getUserPrincipal();
+        (AuthenticatedPolarisPrincipal) requestContext.getSecurityContext().getUserPrincipal();
     if (polarisPrincipal == null) {
       return;
     }

--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalRoleSecurityContextProvider.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/auth/PolarisPrincipalRoleSecurityContextProvider.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.dropwizard.auth;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisGrantManager;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.service.auth.BasePolarisAuthenticator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Priority(Priorities.AUTHENTICATION + 1)
+public class PolarisPrincipalRoleSecurityContextProvider implements ContainerRequestFilter {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PolarisPrincipalRoleSecurityContextProvider.class);
+  @Inject Provider<SecurityContext> securityContextProvider;
+  @Inject MetaStoreManagerFactory metaStoreManager;
+  @Inject Provider<PolarisGrantManager> polarisGrantManagerProvider;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    AuthenticatedPolarisPrincipal polarisPrincipal =
+        (AuthenticatedPolarisPrincipal) securityContextProvider.get().getUserPrincipal();
+    if (polarisPrincipal == null) {
+      return;
+    }
+    SecurityContext securityContext =
+        createSecurityContext(requestContext.getSecurityContext(), polarisPrincipal);
+    requestContext.setSecurityContext(securityContext);
+  }
+
+  public SecurityContext createSecurityContext(
+      SecurityContext ctx, AuthenticatedPolarisPrincipal principal) {
+    RealmContext realmContext = CallContext.getCurrentContext().getRealmContext();
+    List<PrincipalRoleEntity> activeRoles =
+        loadActivePrincipalRoles(
+            principal.getActivatedPrincipalRoleNames(),
+            principal.getPrincipalEntity(),
+            metaStoreManager.getOrCreateMetaStoreManager(realmContext));
+    Set<String> validRoleNames =
+        activeRoles.stream().map(PrincipalRoleEntity::getName).collect(Collectors.toSet());
+    return new SecurityContext() {
+      @Override
+      public Principal getUserPrincipal() {
+        return principal;
+      }
+
+      @Override
+      public boolean isUserInRole(String role) {
+        return validRoleNames.contains(role);
+      }
+
+      @Override
+      public boolean isSecure() {
+        return ctx.isSecure();
+      }
+
+      @Override
+      public String getAuthenticationScheme() {
+        return ctx.getAuthenticationScheme();
+      }
+    };
+  }
+
+  protected List<PrincipalRoleEntity> loadActivePrincipalRoles(
+      Set<String> tokenRoles, PolarisEntity principal, PolarisMetaStoreManager metaStoreManager) {
+    PolarisCallContext polarisContext = CallContext.getCurrentContext().getPolarisCallContext();
+    PolarisGrantManager.LoadGrantsResult principalGrantResults =
+        polarisGrantManagerProvider.get().loadGrantsToGrantee(polarisContext, principal);
+    polarisContext
+        .getDiagServices()
+        .check(
+            principalGrantResults.isSuccess(),
+            "Failed to resolve principal roles for principal name={} id={}",
+            principal.getName(),
+            principal.getId());
+    if (!principalGrantResults.isSuccess()) {
+      LOGGER.warn(
+          "Failed to resolve principal roles for principal name={} id={}",
+          principal.getName(),
+          principal.getId());
+      throw new NotAuthorizedException("Unable to authenticate");
+    }
+    boolean allRoles = tokenRoles.contains(BasePolarisAuthenticator.PRINCIPAL_ROLE_ALL);
+    Predicate<PrincipalRoleEntity> includeRoleFilter =
+        allRoles ? r -> true : r -> tokenRoles.contains(r.getName());
+    List<PrincipalRoleEntity> activeRoles =
+        principalGrantResults.getGrantRecords().stream()
+            .map(
+                gr ->
+                    metaStoreManager.loadEntity(
+                        polarisContext, gr.getSecurableCatalogId(), gr.getSecurableId()))
+            .filter(PolarisMetaStoreManager.EntityResult::isSuccess)
+            .map(PolarisMetaStoreManager.EntityResult::getEntity)
+            .map(PrincipalRoleEntity::of)
+            .filter(includeRoleFilter)
+            .toList();
+    if (activeRoles.size() != principalGrantResults.getGrantRecords().size()) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("principal", principal.getName())
+          .addKeyValue("scopes", tokenRoles)
+          .addKeyValue("roles", activeRoles)
+          .log("Some principal roles were not found in the principal's grants");
+    }
+    return activeRoles;
+  }
+}

--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/PolarisApplicationConfig.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/config/PolarisApplicationConfig.java
@@ -71,7 +71,7 @@ public class PolarisApplicationConfig extends Configuration {
   /**
    * Override the default binding of registered services so that the configured instances are used.
    */
-  private static final int OVERRIDE_BINDING_RANK = 10;
+  private static final int OVERRIDE_BINDING_RANK = 20;
 
   private MetaStoreManagerFactory metaStoreManagerFactory;
   private String defaultRealm = "default-realm";
@@ -125,7 +125,7 @@ public class PolarisApplicationConfig extends Configuration {
             .to(FileIOFactory.class)
             .ranked(OVERRIDE_BINDING_RANK);
         bindFactory(SupplierFactory.create(serviceLocator, config::getPolarisAuthenticator))
-            .to(Authenticator.class)
+            .to(new TypeLiteral<Authenticator<String, AuthenticatedPolarisPrincipal>>() {})
             .ranked(OVERRIDE_BINDING_RANK);
         bindFactory(SupplierFactory.create(serviceLocator, () -> tokenBroker))
             .to(TokenBrokerFactoryConfig.class);

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisAdminServiceAuthzTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisAdminServiceAuthzTest.java
@@ -45,7 +45,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final AuthenticatedPolarisPrincipal authenticatedPrincipal =
         new AuthenticatedPolarisPrincipal(principalEntity, activatedPrincipalRoles);
     return new PolarisAdminService(
-        callContext, entityManager, metaStoreManager, authenticatedPrincipal, polarisAuthorizer);
+        callContext,
+        entityManager,
+        metaStoreManager,
+        securityContext(authenticatedPrincipal, activatedPrincipalRoles),
+        polarisAuthorizer);
   }
 
   private void doTestSufficientPrivileges(

--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/PolarisPassthroughResolutionView.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/catalog/PolarisPassthroughResolutionView.java
@@ -18,10 +18,10 @@
  */
 package org.apache.polaris.service.dropwizard.catalog;
 
+import jakarta.ws.rs.core.SecurityContext;
 import java.util.Arrays;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -42,24 +42,24 @@ import org.apache.polaris.core.persistence.resolver.ResolverPath;
 public class PolarisPassthroughResolutionView implements PolarisResolutionManifestCatalogView {
   private final PolarisEntityManager entityManager;
   private final CallContext callContext;
-  private final AuthenticatedPolarisPrincipal authenticatedPrincipal;
+  private final SecurityContext securityContext;
   private final String catalogName;
 
   public PolarisPassthroughResolutionView(
       CallContext callContext,
       PolarisEntityManager entityManager,
-      AuthenticatedPolarisPrincipal authenticatedPrincipal,
+      SecurityContext securityContext,
       String catalogName) {
     this.entityManager = entityManager;
     this.callContext = callContext;
-    this.authenticatedPrincipal = authenticatedPrincipal;
+    this.securityContext = securityContext;
     this.catalogName = catalogName;
   }
 
   @Override
   public PolarisResolvedPathWrapper getResolvedReferenceCatalogEntity() {
     PolarisResolutionManifest manifest =
-        entityManager.prepareResolutionManifest(callContext, authenticatedPrincipal, catalogName);
+        entityManager.prepareResolutionManifest(callContext, securityContext, catalogName);
     manifest.resolveAll();
     return manifest.getResolvedReferenceCatalogEntity();
   }
@@ -67,7 +67,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   @Override
   public PolarisResolvedPathWrapper getResolvedPath(Object key) {
     PolarisResolutionManifest manifest =
-        entityManager.prepareResolutionManifest(callContext, authenticatedPrincipal, catalogName);
+        entityManager.prepareResolutionManifest(callContext, securityContext, catalogName);
 
     if (key instanceof Namespace namespace) {
       manifest.addPath(
@@ -85,7 +85,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   @Override
   public PolarisResolvedPathWrapper getResolvedPath(Object key, PolarisEntitySubType subType) {
     PolarisResolutionManifest manifest =
-        entityManager.prepareResolutionManifest(callContext, authenticatedPrincipal, catalogName);
+        entityManager.prepareResolutionManifest(callContext, securityContext, catalogName);
 
     if (key instanceof TableIdentifier identifier) {
       manifest.addPath(
@@ -106,7 +106,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   @Override
   public PolarisResolvedPathWrapper getPassthroughResolvedPath(Object key) {
     PolarisResolutionManifest manifest =
-        entityManager.prepareResolutionManifest(callContext, authenticatedPrincipal, catalogName);
+        entityManager.prepareResolutionManifest(callContext, securityContext, catalogName);
 
     if (key instanceof Namespace namespace) {
       manifest.addPassthroughPath(
@@ -124,7 +124,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   public PolarisResolvedPathWrapper getPassthroughResolvedPath(
       Object key, PolarisEntitySubType subType) {
     PolarisResolutionManifest manifest =
-        entityManager.prepareResolutionManifest(callContext, authenticatedPrincipal, catalogName);
+        entityManager.prepareResolutionManifest(callContext, securityContext, catalogName);
 
     if (key instanceof TableIdentifier identifier) {
       manifest.addPassthroughPath(

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
   implementation(libs.swagger.jaxrs)
   implementation(libs.jakarta.inject.api)
   implementation(libs.jakarta.validation.api)
+  implementation(libs.jakarta.ws.rs.api)
   implementation(libs.smallrye.common.annotation)
 
   implementation("org.apache.iceberg:iceberg-aws")

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisGrantManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisGrantManager.java
@@ -119,6 +119,20 @@ public interface PolarisGrantManager {
    * This method should be used by the Polaris app to cache all grant records on a securable.
    *
    * @param callCtx call context
+   * @param securable the securable entity
+   * @return the list of grants and the version of the grant records. We will return
+   *     ENTITY_NOT_FOUND if the securable cannot be found
+   */
+  @Nonnull
+  default LoadGrantsResult loadGrantsOnSecurable(
+      @Nonnull PolarisCallContext callCtx, PolarisBaseEntity securable) {
+    return loadGrantsOnSecurable(callCtx, securable.getCatalogId(), securable.getId());
+  }
+
+  /**
+   * This method should be used by the Polaris app to cache all grant records on a securable.
+   *
+   * @param callCtx call context
    * @param securableCatalogId id of the catalog this securable belongs to
    * @param securableId id of the securable
    * @return the list of grants and the version of the grant records. We will return
@@ -127,6 +141,21 @@ public interface PolarisGrantManager {
   @Nonnull
   LoadGrantsResult loadGrantsOnSecurable(
       @Nonnull PolarisCallContext callCtx, long securableCatalogId, long securableId);
+
+  /**
+   * This method should be used by the Polaris app to load all grants made to a grantee, either a
+   * role or a principal.
+   *
+   * @param callCtx call context
+   * @param grantee the grantee entity
+   * @return the list of grants and the version of the grant records. We will return NULL if the
+   *     grantee does not exist
+   */
+  @Nonnull
+  default LoadGrantsResult loadGrantsToGrantee(
+      @Nonnull PolarisCallContext callCtx, PolarisBaseEntity grantee) {
+    return loadGrantsToGrantee(callCtx, grantee.getCatalogId(), grantee.getId());
+  }
 
   /**
    * This method should be used by the Polaris app to load all grants made to a grantee, either a

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
@@ -20,8 +20,8 @@ package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
-import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
@@ -58,33 +58,28 @@ public class PolarisEntityManager {
       @Nonnull StorageCredentialCache credentialCache,
       @Nonnull EntityCache entityCache) {
     this.metaStoreManager = metaStoreManager;
-    this.entityCache = entityCache;
     this.credentialCache = credentialCache;
+    this.entityCache = entityCache;
   }
 
   public Resolver prepareResolver(
       @Nonnull CallContext callContext,
-      @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
+      @Nonnull SecurityContext securityContext,
       @Nullable String referenceCatalogName) {
     return new Resolver(
         callContext.getPolarisCallContext(),
         metaStoreManager,
-        authenticatedPrincipal.getPrincipalEntity().getId(),
-        null, /* callerPrincipalName */
-        authenticatedPrincipal.getActivatedPrincipalRoleNames().isEmpty()
-            ? null
-            : authenticatedPrincipal.getActivatedPrincipalRoleNames(),
+        securityContext,
         entityCache,
         referenceCatalogName);
   }
 
   public PolarisResolutionManifest prepareResolutionManifest(
       @Nonnull CallContext callContext,
-      @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
+      @Nonnull SecurityContext securityContext,
       @Nullable String referenceCatalogName) {
     PolarisResolutionManifest manifest =
-        new PolarisResolutionManifest(
-            callContext, this, authenticatedPrincipal, referenceCatalogName);
+        new PolarisResolutionManifest(callContext, this, securityContext, referenceCatalogName);
     manifest.setSimulatedResolvedRootContainerEntity(
         getSimulatedResolvedRootContainerEntity(callContext));
     return manifest;

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -111,7 +111,7 @@ public class PolarisServiceImpl
         CallContext.getCurrentContext(),
         entityManager,
         metaStoreManager,
-        authenticatedPrincipal,
+        securityContext,
         polarisAuthorizer);
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/auth/ActiveRolesProvider.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/ActiveRolesProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import java.util.Set;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+
+/**
+ * Provides the active roles for a given principal. Implementations may rely on the active request
+ * or SecurityContext to determine the active roles.
+ */
+public interface ActiveRolesProvider {
+  /**
+   * Returns the active roles for the given principal.
+   *
+   * @param principal the currently authenticated principal
+   * @return the active roles
+   */
+  Set<String> getActiveRoles(AuthenticatedPolarisPrincipal principal);
+}

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultActiveRolesProvider implements ActiveRolesProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultActiveRolesProvider.class);
   @Inject Provider<RealmContext> realmContextProvider;
-  @Inject MetaStoreManagerFactory metaStoreManager;
+  @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject Provider<PolarisGrantManager> polarisGrantManagerProvider;
 
   @Override
@@ -55,7 +55,7 @@ public class DefaultActiveRolesProvider implements ActiveRolesProvider {
         loadActivePrincipalRoles(
             principal.getActivatedPrincipalRoleNames(),
             principal.getPrincipalEntity(),
-            metaStoreManager.getOrCreateMetaStoreManager(realmContextProvider.get()));
+            metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContextProvider.get()));
     return activeRoles.stream().map(PrincipalRoleEntity::getName).collect(Collectors.toSet());
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisGrantManager;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of the {@link ActiveRolesProvider} looks up the grant records for a
+ * principal to determine roles that are available. {@link
+ * AuthenticatedPolarisPrincipal#getActivatedPrincipalRoleNames()} is used to determine which of the
+ * available roles are active for this request.
+ */
+public class DefaultActiveRolesProvider implements ActiveRolesProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultActiveRolesProvider.class);
+  @Inject Provider<RealmContext> realmContextProvider;
+  @Inject MetaStoreManagerFactory metaStoreManager;
+  @Inject Provider<PolarisGrantManager> polarisGrantManagerProvider;
+
+  @Override
+  public Set<String> getActiveRoles(AuthenticatedPolarisPrincipal principal) {
+    List<PrincipalRoleEntity> activeRoles =
+        loadActivePrincipalRoles(
+            principal.getActivatedPrincipalRoleNames(),
+            principal.getPrincipalEntity(),
+            metaStoreManager.getOrCreateMetaStoreManager(realmContextProvider.get()));
+    return activeRoles.stream().map(PrincipalRoleEntity::getName).collect(Collectors.toSet());
+  }
+
+  protected List<PrincipalRoleEntity> loadActivePrincipalRoles(
+      Set<String> tokenRoles, PolarisEntity principal, PolarisMetaStoreManager metaStoreManager) {
+    PolarisCallContext polarisContext = CallContext.getCurrentContext().getPolarisCallContext();
+    PolarisGrantManager.LoadGrantsResult principalGrantResults =
+        polarisGrantManagerProvider.get().loadGrantsToGrantee(polarisContext, principal);
+    polarisContext
+        .getDiagServices()
+        .check(
+            principalGrantResults.isSuccess(),
+            "Failed to resolve principal roles for principal name={} id={}",
+            principal.getName(),
+            principal.getId());
+    if (!principalGrantResults.isSuccess()) {
+      LOGGER.warn(
+          "Failed to resolve principal roles for principal name={} id={}",
+          principal.getName(),
+          principal.getId());
+      throw new NotAuthorizedException("Unable to authenticate");
+    }
+    boolean allRoles = tokenRoles.contains(BasePolarisAuthenticator.PRINCIPAL_ROLE_ALL);
+    Predicate<PrincipalRoleEntity> includeRoleFilter =
+        allRoles ? r -> true : r -> tokenRoles.contains(r.getName());
+    List<PrincipalRoleEntity> activeRoles =
+        principalGrantResults.getGrantRecords().stream()
+            .map(
+                gr ->
+                    metaStoreManager.loadEntity(
+                        polarisContext, gr.getSecurableCatalogId(), gr.getSecurableId()))
+            .filter(PolarisMetaStoreManager.EntityResult::isSuccess)
+            .map(PolarisMetaStoreManager.EntityResult::getEntity)
+            .map(PrincipalRoleEntity::of)
+            .filter(includeRoleFilter)
+            .toList();
+    if (activeRoles.size() != principalGrantResults.getGrantRecords().size()) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("principal", principal.getName())
+          .addKeyValue("scopes", tokenRoles)
+          .addKeyValue("roles", activeRoles)
+          .log("Some principal roles were not found in the principal's grants");
+    }
+    return activeRoles;
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.ws.rs.core.SecurityContext;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
@@ -152,6 +153,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   private final PolarisResolutionManifestCatalogView resolvedEntityView;
   private final CatalogEntity catalogEntity;
   private final TaskExecutor taskExecutor;
+  private final SecurityContext securityContext;
   private final AuthenticatedPolarisPrincipal authenticatedPrincipal;
   private String ioImplClassName;
   private FileIO catalogFileIO;
@@ -177,6 +179,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext,
       PolarisResolutionManifestCatalogView resolvedEntityView,
+      SecurityContext securityContext,
       AuthenticatedPolarisPrincipal authenticatedPrincipal,
       TaskExecutor taskExecutor,
       FileIOFactory fileIOFactory) {
@@ -185,6 +188,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
     this.resolvedEntityView = resolvedEntityView;
     this.catalogEntity =
         CatalogEntity.of(resolvedEntityView.getResolvedReferenceCatalogEntity().getRawLeafEntity());
+    this.securityContext = securityContext;
     this.authenticatedPrincipal = authenticatedPrincipal;
     this.taskExecutor = taskExecutor;
     this.catalogId = catalogEntity.getId();
@@ -1126,7 +1130,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         siblingTables.size() + siblingNamespaces.size());
     PolarisResolutionManifest resolutionManifest =
         new PolarisResolutionManifest(
-            callContext, entityManager, authenticatedPrincipal, parentPath.getFirst().getName());
+            callContext, entityManager, securityContext, parentPath.getFirst().getName());
     siblingTables.forEach(
         tbl ->
             resolutionManifest.addPath(

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -142,7 +142,7 @@ public class IcebergCatalogAdapter
         CallContext.getCurrentContext(),
         entityManager,
         metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-        authenticatedPrincipal,
+        securityContext,
         catalogFactory,
         catalogName,
         polarisAuthorizer);
@@ -542,8 +542,7 @@ public class IcebergCatalogAdapter
     }
     // FIXME remove call to CallContext.getCurrentContext()
     CallContext callContext = CallContext.getCurrentContext();
-    Resolver resolver =
-        entityManager.prepareResolver(callContext, authenticatedPrincipal, warehouse);
+    Resolver resolver = entityManager.prepareResolver(callContext, securityContext, warehouse);
     ResolverStatus resolverStatus = resolver.resolveAll();
     if (!resolverStatus.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
       throw new NotFoundException("Unable to find warehouse %s", warehouse);

--- a/service/common/src/main/java/org/apache/polaris/service/context/CallContextCatalogFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/CallContextCatalogFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.context;
 
+import jakarta.ws.rs.core.SecurityContext;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
@@ -27,5 +28,6 @@ public interface CallContextCatalogFactory {
   Catalog createCallContextCatalog(
       CallContext context,
       AuthenticatedPolarisPrincipal authenticatedPrincipal,
+      SecurityContext securityContext,
       PolarisResolutionManifest resolvedManifest);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.context;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.SecurityContext;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,6 +68,7 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
   public Catalog createCallContextCatalog(
       CallContext context,
       AuthenticatedPolarisPrincipal authenticatedPrincipal,
+      SecurityContext securityContext,
       final PolarisResolutionManifest resolvedManifest) {
     PolarisBaseEntity baseCatalogEntity =
         resolvedManifest.getResolvedReferenceCatalogEntity().getRawLeafEntity();
@@ -85,6 +87,7 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
             metaStoreManagerFactory.getOrCreateMetaStoreManager(context.getRealmContext()),
             context,
             resolvedManifest,
+            securityContext,
             authenticatedPrincipal,
             taskExecutor,
             fileIOFactory);


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Currently, the `Resolver` checks the PrincipalRole usage grants available for a Principal entity when determining which roles are active for a request. These roles are then passed on to the `PolarisAuthorizer` so that authorization can be done on the operation and target object.

This PR changes the `Resolver` to instead rely on the `SecurityContext` to determine which roles the principal has access to. A request filter populates the `SecurityContext` using an `ActiveRolesProvider`. The default implementation still looks up the principal role usage grants, but now the filter can be replaced by new implementations that determine role membership in other ways (e.g., by checking an authentication token or delegating to a third party identity provider).