### PR TITLE
Build/testing: add `java-test-fixtures` to every Java project & reduce repeated dependency declarations

### DIFF
--- a/dropwizard/service/build.gradle.kts
+++ b/dropwizard/service/build.gradle.kts
@@ -125,12 +125,6 @@ dependencies {
 
   testCompileOnly(libs.smallrye.common.annotation)
 
-  testImplementation(platform(libs.junit.bom))
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testImplementation(libs.assertj.core)
-  testImplementation(libs.mockito.core)
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
   testImplementation(project(":polaris-eclipselink"))
 }
 

--- a/extension/persistence/eclipselink/build.gradle.kts
+++ b/extension/persistence/eclipselink/build.gradle.kts
@@ -22,10 +22,7 @@ fun isValidDep(dep: String): Boolean {
   return dep.matches(depRegex)
 }
 
-plugins {
-  id("polaris-server")
-  `java-library`
-}
+plugins { id("polaris-server") }
 
 dependencies {
   implementation(project(":polaris-core"))
@@ -52,12 +49,6 @@ dependencies {
 
   testImplementation(libs.h2)
   testImplementation(testFixtures(project(":polaris-core")))
-
-  testImplementation(platform(libs.junit.bom))
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testImplementation(libs.assertj.core)
-  testImplementation(libs.mockito.core)
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.register<Jar>("createTestConfJar") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "4.0
 javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version = "1.3.2" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.11.4" }
-logback-core = { module = "ch.qos.logback:logback-core", version = "1.4.14" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.4.14" }
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version = "1.14.3" }
 mockito-core = { module = "org.mockito:mockito-core", version = "5.15.2" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "1.46.0" }

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -17,11 +17,7 @@
  * under the License.
  */
 
-plugins {
-  id("polaris-client")
-  id("java-library")
-  id("java-test-fixtures")
-}
+plugins { id("polaris-client") }
 
 dependencies {
   implementation(project(":polaris-api-management-model"))
@@ -95,10 +91,6 @@ dependencies {
   implementation(platform(libs.google.cloud.storage.bom))
   implementation("com.google.cloud:google-cloud-storage")
 
-  testFixturesApi(platform(libs.junit.bom))
-  testFixturesApi("org.junit.jupiter:junit-jupiter")
-  testFixturesApi(libs.assertj.core)
-  testFixturesApi(libs.mockito.core)
   testFixturesApi("com.fasterxml.jackson.core:jackson-core")
   testFixturesApi("com.fasterxml.jackson.core:jackson-databind")
   testFixturesApi(libs.commons.lang3)

--- a/service/common/build.gradle.kts
+++ b/service/common/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
 
   implementation(libs.auth0.jwt)
 
-  implementation(libs.logback.core)
   implementation(libs.bouncycastle.bcprov)
 
   implementation(platform(libs.google.cloud.storage.bom))

--- a/tools/config-docs/annotations/build.gradle.kts
+++ b/tools/config-docs/annotations/build.gradle.kts
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-plugins {
-  id("polaris-client")
-  `java-library`
-}
+plugins { id("polaris-client") }
 
 description = "Polaris reference docs annotations"

--- a/tools/config-docs/generator/build.gradle.kts
+++ b/tools/config-docs/generator/build.gradle.kts
@@ -17,11 +17,7 @@
  * under the License.
  */
 
-plugins {
-  id("polaris-server")
-  `java-library`
-  `java-test-fixtures`
-}
+plugins { id("polaris-server") }
 
 description = "Generates Polaris reference docs"
 
@@ -35,12 +31,6 @@ dependencies {
   implementation(libs.smallrye.config.core)
   implementation(libs.picocli)
   annotationProcessor(libs.picocli.codegen)
-
-  testFixturesApi(platform(libs.junit.bom))
-  testFixturesApi("org.junit.jupiter:junit-jupiter")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-  testFixturesApi(libs.assertj.core)
-  testFixturesApi(libs.mockito.core)
 
   genTesting(project(":polaris-config-docs-annotations"))
   genTesting(libs.smallrye.config.core)

--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -19,12 +19,7 @@
 
 import org.apache.tools.ant.filters.ReplaceTokens
 
-plugins {
-  id("polaris-client")
-  `java-library`
-  `java-test-fixtures`
-  `jvm-test-suite`
-}
+plugins { id("polaris-client") }
 
 dependencies { testFixturesApi(libs.assertj.core) }
 
@@ -81,14 +76,8 @@ val jarTestJar by
 // need to test the `jar:` scheme/protocol resolution.
 testing {
   suites {
-    withType<JvmTestSuite> { useJUnitJupiter(libs.junit.bom.map { it.version!! }) }
-
     register<JvmTestSuite>("jarTest") {
-      dependencies {
-        compileOnly(project())
-        runtimeOnly(files(jarTestJar.get().archiveFile.get().asFile))
-        implementation(libs.assertj.core)
-      }
+      dependencies { runtimeOnly(files(jarTestJar.get().archiveFile.get().asFile)) }
 
       targets.all {
         testTask.configure {


### PR DESCRIPTION
Reduce the amount of dependency declarations in all projects by adding adding the dependencies logback-classic (runtimeOnly) and assertj+mockito (implementation) to all test sources. test-fixtures get junit-jupiter+assertj+mockito as implementation dependencies.

Also ensures that `useJUnitJupiter` is called with the correct version (it implicitly adds the jupiter runtime).

logback-classic is needed at test runtime to actually get logs during test executions, logback-core is a dependency of logback-classic that provides the logback implementation.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
