### PR TITLE
Fix BasePolarisAuthenticator to throw service exception during persistence errors

### DIFF
--- a/service/common/build.gradle.kts
+++ b/service/common/build.gradle.kts
@@ -81,4 +81,10 @@ dependencies {
 
   implementation(platform(libs.azuresdk.bom))
   implementation("com.azure:azure-core")
+
+  testImplementation(platform(libs.junit.bom))
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testImplementation(libs.assertj.core)
+  testImplementation(libs.mockito.core)
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.auth;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.inject.Inject;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
@@ -82,7 +84,7 @@ public abstract class BasePolarisAuthenticator
           .addKeyValue("errMsg", e.getMessage())
           .addKeyValue("stackTrace", ExceptionUtils.getStackTrace(e))
           .log("Unable to authenticate user with token");
-      throw new NotAuthorizedException("Unable to authenticate");
+      throw new ServiceFailureException("Unable to fetch principal entity");
     }
     if (principal == null) {
       LOGGER.warn(
@@ -112,5 +114,10 @@ public abstract class BasePolarisAuthenticator
         .contextVariables()
         .put(CallContext.AUTHENTICATED_PRINCIPAL, authenticatedPrincipal);
     return Optional.of(authenticatedPrincipal);
+  }
+
+  @VisibleForTesting
+  void setMetaStoreManagerFactory(MetaStoreManagerFactory metaStoreManagerFactory) {
+    this.metaStoreManagerFactory = metaStoreManagerFactory;
   }
 }

--- a/service/common/src/test/java/org/apache/polaris/service/auth/BasePolarisAuthenticatorTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/auth/BasePolarisAuthenticatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import static org.mockito.Mockito.when;
+
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.persistence.BaseResult;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class BasePolarisAuthenticatorTest {
+
+  private BasePolarisAuthenticator authenticator;
+  private PolarisMetaStoreManager metaStoreManager;
+  private PolarisCallContext polarisCallContext;
+  private CallContext callContext;
+
+  @BeforeEach
+  public void setUp() {
+    authenticator = Mockito.spy(BasePolarisAuthenticator.class);
+    MetaStoreManagerFactory metaStoreManagerFactory = Mockito.mock(MetaStoreManagerFactory.class);
+    authenticator.setMetaStoreManagerFactory(metaStoreManagerFactory);
+    RealmContext realmContext = Mockito.mock(RealmContext.class);
+    metaStoreManager = Mockito.mock(PolarisMetaStoreManager.class);
+    when(metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext))
+        .thenReturn(metaStoreManager);
+    polarisCallContext = Mockito.mock(PolarisCallContext.class);
+    callContext = CallContext.of(realmContext, polarisCallContext);
+  }
+
+  @Test
+  public void testFetchPrincipalThrowsServiceExceptionOnMetastoreException() {
+    DecodedToken token = Mockito.mock(DecodedToken.class);
+    long principalId = 100L;
+    when(token.getPrincipalId()).thenReturn(principalId);
+    when(metaStoreManager.loadEntity(polarisCallContext, 0L, principalId))
+        .thenThrow(new RuntimeException("Metastore exception"));
+
+    try (CallContext ctx = CallContext.setCurrentContext(callContext)) {
+      Assertions.assertThatThrownBy(() -> authenticator.getPrincipal(token))
+          .isInstanceOf(ServiceFailureException.class)
+          .hasMessage("Unable to fetch principal entity");
+    }
+  }
+
+  @Test
+  public void testFetchPrincipalThrowsNotAuthorizedWhenNotFound() {
+    DecodedToken token = Mockito.mock(DecodedToken.class);
+    long principalId = 100L;
+    when(token.getPrincipalId()).thenReturn(principalId);
+    when(token.getClientId()).thenReturn("abc");
+    when(metaStoreManager.loadEntity(polarisCallContext, 0L, principalId))
+        .thenReturn(
+            new PolarisMetaStoreManager.EntityResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, ""));
+
+    try (CallContext ctx = CallContext.setCurrentContext(callContext)) {
+      Assertions.assertThatThrownBy(() -> authenticator.getPrincipal(token))
+          .isInstanceOf(NotAuthorizedException.class)
+          .hasMessage("Unable to authenticate");
+    }
+  }
+}


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

In cases when the persistence store in unavailable or experiencing errors, the authenticator catches exceptions and causes the service to incorrectly return `401`. These exceptions are almost never retried by upstream clients or reverse proxies, so intermittent failures will cause clients to simply shut down. This correctly throws ServiceFailureExceptions in these cases and adds a unit test specifically for the `BasePolarisAuthenticator`