### PR TITLE
Fix RateLimiterFilter configuration

### DIFF
--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -59,7 +59,8 @@ import org.apache.polaris.service.quarkus.auth.QuarkusAuthenticationConfiguratio
 import org.apache.polaris.service.quarkus.catalog.io.QuarkusFileIOConfiguration;
 import org.apache.polaris.service.quarkus.context.QuarkusRealmContextConfiguration;
 import org.apache.polaris.service.quarkus.persistence.QuarkusPersistenceConfiguration;
-import org.apache.polaris.service.quarkus.ratelimiter.QuarkusRateLimiterConfiguration;
+import org.apache.polaris.service.quarkus.ratelimiter.QuarkusRateLimiterFilterConfiguration;
+import org.apache.polaris.service.quarkus.ratelimiter.QuarkusTokenBucketConfiguration;
 import org.apache.polaris.service.ratelimiter.RateLimiter;
 import org.apache.polaris.service.ratelimiter.TokenBucketFactory;
 import org.apache.polaris.service.task.TaskHandlerConfiguration;
@@ -186,15 +187,15 @@ public class QuarkusProducers {
 
   @Produces
   public RateLimiter rateLimiter(
-      QuarkusRateLimiterConfiguration config, @Any Instance<RateLimiter> rateLimiters) {
+      QuarkusRateLimiterFilterConfiguration config, @Any Instance<RateLimiter> rateLimiters) {
     return rateLimiters.select(Identifier.Literal.of(config.type())).get();
   }
 
   @Produces
   public TokenBucketFactory tokenBucketFactory(
-      QuarkusRateLimiterConfiguration config,
+      QuarkusTokenBucketConfiguration config,
       @Any Instance<TokenBucketFactory> tokenBucketFactories) {
-    return tokenBucketFactories.select(Identifier.Literal.of(config.tokenBucket().type())).get();
+    return tokenBucketFactories.select(Identifier.Literal.of(config.type())).get();
   }
 
   @Produces

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusRateLimiterFilterConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusRateLimiterFilterConfiguration.java
@@ -18,27 +18,16 @@
  */
 package org.apache.polaris.service.quarkus.ratelimiter;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Alternative;
-import jakarta.inject.Inject;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import org.apache.polaris.service.ratelimiter.DefaultTokenBucketFactory;
-import org.apache.polaris.service.ratelimiter.TokenBucketConfiguration;
-import org.threeten.extra.MutableClock;
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
 
-/** TokenBucketFactory with a mock clock */
-@Alternative
-@ApplicationScoped
-public class MockTokenBucketFactory extends DefaultTokenBucketFactory {
-  public static MutableClock CLOCK = MutableClock.of(Instant.now(), ZoneOffset.UTC);
+@StaticInitSafe
+@ConfigMapping(prefix = "polaris.rate-limiter.filter")
+public interface QuarkusRateLimiterFilterConfiguration {
 
-  public MockTokenBucketFactory() {
-    super(0, null, CLOCK);
-  }
-
-  @Inject
-  public MockTokenBucketFactory(TokenBucketConfiguration configuration) {
-    super(configuration, CLOCK);
-  }
+  /**
+   * The type of the rate limiter. Must be a registered {@link
+   * org.apache.polaris.service.ratelimiter.RateLimiter} identifier.
+   */
+  String type();
 }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusTokenBucketConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusTokenBucketConfiguration.java
@@ -20,28 +20,15 @@ package org.apache.polaris.service.quarkus.ratelimiter;
 
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
-import org.apache.polaris.service.ratelimiter.RateLimiterConfiguration;
+import org.apache.polaris.service.ratelimiter.TokenBucketConfiguration;
 
 @StaticInitSafe
-@ConfigMapping(prefix = "polaris.rate-limiter")
-public interface QuarkusRateLimiterConfiguration extends RateLimiterConfiguration {
+@ConfigMapping(prefix = "polaris.rate-limiter.token-bucket")
+public interface QuarkusTokenBucketConfiguration extends TokenBucketConfiguration {
 
   /**
-   * The type of the rate limiter. Must be a registered {@link
-   * org.apache.polaris.service.ratelimiter.RateLimiter} identifier.
+   * The type of the token bucket factory. Must be a registered {@link
+   * org.apache.polaris.service.ratelimiter.TokenBucketFactory} identifier.
    */
   String type();
-
-  /** The configuration for the token bucket rate limiter. */
-  @Override
-  QuarkusTokenBucketConfiguration tokenBucket();
-
-  interface QuarkusTokenBucketConfiguration extends TokenBucketConfiguration {
-
-    /**
-     * The type of the token bucket factory. Must be a registered {@link
-     * org.apache.polaris.service.ratelimiter.TokenBucketFactory} identifier.
-     */
-    String type();
-  }
 }

--- a/quarkus/service/src/main/resources/application.properties
+++ b/quarkus/service/src/main/resources/application.properties
@@ -98,7 +98,7 @@ polaris.metrics.tags.application=Polaris
 # polaris.tasks.max-concurrent-tasks=100
 # polaris.tasks.max-queued-tasks=1000
 
-polaris.rate-limiter.type=no-op
+polaris.rate-limiter.filter.type=no-op
 polaris.rate-limiter.token-bucket.type=default
 polaris.rate-limiter.token-bucket.requests-per-second=9999
 polaris.rate-limiter.token-bucket.window=PT10S

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/RateLimiterFilterTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/RateLimiterFilterTest.java
@@ -66,7 +66,7 @@ public class RateLimiterFilterTest {
     @Override
     public Map<String, String> getConfigOverrides() {
       return Map.of(
-          "polaris.rate-limiter.type",
+          "polaris.rate-limiter.filter.type",
           "default",
           "polaris.rate-limiter.token-bucket.type",
           "default",

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/DefaultTokenBucketFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/DefaultTokenBucketFactory.java
@@ -37,11 +37,8 @@ public class DefaultTokenBucketFactory implements TokenBucketFactory {
   private final Map<String, TokenBucket> perRealmBuckets = new ConcurrentHashMap<>();
 
   @Inject
-  public DefaultTokenBucketFactory(RateLimiterConfiguration configuration, Clock clock) {
-    this(
-        configuration.tokenBucket().requestsPerSecond(),
-        configuration.tokenBucket().window(),
-        clock);
+  public DefaultTokenBucketFactory(TokenBucketConfiguration configuration, Clock clock) {
+    this(configuration.requestsPerSecond(), configuration.window(), clock);
   }
 
   public DefaultTokenBucketFactory(long requestsPerSecond, Duration window, Clock clock) {

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
@@ -18,9 +18,13 @@
  */
 package org.apache.polaris.service.ratelimiter;
 
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
@@ -29,6 +33,9 @@ import org.slf4j.LoggerFactory;
 
 /** Request filter that returns a 429 Too Many Requests if the rate limiter says so */
 @Provider
+@PreMatching
+@Priority(Priorities.USER)
+@ApplicationScoped
 public class RateLimiterFilter implements ContainerRequestFilter {
   private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiterFilter.class);
 

--- a/service/common/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/ratelimiter/TokenBucketConfiguration.java
@@ -20,14 +20,9 @@ package org.apache.polaris.service.ratelimiter;
 
 import java.time.Duration;
 
-public interface RateLimiterConfiguration {
+public interface TokenBucketConfiguration {
 
-  TokenBucketConfiguration tokenBucket();
+  long requestsPerSecond();
 
-  interface TokenBucketConfiguration {
-
-    long requestsPerSecond();
-
-    Duration window();
-  }
+  Duration window();
 }


### PR DESCRIPTION
The filter itself was missing some important annotations.

Its configuration has been simplified slightly as well.