### PR TITLE
Mark polaris-quarkus-defaults as a Quarkus module

### DIFF
--- a/quarkus/defaults/build.gradle.kts
+++ b/quarkus/defaults/build.gradle.kts
@@ -17,6 +17,21 @@
  * under the License.
  */
 
-plugins { id("polaris-server") }
+plugins {
+  alias(libs.plugins.quarkus)
+}
+
+dependencies {
+  compileOnly(platform(libs.quarkus.bom))
+  compileOnly("io.quarkus:quarkus-logging-json")
+  compileOnly("io.quarkus:quarkus-rest-jackson")
+  compileOnly("io.quarkus:quarkus-reactive-routes")
+  compileOnly("io.quarkus:quarkus-hibernate-validator")
+  compileOnly("io.quarkus:quarkus-smallrye-health")
+  compileOnly("io.quarkus:quarkus-micrometer")
+  compileOnly("io.quarkus:quarkus-micrometer-registry-prometheus")
+  compileOnly("io.quarkus:quarkus-opentelemetry")
+  compileOnly("io.quarkus:quarkus-smallrye-context-propagation")
+}
 
 tasks.withType<Javadoc> { isFailOnError = false }

--- a/quarkus/defaults/build.gradle.kts
+++ b/quarkus/defaults/build.gradle.kts
@@ -19,6 +19,8 @@
 
 plugins {
   alias(libs.plugins.quarkus)
+  alias(libs.plugins.jandex)
+  id("polaris-quarkus")
 }
 
 dependencies {

--- a/quarkus/defaults/build.gradle.kts
+++ b/quarkus/defaults/build.gradle.kts
@@ -22,6 +22,9 @@ plugins {
 }
 
 dependencies {
+
+  // The dependencies below are included merely to allow IDEs to provide
+  // support for Quarkus in this module.
   compileOnly(platform(libs.quarkus.bom))
   compileOnly("io.quarkus:quarkus-logging-json")
   compileOnly("io.quarkus:quarkus-rest-jackson")

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -136,6 +136,7 @@ dependencies {
 
   // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
   intTestImplementation(platform(libs.dnsjava))
+  testFixturesImplementation(platform(libs.dnsjava))
 
   // required for QuarkusSparkIT
   intTestImplementation(enforcedPlatform(libs.scala212.lang.library))


### PR DESCRIPTION
If for nothing else, this allows IDEs to enable support for Quarkus in this module, and provide things like autocompletion for properties in `application.properties`, which is very convenient.