### PR TITLE
Add support for setting region for AWS via CLI

### DIFF
--- a/regtests/client/python/cli/command/__init__.py
+++ b/regtests/client/python/cli/command/__init__.py
@@ -54,6 +54,7 @@ class Command(ABC):
                 role_arn=options_get(Arguments.ROLE_ARN),
                 external_id=options_get(Arguments.EXTERNAL_ID),
                 user_arn=options_get(Arguments.USER_ARN),
+                region=options_get(Arguments.REGION),
                 tenant_id=options_get(Arguments.TENANT_ID),
                 multi_tenant_app_name=options_get(Arguments.MULTI_TENANT_APP_NAME),
                 consent_url=options_get(Arguments.CONSENT_URL),

--- a/regtests/client/python/cli/command/catalogs.py
+++ b/regtests/client/python/cli/command/catalogs.py
@@ -51,6 +51,7 @@ class CatalogsCommand(Command):
     role_arn: str
     external_id: str
     user_arn: str
+    region: str
     tenant_id: str
     multi_tenant_app_name: str
     consent_url: str
@@ -81,6 +82,7 @@ class CatalogsCommand(Command):
             if self._has_azure_storage_info() or self._has_gcs_storage_info():
                 raise Exception(f"Storage type 's3' supports the storage credentials"
                                 f" {Argument.to_flag_name(Arguments.ROLE_ARN)},"
+                                f" {Argument.to_flag_name(Arguments.REGION)},"
                                 f" {Argument.to_flag_name(Arguments.EXTERNAL_ID)}, and"
                                 f" {Argument.to_flag_name(Arguments.USER_ARN)}")
         elif self.storage_type == StorageType.AZURE.value:
@@ -101,7 +103,7 @@ class CatalogsCommand(Command):
                 raise Exception("Storage type 'file' does not support any storage credentials")
 
     def _has_aws_storage_info(self):
-        return self.role_arn or self.external_id or self.user_arn
+        return self.role_arn or self.external_id or self.user_arn or self.region
 
     def _has_azure_storage_info(self):
         return self.tenant_id or self.multi_tenant_app_name or self.consent_url
@@ -117,7 +119,8 @@ class CatalogsCommand(Command):
                 allowed_locations=self.allowed_locations,
                 role_arn=self.role_arn,
                 external_id=self.external_id,
-                user_arn=self.user_arn
+                user_arn=self.user_arn,
+                region=self.region
             )
         elif self.storage_type == StorageType.AZURE.value:
             config = AzureStorageConfigInfo(
@@ -212,4 +215,3 @@ class CatalogsCommand(Command):
             api.update_catalog(self.catalog_name, request)
         else:
             raise Exception(f'{self.catalogs_subcommand} is not supported in the CLI')
-

--- a/regtests/client/python/cli/constants.py
+++ b/regtests/client/python/cli/constants.py
@@ -131,6 +131,7 @@ class Arguments:
     BASE_URL = 'base_url'
     PARENT = 'parent'
     LOCATION = 'location'
+    REGION = 'region'
 
 
 class Hints:
@@ -164,6 +165,7 @@ class Hints:
 
             ROLE_ARN = '(Required for S3) A role ARN to use when connecting to S3'
             EXTERNAL_ID = '(Only for S3) The external ID to use when connecting to S3'
+            REGION = '(Only for S3) The region to use when connecting to S3'
             USER_ARN = '(Only for S3) A user ARN to use when connecting to S3'
 
             TENANT_ID = '(Required for Azure) A tenant ID to use when connecting to Azure Storage'

--- a/regtests/client/python/cli/options/option_tree.py
+++ b/regtests/client/python/cli/options/option_tree.py
@@ -87,6 +87,7 @@ class OptionTree:
                     Argument(Arguments.ALLOWED_LOCATION, str, Hints.Catalogs.Create.ALLOWED_LOCATION,
                              allow_repeats=True),
                     Argument(Arguments.ROLE_ARN, str, Hints.Catalogs.Create.ROLE_ARN),
+                    Argument(Arguments.REGION, str, Hints.Catalogs.Create.REGION),
                     Argument(Arguments.EXTERNAL_ID, str, Hints.Catalogs.Create.EXTERNAL_ID),
                     Argument(Arguments.TENANT_ID, str, Hints.Catalogs.Create.TENANT_ID),
                     Argument(Arguments.MULTI_TENANT_APP_NAME, str, Hints.Catalogs.Create.MULTI_TENANT_APP_NAME),

--- a/regtests/client/python/polaris/management/models/aws_storage_config_info.py
+++ b/regtests/client/python/polaris/management/models/aws_storage_config_info.py
@@ -52,6 +52,8 @@ class AwsStorageConfigInfo(StorageConfigInfo):
                                              alias="externalId")
     user_arn: Optional[StrictStr] = Field(default=None, description="the aws user arn used to assume the aws role",
                                           alias="userArn")
