### PR TITLE
Spark JDK 17 for python 3.10

### DIFF
--- a/regtests/Dockerfile
+++ b/regtests/Dockerfile
@@ -17,14 +17,14 @@
 # under the License.
 #
 
-FROM docker.io/apache/spark:3.5.4-python3
+FROM docker.io/apache/spark:3.5.4-java17-python3
 ARG POLARIS_HOST=polaris
 ENV POLARIS_HOST=$POLARIS_HOST
 ENV SPARK_HOME=/opt/spark
 
 USER root
 RUN apt update
-RUN apt-get install -y diffutils wget curl python3.8-venv
+RUN apt-get install -y diffutils wget curl python3.10-venv
 RUN mkdir -p /home/spark &&  \
     chown -R spark /home/spark && \
     mkdir -p /tmp/polaris-regtests && \


### PR DESCRIPTION
Due to the upcoming update of Poetry from version 1.x to 2.x (https://github.com/apache/polaris/pull/873), the minimum Python version requirement will increase to 3.9 (3.8 is EOL already as of 2025). For more details, refer to [Poetry PR #9692](https://github.com/python-poetry/poetry/pull/9692).

This upgrade presents compatibility issues with the current Spark image (`docker.io/apache/spark:3.5.4-python3`), which is based on `eclipse-temurin:11-jre-focal` and uses JDK 11 with Python 3.8. Official Spark images are only available with JDK 11 and JDK 17.

To resolve this, I propose we switch to the JDK 17 version of the Spark image, which uses `eclipse-temurin:17-jammy` and includes Python 3.10. This pull request updates our Spark image accordingly.
