### PR TITLE
Allow overriding the published parent pom's name and description

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -37,6 +37,8 @@ abstract class PublishingHelperExtension
 constructor(objectFactory: ObjectFactory, project: Project) {
   // the following are only relevant on the root project
   val asfProjectName = objectFactory.property<String>().convention(project.name)
+  val overrideName = objectFactory.property<String>()
+  val overrideDescription = objectFactory.property<String>()
   val baseName =
     objectFactory
       .property<String>()

--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -107,8 +107,8 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
             }
             issueManagement { url.set(projectPeople.bugDatabase) }
 
-            name.set(projectPeople.name)
-            description.set(projectPeople.description)
+            name.set(e.overrideName.orElse(projectPeople.name))
+            description.set(e.overrideDescription.orElse(projectPeople.description))
             url.set(projectPeople.website)
             inceptionYear.set(projectPeople.inceptionYear.toString())
 


### PR DESCRIPTION
The publishing-helper in Polaris derives the name and description used in the parent POM from ASF's published project information. If an Apache projects wants to publish the parent pom for a _related_ project, the name and description in the pom (may) need to be different (as for #785). This change allows this.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
