### PR TITLE
Require all conversations to be resolved before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,10 +38,14 @@ github:
   protected_branches:
     main:
       required_pull_request_reviews:
+        # if we want to use this, GitHub CODEOWNERS should be cleanly define, with different patterns/owners
         require_code_owner_reviews: false
         required_approving_review_count: 1
 
       required_linear_history: true
+
+      # requires all conversations to be resolved before merging
+      required_conversation_resolution: true
 
       del_branch_on_merge: true
 


### PR DESCRIPTION
This PR "enforces" that all discussions are resolved in a PR before merging.

NB: I don't change `require_code_owner_reviews` as it won't help regarding our current `.github/CODEOWNERS` file.