+    region: Optional[StrictStr] = Field(default=None, description="the aws region where data is stored",
+                                          alias="region")
     __properties: ClassVar[List[str]] = ["storageType", "allowedLocations"]
 
     model_config = ConfigDict(
@@ -110,6 +112,7 @@ class AwsStorageConfigInfo(StorageConfigInfo):
             "allowedLocations": obj.get("allowedLocations"),
             "roleArn": obj.get("roleArn"),
             "externalId": obj.get("externalId"),
-            "userArn": obj.get("userArn")
+            "userArn": obj.get("userArn"),
+            "region": obj.get("region")
         })
         return _obj

--- a/regtests/client/python/test/test_cli_parsing.py
+++ b/regtests/client/python/test/test_cli_parsing.py
@@ -232,6 +232,18 @@ class TestCliParsing(unittest.TestCase):
             })
         check_arguments(
             mock_execute([
+                'catalogs', 'create', 'my-catalog', '--storage-type', 's3',
+                '--allowed-location', 'a', '--role-arn', 'ra', '--region', 'us-west-2',
+                '--external-id', 'ei', '--default-base-location', 'x']),
+            'create_catalog', {
+                (0, 'catalog.name'): 'my-catalog',
+                (0, 'catalog.storage_config_info.storage_type'): 'S3',
+                (0, 'catalog.properties.default_base_location'): 'x',
+                (0, 'catalog.storage_config_info.allowed_locations'): ['a'],
+                (0, 'catalog.storage_config_info.region'): 'us-west-2',
+            })
+        check_arguments(
+            mock_execute([
                 'catalogs', 'create', 'my-catalog', '--storage-type', 'gcs',
                 '--allowed-location', 'a', '--allowed-location', 'b',
                 '--service-account', 'sa', '--default-base-location', 'x']),

--- a/regtests/t_cli/src/test_cli.py
+++ b/regtests/t_cli/src/test_cli.py
@@ -29,7 +29,6 @@ from typing import Callable
 
 CLI_PYTHONPATH = f'{os.path.dirname(os.path.abspath(__file__))}/../../client/python'
 ROLE_ARN = 'arn:aws:iam::123456789012:role/my-role'
-REGION = 'us-west-2'
 POLARIS_HOST = os.getenv('POLARIS_HOST', 'localhost')
 POLARIS_URL = f'http://{POLARIS_HOST}:8181/api/catalog/v1/oauth/tokens'
 
@@ -194,36 +193,6 @@ def test_quickstart_flow():
         check_output(cli(user_token)('namespaces', 'list', '--catalog', f'test_cli_catalog_{SALT}'),
                      checker=lambda s: f'test_cli_namespace_{SALT}' not in s)
 
-    finally:
-        sys.path.pop(0)
-    pass
-
-
-def test_cli_parsing():
-    """
-    Tests cli parsing
-    """
-    SALT = get_salt()
-    sys.path.insert(0, CLI_PYTHONPATH)
-    try:
-        # Create S3 catalog with custom region
-        check_output(root_cli(
-            'catalogs',
-            'create',
-            '--storage-type',
-            's3',
-            '--role-arn',
-            ROLE_ARN,
-            '--region',
-            REGION,
-            '--default-base-location',
-            f's3://fake-location2-{SALT}',
-            '--external-id',
-            'custom-external-id-123',
-            f'test_cli_catalog_aws_region_{SALT}'), checker=lambda s: s == '')
-        check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_region_{SALT}'),
-                    checker=lambda s: 's3://fake-location2' in s and
-                        'custom-external-id-123' in s and REGION in s)
     finally:
         sys.path.pop(0)
     pass

