### PR TITLE
Make testCreateCatalogWithUnparsableJson() more generic

### DIFF
--- a/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisServiceImplIntegrationTest.java
+++ b/dropwizard/service/src/test/java/org/apache/polaris/service/dropwizard/admin/PolarisServiceImplIntegrationTest.java
@@ -554,11 +554,7 @@ public class PolarisServiceImplIntegrationTest {
       assertThat(response)
           .returns(Response.Status.BAD_REQUEST.getStatusCode(), Response::getStatus);
       ErrorResponse error = response.readEntity(ErrorResponse.class);
-      assertThat(error)
-          .isNotNull()
-          .extracting(ErrorResponse::message)
-          .asString()
-          .startsWith("Invalid JSON: Unexpected character");
+      assertThat(error).isNotNull().extracting(ErrorResponse::message).isNotNull();
     }
   }
 


### PR DESCRIPTION
Remove assertion on too specific JSON parsing error message. The exact message text may vary in different server builds.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
