### PR TITLE
Add `renovate-bot` as a collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -64,6 +64,10 @@ github:
   ghp_branch: gh-pages
   ghp_path: /
 
+  collaborators:
+    # Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved
+    - renovate-bot
+
 notifications:
   commits:      commits@polaris.apache.org
   issues:       issues@polaris.apache.org


### PR DESCRIPTION
Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved, removing one manual step that has to be done for each renovate-PR.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
