### PR TITLE
Site-run: prefer `podman*` over `docker*` binaries

### DIFF
--- a/site/bin/_hugo-docker-include.sh
+++ b/site/bin/_hugo-docker-include.sh
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-DOCKER="$(which docker > /dev/null && echo docker || echo podman)"
-COMPOSE="$(which docker-compose > /dev/null && echo docker-compose || echo podman-compose)"
+DOCKER="$(which podman > /dev/null && echo podman || echo docker)"
+COMPOSE="$(which podman-compose > /dev/null && echo podman-compose || echo docker-compose)"
 
 # absolute path to the Polaris workspace, for the volume mount
 WORKSPACE="$(pwd)"


### PR DESCRIPTION
Podman, if installed, requires some custom arguments. The scripts to run Hugo in a container locally are already prepared for Podman, but fail in case compatibility scripts are installed (aka: `docker-compose` wrapping `podman-compose`). This leads to errors like "no permission to create /hugo/cache/site".

This change reverts the Podman/Docker detection to prefer Podman.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
