### PR TITLE
Fix "too many open files" error when running integration tests

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
@@ -115,7 +115,7 @@ public final class PolarisClient implements AutoCloseable {
 
   /** Requests an access token from the Polaris server for the given {@link ClientCredentials}. */
   public String obtainToken(ClientCredentials credentials) {
-    return polarisServerManager().accessManager().obtainAccessToken(endpoints, credentials);
+    return polarisServerManager().accessManager(client).obtainAccessToken(endpoints, credentials);
   }
 
   private boolean ownedName(String name) {

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisServerManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisServerManager.java
@@ -51,8 +51,8 @@ public interface PolarisServerManager {
    */
   Server serverForContext(ExtensionContext context);
 
-  default PolarisAccessManager accessManager() {
-    return new IcebergTokenAccessManager(createClient());
+  default PolarisAccessManager accessManager(Client client) {
+    return new IcebergTokenAccessManager(client);
   }
 
   /** Create a new HTTP client for accessing the server targeted by tests. */


### PR DESCRIPTION
This was due to the fact that each token fetch created a new client, and the client wasn't closed.

The typical stack trace is:

```
failed to open a new selector
io.netty.channel.ChannelException: failed to open a new selector
	at app//io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:179)
...
	at app//org.apache.polaris.service.it.ext.PolarisServerManager.createClient(PolarisServerManager.java:64)
	at app//org.apache.polaris.service.it.ext.PolarisServerManager.accessManager(PolarisServerManager.java:55)
	at app//org.apache.polaris.service.it.env.PolarisClient.obtainToken(PolarisClient.java:118)
	at app//org.apache.polaris.service.it.env.PolarisClient.managementApi(PolarisClient.java:88)
	at app//org.apache.polaris.service.it.env.PolarisClient.cleanUp(PolarisClient.java:126)
...
Caused by: java.io.IOException: Too many open files
	at java.base/sun.nio.ch.KQueue.create(Native Method)
	at java.base/sun.nio.ch.KQueueSelectorImpl.<init>(KQueueSelectorImpl.java:83)
	at java.base/sun.nio.ch.KQueueSelectorProvider.openSelector(KQueueSelectorProvider.java:36)
	at io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:177)
	... 32 more
```
