### PR TITLE
Bootstrap all configured realms on startup for in-memory metastore

### DIFF
--- a/quarkus/service/src/testFixtures/java/org/apache/polaris/service/quarkus/it/QuarkusServerManager.java
+++ b/quarkus/service/src/testFixtures/java/org/apache/polaris/service/quarkus/it/QuarkusServerManager.java
@@ -47,7 +47,7 @@ public class QuarkusServerManager implements PolarisServerManager {
       @Override
       public ClientPrincipal adminCredentials() {
         // These credentials are injected via env. variables from build scripts.
-        // Cf. POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID
+        // Cf. POLARIS_BOOTSTRAP_CREDENTIALS in build.gradle.kts
         return new ClientPrincipal("root", new ClientCredentials("test-admin", "test-secret"));
       }
 


### PR DESCRIPTION
...and not just the default one. This way if the user has many realms, credentials for all of them are printed.