### PR TITLE
Copy RealmId when passing it to TaskExecutorImpl

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/context/RealmId.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/RealmId.java
@@ -37,6 +37,10 @@ public interface RealmId {
     return ImmutableRealmId.of(id);
   }
 
+  static RealmId copyOf(RealmId realmId) {
+    return ImmutableRealmId.copyOf(realmId);
+  }
+
   @Value.Parameter
   @JsonValue
   String id();

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -97,7 +97,10 @@ public class TaskExecutorImpl implements TaskExecutor {
    */
   @Override
   public void addTaskHandlerContext(long taskEntityId, RealmId realmId) {
-    tryHandleTask(taskEntityId, realmId, null, 1);
+    // Realm id is a request-scoped component, so we need to copy it to ensure it is available when
+    // the task is executed, even if the original realm id is no longer available because the
+    // request has completed.
+    tryHandleTask(taskEntityId, RealmId.copyOf(realmId), null, 1);
   }
 
   private @Nonnull CompletableFuture<Void> tryHandleTask(


### PR DESCRIPTION
Realm id is a request-scoped component, so we need to copy it to ensure it is available when the task is executed, even if the original realm id is no longer available because the request has completed.

This was being done previously afair, even with Quarkus... I guess it got swollen with the many rebases of #469.