### PR TITLE
MetaStoreManagerFactory: make purgeRealms() return purge results

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.persistence;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.polaris.core.auth.PolarisSecretsManager.PrincipalSecretsResult;
@@ -39,8 +38,8 @@ public interface MetaStoreManagerFactory {
   EntityCache getOrCreateEntityCache(RealmContext realmContext);
 
   Map<String, PrincipalSecretsResult> bootstrapRealms(
-      List<String> realms, RootCredentialsSet rootCredentialsSet);
+      Iterable<String> realms, RootCredentialsSet rootCredentialsSet);
 
   /** Purge all metadata for the realms provided */
-  void purgeRealms(List<String> realms);
+  Map<String, BaseResult> purgeRealms(Iterable<String> realms);
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
@@ -83,6 +83,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.persistence.BaseResult;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -345,12 +346,12 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
 
       @Override
       public Map<String, PrincipalSecretsResult> bootstrapRealms(
-          List<String> realms, RootCredentialsSet rootCredentialsSet) {
+          Iterable<String> realms, RootCredentialsSet rootCredentialsSet) {
         throw new NotImplementedException("Bootstrapping realms is not supported");
       }
 
       @Override
-      public void purgeRealms(List<String> realms) {
+      public Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
         throw new NotImplementedException("Purging realms is not supported");
       }
     };


### PR DESCRIPTION
Make the `purgeRealms` method return the purge results.
These changes are a prerequisite for #878 and #887.

