### PR TITLE
Use upstream 1.7.1 rest-catalog-open-api.yaml instead.

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -23,7 +23,7 @@ npm install @redocly/cli -g
 
 ### Generate the Bundle
 ```
-redocly bundle spec/polaris-catalog-open-api.yaml -o spec/generated/generated-polaris-catalog-service.yaml
+redocly bundle spec/polaris-catalog-service.yaml -o spec/generated/bundled-polaris-catalog-service.yaml
 ```
 
 

--- a/spec/polaris-catalog-apis/oauth-tokens-api.yaml
+++ b/spec/polaris-catalog-apis/oauth-tokens-api.yaml
@@ -1,0 +1,99 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+paths:
+  # The /v1/oauth/tokens endpoint is sourced from rest-catalog-open-api.yaml
+  /v1/oauth/tokens:
+
+    post:
+      tags:
+        - OAuth2 API
+      summary: Get a token using an OAuth2 flow (DEPRECATED for REMOVAL)
+      deprecated: true
+      operationId: getToken
+      description:
+        The `oauth/tokens` endpoint is **DEPRECATED for REMOVAL**. It is _not_ recommended to
+        implement this endpoint, unless you are fully aware of the potential security implications.
+
+        All clients are encouraged to explicitly set the configuration property `oauth2-server-uri`
+        to the correct OAuth endpoint.
+
+        Deprecated since Iceberg (Java) 1.6.0. The endpoint and related types will be removed from
+        this spec in Iceberg (Java) 2.0.
+
+        See [Security improvements in the Iceberg REST specification](https://github.com/apache/iceberg/issues/10537)
+
+
+        Exchange credentials for a token using the OAuth2 client credentials flow or token exchange.
+
+
+        This endpoint is used for three purposes -
+
+        1. To exchange client credentials (client ID and secret) for an access token
+        This uses the client credentials flow.
+
+        2. To exchange a client token and an identity token for a more specific access token
+        This uses the token exchange flow.
+
+        3. To exchange an access token for one with the same claims and a refreshed expiration period
+        This uses the token exchange flow.
+
+
+        For example, a catalog client may be configured with client credentials from the OAuth2
+        Authorization flow. This client would exchange its client ID and secret for an access token
+        using the client credentials request with this endpoint (1). Subsequent requests would then
+        use that access token.
+
+
+        Some clients may also handle sessions that have additional user context. These clients would
+        use the token exchange flow to exchange a user token (the "subject" token) from the session
+        for a more specific access token for that user, using the catalog's access token as the
+        "actor" token (2). The user ID token is the "subject" token and can be any token type
+        allowed by the OAuth2 token exchange flow, including a unsecured JWT token with a sub claim.
+        This request should use the catalog's bearer token in the "Authorization" header.
+
+
+        Clients may also use the token exchange flow to refresh a token that is about to expire by
+        sending a token exchange request (3). The request's "subject" token should be the expiring
+        token. This request should use the subject token in the "Authorization" header.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          required: false
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '../rest-catalog-open-api.yaml#/components/schemas/OAuthTokenRequest'
+      responses:
+        200:
+          $ref: '../rest-catalog-open-api.yaml#/components/responses/OAuthTokenResponse'
+        400:
+          $ref: '../rest-catalog-open-api.yaml#/components/responses/OAuthErrorResponse'
+        401:
+          $ref: '../rest-catalog-open-api.yaml#/components/responses/OAuthErrorResponse'
+        5XX:
+          $ref: '../rest-catalog-open-api.yaml#/components/responses/OAuthErrorResponse'
+      security:
+        - BearerAuth: []
+

--- a/spec/polaris-catalog-service.yaml
+++ b/spec/polaris-catalog-service.yaml
@@ -74,8 +74,10 @@ paths:
   /v1/config:
     $ref: './rest-catalog-open-api.yaml#/paths/~1v1~1config'
 
+  # Deprecated, it should be removed or modified in the future according to
+  # https://github.com/apache/polaris/issues/12
   /v1/oauth/tokens:
-    $ref: './rest-catalog-open-api.yaml#/paths/~1v1~1oauth~1tokens'
+    $ref: './polaris-catalog-apis/oauth-tokens-api.yaml#/paths/~1v1~1oauth~1tokens'
 
   /v1/{prefix}/namespaces:
     $ref: './rest-catalog-open-api.yaml#/paths/~1v1~1{prefix}~1namespaces'

--- a/spec/polaris-catalog-service.yaml
+++ b/spec/polaris-catalog-service.yaml
@@ -118,6 +118,15 @@ paths:
   /v1/{prefix}/views/rename:
     $ref: './rest-catalog-open-api.yaml#/paths/~1v1~1{prefix}~1views~1rename'
 
+  # /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan:
+  # Not implemented in Polaris
+
+  # /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/{plan-id}:
+  # Not implemented in Polaris
+
+  # /v1/{prefix}/namespaces/{namespace}/tables/{table}/tasks:
+  # Not implemented in Polaris
+
   ######################
   # Polaris-native API #
   ######################

--- a/spec/rest-catalog-open-api.yaml
+++ b/spec/rest-catalog-open-api.yaml
@@ -221,12 +221,6 @@ paths:
         Clients may also use the token exchange flow to refresh a token that is about to expire by
         sending a token exchange request (3). The request's "subject" token should be the expiring
         token. This request should use the subject token in the "Authorization" header.
-      parameters:
-        - name: Authorization
-          in: header
-          schema:
-            type: string
-          required: false
       requestBody:
         required: true
         content:
@@ -242,8 +236,6 @@ paths:
           $ref: '#/components/responses/OAuthErrorResponse'
         5XX:
           $ref: '#/components/responses/OAuthErrorResponse'
-      security:
-        - BearerAuth: []
 
   /v1/{prefix}/namespaces:
     parameters:
@@ -601,6 +593,261 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+    post:
+      tags:
+        - Catalog API
+      summary: Submit a scan for planning
+      description: >
+        Submits a scan for server-side planning.
+
+
+        Point-in-time scans are planned by passing snapshot-id to identify the
+        table snapshot to scan. Incremental scans are planned by passing both
+        start-snapshot-id and end-snapshot-id. Requests that include both point
+        in time config properties and incremental config properties are
+        invalid. If the request does not include either incremental or
+        point-in-time config properties, scan planning should produce a
+        point-in-time scan of the latest snapshot in the table's main branch.
+
+
+        Responses must include a valid status listed below. A "cancelled" status is considered invalid for this endpoint.  
+
+        - When "completed" the planning operation has produced plan tasks and
+          file scan tasks that must be returned in the response (not fetched
+          later by calling fetchPlanningResult)
+
+        - When "submitted" the response must include a plan-id used to poll
+          fetchPlanningResult to fetch the planning result when it is ready
+
+        - When "failed" the response must be a valid error response
+
+        The response for a "completed" planning operation includes two types of
+        tasks (file scan tasks and plan tasks) and both may be included in the
+        response. Tasks must not be included for any other response status.
+
+
+        Responses that include a plan-id indicate that the service is holding
+        state or performing work for the client.
+
+
+        - Clients should use the plan-id to fetch results from
+          fetchPlanningResult when the response status is "submitted"
+
+        - Clients should inform the service if planning results are no longer
+          needed by calling cancelPlanning. Cancellation is not necessary after
+          fetchScanTasks has been used to fetch scan tasks for each plan task.
+      operationId: planTableScan
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanTableScanRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/PlanTableScanResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        406:
+          $ref: '#/components/responses/UnsupportedOperationResponse'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/{plan-id}:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/plan-id'
+
+    get:
+      tags:
+        - Catalog API
+      summary: Fetches the result of scan planning for a plan-id
+      operationId: fetchPlanningResult
+      description: >
+        Fetches the result of scan planning for a plan-id.
+
+
+        Responses must include a valid status
+
+        - When "completed" the planning operation has produced plan-tasks and
+          file-scan-tasks that must be returned in the response
+
+        - When "submitted" the planning operation has not completed; the client
+          should wait to call this endpoint again to fetch a completed response
+
+        - When "failed" the response must be a valid error response
+
+        - When "cancelled" the plan-id is invalid and should be discarded
+
+
+        The response for a "completed" planning operation includes two types of
+        tasks (file scan tasks and plan tasks) and both may be included in the
+        response. Tasks must not be included for any other response status.
+      responses:
+        200:
+          $ref: '#/components/responses/FetchPlanningResultResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchPlanIdException, the plan-id does not exist
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                PlanIdDoesNotExist:
+                  $ref: '#/components/examples/NoSuchPlanIdError'
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+    delete:
+      tags:
+        - Catalog API
+      summary: Cancels scan planning for a plan-id
+      operationId: cancelPlanning
+      description: >
+        Cancels scan planning for a plan-id.
+
+
+        This notifies the service that it can release resources held for the
+        scan. Clients should cancel scans that are no longer needed, either
+        while the plan-id returns a "submitted" status or while there are
+        remaining plan tasks that have not been fetched.
+
+
+        Cancellation is not necessary when
+
+        - Scan tasks for each plan task have been fetched using fetchScanTasks
+
+        - A plan-id has produced a "failed" or "cancelled" status from
+          planTableScan or fetchPlanningResult
+      responses:
+        204:
+          description: Success, no content
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/tasks:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+
+    post:
+      tags:
+        - Catalog API
+      summary: Fetches result tasks for a plan task
+      operationId: fetchScanTasks
+      description: Fetches result tasks for a plan task.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FetchScanTasksRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/FetchScanTasksResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchPlanTaskException, the plan-task does not exist
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                PlanTaskDoesNotExist:
+                  $ref: '#/components/examples/NoSuchPlanTaskError'
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+
+
   /v1/{prefix}/namespaces/{namespace}/register:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -694,7 +941,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [all, refs]
+            enum: [ all, refs ]
       responses:
         200:
           $ref: '#/components/responses/LoadTableResponse'
@@ -1049,76 +1296,6 @@ paths:
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
-        419:
-          $ref: '#/components/responses/AuthenticationTimeoutResponse'
-        503:
-          $ref: '#/components/responses/ServiceUnavailableResponse'
-        5XX:
-          $ref: '#/components/responses/ServerErrorResponse'
-
-  /v1/{prefix}/namespaces/{namespace}/tables/{table}/notifications:
-    parameters:
-      - $ref: '#/components/parameters/prefix'
-      - $ref: '#/components/parameters/namespace'
-      - $ref: '#/components/parameters/table'
-
-    post:
-      tags:
-        - Catalog API
-      summary: Sends a notification to the table
-      operationId: sendNotification
-      requestBody:
-        description:
-          The request containing the notification to be sent.
-        
-          For each table, Polaris will reject any notification where the timestamp in the request body
-          is older than or equal to the most recent time Polaris has already processed for the table.
-          The responsibility of ensuring the correct order of timestamps for a sequence of notifications 
-          lies with the caller of the API. This includes managing potential clock skew or inconsistencies 
-          when notifications are sent from multiple sources.
-
-          A VALIDATE request behaves like a dry-run of a CREATE or UPDATE request up to but not including
-          loading the contents of a metadata file; this includes validations of permissions, the specified
-          metadata path being within ALLOWED_LOCATIONS, having an EXTERNAL catalog, etc. The intended use
-          case for a VALIDATE notification is to allow a remote catalog to pre-validate the general
-          settings of a receiving catalog against an intended new table location before possibly creating
-          a table intended for sending notifications in the remote catalog at all. For a VALIDATE request,
-          the specified metadata-location can either be a prospective full metadata file path, or a
-          relevant parent directory of the intended table to validate against ALLOWED_LOCATIONS.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NotificationRequest'
-        required: true
-      responses:
-        204:
-          description: Success, no content
-        400:
-          $ref: '#/components/responses/BadRequestErrorResponse'
-        401:
-          $ref: '#/components/responses/UnauthorizedResponse'
-        403:
-          $ref: '#/components/responses/ForbiddenResponse'
-        404:
-          description:
-            Not Found - NoSuchTableException, table to load does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergErrorResponse'
-              examples:
-                TableToLoadDoesNotExist:
-                  $ref: '#/components/examples/NoSuchTableError'
-        409:
-          description:
-            Conflict - The timestamp of the received notification is older than or equal to the 
-            most recent timestamp Polaris has already processed for the specified table.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergErrorResponse'
-              example:
-                $ref: '#/components/examples/OutOfOrderNotificationError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -1634,6 +1811,14 @@ components:
         type: string
       example: "sales"
 
+    plan-id:
+      name: plan-id
+      in: path
+      description: ID used to track a planning request
+      required: true
+      schema:
+        type: string
+
     view:
       name: view
       in: path
@@ -1762,8 +1947,8 @@ components:
         properties:
           type: object
           description: Configured string to string map of properties for the namespace
-          example: {"owner": "Hank Bendickson"}
-          default: {}
+          example: { "owner": "Hank Bendickson" }
+          default: { }
           additionalProperties:
             type: string
 
@@ -1775,10 +1960,10 @@ components:
           uniqueItems: true
           items:
             type: string
-          example: ["department", "access_group"]
+          example: [ "department", "access_group" ]
         updates:
           type: object
-          example: {"owner": "Hank Bendickson"}
+          example: { "owner": "Hank Bendickson" }
           additionalProperties:
             type: string
 
@@ -1798,7 +1983,7 @@ components:
       type: array
       items:
         type: string
-      example: ["accounting", "tax"]
+      example: [ "accounting", "tax" ]
 
     PageToken:
       description:
@@ -2545,7 +2730,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-default-spec"]
+          enum: [ "set-default-spec" ]
         spec-id:
           type: integer
           description: Partition spec ID to set as the default, or -1 to set last added spec
@@ -2559,7 +2744,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["add-sort-order"]
+          enum: [ "add-sort-order" ]
         sort-order:
           $ref: '#/components/schemas/SortOrder'
 
@@ -2572,7 +2757,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-default-sort-order"]
+          enum: [ "set-default-sort-order" ]
         sort-order-id:
           type: integer
           description: Sort order ID to set as the default, or -1 to set last added sort order
@@ -2586,7 +2771,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["add-snapshot"]
+          enum: [ "add-snapshot" ]
         snapshot:
           $ref: '#/components/schemas/Snapshot'
 
@@ -2600,7 +2785,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-snapshot-ref"]
+          enum: [ "set-snapshot-ref" ]
         ref-name:
           type: string
 
@@ -2613,7 +2798,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["remove-snapshots"]
+          enum: [ "remove-snapshots" ]
         snapshot-ids:
           type: array
           items:
@@ -2629,7 +2814,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["remove-snapshot-ref"]
+          enum: [ "remove-snapshot-ref" ]
         ref-name:
           type: string
 
@@ -2642,7 +2827,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-location"]
+          enum: [ "set-location" ]
         location:
           type: string
 
@@ -2655,7 +2840,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-properties"]
+          enum: [ "set-properties" ]
         updates:
           type: object
           additionalProperties:
@@ -2670,7 +2855,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["remove-properties"]
+          enum: [ "remove-properties" ]
         removals:
           type: array
           items:
@@ -2685,7 +2870,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["add-view-version"]
+          enum: [ "add-view-version" ]
         view-version:
           $ref: '#/components/schemas/ViewVersion'
 
@@ -2698,7 +2883,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-current-view-version"]
+          enum: [ "set-current-view-version" ]
         view-version-id:
           type: integer
           description: The view version id to set as current, or -1 to set last added view version id
@@ -2713,7 +2898,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-statistics"]
+          enum: [ "set-statistics" ]
         snapshot-id:
           type: integer
           format: int64
@@ -2729,7 +2914,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["remove-statistics"]
+          enum: [ "remove-statistics" ]
         snapshot-id:
           type: integer
           format: int64
@@ -2743,7 +2928,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["set-partition-statistics"]
+          enum: [ "set-partition-statistics" ]
         partition-statistics:
           $ref: '#/components/schemas/PartitionStatisticsFile'
 
@@ -2756,7 +2941,7 @@ components:
       properties:
         action:
           type: string
-          enum: ["remove-partition-statistics"]
+          enum: [ "remove-partition-statistics" ]
         snapshot-id:
           type: integer
           format: int64
@@ -2863,7 +3048,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-ref-snapshot-id"]
+          enum: [ "assert-ref-snapshot-id" ]
         ref:
           type: string
         snapshot-id:
@@ -2879,7 +3064,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-last-assigned-field-id"]
+          enum: [ "assert-last-assigned-field-id" ]
         last-assigned-field-id:
           type: integer
 
@@ -2892,7 +3077,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-current-schema-id"]
+          enum: [ "assert-current-schema-id" ]
         current-schema-id:
           type: integer
 
@@ -2905,7 +3090,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-last-assigned-partition-id"]
+          enum: [ "assert-last-assigned-partition-id" ]
         last-assigned-partition-id:
           type: integer
 
@@ -2918,7 +3103,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-default-spec-id"]
+          enum: [ "assert-default-spec-id" ]
         default-spec-id:
           type: integer
 
@@ -2931,7 +3116,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-default-sort-order-id"]
+          enum: [ "assert-default-sort-order-id" ]
         default-sort-order-id:
           type: integer
 
@@ -2952,7 +3137,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["assert-view-uuid"]
+          enum: [ "assert-view-uuid" ]
         uuid:
           type: string
 
@@ -3029,6 +3214,140 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageCredential'
+
+    ScanTasks:
+      type: object
+      description: >
+        Scan and planning tasks for server-side scan planning
+
+
+        - `plan-tasks` contains opaque units of planning work
+
+        - `file-scan-tasks` contains a partial or complete list of table scan tasks
+
+        - `delete-files` contains delete files referenced by file scan tasks
+
+
+        Each plan task must be passed to the fetchScanTasks endpoint to fetch
+        the file scan tasks for the plan task.
+
+
+        The list of delete files must contain all delete files referenced by
+        the file scan tasks.
+      properties:
+        delete-files:
+          description: Delete files referenced by file scan tasks
+          type: array
+          items:
+            $ref: '#/components/schemas/DeleteFile'
+        file-scan-tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileScanTask'
+        plan-tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanTask'
+
+    CompletedPlanningResult:
+      type: object
+      description: Completed server-side planning result
+      allOf:
+        - $ref: '#/components/schemas/ScanTasks'
+        - type: object
+          required:
+            - status
+          properties:
+            status:
+              $ref: '#/components/schemas/PlanStatus'
+              enum: ["completed"]
+
+    CompletedPlanningWithIDResult:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/CompletedPlanningResult'
+        - type: object
+          properties:
+            plan-id:
+              description: ID used to track a planning request
+              type: string
+
+    FailedPlanningResult:
+      type: object
+      description: Failed server-side planning result
+      allOf:
+        - $ref: '#/components/schemas/IcebergErrorResponse'
+        - type: object
+          required:
+            - status
+          properties:
+            status:
+              $ref: '#/components/schemas/PlanStatus'
+              enum: ["failed"]
+
+    AsyncPlanningResult:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/PlanStatus'
+          enum: ["submitted"]
+        plan-id:
+          description: ID used to track a planning request
+          type: string
+
+    EmptyPlanningResult:
+      type: object
+      description: Empty server-side planning result
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/PlanStatus'
+          enum: ["submitted", "cancelled"]
+
+    PlanStatus:
+      description: Status of a server-side planning operation
+      type: string
+      enum: ["completed", "submitted", "cancelled", "failed"]
+
+    FetchPlanningResult:
+      type: object
+      description: Result of server-side scan planning for fetchPlanningResult
+      discriminator:
+        propertyName: status
+        mapping:
+          completed: '#/components/schemas/CompletedPlanningResult'
+          submitted: '#/components/schemas/EmptyPlanningResult'
+          cancelled: '#/components/schemas/EmptyPlanningResult'
+          failed: '#/components/schemas/FailedPlanningResult'
+      oneOf:
+        - $ref: '#/components/schemas/CompletedPlanningResult'
+        - $ref: '#/components/schemas/FailedPlanningResult'
+        - $ref: '#/components/schemas/EmptyPlanningResult'
+
+    PlanTableScanResult:
+      type: object
+      description: Result of server-side scan planning for planTableScan
+      discriminator:
+        propertyName: status
+        mapping:
+          completed: '#/components/schemas/CompletedPlanningWithIDResult'
+          submitted: '#/components/schemas/AsyncPlanningResult'
+          cancelled: '#/components/schemas/EmptyPlanningResult'
+          failed: '#/components/schemas/FailedPlanningResult'
+      oneOf:
+        - $ref: '#/components/schemas/CompletedPlanningWithIDResult'
+        - $ref: '#/components/schemas/FailedPlanningResult'
+        - $ref: '#/components/schemas/AsyncPlanningResult'
+        - $ref: '#/components/schemas/EmptyPlanningResult'
+
+    FetchScanTasksResult:
+      type: object
+      description: Response schema for fetchScanTasks
+      allOf:
+        - $ref: '#/components/schemas/ScanTasks'
 
     CommitTableRequest:
       type: object
@@ -3147,7 +3466,6 @@ components:
         ## General Configurations
 
         - `token`: Authorization bearer token to use for view requests if OAuth2 security is enabled
-
       type: object
       required:
         - metadata-location
@@ -3412,45 +3730,6 @@ components:
           additionalProperties:
             type: string
 
-    NotificationRequest:
-      required:
-        - notification-type
-        - payload
-      properties:
-        notification-type:
-          $ref: '#/components/schemas/NotificationType'
-        payload:
-          $ref: '#/components/schemas/TableUpdateNotification'
-
-    NotificationType:
-      type: string
-      enum:
-        - UNKNOWN
-        - CREATE
-        - UPDATE
-        - DROP
-        - VALIDATE
-
-    TableUpdateNotification:
-      type: object
-      required:
-        - table-name
-        - timestamp
-        - table-uuid
-        - metadata-location
-      properties:
-        table-name:
-          type: string
-        timestamp:
-          type: integer
-          format: int64
-        table-uuid:
-          type: string
-        metadata-location:
-          type: string
-        metadata:
-          $ref: '#/components/schemas/TableMetadata'
-
     OAuthError:
       deprecated: true
       description:
@@ -3543,8 +3822,8 @@ components:
             type: string
           description:
             Properties stored on the namespace, if supported by the server.
-          example: {"owner": "Ralph", "created_at": "1452120468"}
-          default: {}
+          example: { "owner": "Ralph", "created_at": "1452120468" }
+          default: { }
 
     GetNamespaceResponse:
       type: object
@@ -3561,8 +3840,8 @@ components:
             If namespace properties are supported, but none are set, it should return an empty object.
           additionalProperties:
             type: string
-          example: {"owner": "Ralph", 'transient_lastDdlTime': '1452120468'}
-          default: {}
+          example: { "owner": "Ralph", 'transient_lastDdlTime': '1452120468' }
+          default: { }
           nullable: true
 
     ListTablesResponse:
@@ -3805,8 +4084,8 @@ components:
           description: "List of Long values, matched to 'keys' by index"
       example:
         {
-          "keys": [1, 2],
-          "values": [100,200]
+          "keys": [ 1, 2 ],
+          "values": [ 100,200 ]
         }
 
     ValueMap:
@@ -3824,8 +4103,8 @@ components:
           description: "List of primitive type values, matched to 'keys' by index"
       example:
         {
-          "keys": [1, 2],
-          "values": [100, "test"]
+          "keys": [ 1, 2 ],
+          "values": [ 100, "test" ]
         }
 
     PrimitiveTypeValue:
@@ -3917,7 +4196,7 @@ components:
       properties:
         content:
           type: string
-          enum: ["data"]
+          enum: [ "data" ]
         column-sizes:
           allOf:
             - $ref: '#/components/schemas/CountMap'
@@ -3961,7 +4240,7 @@ components:
       properties:
         content:
           type: string
-          enum: ["position-deletes"]
+          enum: [ "position-deletes" ]
 
     EqualityDeleteFile:
       allOf:
@@ -3971,12 +4250,112 @@ components:
       properties:
         content:
           type: string
-          enum: ["equality-deletes"]
+          enum: [ "equality-deletes" ]
         equality-ids:
           type: array
           items:
             type: integer
           description: "List of equality field IDs"
+
+    PlanTableScanRequest:
+      type: object
+      properties:
+        snapshot-id:
+          description:
+            Identifier for the snapshot to scan in a point-in-time scan
+          type: integer
+          format: int64
+        select:
+          description: List of selected schema fields
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldName'
+        filter:
+          description:
+            Expression used to filter the table data
+          $ref: '#/components/schemas/Expression'
+        case-sensitive:
+          description: Enables case sensitive field matching for filter and select
+          type: boolean
+          default: true
+        use-snapshot-schema:
+          description:
+            Whether to use the schema at the time the snapshot was written.
+
+            When time travelling, the snapshot schema should be used (true).
+            When scanning a branch, the table schema should be used (false).
+          type: boolean
+          default: false
+        start-snapshot-id:
+          description: Starting snapshot ID for an incremental scan (exclusive)
+          type: integer
+          format: int64
+        end-snapshot-id:
+          description:
+            Ending snapshot ID for an incremental scan (inclusive).
+
+            Required when start-snapshot-id is specified.
+          type: integer
+          format: int64
+        stats-fields:
+          description:
+            List of fields for which the service should send column stats.
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldName'
+
+    FieldName:
+      description:
+        A full field name (including parent field names), such as those passed
+        in APIs like Java `Schema#findField(String name)`.
+
+        The nested field name follows these rules
+        - Nested struct fields are named by concatenating field names at each
+        struct level using dot (`.`) delimiter, e.g.
+        employer.contact_info.address.zip_code
+        - Nested fields in a map key are named using the keyword `key`, e.g.
+        employee_address_map.key.first_name
+        - Nested fields in a map value are named using the keyword `value`,
+        e.g. employee_address_map.value.zip_code
+        - Nested fields in a list are named using the keyword `element`, e.g.
+        employees.element.first_name
+      type: string
+
+    FetchScanTasksRequest:
+      type: object
+      required:
+        - plan-task
+      properties:
+        plan-task:
+          $ref: '#/components/schemas/PlanTask'
+
+    PlanTask:
+      description:
+        An opaque string provided by the REST server that represents a
+        unit of work to produce file scan tasks for scan planning. This allows
+        clients to fetch tasks across multiple requests to accommodate large result sets.
+      type: string
+
+    FileScanTask:
+      type: object
+      required:
+        - data-file
+      properties:
+        data-file:
+          $ref: '#/components/schemas/DataFile'
+        delete-file-references:
+          description: A list of indices in the delete files array (0-based)
+          type: array
+          items:
+            type: integer
+        residual-filter:
+          description:
+            An optional filter to be applied to rows in this file scan task.
+
+            If the residual is not present, the client must produce the
+            residual or use the original filter.
+          allOf:
+            - $ref: '#/components/schemas/Expression'
 
   #############################
   # Reusable Response Objects #
@@ -4075,7 +4454,7 @@ components:
               "message": "The server does not support this operation",
               "type": "UnsupportedOperationException",
               "code": 406
-            }}
+            } }
 
     CreateNamespaceResponse:
       description:
