### PR TITLE
Inject auth tokens into Spark sessions

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.service.it.env;
 
 import static org.apache.polaris.service.it.env.PolarisApiEndpoints.REALM_HEADER;
-import static org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest.PRINCIPAL_ROLE_ALL;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -33,10 +32,12 @@ public final class IcebergHelper {
   private IcebergHelper() {}
 
   public static RESTCatalog restCatalog(
+      PolarisClient client,
       PolarisApiEndpoints endpoints,
       PrincipalWithCredentials credentials,
       String catalog,
       Map<String, String> extraProperties) {
+    String authToken = client.obtainToken(credentials);
     SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
     RESTCatalog restCatalog =
         new RESTCatalog(
@@ -50,12 +51,7 @@ public final class IcebergHelper {
         ImmutableMap.<String, String>builder()
             .put(
                 org.apache.iceberg.CatalogProperties.URI, endpoints.catalogApiEndpoint().toString())
-            .put(
-                OAuth2Properties.CREDENTIAL,
-                credentials.getCredentials().getClientId()
-                    + ":"
-                    + credentials.getCredentials().getClientSecret())
-            .put(OAuth2Properties.SCOPE, PRINCIPAL_ROLE_ALL)
+            .put(OAuth2Properties.TOKEN, authToken)
             .put(
                 org.apache.iceberg.CatalogProperties.FILE_IO_IMPL,
                 "org.apache.iceberg.inmemory.InMemoryFileIO")

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -106,6 +106,7 @@ public class PolarisApplicationIntegrationTest {
   private static PolarisClient client;
   private static ClientCredentials clientCredentials;
   private static ClientPrincipal admin;
+  private static String authToken;
 
   private String principalRoleName;
   private String internalCatalogName;
@@ -118,6 +119,7 @@ public class PolarisApplicationIntegrationTest {
     realm = endpoints.realm();
     admin = adminCredentials;
     clientCredentials = adminCredentials.credentials();
+    authToken = client.obtainToken(clientCredentials);
 
     testDir = Path.of("build/test_data/iceberg/" + realm);
     FileUtils.deleteQuietly(testDir.toFile());
@@ -158,7 +160,7 @@ public class PolarisApplicationIntegrationTest {
   }
 
   @AfterEach
-  public void cleanUp() throws Exception {
+  public void cleanUp() {
     client.cleanUp(clientCredentials);
   }
 
@@ -235,10 +237,8 @@ public class PolarisApplicationIntegrationTest {
         Map.of(
             "uri",
             endpoints.catalogApiEndpoint().toString(),
-            OAuth2Properties.CREDENTIAL,
-            clientCredentials.clientId() + ":" + clientCredentials.clientSecret(),
-            OAuth2Properties.SCOPE,
-            PRINCIPAL_ROLE_ALL,
+            OAuth2Properties.TOKEN,
+            authToken,
             "warehouse",
             catalog,
             "header." + REALM_HEADER,
@@ -579,10 +579,8 @@ public class PolarisApplicationIntegrationTest {
                       Map.of(
                           "uri",
                           endpoints.catalogApiEndpoint().toString(),
-                          OAuth2Properties.CREDENTIAL,
-                          clientCredentials.clientId() + ":" + clientCredentials.clientSecret(),
-                          OAuth2Properties.SCOPE,
-                          PRINCIPAL_ROLE_ALL,
+                          OAuth2Properties.TOKEN,
+                          authToken,
                           "warehouse",
                           emptyEnvironmentVariable,
                           "header." + REALM_HEADER,

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -222,7 +222,11 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
 
     restCatalog =
         IcebergHelper.restCatalog(
-            endpoints, principalCredentials, currentCatalogName, extraPropertiesBuilder.build());
+            client,
+            endpoints,
+            principalCredentials,
+            currentCatalogName,
+            extraPropertiesBuilder.build());
   }
 
   @AfterEach

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -108,7 +108,8 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
             .build();
     managementApi.createCatalog(principalRoleName, catalog);
 
-    restCatalog = IcebergHelper.restCatalog(endpoints, principalCredentials, catalogName, Map.of());
+    restCatalog =
+        IcebergHelper.restCatalog(client, endpoints, principalCredentials, catalogName, Map.of());
   }
 
   @AfterEach


### PR DESCRIPTION
Obtain access tokens from `PolarisAccessManager` (#789) before starting Spark sessions as opposed to passing client ID/secret to Spark and relying on the Iceberg REST Client to obtain access tokens.

This makes all "blackbox" integration tests obtain access tokens the same way.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
