### PR TITLE
Add specialized `polaris-quarkus` build-plugin

### DIFF
--- a/build-logic/src/main/kotlin/polaris-quarkus.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-quarkus.gradle.kts
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import gradle.kotlin.dsl.accessors._fa00c0b20184971a79f32516372275b9.testing
+import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+
+plugins { id("polaris-server") }
+
+testing {
+  suites {
+    withType<JvmTestSuite> {
+      targets.all {
+        if (testTask.name != "test") {
+          testTask.configure {
+            // For Quarkus...
+            //
+            // io.quarkus.test.junit.IntegrationTestUtil.determineBuildOutputDirectory(java.net.URL)
+            // is not smart enough :(
+            systemProperty("build.output.directory", layout.buildDirectory.asFile.get())
+            dependsOn(tasks.named("quarkusBuild"))
+          }
+        }
+      }
+    }
+    register<JvmTestSuite>("intTest") {
+      testType = TestSuiteType.INTEGRATION_TEST
+      targets.all {
+        tasks.named("compileIntTestJava").configure {
+          dependsOn(tasks.named("compileQuarkusTestGeneratedSourcesJava"))
+        }
+      }
+      sources { java.srcDirs(tasks.named("quarkusGenerateCodeTests")) }
+    }
+  }
+}
+
+// Let the test's implementation config extend testImplementation, so it also inherits the
+// project's "main" implementation dependencies (not just the "api" configuration)
+configurations.named("intTestImplementation").configure {
+  extendsFrom(configurations.getByName("testImplementation"))
+}
+
+dependencies { add("intTestImplementation", java.sourceSets.getByName("test").output.dirs) }
+
+configurations.named("intTestRuntimeOnly").configure {
+  extendsFrom(configurations.getByName("testRuntimeOnly"))
+}

--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   alias(libs.plugins.quarkus)
   alias(libs.plugins.jandex)
   alias(libs.plugins.openapi.generator)
-  id("polaris-server")
+  id("polaris-quarkus")
   id("polaris-license-report")
   id("distribution")
 }

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
   alias(libs.plugins.quarkus)
   alias(libs.plugins.openapi.generator)
-  id("polaris-server")
+  id("polaris-quarkus")
   id("polaris-license-report")
   id("distribution")
 }

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
   alias(libs.plugins.quarkus)
   alias(libs.plugins.jandex)
-  id("polaris-server")
+  id("polaris-quarkus")
 }
 
 dependencies {


### PR DESCRIPTION
This change adds a `polaris-quarkus` build-plugin based on `polaris-server`. It has the specialties for Quarkus based projects, like the implicit `intTest` suite.

This has the nice side effect of not having an unused `intTest` test suite in every project, and removes a bunch of `if`s.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
