### PR TITLE
Add data compaction policy schema

### DIFF
--- a/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://polaris.apache.org/schemas/policies/system/data-compaction/2025-02-03.json",
+  "title": "Data Compaction Policy",
+  "description": "Inheritable Polaris policy schema for Iceberg table data compaction.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "2025-02-03",
+      "description": "Schema version."
+    },
+    "enable": {
+      "type": "boolean",
+      "description": "Enable or disable data compaction."
+    },
+    "target_file_size_bytes": {
+      "type": "number",
+      "description": "Target data file size in bytes."
+    },
+    "config": {
+      "type": "object",
+      "description": "A map containing custom configuration properties. Please note that interoperability is not guaranteed.",
+      "additionalProperties": {}
+    }
+  },
+  "required": ["enable"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "version": "2025-02-03",
+      "enable": true,
+      "target_file_size_bytes": 134217728,
+      "config": {
+        "compaction_strategy": "bin-pack",
+        "max-concurrent-file-group-rewrites": 5,
+        "my-key": "my-value"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
@@ -1,4 +1,5 @@
 {
+  "license": "Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
   "$id": "https://polaris.apache.org/schemas/policies/system/data-compaction/2025-02-03.json",
   "title": "Data Compaction Policy",
   "description": "Inheritable Polaris policy schema for Iceberg table data compaction.",

--- a/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/data-compaction/2025-02-03.json
@@ -14,14 +14,12 @@
       "type": "boolean",
       "description": "Enable or disable data compaction."
     },
-    "target_file_size_bytes": {
-      "type": "number",
-      "description": "Target data file size in bytes."
-    },
     "config": {
       "type": "object",
       "description": "A map containing custom configuration properties. Please note that interoperability is not guaranteed.",
-      "additionalProperties": {}
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
     }
   },
   "required": ["enable"],
@@ -30,8 +28,8 @@
     {
       "version": "2025-02-03",
       "enable": true,
-      "target_file_size_bytes": 134217728,
       "config": {
+        "target_file_size_bytes": 134217728,
         "compaction_strategy": "bin-pack",
         "max-concurrent-file-group-rewrites": 5,
         "my-key": "my-value"


### PR DESCRIPTION
This PR adds a policy schema for data compaction. Please refer to the [design doc](https://docs.google.com/document/d/1kIiVkFFg9tPa5SH70b9WwzbmclrzH3qWHKfCKXw5lbs/edit?tab=t.0#heading=h.nly223xz13km)  for more context.
Check out #938 if you want to know more about how a policy is validated. 

The policy schemas will be shipped within the `polaris-core` jar file, so that engines or applications can reuse the `polaris-core` for related functionallities, like schema validation. 

The policy will also be pushed in the Apache Polaris website via a link like https://polaris.apache.org/schemas/policies/system/data-compaction/2025-02-03.json, so that it is easy to refer to.

cc @HonahX @jackye1995 @jbonofre @eric-maynard @dennishuo @collado-mike @RussellSpitzer 