### PR TITLE
Remove testRequestHeaderTooLarge()

### DIFF
--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/PolarisApplicationIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/PolarisApplicationIntegrationTest.java
@@ -27,9 +27,7 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
@@ -671,39 +669,6 @@ public class PolarisApplicationIntegrationTest {
                           realm)))
           .isInstanceOf(BadRequestException.class)
           .hasMessage("Malformed request: Please specify a warehouse");
-    }
-  }
-
-  @Test
-  public void testRequestHeaderTooLarge() {
-    Invocation.Builder request =
-        EXT.client()
-            .target(
-                String.format(
-                    "http://localhost:%d/api/management/v1/principal-roles", EXT.getLocalPort()))
-            .request("application/json");
-
-    // The default limit is 8KiB and each of these headers is at least 8 bytes, so 1500 definitely
-    // exceeds the limit
-    for (int i = 0; i < 1500; i++) {
-      request = request.header("header" + i, "" + i);
-    }
-
-    try {
-      try (Response response =
-          request
-              .header("Authorization", "Bearer " + userToken)
-              .header(REALM_PROPERTY_KEY, realm)
-              .post(Entity.json(new PrincipalRole("r")))) {
-        assertThat(response)
-            .returns(
-                Response.Status.REQUEST_HEADER_FIELDS_TOO_LARGE.getStatusCode(),
-                Response::getStatus);
-      }
-    } catch (ProcessingException e) {
-      // In some runtime environments the request above will return a 431 but in others it'll result
-      // in a ProcessingException from the socket being closed. The test asserts that one of those
-      // things happens.
     }
   }
 


### PR DESCRIPTION
This test is not normative to Polaris APIs.

Moreover, it does not test any of Polaris code, but instead depends on Dropwizard's behaviour.

While the intent of making sure that header sizes are restricted is wise, it does not look like validating that in Polaris CI is the best option. As the comment in the deleted test suggests actual runtime behaviour is heavily affected by the execution environment.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
