### PR TITLE
Cleanup test profile and make it converge with prod profile

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,6 @@
+# Polaris Integration Tests
+
+## Overview
+
+This module contains integration tests for Polaris. These tests are designed as black box tests
+that can be run against a local or remote Polaris instance.

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -86,6 +86,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * @implSpec This test expects the server to be configured with the following features configured:
+ *     <ul>
+ *       <li>{@link org.apache.polaris.core.PolarisConfiguration#ALLOW_OVERLAPPING_CATALOG_URLS}:
+ *           {@code true}
+ *       <li>{@link
+ *           org.apache.polaris.core.PolarisConfiguration#SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION}:
+ *           {@code true}
+ *     </ul>
+ *     The server must also be configured to reject request body sizes larger than 1MB (1000000
+ *     bytes).
+ */
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisApplicationIntegrationTest {
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -86,6 +86,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+/**
+ * @implSpec @implSpec This test expects the server to be configured with the following features
+ *     configured:
+ *     <ul>
+ *       <li>{@link org.apache.polaris.core.PolarisConfiguration#ALLOW_OVERLAPPING_CATALOG_URLS}:
+ *           {@code true}
+ *       <li>{@link
+ *           org.apache.polaris.core.PolarisConfiguration#ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING}:
+ *           {@code true}
+ *     </ul>
+ */
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisManagementServiceIntegrationTest {
   private static final int MAX_IDENTIFIER_LENGTH = 256;

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -96,6 +96,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
  * client.
+ *
+ * @implSpec @implSpec This test expects the server to be configured with the following features
+ *     configured:
+ *     <ul>
+ *       <li>{@link PolarisConfiguration#ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING}: {@code false}
+ *     </ul>
  */
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog> {

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -48,6 +48,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
  * client.
+ *
+ * @implSpec This test expects the server to be configured with {@link
+ *     org.apache.polaris.core.PolarisConfiguration#SUPPORTED_CATALOG_STORAGE_TYPES} set to the
+ *     appropriate storage type.
  */
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogTests<RESTCatalog> {

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisSparkIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisSparkIntegrationTest.java
@@ -58,6 +58,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @implSpec This test expects the server to be configured with the following features enabled:
+ *     <ul>
+ *       <li>{@link
+ *           org.apache.polaris.core.PolarisConfiguration#SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION}:
+ *           {@code true}
+ *       <li>{@link org.apache.polaris.core.PolarisConfiguration#ALLOW_OVERLAPPING_CATALOG_URLS}:
+ *           {@code true}
+ *     </ul>
+ */
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisSparkIntegrationTest {
 

--- a/quarkus/defaults/src/main/resources/application-it.properties
+++ b/quarkus/defaults/src/main/resources/application-it.properties
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Configuration common to ALL integration tests (executed with "it" profile).
+# Note: Quarkus integration tests cannot use QuarkusTestProfile
+
+quarkus.http.limits.max-body-size=1000000
+quarkus.http.port=0
+
+quarkus.management.port=0
+
+polaris.persistence.type=in-memory
+
+polaris.features.defaults."ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING"=false
+polaris.features.defaults."ALLOW_EXTERNAL_METADATA_FILE_LOCATION"=false
+polaris.features.defaults."ALLOW_OVERLAPPING_CATALOG_URLS"=true
+polaris.features.defaults."ALLOW_SPECIFYING_FILE_IO_IMPL"=true
+polaris.features.defaults."ALLOW_WILDCARD_LOCATION"=true
+polaris.features.defaults."ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING"=true
+polaris.features.defaults."INITIALIZE_DEFAULT_CATALOG_FILEIO_FOR_it"=true
+polaris.features.defaults."SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION"=true
+polaris.features.defaults."SUPPORTED_CATALOG_STORAGE_TYPES"=["FILE","S3","GCS","AZURE"]
+
+polaris.storage.gcp.token=token
+polaris.storage.gcp.lifespan=PT1H
+

--- a/quarkus/defaults/src/main/resources/application-test.properties
+++ b/quarkus/defaults/src/main/resources/application-test.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Configuration common to ALL unit tests (executed with "test" profile).
+# Per-test specific configuration should use QuarkusTestProfile
+
+quarkus.log.file.enable=false
+quarkus.otel.sdk.disabled=true

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -72,10 +72,10 @@ quarkus.otel.sdk.disabled=false
 # quarkus.otel.traces.sampler=parentbased_always_on
 # quarkus.otel.traces.sampler.arg=1.0d
 
-quarkus.test.integration-test-profile=test
+quarkus.test.integration-test-profile=it
 
 polaris.realm-context.type=default
-polaris.realm-context.realms=realm1,realm2,realm3
+polaris.realm-context.realms=POLARIS
 polaris.realm-context.header-name=Polaris-Realm
 
 polaris.features.defaults."ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING"=false
@@ -119,34 +119,3 @@ polaris.authentication.token-broker.max-token-generation=PT1H
 # polaris.storage.aws.secret-key=secretKey
 # polaris.storage.gcp.token=token
 # polaris.storage.gcp.lifespan=PT1H
-
-%test.quarkus.log.file.enable=false
-%test.quarkus.log.category."org.apache.polaris".level=INFO
-%test.quarkus.log.category."org.apache.iceberg.rest".level=INFO
-%test.quarkus.log.category."org.apache.iceberg.rest.RESTSessionCatalog".level=ERROR
-%test.quarkus.log.category."org.apache.polaris.core.persistence.PolarisMetaStoreManagerImpl".level=ERROR
-%test.quarkus.log.category."org.apache.polaris.service.context.DefaultRealmContextResolver".level=ERROR
-%test.quarkus.log.category."org.apache.polaris.service.catalog.PolarisCatalogHandlerWrapper".level=ERROR
-%test.quarkus.log.category."org.apache.polaris.service.storage.PolarisStorageIntegrationProviderImpl".level=ERROR
-%test.quarkus.http.limits.max-body-size=1000000
-%test.quarkus.otel.sdk.disabled=true
-%test.polaris.authentication.token-broker.type=symmetric-key
-%test.polaris.authentication.token-broker.symmetric-key.secret=polaris
-%test.polaris.features.defaults."ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING"=false
-%test.polaris.features.defaults."ALLOW_EXTERNAL_METADATA_FILE_LOCATION"=false
-%test.polaris.features.defaults."ALLOW_OVERLAPPING_CATALOG_URLS"=true
-%test.polaris.features.defaults."ALLOW_SPECIFYING_FILE_IO_IMPL"=true
-%test.polaris.features.defaults."ALLOW_WILDCARD_LOCATION"=true
-%test.polaris.features.defaults."ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING"=true
-%test.polaris.features.defaults."INITIALIZE_DEFAULT_CATALOG_FILEIO_FOR_TEST"=true
-%test.polaris.features.defaults."SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION"=true
-%test.polaris.features.defaults."SUPPORTED_CATALOG_STORAGE_TYPES"=["FILE","S3","GCS","AZURE"]
-%test.polaris.realm-context.realms=POLARIS
-%test.polaris.realm-context.type=test
-%test.polaris.storage.aws.access-key=accessKey
-%test.polaris.storage.aws.secret-key=secretKey
-%test.polaris.storage.gcp.token=token
-%test.polaris.storage.gcp.lifespan=PT1H
-# Need to allow a java security manager after Java 21, for Subject.getSubject to work
-# "getSubject is supported only if a security manager is allowed".
-%test.quarkus.test.argLine=-Djava.security.manager=allow

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -162,6 +162,9 @@ tasks.named<Test>("test").configure { maxParallelForks = 4 }
 
 tasks.named<Test>("intTest").configure {
   maxParallelForks = 1
+  // Same issue as above: allow a java security manager after Java 21
+  // (this setting is for the application under test, while the setting above is for test code).
+  systemProperty("quarkus.test.arg-line", "-Djava.security.manager=allow")
   val logsDir = project.layout.buildDirectory.get().asFile.resolve("logs")
   // delete files from previous runs
   doFirst {

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusSparkIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusSparkIT.java
@@ -19,6 +19,9 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.util.Map;
 import org.apache.polaris.service.it.test.PolarisSparkIntegrationTest;
 
 @QuarkusIntegrationTest

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TimedApplicationEventListenerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/TimedApplicationEventListenerTest.java
@@ -56,7 +56,8 @@ public class TimedApplicationEventListenerTest {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of("polaris.metrics.tags.environment", "prod");
+      return Map.of(
+          "polaris.metrics.tags.environment", "prod", "polaris.realm-context.type", "test");
     }
   }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -87,9 +87,9 @@ public abstract class PolarisAuthzTestBase {
     @Override
     public Map<String, String> getConfigOverrides() {
       return Map.of(
-          "polaris.config.defaults.ALLOW_SPECIFYING_FILE_IO_IMPL",
+          "polaris.features.defaults.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
           "true",
-          "polaris.config.defaults.ALLOW_EXTERNAL_METADATA_FILE_LOCATION",
+          "polaris.features.defaults.\"ALLOW_EXTERNAL_METADATA_FILE_LOCATION\"",
           "true");
     }
   }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
@@ -31,6 +31,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
@@ -120,7 +122,23 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 @QuarkusTest
+@TestProfile(BasePolarisCatalogTest.Profile.class)
 public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.defaults.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
+          "true",
+          "polaris.features.defaults.\"INITIALIZE_DEFAULT_CATALOG_FILEIO_FOR_TEST\"",
+          "true",
+          "polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
+          "[\"FILE\"]");
+    }
+  }
+
   protected static final Namespace NS = Namespace.of("newdb");
   protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "table");
   protected static final Schema SCHEMA =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogViewTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
@@ -64,7 +67,27 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 @QuarkusTest
+@TestProfile(BasePolarisCatalogViewTest.Profile.class)
 public class BasePolarisCatalogViewTest extends ViewCatalogTests<BasePolarisCatalog> {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.defaults.\"ALLOW_WILDCARD_LOCATION\"",
+          "true",
+          "polaris.features.defaults.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"",
+          "true",
+          "polaris.features.defaults.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
+          "true",
+          "polaris.features.defaults.\"INITIALIZE_DEFAULT_CATALOG_FILEIO_FOR_TEST\"",
+          "true",
+          "polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
+          "[\"FILE\"]");
+    }
+  }
+
   public static final String CATALOG_NAME = "polaris-catalog";
 
   @Inject MetaStoreManagerFactory managerFactory;

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisCatalogHandlerWrapperAuthzTest.java
@@ -75,7 +75,11 @@ public class PolarisCatalogHandlerWrapperAuthzTest extends PolarisAuthzTestBase 
 
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of("polaris.features.defaults.\"ALLOW_EXTERNAL_METADATA_FILE_LOCATION\"", "true");
+      return Map.of(
+          "polaris.features.defaults.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
+          "true",
+          "polaris.features.defaults.\"ALLOW_EXTERNAL_METADATA_FILE_LOCATION\"",
+          "true");
     }
   }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusApplicationIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusApplicationIntegrationTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
@@ -37,7 +39,19 @@ import org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(QuarkusApplicationIntegrationTest.Profile.class)
 public class QuarkusApplicationIntegrationTest extends PolarisApplicationIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "quarkus.http.limits.max-body-size", "1000000",
+          "polaris.features.defaults.\"ALLOW_OVERLAPPING_CATALOG_URLS\"", "true",
+          "polaris.features.defaults.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "true");
+    }
+  }
 
   @Test
   public void testIcebergRestApiRefreshToken(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusManagementServiceIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusManagementServiceIntegrationTest.java
@@ -19,8 +19,29 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.util.Map;
 import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
 
 @QuarkusTest
+@TestProfile(QuarkusManagementServiceIntegrationTest.Profile.class)
 public class QuarkusManagementServiceIntegrationTest
-    extends PolarisManagementServiceIntegrationTest {}
+    extends PolarisManagementServiceIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.defaults.\"ALLOW_OVERLAPPING_CATALOG_URLS\"",
+          "true",
+          "polaris.features.defaults.\"ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING\"",
+          "true",
+          "polaris.storage.gcp.token",
+          "token",
+          "polaris.storage.gcp.lifespan",
+          "PT1H");
+    }
+  }
+}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogIntegrationTest.java
@@ -19,7 +19,21 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.util.Map;
 import org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationTest;
 
 @QuarkusTest
