### PR TITLE
Make tests work with Java 23

### DIFF
--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -146,7 +146,9 @@ tasks.named<Test>("test").configure {
   // Note: the test secrets are referenced in DropwizardServerManager
   environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,root,test-admin,test-secret")
   jvmArgs("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
-  useJUnitPlatform()
+  // Need to allow a java security manager after Java 21, for Subject.getSubject to work
+  // "getSubject is supported only if a security manager is allowed".
+  systemProperty("java.security.manager", "allow")
   maxParallelForks = 4
 }
 


### PR DESCRIPTION
Example stack trace from Java 23:

```
getSubject is supported only if a security manager is allowed
java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
	at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:588)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3888)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3878)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3666)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:56)
	at org.apache.iceberg.hadoop.HadoopOutputFile.fromPath(HadoopOutputFile.java:53)
	at org.apache.iceberg.hadoop.HadoopFileIO.newOutputFile(HadoopFileIO.java:97)
	at org.apache.polaris.service.dropwizard.catalog.io.TestFileIO.newOutputFile(TestFileIO.java:114)
	at org.apache.iceberg.BaseMetastoreTableOperations.writeNewMetadata(BaseMetastoreTableOperations.java:155)
	at org.apache.iceberg.BaseMetastoreTableOperations.writeNewMetadataIfRequired(BaseMetastoreTableOperations.java:150)
	at org.apache.polaris.service.catalog.BasePolarisCatalog$BasePolarisTableOperations.doCommit(BasePolarisCatalog.java:1343)
	at org.apache.iceberg.BaseMetastoreTableOperations.commit(BaseMetastoreTableOperations.java:125)
	at org.apache.iceberg.BaseMetastoreCatalog$BaseMetastoreCatalogTableBuilder.create(BaseMetastoreCatalog.java:201)
	at org.apache.iceberg.rest.CatalogHandlers.createTable(CatalogHandlers.java:274)
	at org.apache.polaris.service.catalog.PolarisCatalogHandlerWrapper.lambda$createTableDirect$13(PolarisCatalogHandlerWrapper.java:588)
	at org.apache.polaris.service.catalog.PolarisCatalogHandlerWrapper.doCatalogOperation(PolarisCatalogHandlerWrapper.java:517)
	at org.apache.polaris.service.catalog.PolarisCatalogHandlerWrapper.createTableDirect(PolarisCatalogHandlerWrapper.java:588)
	at org.apache.polaris.service.catalog.IcebergCatalogAdapter.createTable(IcebergCatalogAdapter.java:258)
	at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi.createTable(IcebergRestCatalogApi.java:205)
	at org.apache.polaris.service.dropwizard.admin.PolarisOverlappingTableTest.createTable(PolarisOverlappingTableTest.java:61)
	at org.apache.polaris.service.dropwizard.admin.PolarisOverlappingTableTest.testTableLocationRestrictions(PolarisOverlappingTableTest.java:153)
```

Note that `javax.security.auth.Subject#getSubject` is deprecated for removal since Java 17.

`java.lang.System#initPhase3` shows that setting `java.security.manager` to `allow` works around the UOE.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
