### PR TITLE
Remove Minikube Github Action

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set up Minikube
         if: steps.list-changed.outputs.changed == 'true'
-        run:
+        run: |
           curl -LO https://github.com/kubernetes/minikube/releases/download/v1.34.0/minikube_1.34.0-0_amd64.deb
           sudo dpkg -i minikube_1.34.0-0_amd64.deb
           minikube start

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Set up Minikube
         if: steps.list-changed.outputs.changed == 'true'
         run:
-          curl -LO https://github.com/kubernetes/minikube/releases/latest/download/minikube_latest_amd64.deb
-          sudo dpkg -i minikube_latest_amd64.deb
+          curl -LO https://github.com/kubernetes/minikube/releases/download/v1.34.0/minikube_1.34.0-0_amd64.deb
+          sudo dpkg -i minikube_1.34.0-0_amd64.deb
           minikube start
 
       - name: Docker build

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -81,7 +81,10 @@ jobs:
 
       - name: Set up Minikube
         if: steps.list-changed.outputs.changed == 'true'
-        uses: medyagh/setup-minikube@v0.0.18
+        run:
+          curl -LO https://github.com/kubernetes/minikube/releases/latest/download/minikube_latest_amd64.deb
+          sudo dpkg -i minikube_latest_amd64.deb
+          minikube start
 
       - name: Docker build
         if: steps.list-changed.outputs.changed == 'true'

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -20,6 +20,7 @@
 # -- The number of replicas to deploy (horizontal scaling).
 # Beware that replicas are stateless; don't set this number > 1 when using in-memory meta store manager.
 replicaCount: 1
+dummy: "dummy"
 
 image:
   # -- The image repository to pull from.

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -20,7 +20,6 @@
 # -- The number of replicas to deploy (horizontal scaling).
 # Beware that replicas are stateless; don't set this number > 1 when using in-memory meta store manager.
 replicaCount: 1
-dummy: "dummy"
 
 image:
   # -- The image repository to pull from.


### PR DESCRIPTION
...since `medyagh/setup-minikube` is not an "authorized action". We're losing the ability to save the downloaded artifacts to the cache, but 🤷‍♂️ 