### PR TITLE
Enforce Quarkus platform for `:polaris-quarkus-server`

### DIFF
--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -32,7 +32,8 @@ dependencies {
   implementation(project(":polaris-service-common"))
   implementation(project(":polaris-quarkus-service"))
 
-  implementation(platform(libs.quarkus.bom))
+  // enforce the Quarkus _platform_ here, to get a consistent and validated set of dependencies
+  implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-container-image-docker")
 
   // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329


### PR DESCRIPTION
It is highly recommended to enforce the Quarkus platform dependencies. We cannot use `enforcedPlatform()` everywhere else for the Quarkus platform BOM, because that clashes with Spark integration tests, see #727.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