@@ -4089,7 +4468,7 @@ components:
             $ref: '#/components/schemas/CreateNamespaceResponse'
           example: {
             "namespace": ["accounting", "tax"],
-            "properties": {"owner": "Ralph", "created_at": "1452120468"}
+            "properties": { "owner": "Ralph", "created_at": "1452120468" }
           }
 
     GetNamespaceResponse:
@@ -4182,9 +4561,9 @@ components:
           schema:
             $ref: '#/components/schemas/UpdateNamespacePropertiesResponse'
           example: {
-            "updated": ["owner"],
-            "removed": ["foo"],
-            "missing": ["bar"]
+            "updated": [ "owner" ],
+            "removed": [ "foo" ],
+            "missing": [ "bar" ]
           }
 
     CreateTableResponse:
@@ -4193,6 +4572,27 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/LoadTableResult'
+
+    PlanTableScanResponse:
+      description: Result of submitting a table scan to plan
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PlanTableScanResult'
+
+    FetchPlanningResultResponse:
+      description: Result of fetching a submitted scan planning operation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/FetchPlanningResult'
+
+    FetchScanTasksResponse:
+      description: Result of retrieving additional plan tasks and file scan tasks.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/FetchScanTasksResult'
 
     LoadTableResponse:
       description: Table metadata result when loading a table