--- a/regtests/t_cli/src/test_cli.py
+++ b/regtests/t_cli/src/test_cli.py
@@ -29,6 +29,7 @@ from typing import Callable
 
 CLI_PYTHONPATH = f'{os.path.dirname(os.path.abspath(__file__))}/../../client/python'
 ROLE_ARN = 'arn:aws:iam::123456789012:role/my-role'
+REGION = 'us-west-2'
 POLARIS_HOST = os.getenv('POLARIS_HOST', 'localhost')
 POLARIS_URL = f'http://{POLARIS_HOST}:8181/api/catalog/v1/oauth/tokens'
 
@@ -222,6 +223,25 @@ def test_catalog_storage_config():
         check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_{SALT}'),
                      checker=lambda s: 's3://fake-location' in s and
                          'custom-external-id-123' in s)
+
+        # Create S3 catalog with custom region
+        check_output(root_cli(
+            'catalogs',
+            'create',
+            '--storage-type',
+            's3',
+            '--role-arn',
+            ROLE_ARN,
+            '--region',
+            REGION,
+            '--default-base-location',
+            f's3://fake-location2-{SALT}',
+            '--external-id',
+            'custom-external-id-123',
+            f'test_cli_catalog_aws_region_{SALT}'), checker=lambda s: s == '')
+        check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_region_{SALT}'),
+                     checker=lambda s: 's3://fake-location2' in s and
+                         'custom-external-id-123' in s and REGION in s)
 
         # Create Azure catalog
         check_output(root_cli(

--- a/regtests/t_cli/src/test_cli.py
+++ b/regtests/t_cli/src/test_cli.py
@@ -199,6 +199,36 @@ def test_quickstart_flow():
     pass
 
 
+def test_cli_parsing():
+    """
+    Tests cli parsing
+    """
+    SALT = get_salt()
+    sys.path.insert(0, CLI_PYTHONPATH)
+    try:
+        # Create S3 catalog with custom region
+        check_output(root_cli(
+            'catalogs',
+            'create',
+            '--storage-type',
+            's3',
+            '--role-arn',
+            ROLE_ARN,
+            '--region',
+            REGION,
+            '--default-base-location',
+            f's3://fake-location2-{SALT}',
+            '--external-id',
+            'custom-external-id-123',
+            f'test_cli_catalog_aws_region_{SALT}'), checker=lambda s: s == '')
+        check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_region_{SALT}'),
+                    checker=lambda s: 's3://fake-location2' in s and
+                        'custom-external-id-123' in s and REGION in s)
+    finally:
+        sys.path.pop(0)
+    pass
+
+
 def test_catalog_storage_config():
     """
     Tests specific to storage configs of catalogs across different cloud object stores
@@ -223,25 +253,6 @@ def test_catalog_storage_config():
         check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_{SALT}'),
                      checker=lambda s: 's3://fake-location' in s and
                          'custom-external-id-123' in s)
-
-        # Create S3 catalog with custom region
-        check_output(root_cli(
-            'catalogs',
-            'create',
-            '--storage-type',
-            's3',
-            '--role-arn',
-            ROLE_ARN,
-            '--region',
-            REGION,
-            '--default-base-location',
-            f's3://fake-location2-{SALT}',
-            '--external-id',
-            'custom-external-id-123',
-            f'test_cli_catalog_aws_region_{SALT}'), checker=lambda s: s == '')
-        check_output(root_cli('catalogs', 'get', f'test_cli_catalog_aws_region_{SALT}'),
-                     checker=lambda s: 's3://fake-location2' in s and
-                         'custom-external-id-123' in s and REGION in s)
 
         # Create Azure catalog
         check_output(root_cli(


### PR DESCRIPTION
Ass https://github.com/apache/polaris/pull/455 added support for storing AWS region when creating catalog, this PR is to add the support for users to do the same via Polaris CLI.