### PR TITLE
Fix CardinalityLimitSelector ClassNotFoundException when starting Polaris

### DIFF
--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
   // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
   implementation(platform(libs.dnsjava))
 
+  implementation(platform(libs.opentelemetry.bom))
+
   implementation(platform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-logging-json")
   implementation("io.quarkus:quarkus-rest-jackson")


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
When starting Polaris with the command:
```bash
./gradlew :polaris-quarkus-service:quarkusRun
```
a `java.lang.ClassNotFoundException: io.opentelemetry.sdk.metrics.internal.export.CardinalityLimitSelector` is encountered.