### PR TITLE
Docs: Keep the titles consistent

### DIFF
--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-linkTitle: Admin Tool
 title: Admin Tool
 type: docs
 weight: 300

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-linkTitle: Command Line Interface
-title: Apache Polaris (Incubating) CLI
+title: Command Line Interface
 type: docs
 weight: 300
 ---

--- a/site/content/in-dev/unreleased/configuration.md
+++ b/site/content/in-dev/unreleased/configuration.md
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: Configuring Apache Polaris (Incubating)
-linkTitle: Configuring Polaris
+title: Configuring Polaris
 type: docs
 weight: 550
 ---

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -18,7 +18,6 @@
 # under the License.
 #
 title: Metastores
-linkTitle: Metastores
 type: docs
 weight: 700
 ---

--- a/site/content/in-dev/unreleased/telemetry.md
+++ b/site/content/in-dev/unreleased/telemetry.md
@@ -18,7 +18,6 @@
 # under the License.
 #
 title: Telemetry
-linkTitle: Telemetry
 type: docs
 weight: 450
 ---


### PR DESCRIPTION
Keep the link title and page title consistent. They don't have to be the same, but we should try to do that if possible.
