### PR TITLE
Bump spotless to v7

### DIFF
--- a/api/iceberg-service/build.gradle.kts
+++ b/api/iceberg-service/build.gradle.kts
@@ -100,7 +100,7 @@ openApiGenerate {
       "CommitTableRequest" to "org.apache.polaris.service.types.CommitTableRequest",
       "NotificationRequest" to "org.apache.polaris.service.types.NotificationRequest",
       "TableUpdateNotification" to "org.apache.polaris.service.types.TableUpdateNotification",
-      "NotificationType" to "org.apache.polaris.service.types.NotificationType"
+      "NotificationType" to "org.apache.polaris.service.types.NotificationType",
     )
 }
 

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import com.diffplug.spotless.FormatterFunc
+import java.io.Serializable
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
@@ -80,19 +82,23 @@ tasks.withType(Jar::class).configureEach {
 }
 
 spotless {
-  val disallowWildcardImports = { text: String ->
-    val regex = "~/import .*\\.\\*;/".toRegex()
-    if (regex.matches(text)) {
-      throw GradleException("Wildcard imports disallowed - ${regex.findAll(text)}")
-    }
-    text
-  }
   java {
     target("src/main/java/**/*.java", "src/testFixtures/java/**/*.java", "src/test/java/**/*.java")
     googleJavaFormat()
     licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
     endWithNewline()
-    custom("disallowWildcardImports", disallowWildcardImports)
+    custom(
+      "disallowWildcardImports",
+      object : Serializable, FormatterFunc {
+        override fun apply(text: String): String {
+          val regex = "~/import .*\\.\\*;/".toRegex()
+          if (regex.matches(text)) {
+            throw GradleException("Wildcard imports disallowed - ${regex.findAll(text)}")
+          }
+          return text
+        }
+      },
+    )
     toggleOffOn()
   }
   kotlinGradle {

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -76,7 +76,7 @@ tasks.withType(Jar::class).configureEach {
       // manifests for release(-like) builds.
       "Implementation-Title" to "Apache Polaris(TM) (incubating)",
       "Implementation-Vendor" to "Apache Software Foundation",
-      "Implementation-URL" to "https://polaris.apache.org/"
+      "Implementation-URL" to "https://polaris.apache.org/",
     )
   }
 }

--- a/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
@@ -31,9 +31,9 @@ afterEvaluate {
       arrayOf(
         LicenseBundleNormalizer(
           "${rootProject.projectDir}/gradle/license/normalizer-bundle.json",
-          false
+          false,
         ),
-        LicenseFileValidation()
+        LicenseFileValidation(),
       )
     allowedLicensesFile = rootProject.projectDir.resolve("gradle/license/allowed-licenses.json")
     renderers =
@@ -48,7 +48,7 @@ val generateLicenseReport =
     inputs
       .files(
         rootProject.projectDir.resolve("gradle/license/normalizer-bundle.json"),
-        rootProject.projectDir.resolve("gradle/license/allowed-licenses.json")
+        rootProject.projectDir.resolve("gradle/license/allowed-licenses.json"),
       )
       .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("renderersHash", Arrays.hashCode(licenseReport.renderers))

--- a/build-logic/src/main/kotlin/publishing/MemoizedGitInfo.kt
+++ b/build-logic/src/main/kotlin/publishing/MemoizedGitInfo.kt
@@ -80,7 +80,7 @@ internal class MemoizedGitInfo {
             "Apache-Polaris-Build-Git-Describe" to gitDescribe,
             "Apache-Polaris-Build-Timestamp" to timestamp,
             "Apache-Polaris-Build-System" to system,
-            "Apache-Polaris-Build-Java-Version" to javaVersion
+            "Apache-Polaris-Build-Java-Version" to javaVersion,
           )
         rootProject.extra["gitReleaseInfo"] = info
         return info

--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -169,7 +169,7 @@ fun addMissingMandatoryDependencyVersions(project: Project, projectNode: Node) {
           findDependency(
             project.configurations.findByName("testRuntimeClasspath"),
             depGroup,
-            depName
+            depName,
           )
       }
 

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -56,7 +56,7 @@ internal fun configureOnRootProject(project: Project) =
         "--prefix=${e.baseName.get()}/",
         "--format=tar.gz",
         "--output=${e.sourceTarball.get().asFile.relativeTo(projectDir)}",
-        "HEAD"
+        "HEAD",
       )
       workingDir(project.projectDir)
     }

--- a/build-logic/src/main/kotlin/publishing/shadowPub.kt
+++ b/build-logic/src/main/kotlin/publishing/shadowPub.kt
@@ -42,7 +42,7 @@ import org.gradle.api.publish.maven.MavenPublication
 internal fun configureShadowPublishing(
   project: Project,
   mavenPublication: MavenPublication,
-  softwareComponentFactory: SoftwareComponentFactory
+  softwareComponentFactory: SoftwareComponentFactory,
 ) =
   project.run {
     fun isPublishable(element: ConfigurationVariant): Boolean {
@@ -64,15 +64,15 @@ internal fun configureShadowPublishing(
           attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_API))
           attribute(
             Category.CATEGORY_ATTRIBUTE,
-            project.objects.named(Category::class.java, Category.LIBRARY)
+            project.objects.named(Category::class.java, Category.LIBRARY),
           )
           attribute(
             LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-            project.objects.named(LibraryElements::class.java, LibraryElements.JAR)
+            project.objects.named(LibraryElements::class.java, LibraryElements.JAR),
           )
           attribute(
             Bundling.BUNDLING_ATTRIBUTE,
-            project.objects.named(Bundling::class.java, Bundling.SHADOWED)
+            project.objects.named(Bundling::class.java, Bundling.SHADOWED),
           )
         }
         outgoing.artifact(shadowJar)

