### PR TITLE
Admin tool: change root package and create binary distributions

### DIFF
--- a/quarkus/admin/README.md
+++ b/quarkus/admin/README.md
@@ -4,7 +4,26 @@ This module contains a maintenance tool for performing administrative tasks on t
 It is a Quarkus application that can be used to perform various maintenance tasks targeting the
 Polaris database directly.
 
-Building this module will create a runnable uber-jar that can be executed from the command line.
+## Archive distribution
+
+Building this module will create a zip/tar distribution with the Polaris server.
+
+To build the distribution, you can use the following command:
+
+```shell
+./gradlew :polaris-quarkus-admin:build
+```
+
+You can manually unpack and run the distribution archives:
+
+```shell
+cd quarkus/admin/build/distributions
+unzip polaris-quarkus-admin-<version>.zip
+cd polaris-quarkus-admin-<version>
+java -jar polaris-quarkus-admin-<version>-runner.jar
+```
+
+## Docker image
 
 To also build the Docker image, you can use the following command:
 

--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
   alias(libs.plugins.openapi.generator)
   id("polaris-server")
   id("polaris-license-report")
+  id("distribution")
 }
 
 dependencies {
@@ -84,3 +85,17 @@ tasks.named("sourcesJar") { dependsOn("compileQuarkusGeneratedSourcesJava") }
 tasks.named("javadoc") { dependsOn("jandex") }
 
 tasks.named("quarkusDependenciesBuild") { dependsOn("jandex") }
+
+tasks.named("distZip") { dependsOn("quarkusBuild") }
+
+tasks.named("distTar") { dependsOn("quarkusBuild") }
+
+distributions {
+  main {
+    contents {
+      from("../../NOTICE")
+      from("../../LICENSE-BINARY-DIST").rename("LICENSE-BINARY-DIST", "LICENSE")
+      from(project.layout.buildDirectory) { include("polaris-quarkus-admin-*-runner.jar") }
+    }
+  }
+}

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
 import jakarta.inject.Inject;
 import java.util.concurrent.Callable;

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
 import java.util.List;
 import java.util.Map;

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/PolarisAdminTool.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/PolarisAdminTool.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import java.io.PrintWriter;

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/PolarisVersionProvider.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/PolarisVersionProvider.java
@@ -16,32 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.polaris.version.PolarisVersion;
+import picocli.CommandLine.IVersionProvider;
 
-import io.quarkus.test.junit.main.Launch;
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-import org.junit.jupiter.api.Test;
+public class PolarisVersionProvider implements IVersionProvider {
 
-@QuarkusMainTest
-class BootstrapCommandTest {
-
-  @Test
-  @Launch(
-      value = {
-        "bootstrap",
-        "-r",
-        "realm1",
-        "-r",
-        "realm2",
-        "-c",
-        "realm1,root,root,s3cr3t",
-        "-c",
-        "realm2,root,root,s3cr3t"
-      })
-  public void testBootstrap(LaunchResult result) {
-    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
+  @Override
+  public String[] getVersion() {
+    return new String[] {PolarisVersion.polarisVersionString()};
   }
 }

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/PurgeCommand.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/PurgeCommand.java
@@ -16,15 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
-import org.apache.polaris.version.PolarisVersion;
-import picocli.CommandLine.IVersionProvider;
+import java.util.List;
+import picocli.CommandLine;
 
-public class PolarisVersionProvider implements IVersionProvider {
+@CommandLine.Command(
+    name = "purge",
+    mixinStandardHelpOptions = true,
+    description = "Purge principal credentials.")
+public class PurgeCommand extends BaseCommand {
+
+  @CommandLine.Option(
+      names = {"-r", "--realm"},
+      required = true,
+      description = "The name of a realm to purge.")
+  List<String> realms;
 
   @Override
-  public String[] getVersion() {
-    return new String[] {PolarisVersion.polarisVersionString()};
+  public Integer call() {
+    warnOnInMemory();
+
+    try {
+      metaStoreManagerFactory.purgeRealms(realms);
+      spec.commandLine().getOut().println("Purge completed successfully.");
+      return 0;
+    } catch (Exception e) {
+      spec.commandLine().getErr().println("Purge encountered errors during operation.");
+      return EXIT_CODE_PURGE_ERROR;
+    }
   }
 }

--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -16,34 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
-import java.util.List;
-import picocli.CommandLine;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@CommandLine.Command(
-    name = "purge",
-    mixinStandardHelpOptions = true,
-    description = "Purge principal credentials.")
-public class PurgeCommand extends BaseCommand {
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+import org.junit.jupiter.api.Test;
 
-  @CommandLine.Option(
-      names = {"-r", "--realm"},
-      required = true,
-      description = "The name of a realm to purge.")
-  List<String> realms;
+@QuarkusMainTest
+class BootstrapCommandTest {
 
-  @Override
-  public Integer call() {
-    warnOnInMemory();
-
-    try {
-      metaStoreManagerFactory.purgeRealms(realms);
-      spec.commandLine().getOut().println("Purge completed successfully.");
-      return 0;
-    } catch (Exception e) {
-      spec.commandLine().getErr().println("Purge encountered errors during operation.");
-      return EXIT_CODE_PURGE_ERROR;
-    }
+  @Test
+  @Launch(
+      value = {
+        "bootstrap",
+        "-r",
+        "realm1",
+        "-r",
+        "realm2",
+        "-c",
+        "realm1,root,root,s3cr3t",
+        "-c",
+        "realm2,root,root,s3cr3t"
+      })
+  public void testBootstrap(LaunchResult result) {
+    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
   }
 }

--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.admin;
+package org.apache.polaris.admintool;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Small leftovers from #605:

* The root package wasn't accurate (could be confused with packages in `polaris-quarkus-service`)
* The binary distribution wasn't being generated.
