### PR TITLE
Refactor `RealmContext` to `RealmId`

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisCredentialsBootstrap;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -71,16 +71,16 @@ public class EclipseLinkPolarisMetaStoreManagerFactory
   @Override
   protected PolarisMetaStoreSession createMetaStoreSession(
       @Nonnull PolarisEclipseLinkStore store,
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nullable PolarisCredentialsBootstrap credentialsBootstrap,
       @Nonnull PolarisDiagnostics diagnostics) {
     return new PolarisEclipseLinkMetaStoreSessionImpl(
         store,
         storageIntegrationProvider,
-        realmContext,
+        realmId,
         configurationFile(),
         persistenceUnitName(),
-        secretsGenerator(realmContext, credentialsBootstrap),
+        secretsGenerator(realmId, credentialsBootstrap),
         diagnostics);
   }
 

--- a/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManagerImpl;
@@ -101,13 +101,13 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
   protected PolarisTestMetaStoreManager createPolarisTestMetaStoreManager() {
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
     PolarisEclipseLinkStore store = new PolarisEclipseLinkStore(diagServices);
-    RealmContext realmContext = () -> "realm";
+    RealmId realmId = RealmId.newRealmId("realm");
     PolarisMetaStoreSession session =
         new PolarisEclipseLinkMetaStoreSessionImpl(
-            store, Mockito.mock(), realmContext, null, "polaris", RANDOM_SECRETS, diagServices);
+            store, Mockito.mock(), realmId, null, "polaris", RANDOM_SECRETS, diagServices);
     return new PolarisTestMetaStoreManager(
         new PolarisMetaStoreManagerImpl(
-            realmContext,
+            realmId,
             diagServices,
             new PolarisConfigurationStore() {},
             timeSource.withZone(ZoneId.systemDefault())),
@@ -128,7 +128,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
           new PolarisEclipseLinkMetaStoreSessionImpl(
               store,
               Mockito.mock(),
-              () -> "realm",
+              RealmId.newRealmId("realm"),
               confFile,
               "polaris",
               RANDOM_SECRETS,

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.spotbugs.annotations)
 
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
   constraints {
     implementation("org.xerial.snappy:snappy-java:1.1.10.7") {
       because("Vulnerability detected in 1.1.8.2")

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisConfigurationStore.java
@@ -23,7 +23,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 
 /**
@@ -35,11 +35,11 @@ public interface PolarisConfigurationStore {
    * Retrieve the current value for a configuration key. May be null if not set.
    *
    * @param <T> the type of the configuration value
-   * @param realmContext the realm context to check for overrides; may be null.
+   * @param realmId the realm context to check for overrides; may be null.
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key or null if not set
    */
-  default <T> @Nullable T getConfiguration(@Nullable RealmContext realmContext, String configName) {
+  default <T> @Nullable T getConfiguration(@Nullable RealmId realmId, String configName) {
     return null;
   }
 
@@ -48,15 +48,15 @@ public interface PolarisConfigurationStore {
    * value.
    *
    * @param <T> the type of the configuration value
-   * @param realmContext the realm context to check for overrides; may be null.
+   * @param realmId the realm context to check for overrides; may be null.
    * @param configName the name of the configuration key to check
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
    */
   default <T> @Nonnull T getConfiguration(
-      @Nullable RealmContext realmContext, String configName, @Nonnull T defaultValue) {
+      @Nullable RealmId realmId, String configName, @Nonnull T defaultValue) {
     Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");
-    T configValue = getConfiguration(realmContext, configName);
+    T configValue = getConfiguration(realmId, configName);
     return configValue != null ? configValue : defaultValue;
   }
 
@@ -88,13 +88,13 @@ public interface PolarisConfigurationStore {
    * Retrieve the current value for a configuration.
    *
    * @param <T> the type of the configuration value
-   * @param realmContext the realm context to check for overrides; may be null.
+   * @param realmId the realm context to check for overrides; may be null.
    * @param config the configuration to load
    * @return the current value set for the configuration key or null if not set
    */
   default <T> @Nonnull T getConfiguration(
-      @Nullable RealmContext realmContext, PolarisConfiguration<T> config) {
-    T result = getConfiguration(realmContext, config.key, config.defaultValue);
+      @Nullable RealmId realmId, PolarisConfiguration<T> config) {
+    T result = getConfiguration(realmId, config.key, config.defaultValue);
     return tryCast(config, result);
   }
 
@@ -103,20 +103,20 @@ public interface PolarisConfigurationStore {
    * present.
    *
    * @param <T> the type of the configuration value
-   * @param realmContext the realm context to check for overrides; may be null.
+   * @param realmId the realm context to check for overrides; may be null.
    * @param catalogEntity the catalog to check for an override
    * @param config the configuration to load
    * @return the current value set for the configuration key or null if not set
    */
   default <T> @Nonnull T getConfiguration(
-      @Nullable RealmContext realmContext,
+      @Nullable RealmId realmId,
       @Nonnull CatalogEntity catalogEntity,
       PolarisConfiguration<T> config) {
     if (config.hasCatalogConfig()
         && catalogEntity.getPropertiesAsMap().containsKey(config.catalogConfig())) {
       return tryCast(config, catalogEntity.getPropertiesAsMap().get(config.catalogConfig()));
     } else {
-      return getConfiguration(realmContext, config);
+      return getConfiguration(realmId, config);
     }
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 
@@ -30,7 +30,7 @@ import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 public interface PolarisAuthorizer {
 
   void authorizeOrThrow(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
       @Nonnull Set<PolarisBaseEntity> activatedEntities,
       @Nonnull PolarisAuthorizableOperation authzOp,
@@ -38,7 +38,7 @@ public interface PolarisAuthorizer {
       @Nullable PolarisResolvedPathWrapper secondary);
 
   void authorizeOrThrow(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
       @Nonnull Set<PolarisBaseEntity> activatedEntities,
       @Nonnull PolarisAuthorizableOperation authzOp,

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -100,7 +100,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
@@ -487,14 +487,14 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
 
   @Override
   public void authorizeOrThrow(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
       @Nonnull Set<PolarisBaseEntity> activatedEntities,
       @Nonnull PolarisAuthorizableOperation authzOp,
       @Nullable PolarisResolvedPathWrapper target,
       @Nullable PolarisResolvedPathWrapper secondary) {
     authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         activatedEntities,
         authzOp,
@@ -504,7 +504,7 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
 
   @Override
   public void authorizeOrThrow(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull AuthenticatedPolarisPrincipal authenticatedPrincipal,
       @Nonnull Set<PolarisBaseEntity> activatedEntities,
       @Nonnull PolarisAuthorizableOperation authzOp,
@@ -512,8 +512,7 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
     boolean enforceCredentialRotationRequiredState =
         featureConfig.getConfiguration(
-            realmContext,
-            PolarisConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
+            realmId, PolarisConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
     if (enforceCredentialRotationRequiredState
         && authenticatedPrincipal
             .getPrincipalEntity()

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/RealmId.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/RealmId.java
@@ -16,13 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.context;
+package org.apache.polaris.core.context;
 
-import java.util.Map;
-import org.apache.polaris.core.context.RealmContext;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
-public interface RealmContextResolver {
+/**
+ * Represents the ID of the realm used in a REST request associated with routing to independent and
+ * isolated "universes".
+ */
+@PolarisImmutable
+@JsonSerialize(as = ImmutableRealmId.class)
+@JsonDeserialize(as = ImmutableRealmId.class)
+public interface RealmId {
 
-  RealmContext resolveRealmContext(
-      String requestURL, String method, String path, Map<String, String> headers);
+  static RealmId newRealmId(String id) {
+    return ImmutableRealmId.of(id);
+  }
+
+  @Value.Parameter
+  @JsonValue
+  String id();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
@@ -22,20 +22,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.cache.EntityCache;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 
 /** Configuration interface for configuring the {@link PolarisMetaStoreManager}. */
 public interface MetaStoreManagerFactory {
 
-  PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmContext realmContext);
+  PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmId realmId);
 
-  Supplier<PolarisMetaStoreSession> getOrCreateSessionSupplier(RealmContext realmContext);
+  Supplier<PolarisMetaStoreSession> getOrCreateSessionSupplier(RealmId realmId);
 
-  StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext);
+  StorageCredentialCache getOrCreateStorageCredentialCache(RealmId realmId);
 
-  EntityCache getOrCreateEntityCache(RealmContext realmContext);
+  EntityCache getOrCreateEntityCache(RealmId realmId);
 
   Map<String, PrincipalSecretsResult> bootstrapRealms(
       List<String> realms, PolarisCredentialsBootstrap credentialsBootstrap);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManagerImpl.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
@@ -76,17 +76,17 @@ public class PolarisMetaStoreManagerImpl implements PolarisMetaStoreManager {
   /** use synchronous drop for entities */
   private static final boolean USE_SYNCHRONOUS_DROP = true;
 
-  private final RealmContext realmContext;
+  private final RealmId realmId;
   private final PolarisDiagnostics diagnostics;
   private final PolarisConfigurationStore configurationStore;
   private final Clock clock;
 
   public PolarisMetaStoreManagerImpl(
-      RealmContext realmContext,
+      RealmId realmId,
       PolarisDiagnostics diagnostics,
       PolarisConfigurationStore configurationStore,
       Clock clock) {
-    this.realmContext = realmContext;
+    this.realmId = realmId;
     this.diagnostics = diagnostics;
     this.configurationStore = configurationStore;
     this.clock = clock;
@@ -1815,7 +1815,7 @@ public class PolarisMetaStoreManagerImpl implements PolarisMetaStoreManager {
                   PolarisObjectMapperUtil.parseTaskState(entity);
               long taskAgeTimeout =
                   configurationStore.getConfiguration(
-                      realmContext,
+                      realmId,
                       PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
                       PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
               return taskState == null
@@ -1888,7 +1888,7 @@ public class PolarisMetaStoreManagerImpl implements PolarisMetaStoreManager {
     try {
       EnumMap<PolarisCredentialProperty, String> creds =
           storageIntegration.getSubscopedCreds(
-              realmContext,
+              realmId,
               diagnostics,
               storageConfigurationInfo,
               allowListOperation,
@@ -1935,7 +1935,7 @@ public class PolarisMetaStoreManagerImpl implements PolarisMetaStoreManager {
         readStorageConfiguration(diagnostics, reloadedEntity.getEntity());
     Map<String, String> validateLocationAccess =
         storageIntegration
-            .validateAccessToLocations(realmContext, storageConfigurationInfo, actions, locations)
+            .validateAccessToLocations(realmId, storageConfigurationInfo, actions, locations)
             .entrySet()
             .stream()
             .collect(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
@@ -26,11 +26,11 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /**
  * Base class for in-memory implementations of {@link PolarisStorageIntegration}. A basic
- * implementation of {@link PolarisStorageIntegration#validateAccessToLocations(RealmContext,
+ * implementation of {@link PolarisStorageIntegration#validateAccessToLocations(RealmId,
  * PolarisStorageConfigurationInfo, Set, Set)} is provided that checks to see that the list of
  * locations being accessed is among the list of {@link
  * PolarisStorageConfigurationInfo#getAllowedLocations()}. Locations being accessed must be equal to
@@ -53,7 +53,7 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
    * Check that the locations being accessed are all equal to or subdirectories of at least one of
    * the {@link PolarisStorageConfigurationInfo#getAllowedLocations}.
    *
-   * @param realmContext
+   * @param realmId
    * @param configurationStore
    * @param actions a set of operation actions to validate, like LIST/READ/DELETE/WRITE/ALL
    * @param locations a set of locations to get access to
@@ -63,7 +63,7 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
    */
   public static Map<String, Map<PolarisStorageActions, ValidationResult>>
       validateSubpathsOfAllowedLocations(
-          @Nonnull RealmContext realmContext,
+          @Nonnull RealmId realmId,
           @Nonnull PolarisConfigurationStore configurationStore,
           @Nonnull PolarisStorageConfigurationInfo storageConfig,
           @Nonnull Set<PolarisStorageActions> actions,
@@ -86,7 +86,7 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
         allowedLocationStrings.stream().map(StorageLocation::of).collect(Collectors.toList());
 
     boolean allowWildcardLocation =
-        configurationStore.getConfiguration(realmContext, "ALLOW_WILDCARD_LOCATION", false);
+        configurationStore.getConfiguration(realmId, "ALLOW_WILDCARD_LOCATION", false);
 
     if (allowWildcardLocation && allowedLocationStrings.contains("*")) {
       return locations.stream()
@@ -129,11 +129,11 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
   @Override
   @Nonnull
   public Map<String, Map<PolarisStorageActions, ValidationResult>> validateAccessToLocations(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull T storageConfig,
       @Nonnull Set<PolarisStorageActions> actions,
       @Nonnull Set<String> locations) {
     return validateSubpathsOfAllowedLocations(
-        realmContext, configurationStore, storageConfig, actions, locations);
+        realmId, configurationStore, storageConfig, actions, locations);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -40,7 +40,7 @@ import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.Catalog;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
@@ -137,7 +137,7 @@ public abstract class PolarisStorageConfigurationInfo {
   }
 
   public static Optional<PolarisStorageConfigurationInfo> forEntityPath(
-      RealmContext realmContext,
+      RealmId realmId,
       PolarisConfigurationStore configurationStore,
       PolarisDiagnostics diagnostics,
       List<PolarisEntity> entityPath) {
@@ -167,9 +167,7 @@ public abstract class PolarisStorageConfigurationInfo {
               CatalogEntity catalog = CatalogEntity.of(entityPath.get(0));
               boolean allowEscape =
                   configurationStore.getConfiguration(
-                      realmContext,
-                      catalog,
-                      PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION);
+                      realmId, catalog, PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION);
               if (!allowEscape
                   && catalog.getCatalogType() != Catalog.TypeEnum.EXTERNAL
                   && baseLocation != null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /**
  * Abstract of Polaris Storage Integration. It holds the reference to an object that having the
@@ -47,7 +47,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
   /**
    * Subscope the creds against the allowed read and write locations.
    *
-   * @param realmContext the realm context
+   * @param realmId the realm context
    * @param diagnostics the diagnostics service
    * @param storageConfig storage configuration
    * @param allowListOperation whether to allow LIST on all the provided allowed read/write
@@ -57,7 +57,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
    * @return An enum map including the scoped credentials
    */
   public abstract EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull PolarisDiagnostics diagnostics,
       @Nonnull T storageConfig,
       boolean allowListOperation,
@@ -67,7 +67,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
   /**
    * Validate access for the provided operation actions and locations.
    *
-   * @param realmContext
+   * @param realmId
    * @param actions a set of operation actions to validate, like LIST/READ/DELETE/WRITE/ALL
    * @param locations a set of locations to get access to
    * @return A Map of string, representing the result of validation, the key value is {@code
@@ -99,13 +99,13 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
   @Nonnull
   public abstract Map<String, Map<PolarisStorageActions, ValidationResult>>
       validateAccessToLocations(
-          RealmContext realmContext,
+          RealmId realmId,
           @Nonnull T storageConfig,
           @Nonnull Set<PolarisStorageActions> actions,
           @Nonnull Set<String> locations);
 
   /**
-   * Result of calling {@link PolarisStorageIntegration#validateAccessToLocations(RealmContext,
+   * Result of calling {@link PolarisStorageIntegration#validateAccessToLocations(RealmId,
    * PolarisStorageConfigurationInfo, Set, Set)}
    */
   public static final class ValidationResult {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.StorageUtil;
@@ -60,7 +60,7 @@ public class AwsCredentialsStorageIntegration
   /** {@inheritDoc} */
   @Override
   public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull PolarisDiagnostics diagnostics,
       @Nonnull AwsStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
@@ -81,7 +81,7 @@ public class AwsCredentialsStorageIntegration
                         .toJson())
                 .durationSeconds(
                     configurationStore.getConfiguration(
-                        realmContext, STORAGE_CREDENTIAL_DURATION_SECONDS))
+                        realmId, STORAGE_CREDENTIAL_DURATION_SECONDS))
                 .build());
     EnumMap<PolarisCredentialProperty, String> credentialMap =
         new EnumMap<>(PolarisCredentialProperty.class);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -48,7 +48,7 @@ import java.util.Set;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ public class AzureCredentialsStorageIntegration
 
   @Override
   public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull PolarisDiagnostics diagnostics,
       @Nonnull AzureStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
@@ -132,7 +132,7 @@ public class AzureCredentialsStorageIntegration
     OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds =
         configurationStore.getConfiguration(
-            realmContext, PolarisConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+            realmId, PolarisConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -40,7 +40,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -74,7 +74,7 @@ public class GcpCredentialsStorageIntegration
 
   @Override
   public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nonnull PolarisDiagnostics diagnostics,
       @Nonnull GcpStorageConfigurationInfo storageConfig,
       boolean allowListOperation,

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/EntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/EntityCacheTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -84,7 +85,10 @@ public class EntityCacheTest {
         new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock(), RANDOM_SECRETS, diagServices);
     metaStoreManager =
         new PolarisMetaStoreManagerImpl(
-            () -> "test", diagServices, new PolarisConfigurationStore() {}, Clock.systemUTC());
+            RealmId.newRealmId("test"),
+            diagServices,
+            new PolarisConfigurationStore() {},
+            Clock.systemUTC());
 
     // bootstrap the mata store with our test schema
     tm = new PolarisTestMetaStoreManager(metaStoreManager, metaStore, diagServices);

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
@@ -24,6 +24,7 @@ import java.time.ZoneId;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.context.RealmId;
 import org.mockito.Mockito;
 
 public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreManagerTest {
@@ -35,7 +36,7 @@ public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreMana
         new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock(), RANDOM_SECRETS, diagServices);
     return new PolarisTestMetaStoreManager(
         new PolarisMetaStoreManagerImpl(
-            () -> "test",
+            RealmId.newRealmId("test"),
             diagServices,
             new PolarisConfigurationStore() {},
             timeSource.withZone(ZoneId.systemDefault())),

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -37,6 +37,7 @@ import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -105,7 +106,10 @@ public class ResolverTest {
         new PolarisTreeMapMetaStoreSessionImpl(store, Mockito.mock(), RANDOM_SECRETS, diagServices);
     metaStoreManager =
         new PolarisMetaStoreManagerImpl(
-            () -> "test", diagServices, new PolarisConfigurationStore() {}, Clock.systemUTC());
+            RealmId.newRealmId("test"),
+            diagServices,
+            new PolarisConfigurationStore() {},
+            Clock.systemUTC());
 
     // bootstrap the mata store with our test schema
     tm = new PolarisTestMetaStoreManager(metaStoreManager, metaStore, diagServices);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -26,14 +26,14 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class InMemoryStorageIntegrationTest {
 
-  private RealmContext realmContext = () -> "test";
+  private final RealmId realmId = RealmId.newRealmId("test");
 
   @Test
   public void testValidateAccessToLocations() {
@@ -41,7 +41,7 @@ class InMemoryStorageIntegrationTest {
         new MockInMemoryStorageIntegration(new PolarisConfigurationStore() {});
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            realmContext,
+            realmId,
             new AwsStorageConfigurationInfo(
                 PolarisStorageConfigurationInfo.StorageType.S3,
                 List.of(
@@ -96,14 +96,14 @@ class InMemoryStorageIntegrationTest {
         new PolarisConfigurationStore() {
           @SuppressWarnings("unchecked")
           @Override
-          public <T> @Nullable T getConfiguration(RealmContext realmContext, String configName) {
+          public <T> @Nullable T getConfiguration(RealmId realmId, String configName) {
             return (T) config.get(configName);
           }
         };
     MockInMemoryStorageIntegration storage = new MockInMemoryStorageIntegration(configurationStore);
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            realmContext,
+            realmId,
             new FileStorageConfigurationInfo(List.of("file://", "*")),
             Set.of(PolarisStorageActions.READ),
             Set.of(
@@ -144,7 +144,7 @@ class InMemoryStorageIntegrationTest {
         new MockInMemoryStorageIntegration(new PolarisConfigurationStore() {});
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            realmContext,
+            realmId,
             new AwsStorageConfigurationInfo(
                 PolarisStorageConfigurationInfo.StorageType.S3,
                 List.of(),
@@ -180,7 +180,7 @@ class InMemoryStorageIntegrationTest {
         new MockInMemoryStorageIntegration(new PolarisConfigurationStore() {});
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
-            realmContext,
+            realmId,
             new AwsStorageConfigurationInfo(
                 PolarisStorageConfigurationInfo.StorageType.S3,
                 List.of("s3://bucket/path/to/warehouse"),
@@ -206,7 +206,7 @@ class InMemoryStorageIntegrationTest {
 
     @Override
     public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-        @Nonnull RealmContext realmContext,
+        @Nonnull RealmId realmId,
         @Nonnull PolarisDiagnostics diagnostics,
         @Nonnull PolarisStorageConfigurationInfo storageConfig,
         boolean allowListOperation,

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -22,14 +22,14 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for the default behaviors of the PolarisConfigurationStore interface. */
 public class PolarisConfigurationStoreTest {
 
-  private RealmContext realmContext = () -> "test";
+  private final RealmId realmId = RealmId.newRealmId("test");
 
   @Test
   public void testConfigsCanBeCastedFromString() {
@@ -48,7 +48,7 @@ public class PolarisConfigurationStoreTest {
            */
           @SuppressWarnings("unchecked")
           @Override
-          public <T> @Nullable T getConfiguration(RealmContext realmContext, String configName) {
+          public <T> @Nullable T getConfiguration(RealmId realmId, String configName) {
             for (PolarisConfiguration<?> c : configs) {
               if (c.key.equals(configName)) {
                 return (T) String.valueOf(c.defaultValue);
@@ -65,7 +65,7 @@ public class PolarisConfigurationStoreTest {
     // Ensure that we can fetch all the configs and that the value is what we expect, which
     // is the config's default value based on how we've implemented PolarisConfigurationStore above.
     for (PolarisConfiguration<?> c : configs) {
-      Assertions.assertEquals(c.defaultValue, store.getConfiguration(realmContext, c));
+      Assertions.assertEquals(c.defaultValue, store.getConfiguration(realmId, c));
     }
   }
 
@@ -79,14 +79,14 @@ public class PolarisConfigurationStoreTest {
         new PolarisConfigurationStore() {
           @SuppressWarnings("unchecked")
           @Override
-          public <T> T getConfiguration(RealmContext realmContext, String configName) {
+          public <T> T getConfiguration(RealmId realmId, String configName) {
             return (T) "abc123";
           }
         };
 
     for (PolarisConfiguration<?> c : configs) {
       Assertions.assertThrows(
-          NumberFormatException.class, () -> store.getConfiguration(realmContext, c));
+          NumberFormatException.class, () -> store.getConfiguration(realmId, c));
     }
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
@@ -61,7 +61,7 @@ class AwsCredentialsStorageIntegrationTest {
           .build();
   public static final String AWS_PARTITION = "aws";
 
-  private static final RealmContext REALM_CONTEXT = () -> "realm";
+  private static final RealmId REALM_CONTEXT = RealmId.newRealmId("realm");
 
   @Test
   public void testGetSubscopedCreds() {

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
@@ -68,7 +68,7 @@ public class AzureCredentialStorageIntegrationTest {
   private final String clientId = System.getenv("AZURE_CLIENT_ID");
   private final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
   private final String tenantId = System.getenv("AZURE_TENANT_ID");
-  private final RealmContext realmContext = () -> "realm";
+  private final RealmId realmId = RealmId.newRealmId("realm");
 
   private void assumeEnvVariablesNotNull() {
     Assumptions.assumeThat(
@@ -88,10 +88,7 @@ public class AzureCredentialStorageIntegrationTest {
     Assertions.assertThatThrownBy(
             () ->
                 subscopedCredsForOperations(
-                    realmContext,
-                    differentEndpointList,
-                    /* allowedWriteLoc= */ new ArrayList<>(),
-                    true))
+                    realmId, differentEndpointList, /* allowedWriteLoc= */ new ArrayList<>(), true))
         .isInstanceOf(RuntimeException.class);
 
     List<String> differentStorageAccts =
@@ -101,10 +98,7 @@ public class AzureCredentialStorageIntegrationTest {
     Assertions.assertThatThrownBy(
             () ->
                 subscopedCredsForOperations(
-                    realmContext,
-                    differentStorageAccts,
-                    /* allowedWriteLoc= */ new ArrayList<>(),
-                    true))
+                    realmId, differentStorageAccts, /* allowedWriteLoc= */ new ArrayList<>(), true))
         .isInstanceOf(RuntimeException.class);
     List<String> differentContainers =
         Arrays.asList(
@@ -114,10 +108,7 @@ public class AzureCredentialStorageIntegrationTest {
     Assertions.assertThatThrownBy(
             () ->
                 subscopedCredsForOperations(
-                    realmContext,
-                    differentContainers,
-                    /* allowedWriteLoc= */ new ArrayList<>(),
-                    true))
+                    realmId, differentContainers, /* allowedWriteLoc= */ new ArrayList<>(), true))
         .isInstanceOf(RuntimeException.class);
   }
 
@@ -134,7 +125,7 @@ public class AzureCredentialStorageIntegrationTest {
                 service));
     Map<PolarisCredentialProperty, String> credsMap =
         subscopedCredsForOperations(
-            /* allowedReadLoc= */ realmContext,
+            /* allowedReadLoc= */ realmId,
             allowedLoc,
             /* allowedWriteLoc= */ new ArrayList<>(),
             allowListAction);
@@ -206,7 +197,7 @@ public class AzureCredentialStorageIntegrationTest {
                 service, allowedPrefix));
     Map<PolarisCredentialProperty, String> credsMap =
         subscopedCredsForOperations(
-            /* allowedReadLoc= */ realmContext,
+            /* allowedReadLoc= */ realmId,
             allowedLoc,
             /* allowedWriteLoc= */ new ArrayList<>(),
             /* allowListAction= */ false);
@@ -277,7 +268,7 @@ public class AzureCredentialStorageIntegrationTest {
                 service, allowedPrefix));
     Map<PolarisCredentialProperty, String> credsMap =
         subscopedCredsForOperations(
-            /* allowedReadLoc= */ realmContext,
+            /* allowedReadLoc= */ realmId,
             new ArrayList<>(),
             /* allowedWriteLoc= */ allowedLoc,
             /* allowListAction= */ false);
@@ -354,7 +345,7 @@ public class AzureCredentialStorageIntegrationTest {
   }
 
   private Map<PolarisCredentialProperty, String> subscopedCredsForOperations(
-      RealmContext realmContext,
+      RealmId realmId,
       List<String> allowedReadLoc,
       List<String> allowedWriteLoc,
       boolean allowListAction) {
@@ -367,7 +358,7 @@ public class AzureCredentialStorageIntegrationTest {
         new AzureCredentialsStorageIntegration(new PolarisConfigurationStore() {});
     EnumMap<PolarisCredentialProperty, String> credsMap =
         azureCredsIntegration.getSubscopedCreds(
-            realmContext,
+            realmId,
             new PolarisDefaultDiagServiceImpl(),
             azureConfig,
             allowListAction,

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -50,7 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
@@ -73,7 +73,7 @@ class GcpCredentialsStorageIntegrationTest {
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
-    RealmContext realmContext = () -> "realm";
+    RealmId realmId = RealmId.newRealmId("realm");
     List<String> allowedRead =
         Arrays.asList(
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/read1/",
@@ -83,7 +83,7 @@ class GcpCredentialsStorageIntegrationTest {
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/write1/",
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/write2/");
     Storage storageClient =
-        setupStorageClient(realmContext, allowedRead, allowedWrite, allowedListAction);
+        setupStorageClient(realmId, allowedRead, allowedWrite, allowedListAction);
     BlobInfo blobInfoGoodWrite =
         createStorageBlob("sfc-dev1-regtest", "polaris-test/subscoped-test/write1/", "file.txt");
     BlobInfo blobInfoBad =
@@ -126,7 +126,7 @@ class GcpCredentialsStorageIntegrationTest {
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/write2/",
             "gs://sfc-dev1-regtest/polaris-test/subscoped-test/write3/");
     Storage clientForDelete =
-        setupStorageClient(realmContext, List.of(), allowedWrite2, allowedListAction);
+        setupStorageClient(realmId, List.of(), allowedWrite2, allowedListAction);
 
     // can not delete because it is not in allowed write path for this client
     Assertions.assertThatThrownBy(() -> clientForDelete.delete(blobInfoGoodWrite.getBlobId()))
@@ -138,13 +138,13 @@ class GcpCredentialsStorageIntegrationTest {
   }
 
   private Storage setupStorageClient(
-      RealmContext realmContext,
+      RealmId realmId,
       List<String> allowedReadLoc,
       List<String> allowedWriteLoc,
       boolean allowListAction)
       throws IOException {
     Map<PolarisCredentialProperty, String> credsMap =
-        subscopedCredsForOperations(realmContext, allowedReadLoc, allowedWriteLoc, allowListAction);
+        subscopedCredsForOperations(realmId, allowedReadLoc, allowedWriteLoc, allowListAction);
     return createStorageClient(credsMap);
   }
 
@@ -167,7 +167,7 @@ class GcpCredentialsStorageIntegrationTest {
   }
 
   private Map<PolarisCredentialProperty, String> subscopedCredsForOperations(
-      RealmContext realmContext,
+      RealmId realmId,
       List<String> allowedReadLoc,
       List<String> allowedWriteLoc,
       boolean allowListAction)
@@ -183,7 +183,7 @@ class GcpCredentialsStorageIntegrationTest {
             ServiceOptions.getFromServiceLoader(HttpTransportFactory.class, NetHttpTransport::new));
     EnumMap<PolarisCredentialProperty, String> credsMap =
         gcpCredsIntegration.getSubscopedCreds(
-            realmContext,
+            realmId,
             new PolarisDefaultDiagServiceImpl(),
             gcpConfig,
             allowListAction,

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/context/QuarkusRealmContextConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/context/QuarkusRealmContextConfiguration.java
@@ -21,14 +21,15 @@ package org.apache.polaris.service.quarkus.context;
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import org.apache.polaris.service.context.RealmContextConfiguration;
+import org.apache.polaris.service.context.RealmIdResolver;
 
 @StaticInitSafe
 @ConfigMapping(prefix = "polaris.realm-context")
 public interface QuarkusRealmContextConfiguration extends RealmContextConfiguration {
 
   /**
-   * The type of the realm context resolver. Must be a registered {@link
-   * org.apache.polaris.service.context.RealmContextResolver} identifier.
+   * The type of the realm context resolver. Must be a registered {@link RealmIdResolver}
+   * identifier.
    */
   String type();
 }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/logging/QuarkusLoggingMDCFilter.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/logging/QuarkusLoggingMDCFilter.java
@@ -22,7 +22,7 @@ import io.quarkus.vertx.web.RouteFilter;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.slf4j.MDC;
 
 @ApplicationScoped
@@ -33,7 +33,7 @@ public class QuarkusLoggingMDCFilter {
   private static final String REQUEST_ID_KEY = "requestId";
   private static final String REALM_ID_KEY = "realmId";
 
-  @Inject RealmContext realmContext;
+  @Inject RealmId realmId;
 
   @Inject QuarkusLoggingConfiguration loggingConfiguration;
 
@@ -57,8 +57,8 @@ public class QuarkusLoggingMDCFilter {
       MDC.put(REQUEST_ID_KEY, requestId);
       rc.put(REQUEST_ID_KEY, requestId);
     }
-    MDC.put(REALM_ID_KEY, realmContext.getRealmIdentifier());
-    rc.put(REALM_ID_KEY, realmContext.getRealmIdentifier());
+    MDC.put(REALM_ID_KEY, realmId.id());
+    rc.put(REALM_ID_KEY, realmId.id());
     // Do not explicitly remove the MDC values from the request context with an end handler,
     // as this could remove MDC context still in use in TaskExecutor threads
     //    rc.addEndHandler(

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusValueExpressionResolver.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusValueExpressionResolver.java
@@ -22,7 +22,7 @@ import io.micrometer.common.annotation.ValueExpressionResolver;
 import io.micrometer.common.lang.Nullable;
 import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 @ApplicationScoped
 public class QuarkusValueExpressionResolver implements ValueExpressionResolver {
@@ -30,8 +30,8 @@ public class QuarkusValueExpressionResolver implements ValueExpressionResolver {
   @Override
   public String resolve(@Nonnull String expression, @Nullable Object parameter) {
     // TODO maybe replace with CEL of some expression engine and make this more generic
-    if (parameter instanceof RealmContext realmContext && expression.equals("realmIdentifier")) {
-      return realmContext.getRealmIdentifier();
+    if (parameter instanceof RealmId realmId && expression.equals("realmIdentifier")) {
+      return realmId.id();
     }
     return null;
   }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusValueExpressionResolver.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusValueExpressionResolver.java
@@ -30,7 +30,7 @@ public class QuarkusValueExpressionResolver implements ValueExpressionResolver {
   @Override
   public String resolve(@Nonnull String expression, @Nullable Object parameter) {
     // TODO maybe replace with CEL of some expression engine and make this more generic
-    if (parameter instanceof RealmId realmId && expression.equals("realmIdentifier")) {
+    if (parameter instanceof RealmId realmId && expression.equals("realm.id")) {
       return realmId.id();
     }
     return null;

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/RealmIdTagContributor.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/RealmIdTagContributor.java
@@ -24,26 +24,26 @@ import io.vertx.core.http.HttpServerRequest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.HashMap;
-import org.apache.polaris.core.context.RealmContext;
-import org.apache.polaris.service.context.RealmContextResolver;
+import org.apache.polaris.core.context.RealmId;
+import org.apache.polaris.service.context.RealmIdResolver;
 
 @ApplicationScoped
 public class RealmIdTagContributor implements HttpServerMetricsTagsContributor {
 
   public static final String TAG_REALM = "realm_id";
 
-  @Inject RealmContextResolver realmContextResolver;
+  @Inject RealmIdResolver realmIdResolver;
 
   @Override
   public Tags contribute(Context context) {
     // FIXME request scope does not work here, so we have to resolve the realm context manually
     HttpServerRequest request = context.request();
-    RealmContext realmContext = resolveRealmContext(request);
-    return Tags.of(TAG_REALM, realmContext.getRealmIdentifier());
+    RealmId realmId = resolveRealmContext(request);
+    return Tags.of(TAG_REALM, realmId.id());
   }
 
-  private RealmContext resolveRealmContext(HttpServerRequest request) {
-    return realmContextResolver.resolveRealmContext(
+  private RealmId resolveRealmContext(HttpServerRequest request) {
+    return realmIdResolver.resolveRealmContext(
         request.absoluteURI(),
         request.method().name(),
         request.path(),

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/task/QuarkusTaskExecutorImpl.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/task/QuarkusTaskExecutorImpl.java
@@ -30,7 +30,7 @@ import java.time.Clock;
 import java.util.concurrent.ExecutorService;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.quarkus.tracing.QuarkusTracingFilter;
 import org.apache.polaris.service.task.TaskExecutorImpl;
@@ -71,18 +71,17 @@ public class QuarkusTaskExecutorImpl extends TaskExecutorImpl {
   }
 
   @Override
-  protected void handleTask(long taskEntityId, RealmContext realmContext, int attempt) {
+  protected void handleTask(long taskEntityId, RealmId realmId, int attempt) {
     Span span =
         tracer
             .spanBuilder("polaris.task")
             .setParent(Context.current())
-            .setAttribute(
-                QuarkusTracingFilter.REALM_ID_ATTRIBUTE, realmContext.getRealmIdentifier())
+            .setAttribute(QuarkusTracingFilter.REALM_ID_ATTRIBUTE, realmId.id())
             .setAttribute("polaris.task.entity.id", taskEntityId)
             .setAttribute("polaris.task.attempt", attempt)
             .startSpan();
     try (Scope ignored = span.makeCurrent()) {
-      super.handleTask(taskEntityId, realmContext, attempt);
+      super.handleTask(taskEntityId, realmId, attempt);
     } finally {
       span.end();
     }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TestServices.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TestServices.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -53,10 +53,10 @@ import org.mockito.Mockito;
 public record TestServices(
     IcebergRestCatalogApi restApi,
     PolarisCatalogsApi catalogsApi,
-    RealmContext realmContext,
+    RealmId realmId,
     SecurityContext securityContext) {
 
-  private static final RealmContext testRealm = () -> "test-realm";
+  private static final RealmId testRealm = RealmId.newRealmId("test-realm");
 
   public static TestServices inMemory(Map<String, Object> config) {
     return inMemory(new TestFileIOFactory(), config);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TimedApplicationEventListenerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TimedApplicationEventListenerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.quarkus;
 
-import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.TestRealmIdResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
@@ -62,7 +62,7 @@ public class ManagementServiceTest {
                     .catalogsApi()
                     .createCatalog(
                         new CreateCatalogRequest(catalog),
-                        services.realmContext(),
+                        services.realmId(),
                         services.securityContext()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Unsupported storage type: FILE");
@@ -91,7 +91,7 @@ public class ManagementServiceTest {
             .catalogsApi()
             .createCatalog(
                 new CreateCatalogRequest(catalog),
-                services.realmContext(),
+                services.realmId(),
                 services.securityContext())) {
       assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
     }
@@ -101,7 +101,7 @@ public class ManagementServiceTest {
     try (Response response =
         services
             .catalogsApi()
-            .getCatalog(catalogName, services.realmContext(), services.securityContext())) {
+            .getCatalog(catalogName, services.realmId(), services.securityContext())) {
       assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
       fetchedCatalog = (Catalog) response.getEntity();
 
@@ -127,10 +127,7 @@ public class ManagementServiceTest {
                 services
                     .catalogsApi()
                     .updateCatalog(
-                        catalogName,
-                        updateRequest,
-                        services.realmContext(),
-                        services.securityContext()))
+                        catalogName, updateRequest, services.realmId(), services.securityContext()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Unsupported storage type: FILE");
   }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAdminServiceAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAdminServiceAuthzTest.java
@@ -49,7 +49,7 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final AuthenticatedPolarisPrincipal authenticatedPrincipal =
         new AuthenticatedPolarisPrincipal(principalEntity, activatedPrincipalRoles);
     return new PolarisAdminService(
-        realmContext,
+        realmId,
         entityManager,
         metaStoreManager,
         metaStoreSession,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -51,7 +51,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -162,7 +162,7 @@ public abstract class PolarisAuthzTestBase {
   protected PolarisMetaStoreSession metaStoreSession;
   protected PolarisBaseEntity catalogEntity;
   protected PrincipalEntity principalEntity;
-  protected RealmContext realmContext;
+  protected RealmId realmId;
   protected AuthenticatedPolarisPrincipal authenticatedRoot;
 
   @BeforeAll
@@ -177,10 +177,10 @@ public abstract class PolarisAuthzTestBase {
 
   @BeforeEach
   public void before(TestInfo testInfo) {
-    realmContext = testInfo::getDisplayName;
-    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmContext);
-    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmContext).get();
-    entityManager = realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
+    realmId = testInfo::getDisplayName;
+    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmId);
+    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmId).get();
+    entityManager = realmEntityManagerFactory.getOrCreateEntityManager(realmId);
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(
@@ -198,7 +198,7 @@ public abstract class PolarisAuthzTestBase {
 
     this.adminService =
         new PolarisAdminService(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -387,7 +387,7 @@ public abstract class PolarisAuthzTestBase {
             entityManager, metaStoreSession, securityContext, CATALOG_NAME);
     this.baseCatalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingCatalogTest.java
@@ -80,7 +80,7 @@ public class PolarisOverlappingCatalogTest {
     return services
         .catalogsApi()
         .createCatalog(
-            new CreateCatalogRequest(catalog), services.realmContext(), services.securityContext());
+            new CreateCatalogRequest(catalog), services.realmId(), services.securityContext());
   }
 
   @ParameterizedTest

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingTableTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingTableTest.java
@@ -63,7 +63,7 @@ public class PolarisOverlappingTableTest {
                 namespace,
                 createTableRequest,
                 null,
-                services.realmContext(),
+                services.realmId(),
                 services.securityContext())) {
       return response.getStatus();
     } catch (ForbiddenException e) {
@@ -130,7 +130,7 @@ public class PolarisOverlappingTableTest {
             .catalogsApi()
             .createCatalog(
                 new CreateCatalogRequest(catalogObject),
-                services.realmContext(),
+                services.realmId(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
     }
@@ -141,10 +141,7 @@ public class PolarisOverlappingTableTest {
         services
             .restApi()
             .createNamespace(
-                catalog,
-                createNamespaceRequest,
-                services.realmContext(),
-                services.securityContext())) {
+                catalog, createNamespaceRequest, services.realmId(), services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/TokenUtils.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/TokenUtils.java
@@ -19,7 +19,7 @@
 package org.apache.polaris.service.quarkus.auth;
 
 import static org.apache.polaris.service.auth.BasePolarisAuthenticator.PRINCIPAL_ROLE_ALL;
-import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.TestRealmIdResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.client.Client;

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
@@ -72,7 +72,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -140,7 +140,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
   @Inject Clock clock;
 
   private BasePolarisCatalog catalog;
-  private RealmContext realmContext;
+  private RealmId realmId;
   private PolarisMetaStoreManager metaStoreManager;
   private PolarisMetaStoreSession metaStoreSession;
   private PolarisAdminService adminService;
@@ -164,10 +164,10 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
         "realm_%s_%s"
             .formatted(
                 testInfo.getTestMethod().map(Method::getName).orElse("test"), System.nanoTime());
-    realmContext = () -> realmName;
-    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmContext);
-    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmContext).get();
-    entityManager = entityManagerFactory.getOrCreateEntityManager(realmContext);
+    realmId = RealmId.newRealmId(realmName);
+    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmId);
+    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmId).get();
+    entityManager = entityManagerFactory.getOrCreateEntityManager(realmId);
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(
@@ -188,7 +188,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     when(securityContext.isUserInRole(isA(String.class))).thenReturn(true);
     adminService =
         new PolarisAdminService(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -225,7 +225,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     TaskExecutor taskExecutor = Mockito.mock();
     this.catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -290,23 +290,22 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
   private MetaStoreManagerFactory createMockMetaStoreManagerFactory() {
     return new MetaStoreManagerFactory() {
       @Override
-      public PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmContext realmContext) {
+      public PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmId realmId) {
         return metaStoreManager;
       }
 
       @Override
-      public Supplier<PolarisMetaStoreSession> getOrCreateSessionSupplier(
-          RealmContext realmContext) {
+      public Supplier<PolarisMetaStoreSession> getOrCreateSessionSupplier(RealmId realmId) {
         return () -> metaStoreSession;
       }
 
       @Override
-      public StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext) {
+      public StorageCredentialCache getOrCreateStorageCredentialCache(RealmId realmId) {
         return new StorageCredentialCache(diagServices, configurationStore);
       }
 
       @Override
-      public EntityCache getOrCreateEntityCache(RealmContext realmContext) {
+      public EntityCache getOrCreateEntityCache(RealmId realmId) {
         return new EntityCache(metaStoreManager, diagServices);
       }
 
@@ -495,7 +494,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     FileIOFactory fileIoFactory = spy(new DefaultFileIOFactory());
     BasePolarisCatalog catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -823,7 +822,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     TaskExecutor taskExecutor = Mockito.mock();
     BasePolarisCatalog catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -857,7 +856,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
     if (!configurationStore
-        .getConfiguration(realmContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(realmId, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -888,7 +887,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     TaskExecutor taskExecutor = Mockito.mock();
     BasePolarisCatalog catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -924,7 +923,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
     if (!configurationStore
-        .getConfiguration(realmContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(realmId, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -944,7 +943,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
     if (!configurationStore
-        .getConfiguration(realmContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(realmId, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, newRequest))
           .isInstanceOf(ForbiddenException.class)
@@ -1392,7 +1391,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     FileIO fileIO =
         new TaskFileIOSupplier(
                 createMockMetaStoreManagerFactory(), new DefaultFileIOFactory(), configurationStore)
-            .apply(taskEntity, realmContext);
+            .apply(taskEntity, realmId);
     Assertions.assertThat(fileIO).isNotNull().isInstanceOf(InMemoryFileIO.class);
   }
 
@@ -1424,7 +1423,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
             entityManager, metaStoreSession, securityContext, noPurgeCatalogName);
     BasePolarisCatalog noPurgeCatalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -1508,7 +1507,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     TestFileIOFactory measured = new TestFileIOFactory();
     BasePolarisCatalog catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -1556,7 +1555,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
                 .loadTasks(metaStoreSession, "testExecutor", 1)
                 .getEntities()
                 .getFirst()),
-        realmContext);
+        realmId);
     Assertions.assertThat(measured.getNumDeletedFiles()).as("A table was deleted").isGreaterThan(0);
   }
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogViewTest.java
@@ -41,7 +41,7 @@ import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -98,10 +98,10 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
         "realm_%s_%s"
             .formatted(
                 testInfo.getTestMethod().map(Method::getName).orElse("test"), System.nanoTime());
-    RealmContext realmContext = () -> realmName;
+    RealmId realmId = RealmId.newRealmId(realmName);
 
-    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmContext);
-    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmContext).get();
+    metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmId);
+    metaStoreSession = managerFactory.getOrCreateSessionSupplier(realmId).get();
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(
@@ -117,15 +117,14 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
     AuthenticatedPolarisPrincipal authenticatedRoot =
         new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
 
-    PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(realmContext);
+    PolarisEntityManager entityManager = entityManagerFactory.getOrCreateEntityManager(realmId);
 
     SecurityContext securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
     when(securityContext.isUserInRole(Mockito.anyString())).thenReturn(true);
     PolarisAdminService adminService =
         new PolarisAdminService(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,
@@ -151,7 +150,7 @@ public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCata
             entityManager, metaStoreSession, securityContext, CATALOG_NAME);
     this.catalog =
         new BasePolarisCatalog(
-            realmContext,
+            realmId,
             entityManager,
             metaStoreManager,
             metaStoreSession,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
@@ -103,7 +103,7 @@ public class PolarisCatalogHandlerWrapperAuthzTest extends PolarisAuthzTestBase 
   private PolarisCatalogHandlerWrapper newWrapper(
       SecurityContext securityContext, String catalogName) {
     return new PolarisCatalogHandlerWrapper(
-        realmContext,
+        realmId,
         metaStoreSession,
         configurationStore,
         diagServices,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/TestUtil.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/TestUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.quarkus.catalog;
 
-import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.TestRealmIdResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
@@ -81,7 +81,7 @@ public class FileIOExceptionsTest {
             .catalogsApi()
             .createCatalog(
                 new CreateCatalogRequest(catalog),
-                services.realmContext(),
+                services.realmId(),
                 services.securityContext())) {
       assertThat(res.getStatus()).isEqualTo(201);
     }
@@ -92,7 +92,7 @@ public class FileIOExceptionsTest {
             .createNamespace(
                 FileIOExceptionsTest.catalog,
                 CreateNamespaceRequest.builder().withNamespace(Namespace.of("ns1")).build(),
-                services.realmContext(),
+                services.realmId(),
                 services.securityContext())) {
       assertThat(res.getStatus()).isEqualTo(200);
     }
@@ -112,7 +112,7 @@ public class FileIOExceptionsTest {
         services
             .restApi()
             .createTable(
-                catalog, "ns1", request, null, services.realmContext(), services.securityContext());
+                catalog, "ns1", request, null, services.realmId(), services.securityContext());
     res.close();
   }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
@@ -21,7 +21,7 @@ package org.apache.polaris.service.quarkus.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.service.config.DefaultConfigurationStore;
 import org.junit.jupiter.api.Test;
 
@@ -31,17 +31,16 @@ public class DefaultConfigurationStoreTest {
   public void testGetConfiguration() {
     DefaultConfigurationStore defaultConfigurationStore =
         new DefaultConfigurationStore(Map.of("key1", 1, "key2", "value"));
-    RealmContext realmContext = () -> "test";
-    Object value =
-        defaultConfigurationStore.getConfiguration(realmContext, "missingKeyWithoutDefault");
+    RealmId realmId = RealmId.newRealmId("test");
+    Object value = defaultConfigurationStore.getConfiguration(realmId, "missingKeyWithoutDefault");
     assertThat(value).isNull();
     Object defaultValue =
         defaultConfigurationStore.getConfiguration(
-            realmContext, "missingKeyWithDefault", "defaultValue");
+            realmId, "missingKeyWithDefault", "defaultValue");
     assertThat(defaultValue).isEqualTo("defaultValue");
-    Integer keyOne = defaultConfigurationStore.getConfiguration(realmContext, "key1");
+    Integer keyOne = defaultConfigurationStore.getConfiguration(realmId, "key1");
     assertThat(keyOne).isEqualTo(1);
-    String keyTwo = defaultConfigurationStore.getConfiguration(realmContext, "key2");
+    String keyTwo = defaultConfigurationStore.getConfiguration(realmId, "key2");
     assertThat(keyTwo).isEqualTo("value");
   }
 
@@ -63,31 +62,30 @@ public class DefaultConfigurationStoreTest {
                 Map.of("key1", realm2KeyOneValue, "key2", realm2KeyTwoValue)));
 
     // check realm1 values
-    RealmContext realmContext = () -> "realm1";
-    Object value =
-        defaultConfigurationStore.getConfiguration(realmContext, "missingKeyWithoutDefault");
+    RealmId realmId = RealmId.newRealmId("realm1");
+    Object value = defaultConfigurationStore.getConfiguration(realmId, "missingKeyWithoutDefault");
     assertThat(value).isNull();
     Object defaultValue =
         defaultConfigurationStore.getConfiguration(
-            realmContext, "missingKeyWithDefault", "defaultValue");
+            realmId, "missingKeyWithDefault", "defaultValue");
     assertThat(defaultValue).isEqualTo("defaultValue");
-    Integer keyOneRealm1 = defaultConfigurationStore.getConfiguration(realmContext, "key1");
+    Integer keyOneRealm1 = defaultConfigurationStore.getConfiguration(realmId, "key1");
     assertThat(keyOneRealm1).isEqualTo(realm1KeyOneValue);
-    String keyTwoRealm1 = defaultConfigurationStore.getConfiguration(realmContext, "key2");
+    String keyTwoRealm1 = defaultConfigurationStore.getConfiguration(realmId, "key2");
     assertThat(keyTwoRealm1).isEqualTo(defaultKeyTwoValue);
 
     // check realm2 values
-    realmContext = () -> "realm2";
-    Integer keyOneRealm2 = defaultConfigurationStore.getConfiguration(realmContext, "key1");
+    realmId = RealmId.newRealmId("realm2");
+    Integer keyOneRealm2 = defaultConfigurationStore.getConfiguration(realmId, "key1");
     assertThat(keyOneRealm2).isEqualTo(realm2KeyOneValue);
-    String keyTwoRealm2 = defaultConfigurationStore.getConfiguration(realmContext, "key2");
+    String keyTwoRealm2 = defaultConfigurationStore.getConfiguration(realmId, "key2");
     assertThat(keyTwoRealm2).isEqualTo(realm2KeyTwoValue);
 
     // realm3 has no realm-overrides, so just returns default values
-    realmContext = () -> "realm3";
-    Integer keyOneRealm3 = defaultConfigurationStore.getConfiguration(realmContext, "key1");
+    realmId = RealmId.newRealmId("realm3");
+    Integer keyOneRealm3 = defaultConfigurationStore.getConfiguration(realmId, "key1");
     assertThat(keyOneRealm3).isEqualTo(defaultKeyOneValue);
-    String keyTwoRealm3 = defaultConfigurationStore.getConfiguration(realmContext, "key2");
+    String keyTwoRealm3 = defaultConfigurationStore.getConfiguration(realmId, "key2");
     assertThat(keyTwoRealm3).isEqualTo(defaultKeyTwoValue);
   }
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/TestUtil.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/TestUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.quarkus.ratelimiter;
 
-import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.TestRealmIdResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.core.Response;

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
@@ -46,7 +46,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.service.task.ManifestFileCleanupTaskHandler;
@@ -58,7 +58,7 @@ class ManifestFileCleanupTaskHandlerTest {
 
   @Inject PolarisDiagnostics diagnostics;
 
-  private final RealmContext realmContext = () -> "realmName";
+  private final RealmId realmId = RealmId.newRealmId("realmName");
 
   @Test
   public void testCleanupFileNotExists() throws IOException {
@@ -81,7 +81,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
   }
 
   @Test
@@ -104,7 +104,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
   }
 
   @Test
@@ -142,7 +142,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
     assertThat(TaskUtils.exists(dataFile1Path, fileIO)).isFalse();
     assertThat(TaskUtils.exists(dataFile2Path, fileIO)).isFalse();
   }
@@ -196,7 +196,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
     assertThat(TaskUtils.exists(dataFile1Path, fileIO)).isFalse();
     assertThat(TaskUtils.exists(dataFile2Path, fileIO)).isFalse();
   }
@@ -288,7 +288,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
 
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
 
     assertThat(TaskUtils.exists(firstMetadataFile, fileIO)).isFalse();
     assertThat(TaskUtils.exists(statisticsFile1.path(), fileIO)).isFalse();
@@ -330,7 +330,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
     assertThat(handler.canHandleTask(task)).isTrue();
-    assertThat(handler.handleTask(task, realmContext)).isTrue();
+    assertThat(handler.handleTask(task, realmId)).isTrue();
   }
 
   @Test
@@ -390,7 +390,7 @@ class ManifestFileCleanupTaskHandlerTest {
           CompletableFuture.runAsync(
               () -> {
                 assertThat(handler.canHandleTask(task)).isTrue();
-                handler.handleTask(task, realmContext); // this will schedule the batch deletion
+                handler.handleTask(task, realmId); // this will schedule the batch deletion
               },
               executor);
       // Wait for all async tasks to finish

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -60,12 +60,12 @@ class TableCleanupTaskHandlerTest {
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisDiagnostics diagnostics;
 
-  private final RealmContext realmContext = () -> "realmName";
+  private final RealmId realmId = RealmId.newRealmId("realmName");
 
   @Test
   public void testTableCleanup() throws IOException {
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
     TableCleanupTaskHandler handler =
@@ -105,11 +105,11 @@ class TableCleanupTaskHandlerTest {
             .build();
     Assertions.assertThatPredicate(handler::canHandleTask).accepts(task);
 
-    handler.handleTask(task, realmContext);
+    handler.handleTask(task, realmId);
 
     assertThat(
             metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+                .getOrCreateMetaStoreManager(realmId)
                 .loadTasks(metaStoreSession, "test", 2)
                 .getEntities())
         .hasSize(2)
@@ -148,7 +148,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupHandlesAlreadyDeletedMetadata() throws IOException {
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     FileIO fileIO =
         new InMemoryFileIO() {
           @Override
@@ -191,13 +191,13 @@ class TableCleanupTaskHandlerTest {
     // handle the same task twice
     // the first one should successfully delete the metadata
     List<Boolean> results =
-        List.of(handler.handleTask(task, realmContext), handler.handleTask(task, realmContext));
+        List.of(handler.handleTask(task, realmId), handler.handleTask(task, realmId));
     assertThat(results).containsExactly(true, true);
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(
             metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+                .getOrCreateMetaStoreManager(realmId)
                 .loadTasks(metaStoreSession, "test", 5)
                 .getEntities())
         .hasSize(1);
@@ -206,7 +206,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupDuplicatesTasksIfFileStillExists() throws IOException {
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     FileIO fileIO =
         new InMemoryFileIO() {
           @Override
@@ -257,13 +257,13 @@ class TableCleanupTaskHandlerTest {
     // handle the same task twice
     // the first one should successfully delete the metadata
     List<Boolean> results =
-        List.of(handler.handleTask(task, realmContext), handler.handleTask(task, realmContext));
+        List.of(handler.handleTask(task, realmId), handler.handleTask(task, realmId));
     assertThat(results).containsExactly(true, true);
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(
             metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+                .getOrCreateMetaStoreManager(realmId)
                 .loadTasks(metaStoreSession, "test", 5)
                 .getEntities())
         .hasSize(2)
@@ -303,7 +303,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupMultipleSnapshots() throws IOException {
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
     TableCleanupTaskHandler handler =
@@ -365,11 +365,11 @@ class TableCleanupTaskHandlerTest {
             .build();
     Assertions.assertThatPredicate(handler::canHandleTask).accepts(task);
 
-    handler.handleTask(task, realmContext);
+    handler.handleTask(task, realmId);
 
     List<PolarisBaseEntity> entities =
         metaStoreManagerFactory
-            .getOrCreateMetaStoreManager(realmContext)
+            .getOrCreateMetaStoreManager(realmId)
             .loadTasks(metaStoreSession, "test", 5)
             .getEntities();
 
@@ -452,7 +452,7 @@ class TableCleanupTaskHandlerTest {
   @Test
   public void testTableCleanupMultipleMetadata() throws IOException {
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
     TableCleanupTaskHandler handler =
@@ -528,11 +528,11 @@ class TableCleanupTaskHandlerTest {
 
     Assertions.assertThatPredicate(handler::canHandleTask).accepts(task);
 
-    handler.handleTask(task, realmContext);
+    handler.handleTask(task, realmId);
 
     List<PolarisBaseEntity> entities =
         metaStoreManagerFactory
-            .getOrCreateMetaStoreManager(realmContext)
+            .getOrCreateMetaStoreManager(realmId)
             .loadTasks(metaStoreSession, "test", 6)
             .getEntities();
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.quarkus.test;
 
-import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
+import static org.apache.polaris.service.context.TestRealmIdResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,7 +35,7 @@ import org.apache.polaris.core.admin.model.GrantPrincipalRoleRequest;
 import org.apache.polaris.core.admin.model.Principal;
 import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -100,12 +100,12 @@ public class PolarisIntegrationTestFixture {
           List.of(realm), PolarisCredentialsBootstrap.fromEnvironment());
     }
 
-    RealmContext realmContext = () -> realm;
+    RealmId realmId = RealmId.newRealmId(realm);
 
     PolarisMetaStoreSession metaStoreSession =
-        helper.metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        helper.metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     PolarisMetaStoreManager metaStoreManager =
-        helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+        helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId);
     PolarisMetaStoreManager.EntityResult principal =
         metaStoreManager.readEntityByName(
             metaStoreSession,

--- a/server-templates/api.mustache
+++ b/server-templates/api.mustache
@@ -108,7 +108,7 @@ public class {{classname}}  {
   @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}{{#hasAuthMethods}}
   {{#authMethods}}{{#isOAuth}}@RolesAllowed({ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }){{/isOAuth}}{{/authMethods}}{{/hasAuthMethods}}
   @Timed("{{metricsPrefix}}.{{baseName}}.{{nickname}}")
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realmIdentifier") RealmId realmId,@Context SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realm.id") RealmId realmId,@Context SecurityContext securityContext) {
 {{! Don't log form or header params in case there are secrets, e.g., OAuth tokens }}
     LOGGER.atDebug().setMessage("Invoking {{baseName}} with params")
       .addKeyValue("operation", "{{nickname}}"){{#allParams}}{{^isHeaderParam}}{{^isFormParam}}

--- a/server-templates/api.mustache
+++ b/server-templates/api.mustache
@@ -55,7 +55,7 @@ import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 import {{javaxPackage}}.inject.Inject;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +108,7 @@ public class {{classname}}  {
   @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}{{#hasAuthMethods}}
   {{#authMethods}}{{#isOAuth}}@RolesAllowed({ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }){{/isOAuth}}{{/authMethods}}{{/hasAuthMethods}}
   @Timed("{{metricsPrefix}}.{{baseName}}.{{nickname}}")
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realmIdentifier") RealmContext realmContext,@Context SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realmIdentifier") RealmId realmId,@Context SecurityContext securityContext) {
 {{! Don't log form or header params in case there are secrets, e.g., OAuth tokens }}
     LOGGER.atDebug().setMessage("Invoking {{baseName}} with params")
       .addKeyValue("operation", "{{nickname}}"){{#allParams}}{{^isHeaderParam}}{{^isFormParam}}
@@ -116,7 +116,7 @@ public class {{classname}}  {
       .log();
 
     Response ret =
-      service.{{nickname}}({{#isMultipart}}input,{{/isMultipart}}{{#allParams}}{{^isMultipart}}{{paramName}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}realmContext,securityContext);
+      service.{{nickname}}({{#isMultipart}}input,{{/isMultipart}}{{#allParams}}{{^isMultipart}}{{paramName}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}realmId,securityContext);
     LOGGER.debug("Completed execution of {{nickname}} API with status code {}", ret.getStatus());
     return ret;
   }

--- a/server-templates/apiService.mustache
+++ b/server-templates/apiService.mustache
@@ -35,7 +35,7 @@ import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.ws.rs.core.Response;
 import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 {{!
 Note that this template is copied from https://github.com/OpenAPITools/openapi-generator/blob/783e68c7acbbdcbb2282d167d1644b069f12d486/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiService.mustache
@@ -54,7 +54,7 @@ It is here to remove some unsupported imports and to update the default implemen
 {{#operations}}
 public interface {{classname}}Service {
   {{#operation}}
-  default Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmContext realmContext,SecurityContext securityContext) {
+  default Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmId realmId,SecurityContext securityContext) {
     return Response.status(501).build(); // not implemented
   }
   {{/operation}}

--- a/server-templates/apiServiceImpl.mustache
+++ b/server-templates/apiServiceImpl.mustache
@@ -36,7 +36,7 @@ import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.ws.rs.core.Response;
 import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 {{!
 Note that this template is copied from https://github.com/OpenAPITools/openapi-generator/blob/783e68c7acbbdcbb2282d167d1644b069f12d486/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiServiceImpl.mustache
@@ -55,7 +55,7 @@ It is here to remove some unsupported imports (ApiResponseMessage, openapi.tools
 {{#operations}}
 public class {{classname}}ServiceImpl implements {{classname}}Service {
   {{#operation}}
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmContext realmContext,SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{^isMultipart}}{{>serviceFormParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}RealmId realmId,SecurityContext securityContext) {
     return Response.status(501).build(); // not implemented
   }
   {{/operation}}

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -66,7 +66,7 @@ import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisGrantManager.LoadGrantsResult;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.NamespaceEntity;
@@ -107,7 +107,7 @@ import org.slf4j.LoggerFactory;
 public class PolarisAdminService {
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisAdminService.class);
 
-  private final RealmContext realmContext;
+  private final RealmId realmId;
   private final PolarisMetaStoreSession metaStoreSession;
   private final PolarisConfigurationStore configurationStore;
   private final PolarisEntityManager entityManager;
@@ -120,7 +120,7 @@ public class PolarisAdminService {
   private PolarisResolutionManifest resolutionManifest = null;
 
   public PolarisAdminService(
-      RealmContext realmContext,
+      RealmId realmId,
       PolarisEntityManager entityManager,
       PolarisMetaStoreManager metaStoreManager,
       PolarisMetaStoreSession metaStoreSession,
@@ -128,7 +128,7 @@ public class PolarisAdminService {
       PolarisDiagnostics diagServices,
       SecurityContext securityContext,
       PolarisAuthorizer authorizer) {
-    this.realmContext = realmContext;
+    this.realmId = realmId;
     this.metaStoreSession = metaStoreSession;
     this.configurationStore = configurationStore;
     this.entityManager = entityManager;
@@ -176,7 +176,7 @@ public class PolarisAdminService {
     PolarisResolvedPathWrapper rootContainerWrapper =
         resolutionManifest.getResolvedRootContainerEntityAsPath();
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedPrincipalRoleEntities(),
         op,
@@ -222,7 +222,7 @@ public class PolarisAdminService {
       return;
     }
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -243,7 +243,7 @@ public class PolarisAdminService {
       throw new NotFoundException("CatalogRole does not exist: %s", catalogRoleName);
     }
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -274,7 +274,7 @@ public class PolarisAdminService {
             principalRoleName, PolarisEntityType.PRINCIPAL_ROLE);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -311,7 +311,7 @@ public class PolarisAdminService {
             principalRoleName, PolarisEntityType.PRINCIPAL_ROLE);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -342,7 +342,7 @@ public class PolarisAdminService {
         resolutionManifest.getResolvedTopLevelEntity(principalName, PolarisEntityType.PRINCIPAL);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -381,7 +381,7 @@ public class PolarisAdminService {
         resolutionManifest.getResolvedPath(catalogRoleName, true);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -411,7 +411,7 @@ public class PolarisAdminService {
     PolarisResolvedPathWrapper catalogRoleWrapper =
         resolutionManifest.getResolvedPath(catalogRoleName, true);
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -451,7 +451,7 @@ public class PolarisAdminService {
         resolutionManifest.getResolvedPath(catalogRoleName, true);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -496,7 +496,7 @@ public class PolarisAdminService {
         resolutionManifest.getResolvedPath(catalogRoleName, true);
 
     authorizer.authorizeOrThrow(
-        realmContext,
+        realmId,
         authenticatedPrincipal,
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
@@ -535,7 +535,7 @@ public class PolarisAdminService {
   private boolean catalogOverlapsWithExistingCatalog(CatalogEntity catalogEntity) {
     boolean allowOverlappingCatalogUrls =
         configurationStore.getConfiguration(
-            realmContext, PolarisConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
+            realmId, PolarisConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
 
     if (allowOverlappingCatalogUrls) {
       return false;
@@ -602,8 +602,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
     // TODO: Handle return value in case of concurrent modification
     boolean cleanup =
-        configurationStore.getConfiguration(
-            realmContext, PolarisConfiguration.CLEANUP_ON_CATALOG_DROP);
+        configurationStore.getConfiguration(realmId, PolarisConfiguration.CLEANUP_ON_CATALOG_DROP);
     PolarisMetaStoreManager.DropEntityResult dropEntityResult =
         metaStoreManager.dropEntityIfExists(metaStoreSession, null, entity, Map.of(), cleanup);
 

--- a/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -39,9 +39,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Base implementation of {@link Authenticator} constructs a {@link AuthenticatedPolarisPrincipal}
  * from the token parsed by subclasses. The {@link AuthenticatedPolarisPrincipal} is read from the
- * {@link PolarisMetaStoreManager} for the current {@link RealmContext}. If the token defines a
- * non-empty set of scopes, only the principal roles specified in the scopes will be active for the
- * current principal. Only the grants assigned to these roles will be active in the current request.
+ * {@link PolarisMetaStoreManager} for the current {@link RealmId}. If the token defines a non-empty
+ * set of scopes, only the principal roles specified in the scopes will be active for the current
+ * principal. Only the grants assigned to these roles will be active in the current request.
  */
 public abstract class BasePolarisAuthenticator
     implements Authenticator<String, AuthenticatedPolarisPrincipal> {

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisGrantManager;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultActiveRolesProvider implements ActiveRolesProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultActiveRolesProvider.class);
 
-  @Inject RealmContext realmContext;
+  @Inject RealmId realmId;
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisDiagnostics diagnostics;
 
@@ -57,8 +57,8 @@ public class DefaultActiveRolesProvider implements ActiveRolesProvider {
         loadActivePrincipalRoles(
             principal.getActivatedPrincipalRoleNames(),
             principal.getPrincipalEntity(),
-            metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-            metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get());
+            metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId),
+            metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get());
     return activeRoles.stream().map(PrincipalRoleEntity::getName).collect(Collectors.toSet());
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
@@ -27,7 +27,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.service.catalog.api.IcebergRestOAuth2ApiService;
 import org.apache.polaris.service.types.TokenType;
 import org.slf4j.Logger;
@@ -65,10 +65,10 @@ public class DefaultOAuth2ApiService implements IcebergRestOAuth2ApiService {
       TokenType subjectTokenType,
       String actorToken,
       TokenType actorTokenType,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
 
-    TokenBroker tokenBroker = tokenBrokerFactory.apply(realmContext);
+    TokenBroker tokenBroker = tokenBrokerFactory.apply(realmId);
     if (!tokenBroker.supportsGrantType(grantType)) {
       return OAuthUtils.getResponseFromError(OAuthTokenErrorResponse.Error.unsupported_grant_type);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.RSAKeyPairConfiguration;
@@ -53,10 +53,10 @@ public class JWTRSAKeyPairFactory implements TokenBrokerFactory {
   }
 
   @Override
-  public TokenBroker apply(RealmContext realmContext) {
+  public TokenBroker apply(RealmId realmId) {
     return new JWTRSAKeyPair(
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId),
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get(),
         (int) tokenBrokerConfiguration.maxTokenGeneration().toSeconds(),
         keyPairConfiguration.publicKeyFile(),
         keyPairConfiguration.privateKeyFile());

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTSymmetricKeyFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTSymmetricKeyFactory.java
@@ -28,7 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.function.Supplier;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.SymmetricKeyConfiguration;
 
@@ -58,10 +58,10 @@ public class JWTSymmetricKeyFactory implements TokenBrokerFactory {
   }
 
   @Override
-  public TokenBroker apply(RealmContext realmContext) {
+  public TokenBroker apply(RealmId realmId) {
     return new JWTSymmetricKeyBroker(
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext),
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId),
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get(),
         (int) maxTokenGeneration.toSeconds(),
         secretSupplier);
   }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
@@ -20,7 +20,7 @@ package org.apache.polaris.service.auth;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.service.types.TokenType;
 
 /** Default {@link TokenBrokerFactory} that produces token brokers that do not do anything. */
@@ -59,7 +59,7 @@ public class NoneTokenBrokerFactory implements TokenBrokerFactory {
       };
 
   @Override
-  public TokenBroker apply(RealmContext realmContext) {
+  public TokenBroker apply(RealmId realmId) {
     return NONE_TOKEN_BROKER;
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/TestOAuth2ApiService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/TestOAuth2ApiService.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -58,7 +58,7 @@ public class TestOAuth2ApiService implements IcebergRestOAuth2ApiService {
       TokenType subjectTokenType,
       String actorToken,
       TokenType actorTokenType,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Map<String, Object> response = new HashMap<>();
     String principalName = getPrincipalName(clientId);
@@ -69,7 +69,7 @@ public class TestOAuth2ApiService implements IcebergRestOAuth2ApiService {
             + ";password:"
             + clientSecret
             + ";realm:"
-            + realmContext.getRealmIdentifier()
+            + realmId.id()
             + ";role:"
             + scope.replaceAll(BasePolarisAuthenticator.PRINCIPAL_ROLE_PREFIX, ""));
     response.put("token_type", "bearer");

--- a/service/common/src/main/java/org/apache/polaris/service/auth/TokenBrokerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/TokenBrokerFactory.java
@@ -19,10 +19,10 @@
 package org.apache.polaris.service.auth;
 
 import java.util.function.Function;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /**
  * Factory that creates a {@link TokenBroker} for generating and parsing. The {@link TokenBroker} is
  * created based on the realm context.
  */
-public interface TokenBrokerFactory extends Function<RealmContext, TokenBroker> {}
+public interface TokenBrokerFactory extends Function<RealmId, TokenBroker> {}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -79,7 +79,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -154,7 +154,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   private final PolarisMetaStoreSession metaStoreSession;
   private final PolarisConfigurationStore configurationStore;
   private final PolarisDiagnostics diagnostics;
-  private final RealmContext realmContext;
+  private final RealmId realmId;
   private final PolarisResolutionManifestCatalogView resolvedEntityView;
   private final CatalogEntity catalogEntity;
   private final TaskExecutor taskExecutor;
@@ -172,7 +172,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   private Map<String, String> tableDefaultProperties;
 
   /**
-   * @param realmContext the current RealmContext
+   * @param realmId the current RealmId
    * @param entityManager provides handle to underlying PolarisMetaStoreManager with which to
    *     perform mutations on entities.
    * @param resolvedEntityView accessor to resolved entity paths that have been pre-vetted to ensure
@@ -180,7 +180,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
    * @param taskExecutor Executor we use to register cleanup task handlers
    */
   public BasePolarisCatalog(
-      RealmContext realmContext,
+      RealmId realmId,
       PolarisEntityManager entityManager,
       PolarisMetaStoreManager metaStoreManager,
       PolarisMetaStoreSession metaStoreSession,
@@ -190,7 +190,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       SecurityContext securityContext,
       TaskExecutor taskExecutor,
       FileIOFactory fileIOFactory) {
-    this.realmContext = realmContext;
+    this.realmId = realmId;
     this.entityManager = entityManager;
     this.metaStoreManager = metaStoreManager;
     this.metaStoreSession = metaStoreSession;
@@ -450,7 +450,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
           "Scheduled cleanup task {} for table {}",
           dropEntityResult.getCleanupTaskId(),
           tableIdentifier);
-      taskExecutor.addTaskHandlerContext(dropEntityResult.getCleanupTaskId(), realmContext);
+      taskExecutor.addTaskHandlerContext(dropEntityResult.getCleanupTaskId(), realmId);
     }
 
     return true;
@@ -514,7 +514,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
             .setBaseLocation(baseLocation)
             .build();
     if (!configurationStore.getConfiguration(
-        realmContext, PolarisConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+        realmId, PolarisConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap for {} with sibling tables or namespaces", namespace);
       validateNoLocationOverlap(
           entity.getBaseLocation(), resolvedParent.getRawFullPath(), entity.getName());
@@ -639,7 +639,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
                 leafEntity,
                 Map.of(),
                 configurationStore.getConfiguration(
-                    realmContext, PolarisConfiguration.CLEANUP_ON_NAMESPACE_DROP));
+                    realmId, PolarisConfiguration.CLEANUP_ON_NAMESPACE_DROP));
 
     if (!dropEntityResult.isSuccess() && dropEntityResult.failedBecauseNotEmpty()) {
       throw new NamespaceNotEmptyException("Namespace %s is not empty", namespace);
@@ -665,7 +665,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         new PolarisEntity.Builder(entity).setProperties(newProperties).build();
 
     if (!configurationStore.getConfiguration(
-        realmContext, PolarisConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+        realmId, PolarisConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap with sibling tables or namespaces");
       validateNoLocationOverlap(
           NamespaceEntity.of(updatedEntity).getBaseLocation(),
@@ -953,14 +953,14 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       PolarisResolvedPathWrapper resolvedStorageEntity) {
     Optional<PolarisStorageConfigurationInfo> optStorageConfiguration =
         PolarisStorageConfigurationInfo.forEntityPath(
-            realmContext, configurationStore, diagnostics, resolvedStorageEntity.getRawFullPath());
+            realmId, configurationStore, diagnostics, resolvedStorageEntity.getRawFullPath());
 
     optStorageConfiguration.ifPresentOrElse(
         storageConfigInfo -> {
           Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>>
               validationResults =
                   InMemoryStorageIntegration.validateSubpathsOfAllowedLocations(
-                      realmContext,
+                      realmId,
                       configurationStore,
                       storageConfigInfo,
                       Set.of(PolarisStorageActions.ALL),
@@ -1007,7 +1007,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         () -> {
           List<String> allowedStorageTypes =
               configurationStore.getConfiguration(
-                  realmContext, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
+                  realmId, PolarisConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
           if (!allowedStorageTypes.contains(StorageConfigInfo.StorageTypeEnum.FILE.name())) {
             List<String> invalidLocations =
                 locations.stream()
@@ -1032,7 +1032,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       List<PolarisEntity> resolvedNamespace,
       String location) {
     if (configurationStore.getConfiguration(
-        realmContext, catalog, PolarisConfiguration.ALLOW_TABLE_LOCATION_OVERLAP)) {
+        realmId, catalog, PolarisConfiguration.ALLOW_TABLE_LOCATION_OVERLAP)) {
       LOGGER.debug("Skipping location overlap validation for identifier '{}'", identifier);
     } else { // if (entity.getSubType().equals(PolarisEntitySubType.TABLE)) {
       // TODO - is this necessary for views? overlapping views do not expose subdirectories via the
@@ -1399,10 +1399,10 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       TableIdentifier identifier, TableMetadata metadata, CatalogEntity catalog) {
     boolean allowEscape =
         configurationStore.getConfiguration(
-            realmContext, PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
+            realmId, PolarisConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
     if (!allowEscape
         && !configurationStore.getConfiguration(
-            realmContext, PolarisConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
+            realmId, PolarisConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
       LOGGER.debug(
           "Validating base location {} for table {} in metadata file {}",
           metadata.location(),
@@ -1836,7 +1836,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
     if (catalogPath != null && !catalogPath.isEmpty() && purge) {
       boolean dropWithPurgeEnabled =
           configurationStore.getConfiguration(
-              realmContext, catalogEntity, PolarisConfiguration.DROP_WITH_PURGE_ENABLED);
+              realmId, catalogEntity, PolarisConfiguration.DROP_WITH_PURGE_ENABLED);
       if (!dropWithPurgeEnabled) {
         throw new ForbiddenException(
             String.format(
@@ -2055,7 +2055,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
 
   /** Helper to retrieve dynamic context-based configuration that has a boolean value. */
   private Boolean getBooleanContextConfiguration(String configKey, boolean defaultValue) {
-    return configurationStore.getConfiguration(realmContext, configKey, defaultValue);
+    return configurationStore.getConfiguration(realmId, configKey, defaultValue);
   }
 
   /**

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -58,7 +58,7 @@ import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
 /**
  * {@link IcebergRestCatalogApiService} implementation that delegates operations to {@link
  * org.apache.iceberg.rest.CatalogHandlers} after finding the appropriate {@link Catalog} for the
- * current {@link RealmContext}.
+ * current {@link RealmId}.
  */
 @RequestScoped
 public class IcebergCatalogAdapter
@@ -119,7 +119,7 @@ public class IcebergCatalogAdapter
           .add(Endpoint.create("POST", ResourcePaths.V1_TRANSACTIONS_COMMIT))
           .build();
 
-  private final RealmContext realmContext;
+  private final RealmId realmId;
   private final PolarisMetaStoreManager metaStoreManager;
   private final PolarisEntityManager entityManager;
   private final PolarisMetaStoreSession session;
@@ -131,7 +131,7 @@ public class IcebergCatalogAdapter
 
   @Inject
   public IcebergCatalogAdapter(
-      RealmContext realmContext,
+      RealmId realmId,
       PolarisEntityManager entityManager,
       PolarisMetaStoreManager metaStoreManager,
       PolarisMetaStoreSession session,
@@ -140,7 +140,7 @@ public class IcebergCatalogAdapter
       PolarisAuthorizer polarisAuthorizer,
       TaskExecutor taskExecutor,
       FileIOFactory fileIOFactory) {
-    this.realmContext = realmContext;
+    this.realmId = realmId;
     this.entityManager = entityManager;
     this.metaStoreManager = metaStoreManager;
     this.session = session;
@@ -179,7 +179,7 @@ public class IcebergCatalogAdapter
     }
 
     return new PolarisCatalogHandlerWrapper(
-        realmContext,
+        realmId,
         session,
         configurationStore,
         diagnostics,
@@ -196,7 +196,7 @@ public class IcebergCatalogAdapter
   public Response createNamespace(
       String prefix,
       CreateNamespaceRequest createNamespaceRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     return withCatalog(
         securityContext,
@@ -210,7 +210,7 @@ public class IcebergCatalogAdapter
       String pageToken,
       Integer pageSize,
       String parent,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Optional<Namespace> namespaceOptional =
         Optional.ofNullable(parent).map(IcebergCatalogAdapter::decodeNamespace);
@@ -223,7 +223,7 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response loadNamespaceMetadata(
-      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
+      String prefix, String namespace, RealmId realmId, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
         securityContext, prefix, catalog -> Response.ok(catalog.loadNamespaceMetadata(ns)).build());
@@ -235,7 +235,7 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response namespaceExists(
-      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
+      String prefix, String namespace, RealmId realmId, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
         securityContext,
@@ -248,7 +248,7 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response dropNamespace(
-      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
+      String prefix, String namespace, RealmId realmId, SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
         securityContext,
@@ -264,7 +264,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
@@ -291,7 +291,7 @@ public class IcebergCatalogAdapter
       String namespace,
       CreateTableRequest createTableRequest,
       String accessDelegationMode,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
@@ -323,7 +323,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String pageToken,
       Integer pageSize,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
@@ -337,7 +337,7 @@ public class IcebergCatalogAdapter
       String table,
       String accessDelegationMode,
       String snapshots,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
@@ -361,7 +361,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String table,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
@@ -380,7 +380,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       Boolean purgeRequested,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
@@ -402,7 +402,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       RegisterTableRequest registerTableRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
@@ -415,7 +415,7 @@ public class IcebergCatalogAdapter
   public Response renameTable(
       String prefix,
       RenameTableRequest renameTableRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     return withCatalog(
         securityContext,
@@ -432,7 +432,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       CommitTableRequest commitTableRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
@@ -455,7 +455,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       CreateViewRequest createViewRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
@@ -470,7 +470,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String pageToken,
       Integer pageSize,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return withCatalog(
@@ -482,7 +482,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String view,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
@@ -495,7 +495,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String view,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
@@ -513,7 +513,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String view,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
@@ -530,7 +530,7 @@ public class IcebergCatalogAdapter
   public Response renameView(
       String prefix,
       RenameTableRequest renameTableRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     return withCatalog(
         securityContext,
@@ -547,7 +547,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String view,
       CommitViewRequest commitViewRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
@@ -561,7 +561,7 @@ public class IcebergCatalogAdapter
   public Response commitTransaction(
       String prefix,
       CommitTransactionRequest commitTransactionRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     return withCatalog(
         securityContext,
@@ -578,7 +578,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       ReportMetricsRequest reportMetricsRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -589,7 +589,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       NotificationRequest notificationRequest,
-      RealmContext realmContext,
+      RealmId realmId,
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
@@ -604,8 +604,7 @@ public class IcebergCatalogAdapter
 
   /** From IcebergRestConfigurationApiService. */
   @Override
-  public Response getConfig(
-      String warehouse, RealmContext realmContext, SecurityContext securityContext) {
+  public Response getConfig(String warehouse, RealmId realmId, SecurityContext securityContext) {
     // 'warehouse' as an input here is catalogName.
     // 'warehouse' as an output will be treated by the client as a default catalog
     // storage

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -24,7 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 @ApplicationScoped
 public class DefaultConfigurationStore implements PolarisConfigurationStore {
@@ -53,13 +53,11 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   }
 
   @Override
-  public <T> @Nullable T getConfiguration(@Nullable RealmContext realmContext, String configName) {
+  public <T> @Nullable T getConfiguration(@Nullable RealmId realmId, String configName) {
     Object rawValue = defaults.get(configName);
-    if (realmContext != null) {
+    if (realmId != null) {
       rawValue =
-          realmOverrides
-              .getOrDefault(realmContext.getRealmIdentifier(), Map.of())
-              .getOrDefault(configName, rawValue);
+          realmOverrides.getOrDefault(realmId.id(), Map.of()).getOrDefault(configName, rawValue);
     }
     @SuppressWarnings("unchecked")
     T value = (T) rawValue;

--- a/service/common/src/main/java/org/apache/polaris/service/config/RealmEntityManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/RealmEntityManagerFactory.java
@@ -23,13 +23,13 @@ import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Gets or creates PolarisEntityManager instances based on config values and RealmContext. */
+/** Gets or creates PolarisEntityManager instances based on config values and RealmId. */
 @ApplicationScoped
 public class RealmEntityManagerFactory {
 
@@ -48,8 +48,8 @@ public class RealmEntityManagerFactory {
     this.diagnostics = diagnostics;
   }
 
-  public PolarisEntityManager getOrCreateEntityManager(RealmContext context) {
-    String realm = context.getRealmIdentifier();
+  public PolarisEntityManager getOrCreateEntityManager(RealmId context) {
+    String realm = context.id();
 
     LOGGER.debug("Looking up PolarisEntityManager for realm {}", realm);
 

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmIdResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmIdResolver.java
@@ -22,21 +22,21 @@ import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 @ApplicationScoped
 @Identifier("default")
-public class DefaultRealmContextResolver implements RealmContextResolver {
+public class DefaultRealmIdResolver implements RealmIdResolver {
 
   private final RealmContextConfiguration configuration;
 
   @Inject
-  public DefaultRealmContextResolver(RealmContextConfiguration configuration) {
+  public DefaultRealmIdResolver(RealmContextConfiguration configuration) {
     this.configuration = configuration;
   }
 
   @Override
-  public RealmContext resolveRealmContext(
+  public RealmId resolveRealmContext(
       String requestURL, String method, String path, Map<String, String> headers) {
 
     String realm;
@@ -50,6 +50,6 @@ public class DefaultRealmContextResolver implements RealmContextResolver {
       realm = configuration.defaultRealm();
     }
 
-    return () -> realm;
+    return RealmId.newRealmId(realm);
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/context/RealmIdResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/RealmIdResolver.java
@@ -16,19 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.core.context;
+package org.apache.polaris.service.context;
 
-/**
- * Represents the elements of a REST request associated with routing to independent and isolated
- * "universes". This may include properties such as region, deployment environment (e.g. dev, qa,
- * prod), and/or account.
- */
-public interface RealmContext {
+import java.util.Map;
+import org.apache.polaris.core.context.RealmId;
 
-  static RealmContext copyOf(RealmContext original) {
-    String realmIdentifier = original.getRealmIdentifier();
-    return () -> realmIdentifier;
-  }
+public interface RealmIdResolver {
 
-  String getRealmIdentifier();
+  RealmId resolveRealmContext(
+      String requestURL, String method, String path, Map<String, String> headers);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/context/TestRealmIdResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/TestRealmIdResolver.java
@@ -24,7 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,26 +36,25 @@ import org.slf4j.LoggerFactory;
  */
 @ApplicationScoped
 @Identifier("test")
-public class TestRealmContextResolver implements RealmContextResolver {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRealmContextResolver.class);
+public class TestRealmIdResolver implements RealmIdResolver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRealmIdResolver.class);
 
   public static final String REALM_PROPERTY_KEY = "realm";
 
   private final RealmContextConfiguration configuration;
 
   @Inject
-  public TestRealmContextResolver(RealmContextConfiguration configuration) {
+  public TestRealmIdResolver(RealmContextConfiguration configuration) {
     this.configuration = configuration;
   }
 
   @Override
-  public RealmContext resolveRealmContext(
+  public RealmId resolveRealmContext(
       String requestURL, String method, String path, Map<String, String> headers) {
     // Since this default resolver is strictly for use in test/dev environments, we'll consider
     // it safe to log all contents. Any "real" resolver used in a prod environment should make
     // sure to only log non-sensitive contents.
-    LOGGER.debug(
-        "Resolving RealmContext for method: {}, path: {}, headers: {}", method, path, headers);
+    LOGGER.debug("Resolving RealmId for method: {}, path: {}, headers: {}", method, path, headers);
     Map<String, String> parsedProperties = parseBearerTokenAsKvPairs(headers);
 
     if (!parsedProperties.containsKey(REALM_PROPERTY_KEY)
@@ -71,7 +70,7 @@ public class TestRealmContextResolver implements RealmContextResolver {
       parsedProperties.put(REALM_PROPERTY_KEY, configuration.defaultRealm());
     }
     String realmId = parsedProperties.get(REALM_PROPERTY_KEY);
-    return () -> realmId;
+    return RealmId.newRealmId(realmId);
   }
 
   /**

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisCredentialsBootstrap;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -76,34 +76,28 @@ public class InMemoryPolarisMetaStoreManagerFactory
   @Override
   protected PolarisMetaStoreSession createMetaStoreSession(
       @Nonnull PolarisTreeMapStore store,
-      @Nonnull RealmContext realmContext,
+      @Nonnull RealmId realmId,
       @Nullable PolarisCredentialsBootstrap credentialsBootstrap,
       @Nonnull PolarisDiagnostics diagnostics) {
     return new PolarisTreeMapMetaStoreSessionImpl(
-        store,
-        storageIntegration,
-        secretsGenerator(realmContext, credentialsBootstrap),
-        diagnostics);
+        store, storageIntegration, secretsGenerator(realmId, credentialsBootstrap), diagnostics);
   }
 
   @Override
-  public synchronized PolarisMetaStoreManager getOrCreateMetaStoreManager(
-      RealmContext realmContext) {
-    String realmId = realmContext.getRealmIdentifier();
-    if (!bootstrappedRealms.contains(realmId)) {
-      bootstrapRealmAndPrintCredentials(realmId);
+  public synchronized PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmId realmId) {
+    if (!bootstrappedRealms.contains(realmId.id())) {
+      bootstrapRealmAndPrintCredentials(realmId.id());
     }
-    return super.getOrCreateMetaStoreManager(realmContext);
+    return super.getOrCreateMetaStoreManager(realmId);
   }
 
   @Override
   public synchronized Supplier<PolarisMetaStoreSession> getOrCreateSessionSupplier(
-      RealmContext realmContext) {
-    String realmId = realmContext.getRealmIdentifier();
-    if (!bootstrappedRealms.contains(realmId)) {
-      bootstrapRealmAndPrintCredentials(realmId);
+      RealmId realmId) {
+    if (!bootstrappedRealms.contains(realmId.id())) {
+      bootstrapRealmAndPrintCredentials(realmId.id());
     }
-    return super.getOrCreateSessionSupplier(realmContext);
+    return super.getOrCreateSessionSupplier(realmId);
   }
 
   private void bootstrapRealmAndPrintCredentials(String realmId) {

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/DefaultTokenBucketFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/DefaultTokenBucketFactory.java
@@ -25,7 +25,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 @ApplicationScoped
 @Identifier("default")
@@ -51,10 +51,9 @@ public class DefaultTokenBucketFactory implements TokenBucketFactory {
   }
 
   @Override
-  public TokenBucket getOrCreateTokenBucket(RealmContext realmContext) {
-    String realmId = realmContext.getRealmIdentifier();
+  public TokenBucket getOrCreateTokenBucket(RealmId realmId) {
     return perRealmBuckets.computeIfAbsent(
-        realmId,
+        realmId.id(),
         k ->
             new TokenBucket(
                 requestsPerSecond,

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/RealmTokenBucketRateLimiter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/RealmTokenBucketRateLimiter.java
@@ -21,7 +21,7 @@ package org.apache.polaris.service.ratelimiter;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /**
  * Rate limiter that maps the request's realm identifier to its own TokenBucket, with its own
@@ -32,13 +32,12 @@ import org.apache.polaris.core.context.RealmContext;
 public class RealmTokenBucketRateLimiter implements RateLimiter {
 
   private final TokenBucketFactory tokenBucketFactory;
-  private final RealmContext realmContext;
+  private final RealmId realmId;
 
   @Inject
-  public RealmTokenBucketRateLimiter(
-      TokenBucketFactory tokenBucketFactory, RealmContext realmContext) {
+  public RealmTokenBucketRateLimiter(TokenBucketFactory tokenBucketFactory, RealmId realmId) {
     this.tokenBucketFactory = tokenBucketFactory;
-    this.realmContext = realmContext;
+    this.realmId = realmId;
   }
 
   /**
@@ -49,6 +48,6 @@ public class RealmTokenBucketRateLimiter implements RateLimiter {
    */
   @Override
   public boolean canProceed() {
-    return tokenBucketFactory.getOrCreateTokenBucket(realmContext).tryAcquire();
+    return tokenBucketFactory.getOrCreateTokenBucket(realmId).tryAcquire();
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketFactory.java
@@ -18,10 +18,10 @@
  */
 package org.apache.polaris.service.ratelimiter;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /** Factory for creating token buckets per realm. */
 public interface TokenBucketFactory {
 
-  TokenBucket getOrCreateTokenBucket(RealmContext realmContext);
+  TokenBucket getOrCreateTokenBucket(RealmId realmId);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -102,7 +102,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
             new PolarisStorageIntegration<>("file") {
               @Override
               public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-                  @Nonnull RealmContext realmContext,
+                  @Nonnull RealmId realmId,
                   @Nonnull PolarisDiagnostics diagnostics,
                   @Nonnull T storageConfig,
                   boolean allowListOperation,
@@ -114,7 +114,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
               @Override
               public @Nonnull Map<String, Map<PolarisStorageActions, ValidationResult>>
                   validateAccessToLocations(
-                      @Nonnull RealmContext realmContext,
+                      @Nonnull RealmId realmId,
                       @Nonnull T storageConfig,
                       @Nonnull Set<PolarisStorageActions> actions,
                       @Nonnull Set<String> locations) {

--- a/service/common/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.slf4j.Logger;
@@ -56,12 +56,12 @@ public class ManifestFileCleanupTaskHandler implements TaskHandler {
   public static final int FILE_DELETION_RETRY_MILLIS = 100;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ManifestFileCleanupTaskHandler.class);
-  private final BiFunction<TaskEntity, RealmContext, FileIO> fileIOSupplier;
+  private final BiFunction<TaskEntity, RealmId, FileIO> fileIOSupplier;
   private final ExecutorService executorService;
   private final PolarisDiagnostics diagnostics;
 
   public ManifestFileCleanupTaskHandler(
-      BiFunction<TaskEntity, RealmContext, FileIO> fileIOSupplier,
+      BiFunction<TaskEntity, RealmId, FileIO> fileIOSupplier,
       ExecutorService executorService,
       PolarisDiagnostics diagnostics) {
     this.fileIOSupplier = fileIOSupplier;
@@ -76,10 +76,10 @@ public class ManifestFileCleanupTaskHandler implements TaskHandler {
   }
 
   @Override
-  public boolean handleTask(TaskEntity task, RealmContext realmContext) {
+  public boolean handleTask(TaskEntity task, RealmId realmId) {
     ManifestCleanupTask cleanupTask = task.readData(diagnostics, ManifestCleanupTask.class);
     TableIdentifier tableId = cleanupTask.getTableId();
-    try (FileIO authorizedFileIO = fileIOSupplier.apply(task, realmContext)) {
+    try (FileIO authorizedFileIO = fileIOSupplier.apply(task, realmId)) {
       if (task.getTaskType(diagnostics) == AsyncTaskType.MANIFEST_FILE_CLEANUP) {
         ManifestFile manifestFile = decodeManifestData(cleanupTask.getManifestFileData());
         return cleanUpManifestFile(manifestFile, authorizedFileIO, tableId);

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -59,7 +59,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final PolarisConfigurationStore configurationStore;
   private final PolarisDiagnostics diagnostics;
-  private final BiFunction<TaskEntity, RealmContext, FileIO> fileIOSupplier;
+  private final BiFunction<TaskEntity, RealmId, FileIO> fileIOSupplier;
   private final Clock clock;
 
   public TableCleanupTaskHandler(
@@ -67,7 +67,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
       MetaStoreManagerFactory metaStoreManagerFactory,
       PolarisConfigurationStore configurationStore,
       PolarisDiagnostics diagnostics,
-      BiFunction<TaskEntity, RealmContext, FileIO> fileIOSupplier,
+      BiFunction<TaskEntity, RealmId, FileIO> fileIOSupplier,
       Clock clock) {
     this.taskExecutor = taskExecutor;
     this.metaStoreManagerFactory = metaStoreManagerFactory;
@@ -89,12 +89,12 @@ public class TableCleanupTaskHandler implements TaskHandler {
   }
 
   @Override
-  public boolean handleTask(TaskEntity cleanupTask, RealmContext realmContext) {
+  public boolean handleTask(TaskEntity cleanupTask, RealmId realmId) {
     PolarisBaseEntity entity = cleanupTask.readData(diagnostics, PolarisBaseEntity.class);
     PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId);
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
 
     TableLikeEntity tableEntity = TableLikeEntity.of(entity);
     LOGGER
@@ -106,7 +106,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
     // It's likely the cleanupTask has already been completed, but wasn't dropped successfully.
     // Log a
     // warning and move on
-    try (FileIO fileIO = fileIOSupplier.apply(cleanupTask, realmContext)) {
+    try (FileIO fileIO = fileIOSupplier.apply(cleanupTask, realmId)) {
       if (!TaskUtils.exists(tableEntity.getMetadataLocation(), fileIO)) {
         LOGGER
             .atWarn()
@@ -132,7 +132,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
       // TODO: handle partition statistics files
       Stream<TaskEntity> metadataFileCleanupTasks =
           getMetadataTaskStream(
-              realmContext,
+              realmId,
               cleanupTask,
               tableMetadata,
               tableEntity,
@@ -157,7 +157,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
             .log(
                 "Successfully queued tasks to delete manifests, previous metadata, and statistics files - deleting table metadata file");
         for (PolarisBaseEntity createdTask : createdTasks) {
-          taskExecutor.addTaskHandlerContext(createdTask.getId(), realmContext);
+          taskExecutor.addTaskHandlerContext(createdTask.getId(), realmId);
         }
 
         fileIO.deleteFile(tableEntity.getMetadataLocation());
@@ -222,7 +222,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
   }
 
   private Stream<TaskEntity> getMetadataTaskStream(
-      RealmContext realmContext,
+      RealmId realmId,
       TaskEntity cleanupTask,
       TableMetadata tableMetadata,
       TableLikeEntity tableEntity,
@@ -230,7 +230,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
       PolarisMetaStoreSession metaStoreSession,
       PolarisConfigurationStore configurationStore,
       Clock clock) {
-    int batchSize = configurationStore.getConfiguration(realmContext, BATCH_SIZE_CONFIG_KEY, 10);
+    int batchSize = configurationStore.getConfiguration(realmId, BATCH_SIZE_CONFIG_KEY, 10);
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutor.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutor.java
@@ -18,12 +18,12 @@
  */
 package org.apache.polaris.service.task;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 
 /**
  * Execute a task asynchronously with a provided context. The context must be cloned so that callers
  * can close their own context and closables
  */
 public interface TaskExecutor {
-  void addTaskHandlerContext(long taskEntityId, RealmContext realmContext);
+  void addTaskHandlerContext(long taskEntityId, RealmId realmId);
 }

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Given a list of registered {@link TaskHandler}s, execute tasks asynchronously with the provided
- * {@link RealmContext}.
+ * {@link RealmId}.
  */
 public class TaskExecutorImpl implements TaskExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecutorImpl.class);
@@ -91,37 +91,36 @@ public class TaskExecutorImpl implements TaskExecutor {
   }
 
   /**
-   * Register a {@link RealmContext} for a specific task id. That task will be loaded and executed
-   * asynchronously with a copy of the provided {@link RealmContext} (because the realm context is a
+   * Register a {@link RealmId} for a specific task id. That task will be loaded and executed
+   * asynchronously with a copy of the provided {@link RealmId} (because the realm context is a
    * request-scoped component).
    */
   @Override
-  public void addTaskHandlerContext(long taskEntityId, RealmContext realmContext) {
-    tryHandleTask(taskEntityId, RealmContext.copyOf(realmContext), null, 1);
+  public void addTaskHandlerContext(long taskEntityId, RealmId realmId) {
+    tryHandleTask(taskEntityId, realmId, null, 1);
   }
 
   private @Nonnull CompletableFuture<Void> tryHandleTask(
-      long taskEntityId, RealmContext realmContext, Throwable e, int attempt) {
+      long taskEntityId, RealmId realmId, Throwable e, int attempt) {
     if (attempt > 3) {
       return CompletableFuture.failedFuture(e);
     }
-    return CompletableFuture.runAsync(
-            () -> handleTask(taskEntityId, realmContext, attempt), executor)
+    return CompletableFuture.runAsync(() -> handleTask(taskEntityId, realmId, attempt), executor)
         .exceptionallyComposeAsync(
             (t) -> {
               LOGGER.warn("Failed to handle task entity id {}", taskEntityId, t);
-              return tryHandleTask(taskEntityId, realmContext, t, attempt + 1);
+              return tryHandleTask(taskEntityId, realmId, t, attempt + 1);
             },
             CompletableFuture.delayedExecutor(
                 TASK_RETRY_DELAY * (long) attempt, TimeUnit.MILLISECONDS, executor));
   }
 
-  protected void handleTask(long taskEntityId, RealmContext realmContext, int attempt) {
+  protected void handleTask(long taskEntityId, RealmId realmId, int attempt) {
     LOGGER.info("Handling task entity id {}", taskEntityId);
     PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId);
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     PolarisBaseEntity taskEntity =
         metaStoreManager.loadEntity(metaStoreSession, 0L, taskEntityId).getEntity();
     if (!PolarisEntityType.TASK.equals(taskEntity.getType())) {
@@ -139,7 +138,7 @@ public class TaskExecutorImpl implements TaskExecutor {
       return;
     }
     TaskHandler handler = handlerOpt.get();
-    boolean success = handler.handleTask(task, realmContext);
+    boolean success = handler.handleTask(task, realmId);
     if (success) {
       LOGGER
           .atInfo()

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskFileIOSupplier.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskFileIOSupplier.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -37,7 +37,7 @@ import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 
 @ApplicationScoped
-public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmContext, FileIO> {
+public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmId, FileIO> {
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final FileIOFactory fileIOFactory;
   private final PolarisConfigurationStore configurationStore;
@@ -53,25 +53,25 @@ public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmContext, 
   }
 
   @Override
-  public FileIO apply(TaskEntity task, RealmContext realmContext) {
+  public FileIO apply(TaskEntity task, RealmId realmId) {
     Map<String, String> internalProperties = task.getInternalPropertiesAsMap();
     String location = internalProperties.get(PolarisTaskConstants.STORAGE_LOCATION);
     PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmId);
     PolarisMetaStoreSession metaStoreSession =
-        metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+        metaStoreManagerFactory.getOrCreateSessionSupplier(realmId).get();
     Map<String, String> properties = new HashMap<>(internalProperties);
 
     Boolean skipCredentialSubscopingIndirection =
         configurationStore.getConfiguration(
-            realmContext,
+            realmId,
             PolarisConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.key,
             PolarisConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.defaultValue);
 
     if (!skipCredentialSubscopingIndirection) {
       properties.putAll(
           metaStoreManagerFactory
-              .getOrCreateStorageCredentialCache(realmContext)
+              .getOrCreateStorageCredentialCache(realmId)
               .getOrGenerateSubScopeCreds(
                   metaStoreManager,
                   metaStoreSession,

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskHandler.java
@@ -18,11 +18,11 @@
  */
 package org.apache.polaris.service.task;
 
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.RealmId;
 import org.apache.polaris.core.entity.TaskEntity;
 
 public interface TaskHandler {
   boolean canHandleTask(TaskEntity task);
 
-  boolean handleTask(TaskEntity task, RealmContext realmContext);
+  boolean handleTask(TaskEntity task, RealmId realmId);
 }

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -44,7 +44,7 @@ Notable configuration used to secure a Polaris deployment are outlined below.
 > [!WARNING]  
 > Ensure that the `tokenBroker` setting reflects the token broker specified in `oauth2` above.
 
-#### callContextResolver & realmContextResolver
+#### callContextResolver & realmIdResolver
 * Use these configurations to specify a service that can resolve a realm from bearer tokens.
 * The service(s) used here must implement the relevant interfaces (i.e. [CallContextResolver](https://github.com/apache/polaris/blob/8290019c10290a600e40b35ddb1e2f54bf99e120/polaris-service/src/main/java/io/polaris/service/context/CallContextResolver.java#L27) and [RealmContextResolver](https://github.com/apache/polaris/blob/7ce86f10a68a3b56aed766235c88d6027c0de038/polaris-service/src/main/java/io/polaris/service/context/RealmContextResolver.java)).
 


### PR DESCRIPTION
`RealmContext` is not an actual context but just a container for the ID of the realm. This change makes this explicit.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