-public class QuarkusRestCatalogIntegrationTest extends PolarisRestCatalogIntegrationTest {}
+@TestProfile(QuarkusRestCatalogIntegrationTest.Profile.class)
+public class QuarkusRestCatalogIntegrationTest extends PolarisRestCatalogIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.defaults.\"ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING\"", "false");
+    }
+  }
+}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAwsIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAwsIntegrationTest.java
@@ -19,16 +19,28 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Map;
 import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewAwsIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusTest
+@TestProfile(QuarkusRestCatalogViewAwsIntegrationTest.Profile.class)
 public class QuarkusRestCatalogViewAwsIntegrationTest
     extends PolarisRestCatalogViewAwsIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"S3\"]");
+    }
+  }
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAzureIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAzureIntegrationTest.java
@@ -19,16 +19,27 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Map;
 import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewAzureIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusTest
+@TestProfile(QuarkusRestCatalogViewAzureIntegrationTest.Profile.class)
 public class QuarkusRestCatalogViewAzureIntegrationTest
     extends PolarisRestCatalogViewAzureIntegrationTest {
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"AZURE\"]");
+    }
+  }
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIntegrationTest.java
@@ -19,8 +19,10 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Map;
 import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,14 @@ import org.junit.jupiter.api.io.TempDir;
 @QuarkusTest
 public class QuarkusRestCatalogViewFileIntegrationTest
     extends PolarisRestCatalogViewFileIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
+    }
+  }
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewGcpIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewGcpIntegrationTest.java
@@ -19,8 +19,10 @@
 package org.apache.polaris.service.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Map;
 import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewGcpIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,14 @@ import org.junit.jupiter.api.io.TempDir;
 @QuarkusTest
 public class QuarkusRestCatalogViewGcpIntegrationTest
     extends PolarisRestCatalogViewGcpIntegrationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("polaris.features.defaults.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"GCS\"]");
+    }
+  }
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/RateLimiterFilterTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/ratelimiter/RateLimiterFilterTest.java
@@ -75,7 +75,9 @@ public class RateLimiterFilterTest {
           "polaris.rate-limiter.token-bucket.window",
           WINDOW.toString(),
           "polaris.metrics.tags.environment",
-          "prod");
+          "prod",
+          "polaris.realm-context.type",
+          "test");
     }
   }
 


### PR DESCRIPTION
This PR cleans up the test profile and makes it converge with the prod profile, which is better as by default, tests are testing the real-life application.

If tests need to customize the configuration, this is now done on a per-test basis.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
