### PR TITLE
Use HTTP status code 413 for exceedingly large payloads

### DIFF
--- a/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/throttling/StreamReadConstraintsExceptionMapper.java
+++ b/dropwizard/service/src/main/java/org/apache/polaris/service/dropwizard/throttling/StreamReadConstraintsExceptionMapper.java
@@ -34,7 +34,7 @@ public class StreamReadConstraintsExceptionMapper
 
   @Override
   public Response toResponse(StreamConstraintsException exception) {
-    return Response.status(Response.Status.BAD_REQUEST)
+    return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
         .type(MediaType.APPLICATION_JSON_TYPE)
         .entity(new RequestThrottlingErrorResponse(REQUEST_TOO_LARGE))
         .build();


### PR DESCRIPTION
The 413 status code seems to be more appropriate than
400 (Bad Request) in this case.