### PR TITLE
Add label to easily filter renovatebot PR notifications

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,4 +71,7 @@
   // concurrent PRs limit.
   prConcurrentLimit: 50,
   prHourlyLimit: 5,
+
+  // add renovate-polaris label to easily filter PRs/email
+  labels: ["renovate-polaris"],
 }


### PR DESCRIPTION
This PR proposes:
* to schedule renovatebot daily before 4 AM
* to add `renovatebot` label to easily filter PRs and emails