### PR TITLE
Update a Slack invite link never expired

### DIFF
--- a/CHAT_BYLAWS.md
+++ b/CHAT_BYLAWS.md
@@ -24,7 +24,7 @@ Apache Polaris is currently undergoing Incubation at the Apache Software Foundat
 ## Motivation
 
 Apache Polaris uses two public and open chat services:
-* Slack workspace (join [here](https://join.slack.com/t/apache-polaris/shared_invite/zt-2w1fddyh3-zqCeeJwn7wNvhn3mVT5njQ))
+* Slack workspace (join [here](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw))
 * Zuplip hosted at https://polaris-catalog.zulipchat.com
 
 A few rules shall ensure that the chat conforms to the rules and best

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When filing an [issue](https://github.com/apache/polaris/issues), make sure to a
 5. What did you see instead?
 
 Troubleshooting questions should be posted on: 
-* [Slack](https://join.slack.com/t/apache-polaris/shared_invite/zt-2w1fddyh3-zqCeeJwn7wNvhn3mVT5njQ)
+* [Slack](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw)
 * [Zulip](https://polaris-catalog.zulipchat.com/)
 * [dev mailing list](mailto:dev@polaris.apache.org) (you can [subscribe](mailto:dev-subscribe@polaris.apache.org)) instead of the issue tracker. 
 

--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -30,7 +30,7 @@ cascade:
 {{% blocks/feature icon="fa-solid fa-graduation-cap" title="Learn, Connect and Collaborate" %}}
 [cols="2,3"]
 |===
-| link:https://join.slack.com/t/apache-polaris/shared_invite/zt-2w1fddyh3-zqCeeJwn7wNvhn3mVT5njQ[Slack]
+| link:https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw[Slack]
 | Public chat, open to everybody
 
 | link:https://polaris-catalog.zulipchat.com/[Zulip]


### PR DESCRIPTION
The original link expired after 30 days. This PR updates a link never expired.