### PR TITLE
Ability to run quarkusRun on polaris-quarkus-server

### DIFF
--- a/quarkus/server/README.md
+++ b/quarkus/server/README.md
@@ -2,7 +2,26 @@
 
 This module contains the Quarkus-based Polaris server main artifact.
 
+## Archive distribution
+
 Building this module will create a zip/tar distribution with the Polaris server.
+
+To build the distribution, you can use the following command:
+
+```shell
+./gradlew :polaris-quarkus-server:build
+```
+
+You can manually unpack and run the distribution archives:
+
+```shell
+cd quarkus/server/build/distributions
+unzip polaris-quarkus-server-<version>.zip
+cd polaris-quarkus-server-<version>
+java -jar quarkus-run.jar
+```
+
+## Docker image
 
 To also build the Docker image, you can use the following command (a running Docker daemon is
 required):

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -61,9 +61,7 @@ tasks.named("distZip") { dependsOn("quarkusBuild") }
 
 tasks.named("distTar") { dependsOn("quarkusBuild") }
 
-tasks.named("javadoc") { enabled = false }
-
-tasks.named("sourcesJar") { enabled = false }
+tasks.withType<Javadoc> { isFailOnError = false }
 
 tasks.register("polarisServerRun") { dependsOn("quarkusRun") }
 

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -61,6 +61,12 @@ tasks.named("distZip") { dependsOn("quarkusBuild") }
 
 tasks.named("distTar") { dependsOn("quarkusBuild") }
 
+tasks.named("javadoc") { enabled = false }
+
+tasks.named("sourcesJar") { enabled = false }
+
+tasks.register("polarisServerRun") { dependsOn("quarkusRun") }
+
 distributions {
   main {
     contents {

--- a/quarkus/server/src/main/java/org/apache/polaris/server/quarkus/package-info.java
+++ b/quarkus/server/src/main/java/org/apache/polaris/server/quarkus/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.server.quarkus;
+
+// This file is here as a placeholder to allow quarkusDev and quarkusRun
+// tasks to work, since this module currently has no source files.


### PR DESCRIPTION
Also adds a task named `polarisServerRun` to make it easier to run a Polaris server with Gradle. Note: the server is started with `prod` profile.
Also adds a note about the binary distribution and how to unpack and run it.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
