### PR TITLE
[WIP] Make dev profile compatible with tests and regtests

### DIFF
--- a/quarkus/defaults/src/main/resources/application-dev.properties
+++ b/quarkus/defaults/src/main/resources/application-dev.properties
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Configuration for the "dev" profile. This profile is active by default
+# when running the quarkusDev Gradle task.
+
+# This profile is configured to match the expectations of regression tests
+# in terms of configuration, but it also allows unit tests to pass when
+# executed with quarkusDev.
+
+quarkus.log.file.enable=false
+quarkus.live-reload.instrumentation=true
+
+polaris.persistence.type=in-memory
+polaris.authentication.authenticator.type=test
+polaris.authentication.token-service.type=test
+polaris.features.defaults."SUPPORTED_CATALOG_STORAGE_TYPES"=["FILE","S3","GCS","AZURE"]
+polaris.realm-context.realms=default-realm,realm1

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -64,8 +64,6 @@ tasks.named("distTar") { dependsOn("quarkusBuild") }
 
 tasks.withType<Javadoc> { isFailOnError = false }
 
-tasks.register("polarisServerRun") { dependsOn("quarkusRun") }
-
 distributions {
   main {
     contents {

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -191,3 +191,11 @@ fun JavaForkOptions.addSparkJvmOptions() {
         "-Djdk.reflect.useDirectMethodHandle=false",
       )
 }
+
+tasks.register("polarisServerRun") {
+  dependsOn("quarkusRun")
+}
+
+tasks.register("polarisServerDev") {
+  dependsOn("quarkusDev")
+}


### PR DESCRIPTION
Requires #610 and #786.

The `dev` profile is used by default when running `quarkusDev`. It is therefore quite convenient if this profile could work with both tests and regression tests.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
