### PR TITLE
[Site] Explicitly specify CSP policy

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -251,3 +251,11 @@ privacy:
     simple: true
   youtube:
     privacyEnhanced: true
+
+server:
+  headers:
+    for: /**
+    values:
+      Content-Security-Policy: >2
+            script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/ https://cdn.jsdelivr.net
+


### PR DESCRIPTION
Solves : https://github.com/apache/polaris/issues/941

CSP policy whats being specified in prod url of polaris is `"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/"` this makes rendering of js script fail due to CSP being enforce.

This change explicitly adds the js script in the CSP policy so that rendering of the page happens correctly. 

please ref this for steps of repro : 
https://github.com/apache/polaris/issues/941#issuecomment-2635142316

I am not sure if this is the best way to fix this, but the above steps fixes the rendering issue !

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
