### PR TITLE
Revert "Update Site's REST Catalog Spec Reference to Bundled Polaris …

### DIFF
--- a/site/content/in-dev/unreleased/rest-catalog-open-api.md
+++ b/site/content/in-dev/unreleased/rest-catalog-open-api.md
@@ -17,11 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: 'Apache Polaris and Iceberg Catalog OpenAPI'
-linkTitle: 'Catalog OpenAPI'
+title: 'Apache Iceberg OpenAPI'
+linkTitle: 'Iceberg OpenAPI'
 weight: 900
 params:
   show_page_toc: false
 ---
 
-{{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}
+{{< redoc-polaris "rest-catalog-open-api.yaml" >}}


### PR DESCRIPTION
…+ Iceberg API YAML (#935)"

This reverts commit 3685065f30870dd88f82ed3869f1108f73ddfcac.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This reverts #935 because it breaks the site unexpectedly with error, although locally everything works fine
![Screenshot 2025-02-04 at 11 10 46 AM](https://github.com/user-attachments/assets/e704270c-0f9d-457f-bf1f-d37a7ac9cecc)
```
Refused to load the script 'https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

```

While exploring the issue, I think we should first revert the change to make site work again

cc @flyrain 
