### PR TITLE
Add default region to spark client for quick start guide

### DIFF
--- a/site/content/in-dev/unreleased/quickstart.md
+++ b/site/content/in-dev/unreleased/quickstart.md
@@ -271,7 +271,8 @@ bin/spark-shell \
 --conf spark.sql.catalog.quickstart_catalog.uri=http://localhost:8181/api/catalog \
 --conf spark.sql.catalog.quickstart_catalog.credential='XXXX:YYYY' \
 --conf spark.sql.catalog.quickstart_catalog.scope='PRINCIPAL_ROLE:ALL' \
---conf spark.sql.catalog.quickstart_catalog.token-refresh-enabled=true
+--conf spark.sql.catalog.quickstart_catalog.token-refresh-enabled=true \
+--conf spark.sql.catalog.quickstart_catalog.client.region=us-west-2
 ```
 
 


### PR DESCRIPTION
This is to fix https://github.com/apache/polaris/issues/625 where when no default region is set, spark won't be able to perform write.