### PR TITLE
Simplify credentials format when bootstrapping

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrap.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrap.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 
 /**
@@ -95,15 +96,20 @@ public class PolarisCredentialsBootstrap {
 
   /**
    * Get the secrets for the specified principal in the specified realm, if available among the
-   * credentials that were supplied for bootstrap.
+   * credentials that were supplied for bootstrap. Only credentials for the root principal are
+   * supported.
    */
-  public Optional<PolarisPrincipalSecrets> getSecrets(String realmName, long principalId) {
-    return Optional.ofNullable(credentials.get(realmName))
-        .map(
-            credentials -> {
-              String clientId = credentials.getKey();
-              String secret = credentials.getValue();
-              return new PolarisPrincipalSecrets(principalId, clientId, secret, secret);
-            });
+  public Optional<PolarisPrincipalSecrets> getSecrets(
+      String realmName, long principalId, String principalName) {
+    if (principalName.equals(PolarisEntityConstants.getRootPrincipalName())) {
+      return Optional.ofNullable(credentials.get(realmName))
+          .map(
+              credentials -> {
+                String clientId = credentials.getKey();
+                String secret = credentials.getValue();
+                return new PolarisPrincipalSecrets(principalId, clientId, secret, secret);
+              });
+    }
+    return Optional.empty();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrap.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrap.java
@@ -25,7 +25,6 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 
@@ -54,7 +53,7 @@ public class PolarisCredentialsBootstrap {
    * Parse a string of credentials in the format:
    *
    * <pre>
-   * realm1,user1a,client1a,secret1a;realm1,user1b,client1b,secret1b;realm2,user2a,client2a,secret2a;...
+   * realm1,client1,secret1;realm2,client2,secret2;...
    * </pre>
    */
   public static PolarisCredentialsBootstrap fromString(@Nullable String credentialsString) {
@@ -65,36 +64,32 @@ public class PolarisCredentialsBootstrap {
 
   /**
    * Parse a list of credentials; each element should be in the format: {@code
-   * realm,principal,clientId,clientSecret}.
+   * realm,clientId,clientSecret}.
    */
   public static PolarisCredentialsBootstrap fromList(List<String> credentialsList) {
-    Map<String, Map<String, Map.Entry<String, String>>> credentials = new HashMap<>();
-    for (String quadruple : credentialsList) {
-      if (!quadruple.isBlank()) {
-        List<String> parts = Splitter.on(',').trimResults().splitToList(quadruple);
-        if (parts.size() != 4) {
-          throw new IllegalArgumentException("Invalid credentials format: " + quadruple);
+    Map<String, Map.Entry<String, String>> credentials = new HashMap<>();
+    for (String triplet : credentialsList) {
+      if (!triplet.isBlank()) {
+        List<String> parts = Splitter.on(',').trimResults().splitToList(triplet);
+        if (parts.size() != 3) {
+          throw new IllegalArgumentException("Invalid credentials format: " + triplet);
         }
         String realmName = parts.get(0);
-        String principalName = parts.get(1);
-        String clientId = parts.get(2);
-        String clientSecret = parts.get(3);
-        credentials
-            .computeIfAbsent(realmName, k -> new HashMap<>())
-            .merge(
-                principalName,
-                new SimpleEntry<>(clientId, clientSecret),
-                (a, b) -> {
-                  throw new IllegalArgumentException("Duplicate principal: " + principalName);
-                });
+        String clientId = parts.get(1);
+        String clientSecret = parts.get(2);
+
+        if (credentials.containsKey(realmName)) {
+          throw new IllegalArgumentException("Duplicate realm: " + realmName);
+        }
+        credentials.put(realmName, new SimpleEntry<>(clientId, clientSecret));
       }
     }
     return credentials.isEmpty() ? EMPTY : new PolarisCredentialsBootstrap(credentials);
   }
 
-  @VisibleForTesting final Map<String, Map<String, Map.Entry<String, String>>> credentials;
+  @VisibleForTesting final Map<String, Map.Entry<String, String>> credentials;
 
-  private PolarisCredentialsBootstrap(Map<String, Map<String, Entry<String, String>>> credentials) {
+  private PolarisCredentialsBootstrap(Map<String, Map.Entry<String, String>> credentials) {
     this.credentials = credentials;
   }
 
@@ -102,10 +97,8 @@ public class PolarisCredentialsBootstrap {
    * Get the secrets for the specified principal in the specified realm, if available among the
    * credentials that were supplied for bootstrap.
    */
-  public Optional<PolarisPrincipalSecrets> getSecrets(
-      String realmName, long principalId, String principalName) {
+  public Optional<PolarisPrincipalSecrets> getSecrets(String realmName, long principalId) {
     return Optional.ofNullable(credentials.get(realmName))
-        .flatMap(principals -> Optional.ofNullable(principals.get(principalName)))
         .map(
             credentials -> {
               String clientId = credentials.getKey();

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PrincipalSecretsGenerator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PrincipalSecretsGenerator.java
@@ -63,7 +63,7 @@ public interface PrincipalSecretsGenerator {
       String realmName, @Nullable PolarisCredentialsBootstrap credentialsSupplier) {
     return (principalName, principalId) ->
         Optional.ofNullable(credentialsSupplier)
-            .flatMap(credentials -> credentials.getSecrets(realmName, principalId, principalName))
+            .flatMap(credentials -> credentials.getSecrets(realmName, principalId))
             .orElseGet(() -> RANDOM_SECRETS.produceSecrets(principalName, principalId));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PrincipalSecretsGenerator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PrincipalSecretsGenerator.java
@@ -63,7 +63,7 @@ public interface PrincipalSecretsGenerator {
       String realmName, @Nullable PolarisCredentialsBootstrap credentialsSupplier) {
     return (principalName, principalId) ->
         Optional.ofNullable(credentialsSupplier)
-            .flatMap(credentials -> credentials.getSecrets(realmName, principalId))
+            .flatMap(credentials -> credentials.getSecrets(realmName, principalId, principalName))
             .orElseGet(() -> RANDOM_SECRETS.produceSecrets(principalName, principalId));
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrapTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisCredentialsBootstrapTest.java
@@ -62,51 +62,28 @@ class PolarisCredentialsBootstrapTest {
   }
 
   @Test
-  void duplicatePrincipal() {
+  void duplicateRealm() {
     assertThatThrownBy(
             () ->
                 PolarisCredentialsBootstrap.fromString(
-                    "realm1,user1a,client1a,secret1a;realm1,user1a,client1b,secret1b"))
-        .hasMessage("Duplicate principal: user1a");
+                    "realm1,client1a,secret1a;realm1,client1b,secret1b"))
+        .hasMessage("Duplicate realm: realm1");
   }
 
   @Test
   void getSecretsValidString() {
     PolarisCredentialsBootstrap credentials =
         PolarisCredentialsBootstrap.fromString(
-            " ; realm1 , user1a , client1a , secret1a ; realm1 , user1b , client1b , secret1b ; realm2 , user2a , client2a , secret2a ; ");
-    assertThat(credentials.getSecrets("realm1", 123, "nonexistent")).isEmpty();
-    assertThat(credentials.getSecrets("nonexistent", 123, "user1a")).isEmpty();
-    assertThat(credentials.getSecrets("realm1", 123, "user1a"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client1a", "secret1a", "secret1a"));
-    assertThat(credentials.getSecrets("realm1", 123, "user1b"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client1b", "secret1b", "secret1b"));
-    assertThat(credentials.getSecrets("realm2", 123, "user2a"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client2a", "secret2a", "secret2a"));
+            " ; realm1 , client1 , secret1 ; realm2 , client2 , secret2 ; ");
+    assertCredentials(credentials);
   }
 
   @Test
   void getSecretsValidList() {
     PolarisCredentialsBootstrap credentials =
         PolarisCredentialsBootstrap.fromList(
-            List.of(
-                "realm1,user1a,client1a,secret1a",
-                "realm1,user1b,client1b,secret1b",
-                "realm2,user2a,client2a,secret2a"));
-    assertThat(credentials.getSecrets("realm1", 123, "nonexistent")).isEmpty();
-    assertThat(credentials.getSecrets("nonexistent", 123, "user1a")).isEmpty();
-    assertThat(credentials.getSecrets("realm1", 123, "user1a"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client1a", "secret1a", "secret1a"));
-    assertThat(credentials.getSecrets("realm1", 123, "user1b"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client1b", "secret1b", "secret1b"));
-    assertThat(credentials.getSecrets("realm2", 123, "user2a"))
-        .usingValueComparator(comparator)
-        .contains(new PolarisPrincipalSecrets(123, "client2a", "secret2a", "secret2a"));
+            List.of("realm1,client1,secret1", "realm2,client2,secret2"));
+    assertCredentials(credentials);
   }
 
   @Test
@@ -114,15 +91,23 @@ class PolarisCredentialsBootstrapTest {
     PolarisCredentialsBootstrap credentials = PolarisCredentialsBootstrap.fromEnvironment();
     assertThat(credentials.credentials).isEmpty();
     try {
-      System.setProperty("polaris.bootstrap.credentials", "realm1,user1a,client1a,secret1a");
+      System.setProperty(
+          "polaris.bootstrap.credentials", "realm1,client1,secret1;realm2,client2,secret2");
       credentials = PolarisCredentialsBootstrap.fromEnvironment();
-      assertThat(credentials.getSecrets("realm1", 123, "nonexistent")).isEmpty();
-      assertThat(credentials.getSecrets("nonexistent", 123, "user1a")).isEmpty();
-      assertThat(credentials.getSecrets("realm1", 123, "user1a"))
-          .usingValueComparator(comparator)
-          .contains(new PolarisPrincipalSecrets(123, "client1a", "secret1a", "secret1a"));
+      assertCredentials(credentials);
     } finally {
       System.clearProperty("polaris.bootstrap.credentials");
     }
+  }
+
+  private void assertCredentials(PolarisCredentialsBootstrap credentials) {
+    assertThat(credentials.getSecrets("realm3", 123)).isEmpty();
+    assertThat(credentials.getSecrets("nonexistent", 123)).isEmpty();
+    assertThat(credentials.getSecrets("realm1", 123))
+        .usingValueComparator(comparator)
+        .contains(new PolarisPrincipalSecrets(123, "client1", "secret1", "secret1"));
+    assertThat(credentials.getSecrets("realm2", 123))
+        .usingValueComparator(comparator)
+        .contains(new PolarisPrincipalSecrets(123, "client2", "secret2", "secret2"));
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PrincipalSecretsGeneratorTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PrincipalSecretsGeneratorTest.java
@@ -40,7 +40,7 @@ class PrincipalSecretsGeneratorTest {
   void testSecretOverride() {
     PrincipalSecretsGenerator gen =
         bootstrap(
-            "test-Realm", PolarisCredentialsBootstrap.fromString("test-Realm,user1,client1,sec2"));
+            "test-Realm", PolarisCredentialsBootstrap.fromString("test-Realm,client1,sec2"));
     PolarisPrincipalSecrets s = gen.produceSecrets("user1", 123);
     assertThat(s).isNotNull();
     assertThat(s.getPrincipalId()).isEqualTo(123);

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PrincipalSecretsGeneratorTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PrincipalSecretsGeneratorTest.java
@@ -39,9 +39,8 @@ class PrincipalSecretsGeneratorTest {
   @Test
   void testSecretOverride() {
     PrincipalSecretsGenerator gen =
-        bootstrap(
-            "test-Realm", PolarisCredentialsBootstrap.fromString("test-Realm,client1,sec2"));
-    PolarisPrincipalSecrets s = gen.produceSecrets("user1", 123);
+        bootstrap("test-Realm", PolarisCredentialsBootstrap.fromString("test-Realm,client1,sec2"));
+    PolarisPrincipalSecrets s = gen.produceSecrets("root", 123);
     assertThat(s).isNotNull();
     assertThat(s.getPrincipalId()).isEqualTo(123);
     assertThat(s.getPrincipalClientId()).isEqualTo("client1");

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -39,7 +39,7 @@ public class BootstrapCommand extends BaseCommand {
   @CommandLine.Option(
       names = {"-c", "--credential"},
       description =
-          "Principal credentials to bootstrap. Must be of the form 'realm,userName,clientId,clientSecret'.")
+          "Root principal credentials to bootstrap. Must be of the form 'realm,clientId,clientSecret'.")
   List<String> credentials;
 
   @Override

--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -37,9 +37,9 @@ class BootstrapCommandTest {
         "-r",
         "realm2",
         "-c",
-        "realm1,root,root,s3cr3t",
+        "realm1,root,s3cr3t",
         "-c",
-        "realm2,root,root,s3cr3t"
+        "realm2,root,s3cr3t"
       })
   public void testBootstrap(LaunchResult result) {
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -149,8 +149,9 @@ tasks.withType(Test::class.java).configureEach {
   if (System.getenv("AWS_REGION") == null) {
     environment("AWS_REGION", "us-west-2")
   }
-  // Note: the test secrets are referenced in DropwizardServerManager
-  environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,root,test-admin,test-secret")
+  // Note: the test secrets are referenced in
+  // org.apache.polaris.service.quarkus.it.QuarkusServerManager
+  environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,test-admin,test-secret")
   jvmArgs("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
   // Need to allow a java security manager after Java 21, for Subject.getSubject to work
   // "getSubject is supported only if a security manager is allowed".

--- a/quarkus/service/src/testFixtures/java/org/apache/polaris/service/quarkus/it/QuarkusServerManager.java
+++ b/quarkus/service/src/testFixtures/java/org/apache/polaris/service/quarkus/it/QuarkusServerManager.java
@@ -47,7 +47,7 @@ public class QuarkusServerManager implements PolarisServerManager {
       @Override
       public ClientPrincipal adminCredentials() {
         // These credentials are injected via env. variables from build scripts.
-        // Cf. POLARIS_BOOTSTRAP_POLARIS_ROOT_CLIENT_ID
+        // Cf. POLARIS_BOOTSTRAP_CREDENTIALS in build.gradle.kts
         return new ClientPrincipal("root", new ClientCredentials("test-admin", "test-secret"));
       }
 

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -75,21 +75,19 @@ Before using Polaris when using a metastore manager other than `in-memory`, you 
 By default, Polaris will create randomised `CLIENT_ID` and `CLIENT_SECRET` for the `root` principal and store their hashes in the metastore backend. In order to provide your own credentials for `root` principal (so you can request tokens via `api/catalog/v1/oauth/tokens`), set the `POLARIS_BOOTSTRAP_CREDENTIALS` environment variable as follows:
 
 ```
-export POLARIS_BOOTSTRAP_CREDENTIALS=my_realm,root,my-client-id,my-client-secret
+export POLARIS_BOOTSTRAP_CREDENTIALS=my_realm,my-client-id,my-client-secret
 ```
 
-The format of the environment variable is `realm,principal,client_id,client_secret`. You can provide multiple credentials separated by `;`. For example, to provide credentials for two realms `my_realm` and `my_realm2`:
+The format of the environment variable is `realm,client_id,client_secret`. You can provide multiple credentials separated by `;`. For example, to provide credentials for two realms `my_realm` and `my_realm2`:
 
 ```
-export POLARIS_BOOTSTRAP_CREDENTIALS=my_realm,root,my-client-id,my-client-secret;my_realm2,root,my-client-id2,my-client-secret2
+export POLARIS_BOOTSTRAP_CREDENTIALS=my_realm,my-client-id,my-client-secret;my_realm2,my-client-id2,my-client-secret2
 ```
-
-You can also provide credentials for other users too. 
 
 It is also possible to use system properties to provide the credentials:
 
 ```
-java -Dpolaris.bootstrap.credentials=my_realm,root,my-client-id,my-client-secret -jar /path/to/jar/polaris-service-all.jar bootstrap polaris-server.yml
+java -Dpolaris.bootstrap.credentials=my_realm,my-client-id,my-client-secret -jar /path/to/jar/polaris-service-all.jar bootstrap polaris-server.yml
 ```
 
 Now, to bootstrap Polaris, run:


### PR DESCRIPTION
It turns out that only `root` credentials can be created during bootstrap, since the principal name is hard-coded to `PolarisEntityConstants.getRootPrincipalName()`:

https://github.com/apache/polaris/blob/390f1fa57bb1af24a21aa95fdbff49a46e31add7/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManagerImpl.java#L612

Because of that, the second element in the quadruplet `realm,name,id,secret` is useless and can be removed.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
