### PR TITLE
Fix catalog names in integration tests

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -353,8 +353,8 @@ public class PolarisApplicationIntegrationTest {
   }
 
   @Test
-  public void testIcebergCreateTablesInExternalCatalog(TestInfo testInfo) throws IOException {
-    String catalogName = testInfo.getTestMethod().orElseThrow().getName() + "External";
+  public void testIcebergCreateTablesInExternalCatalog() throws IOException {
+    String catalogName = client.newEntityName("testIcebergCreateTablesInExternalCatalogExternal");
     createCatalog(catalogName, Catalog.TypeEnum.EXTERNAL, principalRoleName);
     try (RESTSessionCatalog sessionCatalog = newSessionCatalog(catalogName)) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
@@ -380,8 +380,9 @@ public class PolarisApplicationIntegrationTest {
   }
 
   @Test
-  public void testIcebergCreateTablesWithWritePathBlocked(TestInfo testInfo) throws IOException {
-    String catalogName = testInfo.getTestMethod().orElseThrow().getName() + "Internal";
+  public void testIcebergCreateTablesWithWritePathBlocked() throws IOException {
+    String catalogName =
+        client.newEntityName("testIcebergCreateTablesWithWritePathBlockedInternal");
     createCatalog(catalogName, Catalog.TypeEnum.INTERNAL, principalRoleName);
     try (RESTSessionCatalog sessionCatalog = newSessionCatalog(catalogName)) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
@@ -424,8 +425,8 @@ public class PolarisApplicationIntegrationTest {
   }
 
   @Test
-  public void testIcebergRegisterTableInExternalCatalog(TestInfo testInfo) throws IOException {
-    String catalogName = testInfo.getTestMethod().orElseThrow().getName() + "External";
+  public void testIcebergRegisterTableInExternalCatalog() throws IOException {
+    String catalogName = client.newEntityName("testIcebergRegisterTableInExternalCatalogExternal");
     createCatalog(
         catalogName,
         Catalog.TypeEnum.EXTERNAL,
@@ -443,8 +444,7 @@ public class PolarisApplicationIntegrationTest {
       String location =
           "file://"
               + testDir.toFile().getAbsolutePath()
-              + "/"
-              + testInfo.getTestMethod().get().getName();
+              + "/testIcebergRegisterTableInExternalCatalog";
       String metadataLocation = location + "/metadata/000001-494949494949494949.metadata.json";
 
       TableMetadata tableMetadata =
@@ -471,8 +471,8 @@ public class PolarisApplicationIntegrationTest {
   }
 
   @Test
-  public void testIcebergUpdateTableInExternalCatalog(TestInfo testInfo) throws IOException {
-    String catalogName = testInfo.getTestMethod().orElseThrow().getName() + "External";
+  public void testIcebergUpdateTableInExternalCatalog() throws IOException {
+    String catalogName = client.newEntityName("testIcebergUpdateTableInExternalCatalogExternal");
     createCatalog(
         catalogName,
         Catalog.TypeEnum.EXTERNAL,
@@ -490,8 +490,7 @@ public class PolarisApplicationIntegrationTest {
       String location =
           "file://"
               + testDir.toFile().getAbsolutePath()
-              + "/"
-              + testInfo.getTestMethod().get().getName();
+              + "/testIcebergUpdateTableInExternalCatalog";
       String metadataLocation = location + "/metadata/000001-494949494949494949.metadata.json";
 
       Types.NestedField col1 = Types.NestedField.of(1, false, "col1", Types.StringType.get());

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -396,7 +396,8 @@ public class PolarisManagementServiceIntegrationTest {
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setAllowedLocations(List.of("s3://my-old-bucket/path/to/data"))
             .build();
-    String catalogName = "mycatalog";
+    String catalogName =
+        client.newEntityName("testUpdateCatalogWithoutDefaultBaseLocationInUpdate");
     Catalog catalog =
         PolarisCatalog.builder()
             .setType(Catalog.TypeEnum.INTERNAL)


### PR DESCRIPTION
A few tests were still creating catalog names "manually". Depending on the order of test execution, you could see test failures, e.g. in `ManagementServiceIntegrationTest#testListCatalogs()`:

```
expected:
  []
 but was:
  [...]
```

Because some catalogs created in previous tests weren't deleted.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
