### PR TITLE
Fix deprecation warning for `ShadowExtension`

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -19,7 +19,7 @@
 
 package publishing
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import javax.inject.Inject
 import org.gradle.api.*
 import org.gradle.api.component.SoftwareComponentFactory
@@ -124,7 +124,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
               afterEvaluate {
                 // This MUST happen in an 'afterEvaluate' to ensure that the Shadow*Plugin has
                 // been applied.
-                if (project.extensions.findByType(ShadowExtension::class.java) != null) {
+                if (project.plugins.hasPlugin(ShadowPlugin::class.java)) {
                   configureShadowPublishing(project, mavenPublication, softwareComponentFactory)
                 } else {
                   from(components.firstOrNull { c -> c.name == "javaPlatform" || c.name == "java" })


### PR DESCRIPTION
The build-logic code checked for the _existence_ of the `ShadowExtension`, replacing with a check against the `ShadowPlugin`, yielding the same results.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