@@ -4233,13 +4633,13 @@ components:
     ListTablesEmptyExample:
       summary: An empty list for a namespace with no tables
       value: {
-        "identifiers": []
+        "identifiers": [ ]
       }
 
     ListNamespacesEmptyExample:
       summary: An empty list of namespaces
       value: {
-        "namespaces": []
+        "namespaces": [ ]
       }
 
     ListNamespacesNonEmptyExample:
@@ -4255,8 +4655,8 @@ components:
       summary: A non-empty list of table identifiers
       value: {
         "identifiers": [
-          {"namespace": ["accounting", "tax"], "name": "paid"},
-          {"namespace": ["accounting", "tax"], "name": "owed"}
+          { "namespace": ["accounting", "tax"], "name": "paid" },
+          { "namespace": ["accounting", "tax"], "name": "owed" }
         ]
       }
 
@@ -4265,7 +4665,7 @@ components:
       value: "accounting%1Ftax"
 
     NamespaceAsPathVariable:
-      summary: A single part namespace, as represented in a path parameter
+      summary: A single part namespace, as represented in a path paremeter
       value: "accounting"
 
     NamespaceAlreadyExistsError:
@@ -4275,6 +4675,26 @@ components:
           "message": "The given namespace already exists",
           "type": "AlreadyExistsException",
           "code": 409
