### PR TITLE
Throw NotAuthorizedException when realm is unknown

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmIdResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultRealmIdResolver.java
@@ -22,6 +22,7 @@ import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.context.RealmId;
 
 @ApplicationScoped
@@ -44,7 +45,7 @@ public class DefaultRealmIdResolver implements RealmIdResolver {
     if (headers.containsKey(configuration.headerName())) {
       realm = headers.get(configuration.headerName());
       if (!configuration.realms().contains(realm)) {
-        throw new IllegalArgumentException("Unknown realm: " + realm);
+        throw new NotAuthorizedException("Unknown realm: " + realm);
       }
     } else {
       realm = configuration.defaultRealm();


### PR DESCRIPTION
Throwing IllegalArgumentException, as before, translates into HTTP 500, which is not great.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
