### PR TITLE
Generate docs for Quarkus configs

### DIFF
--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -23,7 +23,10 @@ plugins {
 
 description = "Polaris site - reference docs"
 
-val genProjectPaths = listOf<String>()
+val genProjectPaths = listOf(
+  ":polaris-quarkus-service",
+  ":polaris-eclipselink",
+)
 
 val genProjects by configurations.creating
 val genSources by configurations.creating


### PR DESCRIPTION
... also fixes an issue when resolving _inner_ classes leading to `$` to be replaced with `.` (not 100% conformant, but works).

The generated docs can currently only be inspected after running `./gradlew :polaris-config-docs-site:generateDocs` in `tools/config-docs/site/build/markdown-docs`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