--- a/build-logic/src/main/kotlin/publishing/util.kt
+++ b/build-logic/src/main/kotlin/publishing/util.kt
@@ -34,7 +34,7 @@ import org.gradle.api.artifacts.result.DependencyResult
 internal fun findDependency(
   config: Configuration?,
   depGroup: String,
-  depName: String
+  depName: String,
 ): DependencyResult? {
   if (config != null) {
     val depResult =
@@ -78,7 +78,8 @@ internal fun generateDigest(input: File, output: File, algorithm: String) {
 }
 
 internal fun <T : Any> unsafeCast(o: Any?): T {
-  @Suppress("UNCHECKED_CAST") return o as T
+  @Suppress("UNCHECKED_CAST")
+  return o as T
 }
 
 internal fun <T : Any> parseJson(url: String): T {
@@ -206,7 +207,7 @@ internal fun fetchProjectPeople(apacheId: String): ProjectPeople {
     licenseUrl,
     bugDatabase,
     inceptionYear,
-    peopleList
+    peopleList,
   )
 }
 
@@ -219,7 +220,7 @@ internal class ProjectPeople(
   val licenseUrl: String,
   val bugDatabase: String,
   val inceptionYear: Int,
-  val people: List<ProjectMember>
+  val people: List<ProjectMember>,
 )
 
 internal class ProjectMember(val apacheId: String, val name: String, val roles: List<String>)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,12 +20,7 @@
 import java.net.URI
 import org.nosphere.apache.rat.RatTask
 
-buildscript {
-  repositories { maven { url = java.net.URI("https://plugins.gradle.org/m2/") } }
-  dependencies {
-    classpath("com.diffplug.spotless:spotless-plugin-gradle:${libs.plugins.spotless.get().version}")
-  }
-}
+buildscript { repositories { maven { url = java.net.URI("https://plugins.gradle.org/m2/") } } }
 
 plugins {
   id("idea")

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -23,4 +23,4 @@ idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle
 license-report = { module = "com.github.jk1:gradle-license-report", version = "2.9" }
 nexus-publish = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.5" }
-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,4 +80,3 @@ threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
 [plugins]
 openapi-generator = { id = "org.openapi.generator", version = "7.10.0" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
-spotless = { id = "com.diffplug.spotless", version = "6.25.0" }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Nullable;
  */
 public interface PolarisStorageIntegrationProvider {
   @SuppressWarnings("unchecked")
-  <T extends PolarisStorageConfigurationInfo> @Nullable
-      PolarisStorageIntegration<T> getStorageIntegrationForConfig(
+  <T extends PolarisStorageConfigurationInfo>
+      @Nullable PolarisStorageIntegration<T> getStorageIntegrationForConfig(
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -519,8 +519,8 @@ public class PolarisServiceImpl
         catalogName);
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     switch (grantRequest.getGrant()) {
-        // The per-securable-type Privilege enums must be exact String match for a subset of all
-        // PolarisPrivilege values.
+      // The per-securable-type Privilege enums must be exact String match for a subset of all
+      // PolarisPrivilege values.
       case ViewGrant viewGrant:
         {
           PolarisPrivilege privilege =
@@ -595,8 +595,8 @@ public class PolarisServiceImpl
 
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     switch (grantRequest.getGrant()) {
-        // The per-securable-type Privilege enums must be exact String match for a subset of all
-        // PolarisPrivilege values.
+      // The per-securable-type Privilege enums must be exact String match for a subset of all
+      // PolarisPrivilege values.
       case ViewGrant viewGrant:
         {
           PolarisPrivilege privilege =

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -1735,16 +1735,16 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
           throw new NotFoundException("Cannot rename %s to %s. %s does not exist", from, to, from);
 
-          // this is temporary. Should throw a special error that will be caught and retried
+        // this is temporary. Should throw a special error that will be caught and retried
         case BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED:
         case BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED:
           throw new RuntimeException("concurrent update detected, please retry");
 
-          // some entities cannot be renamed
+        // some entities cannot be renamed
         case BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RENAMED:
           throw new BadRequestException("Cannot rename built-in object %s", leafEntity.getName());
 
-          // some entities cannot be renamed
+        // some entities cannot be renamed
         default:
           throw new IllegalStateException(
               "Unknown error status " + returnedEntityResult.getReturnStatus());

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -54,8 +54,8 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends PolarisStorageConfigurationInfo> @Nullable
-      PolarisStorageIntegration<T> getStorageIntegrationForConfig(
+  public <T extends PolarisStorageConfigurationInfo>
+      @Nullable PolarisStorageIntegration<T> getStorageIntegrationForConfig(
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
     if (polarisStorageConfigurationInfo == null) {
       return null;


### PR DESCRIPTION
spotless v7 fails on Gradle with some `SerializationException`, moving the `callable` works around this issue (as [mentioned here](https://github.com/diffplug/spotless/issues/2387)).

Also removing the unnecessary `buildscript.dependencies` and the implied 2nd spotless version definition.

Supersedes #680 + #686