### PR TITLE
Remove dns-java workarounds

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,8 +51,7 @@ errorprone = { module = "com.google.errorprone:error_prone_core", version = "2.3
 google-cloud-storage-bom = { module = "com.google.cloud:google-cloud-storage-bom", version = "2.47.0" }
 guava = { module = "com.google.guava:guava", version = "33.4.0-jre" }
 h2 = { module = "com.h2database:h2", version = "2.3.232" }
-# Strict dnsjava downgrade due to https://github.com/dnsjava/dnsjava/issues/329
-dnsjava = { module = "dnsjava:dnsjava", version = "3.5.3!!" }
+dnsjava = { module = "dnsjava:dnsjava", version = "3.6.2" }
 hadoop-client-api = { module = "org.apache.hadoop:hadoop-client-api", version.ref = "hadoop" }
 hadoop-client-runtime = { module = "org.apache.hadoop:hadoop-client-runtime", version.ref = "hadoop" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }

--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -47,9 +47,6 @@ dependencies {
 
   implementation("org.jboss.slf4j:slf4j-jboss-logmanager")
 
-  // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
-  implementation(platform(libs.dnsjava))
-
   testImplementation(enforcedPlatform(libs.quarkus.bom))
   testImplementation("io.quarkus:quarkus-junit5")
 }

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -40,9 +40,6 @@ dependencies {
   // enforce the Quarkus _platform_ here, to get a consistent and validated set of dependencies
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-container-image-docker")
-
-  // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
-  implementation(platform(libs.dnsjava))
 }
 
 quarkus {

--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -35,9 +35,6 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-core")
   implementation("org.apache.iceberg:iceberg-aws")
 
-  // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
-  implementation(platform(libs.dnsjava))
-
   implementation(platform(libs.opentelemetry.bom))
 
   implementation(platform(libs.quarkus.bom))
@@ -133,10 +130,6 @@ dependencies {
 
   intTestImplementation(platform(libs.quarkus.bom))
   intTestImplementation("io.quarkus:quarkus-junit5")
-
-  // override dnsjava version in dependencies due to https://github.com/dnsjava/dnsjava/issues/329
-  intTestImplementation(platform(libs.dnsjava))
-  testFixturesImplementation(platform(libs.dnsjava))
 
   // required for QuarkusSparkIT
   intTestImplementation(enforcedPlatform(libs.scala212.lang.library))


### PR DESCRIPTION
The latest 3.6.2 version seems to fix the issue. I also tested with Postgres using the docker-compose files from #859 and had no issues.