### PR TITLE
Disable OTel SDK by default

### DIFF
--- a/quarkus/defaults/src/main/resources/application-test.properties
+++ b/quarkus/defaults/src/main/resources/application-test.properties
@@ -21,4 +21,3 @@
 # Per-test specific configuration should use QuarkusTestProfile
 
 quarkus.log.file.enable=false
-quarkus.otel.sdk.disabled=true

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -65,7 +65,7 @@ quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
 quarkus.otel.enabled=true
-quarkus.otel.sdk.disabled=false
+quarkus.otel.sdk.disabled=true
 # quarkus.otel.exporter.otlp.endpoint=http://otlp-collector:4317
 # quarkus.otel.resource.attributes=service.name=polaris,deployment.env=prod,region=us-west-2
 # quarkus.otel.service.name=polaris

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -64,7 +64,12 @@ quarkus.management.test-port=0
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
+# quarkus.otel.enabled is a build-time property. If it is disabled at build time, it will not be
+# possible to reset it at runtime, consequently all OTel functionality will be disabled.
 quarkus.otel.enabled=true
+# quarkus.otel.sdk.disabled is set to `true` by default to avoid spuriour errors about
+# trace collector connections being impossible to establish. This setting can be enabled
+# at runtime after configuring other OTel properties for proper trace data collection.
 quarkus.otel.sdk.disabled=true
 # quarkus.otel.exporter.otlp.endpoint=http://otlp-collector:4317
 # quarkus.otel.resource.attributes=service.name=polaris,deployment.env=prod,region=us-west-2

--- a/site/content/in-dev/unreleased/telemetry.md
+++ b/site/content/in-dev/unreleased/telemetry.md
@@ -53,13 +53,17 @@ Traces are published using [OpenTelemetry].
 
 [OpenTelemetry]: https://quarkus.io/guides/opentelemetry-tracing
 
-To enable OpenTelemetry and publish traces for Polaris, set a valid collector endpoint URL with
-`http://` or `https://` as the server property `quarkus.otel.exporter.otlp.traces.endpoint`. The
-collector must talk the OpenTelemetry protocol (OTLP) and the port must be its gRPC port (by default
-4317), e.g. "http://otlp-collector:4317". _If this property is not set, the server will not publish
-traces._
+By default OpenTelemetry is disabled in Polaris, because there is no reasonable default
+for the collector endpoint for all cases.
 
-You can disable OpenTelemetry at runtime by setting `quarkus.otel.sdk.disabled=true`.
+To enable OpenTelemetry and publish traces for Polaris set `quarkus.otel.sdk.disabled=false`
+and configure a valid collector endpoint URL with `http://` or `https://` as the server property
+`quarkus.otel.exporter.otlp.traces.endpoint`.
+
+_If these properties are not set, the server will not publish traces._
+
+The collector must talk the OpenTelemetry protocol (OTLP) and the port must be its gRPC port
+(by default 4317), e.g. "http://otlp-collector:4317".
 
 By default, Polaris adds a few attributes to the [OpenTelemetry Resource] to identify the server,
 and notably:


### PR DESCRIPTION
Set `quarkus.otel.sdk.disabled` to `true` by default to avoid spurious "connection refused" warnings, for example:

```
2025-01-31 20:51:56,989 WARNING [io.qua.ope.run.exp.otl.sen.VertxGrpcSender] [,] [,,,] (vert.x-eventloop-thread-2) Failed to export TraceRequestMarshalers. The request could not be executed. Full error message: Connection refused: localhost/127.0.0.1:4317
```

Proper trace collection requires running some additional infrastructure, so enabling it by default is not very meaningful. When OTel collectors are available `quarkus.otel.sdk.disabled` can be set to `false` to re-enable tracing at the server start time.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
