### PR TITLE
Fix poetry version used by demo

### DIFF
--- a/getting-started/spark/notebooks/Dockerfile
+++ b/getting-started/spark/notebooks/Dockerfile
@@ -20,7 +20,8 @@
 FROM jupyter/all-spark-notebook:spark-3.5.0
 
 COPY --chown=jovyan regtests/client /home/jovyan/client
-RUN pip install poetry==1.5.0 && \
+COPY --chown=jovyan regtests/requirements.txt /tmp
+RUN pip install -r /tmp/requirements.txt && \
     cd client/python && \
     python3 -m poetry install && \
     pip install -e .


### PR DESCRIPTION
Reported issue: https://apache-polaris.slack.com/archives/C084XDM50CB/p1738620667525009

As part of https://github.com/apache/polaris/pull/726, we change the poetry version from 1.5.0 to 1.8.5. There was a concern around whether we should automate the poetry version for demo (getting-started). After revisited this, I think it makes sense to automate this one as well and use the same version as the one we have in CLI. This is because the demo we have is highly depends on polaris cli (as it copies regtest/client into the container and install it via poetry). Thus, it makes more sense to update both when we update poetry.

 