### PR TITLE
Do not log errors for propagated exceptions in IcebergCatalogAdapter

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -162,7 +162,7 @@ public class IcebergCatalogAdapter
     try (PolarisCatalogHandlerWrapper wrapper = newHandlerWrapper(securityContext, catalogName)) {
       return action.apply(wrapper);
     } catch (RuntimeException e) {
-      LOGGER.error("Error while operating on catalog", e);
+      LOGGER.debug("RuntimeException while operating on catalog. Propagating to caller.", e);
       throw e;
     } catch (Exception e) {
       LOGGER.error("Error while operating on catalog", e);


### PR DESCRIPTION
Log them as "DEBUG" instead.

This is to avoid having an "ERROR" log message about "namespace not found" (with a long stack trace) when, for example, Spark executes a `CREATE NAMESPACE myNewNamespace`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
