### PR TITLE
Make PolarisApiEndpoints respect base URI path prefixes

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisApiEndpoints.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisApiEndpoints.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.it.env;
 
 import java.io.Serializable;
 import java.net.URI;
-import java.nio.file.Path;
 
 /**
  * This class contains the most fundamental information for accessing Polaris APIs, such as the base
@@ -40,11 +39,11 @@ public final class PolarisApiEndpoints implements Serializable {
   }
 
   public URI catalogApiEndpoint() {
-    return baseUri.resolve(Path.of(baseUri.getRawPath(), "api/catalog").toString());
+    return baseUri.resolve(baseUri.getRawPath() + "/api/catalog").normalize();
   }
 
   public URI managementApiEndpoint() {
-    return baseUri.resolve(Path.of(baseUri.getRawPath(), "api/management").toString());
+    return baseUri.resolve(baseUri.getRawPath() + "/api/management").normalize();
   }
 
   public String realm() {

--- a/integration-tests/src/test/java/org/apache/polaris/service/it/env/PolarisApiEndpointsTest.java
+++ b/integration-tests/src/test/java/org/apache/polaris/service/it/env/PolarisApiEndpointsTest.java
@@ -16,22 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.it.env;
 
+import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
-
-/**
- * Unit tests for PolarisApiEndpoints
- */
+/** Unit tests for PolarisApiEndpoints */
 public class PolarisApiEndpointsTest {
-    @Test
-    void testEndpointRespectsPathPrefix() {
-        URI baseUri = URI.create("http://myserver.com/polaris");
-        Assertions.assertEquals("http://myserver.com/polaris/api/catalog", new PolarisApiEndpoints(baseUri, "").catalogApiEndpoint().toString());
-        Assertions.assertEquals("http://myserver.com/polaris/api/management", new PolarisApiEndpoints(baseUri, "").managementApiEndpoint().toString());
-    }
+  @Test
+  void testEndpointRespectsPathPrefix() {
+    PolarisApiEndpoints endpoints =
+        new PolarisApiEndpoints(URI.create("http://myserver.com/polaris"), "");
+    Assertions.assertEquals(
+        "http://myserver.com/polaris/api/catalog", endpoints.catalogApiEndpoint().toString());
+    Assertions.assertEquals(
+        "http://myserver.com/polaris/api/management", endpoints.managementApiEndpoint().toString());
+  }
 }

--- a/integration-tests/src/test/java/org/apache/polaris/service/it/env/PolarisApiEndpointsTest.java
+++ b/integration-tests/src/test/java/org/apache/polaris/service/it/env/PolarisApiEndpointsTest.java
@@ -16,38 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.polaris.service.it.env;
 
-import java.io.Serializable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.net.URI;
-import java.nio.file.Path;
 
 /**
- * This class contains the most fundamental information for accessing Polaris APIs, such as the base
- * URI and realm ID and provides methods for obtaining Icenberg REST API and Polaris Management
- * endpoints.
+ * Unit tests for PolarisApiEndpoints
  */
-public final class PolarisApiEndpoints implements Serializable {
-
-  public static String REALM_HEADER = "realm";
-
-  private final URI baseUri;
-  private final String realm;
-
-  public PolarisApiEndpoints(URI baseUri, String realm) {
-    this.baseUri = baseUri;
-    this.realm = realm;
-  }
-
-  public URI catalogApiEndpoint() {
-    return baseUri.resolve(Path.of(baseUri.getRawPath(), "api/catalog").toString());
-  }
-
-  public URI managementApiEndpoint() {
-    return baseUri.resolve(Path.of(baseUri.getRawPath(), "api/management").toString());
-  }
-
-  public String realm() {
-    return realm;
-  }
+public class PolarisApiEndpointsTest {
+    @Test
+    void testEndpointRespectsPathPrefix() {
+        URI baseUri = URI.create("http://myserver.com/polaris");
+        Assertions.assertEquals("http://myserver.com/polaris/api/catalog", new PolarisApiEndpoints(baseUri, "").catalogApiEndpoint().toString());
+        Assertions.assertEquals("http://myserver.com/polaris/api/management", new PolarisApiEndpoints(baseUri, "").managementApiEndpoint().toString());
+    }
 }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Currently you're able to supply a base URI to tests but the path is ignored because `resolve()` ignores it. This makes it so tests respect the base path, which allows you to run integration tests against a server where Polaris is under a prefix.

It's not possible to circumvent this by specifying a custom HTTP client either, as the custom HTTP client is only used for the management API and not the catalog API.