### PR TITLE
Update community sync link

### DIFF
--- a/site/content/community/meetings/_index.adoc
+++ b/site/content/community/meetings/_index.adoc
@@ -29,7 +29,7 @@ cascade:
 
 We have bi-weekly community meeting using https://meet.google.com/pii-faxn-woh[Google Meet].
 
-Join https://calendar.app.google/pUm1MH1gWiMYzXzD8[Polaris Community Sync invite].
+Join https://groups.google.com/u/0/g/polaris-community-sync[Polaris Community Sync invite].
 
 == Scheduled Meetings
 


### PR DESCRIPTION
I don't have the google calendar access. But maybe we can use https://groups.google.com/u/0/g/polaris-community-sync instead? 