### PR TITLE
IntelliJ: exclude some directories from being indexed

### DIFF
--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -44,6 +44,19 @@ if (System.getProperty("idea.sync.active").toBoolean()) {
       isDownloadJavadoc = false // was 'true', but didn't work
       isDownloadSources = false // was 'true', but didn't work
       inheritOutputDirs = true
+
+      excludeDirs =
+        excludeDirs +
+          setOf(
+            projectDir.resolve("build-logic/.kotlin"),
+            projectDir.resolve("integration-tests/build"),
+            projectDir.resolve("site/resources/_gen"),
+            projectDir.resolve("site/build"),
+            projectDir.resolve("logs"),
+            projectDir.resolve("polaris-venv"),
+            projectDir.resolve(".idea"),
+          ) +
+          allprojects.map { prj -> prj.layout.buildDirectory.asFile.get() }
     }
 
     project.settings {


### PR DESCRIPTION
When editing `.gitignore`, IntelliJ warns about a couple directories being ignored but not excluded from being indexed and searched. This change ignores the mentioned directories, except the one for DW, which is going away with #469.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
