### PR TITLE
Allow Gradle included builds to use a different group ID

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-group=org.apache.polaris
 
 # enable the Gradle build cache
 org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,4 +72,7 @@ dependencyResolutionManagement {
   }
 }
 
-gradle.beforeProject { version = baseVersion }
+gradle.beforeProject {
+  version = baseVersion
+  group = "org.apache.polaris"
+}


### PR DESCRIPTION
When adding an included build to the Polaris main repo, the (Maven) group ID _must_ be different. This change allows sharing (symling) the `gradle.properties` file with an included build (#785 in this case).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
