### PR TITLE
Move dummy package-info.java to Readme.java

### DIFF
--- a/quarkus/defaults/build.gradle.kts
+++ b/quarkus/defaults/build.gradle.kts
@@ -38,5 +38,3 @@ dependencies {
   compileOnly("io.quarkus:quarkus-opentelemetry")
   compileOnly("io.quarkus:quarkus-smallrye-context-propagation")
 }
-
-tasks.withType<Javadoc> { isFailOnError = false }

--- a/quarkus/defaults/src/main/java/org/apache/polaris/service/defaults/Readme.java
+++ b/quarkus/defaults/src/main/java/org/apache/polaris/service/defaults/Readme.java
@@ -16,9 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.defaults;
 
-// This file is here as a placeholder to have some java content in
-// the corresponding jar. Relevant data is in the application.properties
-// file at the root of the resources tree.
+/**
+ * This file is here as a placeholder to have some java content in the corresponding jar. Relevant
+ * data is in the application.properties file at the root of the resources tree.
+ */
+@SuppressWarnings("unused")
+public final class Readme {
+  private Readme() {}
+}

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -65,8 +65,6 @@ tasks.named("distZip") { dependsOn("quarkusBuild") }
 
 tasks.named("distTar") { dependsOn("quarkusBuild") }
 
-tasks.withType<Javadoc> { isFailOnError = false }
-
 tasks.register("run") { dependsOn("quarkusRun") }
 
 tasks.named<QuarkusRun>("quarkusRun") {

--- a/quarkus/server/src/main/java/org/apache/polaris/server/quarkus/Readme.java
+++ b/quarkus/server/src/main/java/org/apache/polaris/server/quarkus/Readme.java
@@ -16,8 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.server.quarkus;
 
-// This file is here as a placeholder to allow quarkusDev and quarkusRun
-// tasks to work, since this module currently has no source files.
+/**
+ * This file is here as a placeholder to allow quarkusDev and quarkusRun tasks to work, since this
+ * module currently has no source files.
+ */
+@SuppressWarnings("unused")
+public final class Readme {
+  private Readme() {}
+}


### PR DESCRIPTION
This is to avoid spurious error messages during build, such as: `error: No public or protected classes found to document`