### PR TITLE
Make `@QuarkusIntegrationTest`s also work with Java 23

### DIFF
--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -146,9 +146,6 @@ dependencies {
 tasks.withType(Test::class.java).configureEach {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
   addSparkJvmOptions()
-}
-
-tasks.named<Test>("test").configure {
   if (System.getenv("AWS_REGION") == null) {
     environment("AWS_REGION", "us-west-2")
   }
@@ -158,21 +155,11 @@ tasks.named<Test>("test").configure {
   // Need to allow a java security manager after Java 21, for Subject.getSubject to work
   // "getSubject is supported only if a security manager is allowed".
   systemProperty("java.security.manager", "allow")
-  maxParallelForks = 4
 }
 
-tasks.named<Test>("intTest").configure {
-  if (System.getenv("AWS_REGION") == null) {
-    environment("AWS_REGION", "us-west-2")
-  }
-  // Note: the test secrets are referenced in DropwizardServerManager
-  environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,root,test-admin,test-secret")
-  jvmArgs("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
-  // Need to allow a java security manager after Java 21, for Subject.getSubject to work
-  // "getSubject is supported only if a security manager is allowed".
-  systemProperty("java.security.manager", "allow")
-  maxParallelForks = 1
-}
+tasks.named<Test>("test").configure { maxParallelForks = 4 }
+
+tasks.named<Test>("intTest").configure { maxParallelForks = 1 }
 
 /**
  * Adds the JPMS options required for Spark to run on Java 17, taken from the

--- a/quarkus/service/src/main/resources/application.properties
+++ b/quarkus/service/src/main/resources/application.properties
@@ -147,3 +147,6 @@ polaris.authentication.token-broker.max-token-generation=PT1H
 %test.polaris.storage.aws.secret-key=secretKey
 %test.polaris.storage.gcp.token=token
 %test.polaris.storage.gcp.lifespan=PT1H
+# Need to allow a java security manager after Java 21, for Subject.getSubject to work
+# "getSubject is supported only if a security manager is allowed".
+%test.quarkus.test.argLine=-Djava.security.manager=allow


### PR DESCRIPTION
This is basically the same issue as #723, just via `@QuarkusIntegrationTest`s, which spawn a separate process. The (JVM) arguments for this need to be specified in a different way.

This also simplifies the Quarksu service build file a little.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