+        }
+      }
+
+    NoSuchPlanIdError:
+      summary: The plan id does not exist
+      value: {
+        "error": {
+          "message": "The plan id does not exist",
+          "type": "NoSuchPlanIdException",
+          "code": 404
+        }
+      }
+
+    NoSuchPlanTaskError:
+      summary: The plan task does not exist
+      value: {
+        "error": {
+          "message": "The plan task does not exist",
+          "type": "NoSuchPlanTaskException",
+          "code": 404
         }
       }
 
@@ -4311,15 +4731,15 @@ components:
     RenameTableSameNamespace:
       summary: Rename a table in the same namespace
       value: {
-        "source": {"namespace": ["accounting", "tax"], "name": "paid"},
-        "destination": {"namespace": ["accounting", "tax"], "name": "owed"}
+        "source": { "namespace": ["accounting", "tax"], "name": "paid" },
+        "destination": { "namespace": ["accounting", "tax"], "name": "owed" }
       }
 
     RenameViewSameNamespace:
       summary: Rename a view in the same namespace
       value: {
-        "source": {"namespace": ["accounting", "tax"], "name": "paid-view"},
-        "destination": {"namespace": ["accounting", "tax"], "name": "owed-view"}
+        "source": { "namespace": [ "accounting", "tax" ], "name": "paid-view" },
+        "destination": { "namespace": [ "accounting", "tax" ], "name": "owed-view" }
       }
 
     TableAlreadyExistsError:
@@ -4358,20 +4778,8 @@ components:
     UpdateAndRemoveNamespacePropertiesRequest:
       summary: An update namespace properties request with both properties to remove and properties to upsert.
       value: {
-        "removals": ["foo", "bar"],
-        "updates": {"owner": "Raoul"}
-      }
-
-    OutOfOrderNotificationError:
-      summary:
-        The timestamp of the received notification is older than or equal to the most recent timestamp 
-        Polaris has already processed for the specified table.
-      value: {
-        "error": {
-          "message": "A notification with a newer timestamp has been admitted for table",
-          "type": "AlreadyExistsException",
-          "code": 409
-        }
+        "removals": [ "foo", "bar" ],
+        "updates": { "owner": "Raoul" }
       }
 
   securitySchemes:


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Depends on #935 

This is a second follow-up of #906. This PR makes the `rest-catalog-open-api.yaml` identical to the upstream released version (1.7.1)
