### PR TITLE
Add a note about EclipseLink persistence.xml location

### DIFF
--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -49,7 +49,7 @@ The `configuration-file` option must point to an [EclipseLink configuration file
 `persistence.xml`, is used to set up the database connection properties, which can differ depending
 on the type of database and its configuration.
 
-> Note: EclipseLink is scanning the folder containing the `persistence.xml` but also the parent folder. If this reason, you have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is correct, whereas `/deployments/persistence.xml` is not correct.
+> Note: EclipseLink is scanning the folder containing the `persistence.xml` but also the parent folder. For this reason, you have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is correct, whereas `/deployments/persistence.xml` is not correct.
 
 [Quarkus Configuration Reference]: https://quarkus.io/guides/config-reference
 [EclipseLink configuration file]: https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -49,6 +49,8 @@ The `configuration-file` option must point to an [EclipseLink configuration file
 `persistence.xml`, is used to set up the database connection properties, which can differ depending
 on the type of database and its configuration.
 
+> Note: EclipseLink is scanning the folder containing the `persistence.xml` but also the parent folder. If this reason, you have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is correct, whereas `/deployments/persistence.xml` is not correct.
+
 [Quarkus Configuration Reference]: https://quarkus.io/guides/config-reference
 [EclipseLink configuration file]: https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm
 

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -49,8 +49,7 @@ The `configuration-file` option must point to an [EclipseLink configuration file
 `persistence.xml`, is used to set up the database connection properties, which can differ depending
 on the type of database and its configuration.
 
-> Note: EclipseLink is scanning the folder containing the `persistence.xml` but also the parent folder. For this reason, you have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is correct, whereas `/deployments/persistence.xml` is not correct.
-
+> Note: You have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is OK, whereas `/deployments/persistence.xml` will cause an infinity loop.
 [Quarkus Configuration Reference]: https://quarkus.io/guides/config-reference
 [EclipseLink configuration file]: https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm
 


### PR DESCRIPTION
This is related to a known issue, and a question on Slack. If the HELM charts are correct, this note informs the users.

@adutra does it look good to you ?

@flyrain this is the issue discussed on Slack about EclipseLink "stuck" while loading the `persistence.xml`.
