### PR TITLE
Update Site's REST Catalog Spec Reference to Bundled Polaris + Iceberg API YAML

### DIFF
--- a/site/content/in-dev/unreleased/rest-catalog-open-api.md
+++ b/site/content/in-dev/unreleased/rest-catalog-open-api.md
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: 'Apache Polaris Catalog OpenAPI'
+title: 'Apache Polaris and Iceberg Catalog OpenAPI'
 linkTitle: 'Catalog OpenAPI'
 weight: 900
 params:

--- a/site/content/in-dev/unreleased/rest-catalog-open-api.md
+++ b/site/content/in-dev/unreleased/rest-catalog-open-api.md
@@ -17,11 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: 'Apache Iceberg OpenAPI'
-linkTitle: 'Iceberg OpenAPI'
+title: 'Apache Polaris Catalog OpenAPI'
+linkTitle: 'Catalog OpenAPI'
 weight: 900
 params:
   show_page_toc: false
 ---
 
-{{< redoc-polaris "rest-catalog-open-api.yaml" >}}
+{{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

This PR is the first follow-up of https://github.com/apache/polaris/pull/906

Updated the website's reference to `generated/bundled-polaris-catalog-service.yaml` instead of `rest-catalog-open-api.yaml`. This change ensures that Polaris-native APIs and models can be removed from `rest-catalog-open-api.yaml` in the next step, allowing it to align with the released version.

cc: @flyrain @jackye1995 