### PR TITLE
Remove ref to Zulip (in favor of Slack)

### DIFF
--- a/CHAT_BYLAWS.md
+++ b/CHAT_BYLAWS.md
@@ -23,9 +23,7 @@ Apache Polaris is currently undergoing Incubation at the Apache Software Foundat
 
 ## Motivation
 
-Apache Polaris uses two public and open chat services:
-* Slack workspace (join [here](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw))
-* Zuplip hosted at https://polaris-catalog.zulipchat.com
+Apache Polaris uses public Slack workspace (join [here](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw)).
 
 A few rules shall ensure that the chat conforms to the rules and best
 practices of the Apache Software Foundation and serves well as a collaboration tool for the project.
@@ -43,8 +41,7 @@ the Polaris project public chat.
 * The Polaris project’s chat tool is not provided by the ASF - the Polaris project (P)PMC members govern and monitor the
   chat service.
 * Everybody is welcome to join the Polaris project chat. Invites are not needed.
-* All users are automatically promoted to “members” (don’t stay in “guests”).
-* Polaris project (P)PMC members have “owner” privileges on the Zulip and Slack chat. Polaris project committers are granted
+* Polaris project (P)PMC members have “administrator” privileges on the Slack chat. Polaris project committers are granted
   “moderator” or “administrator” privileges for moderation purposes.
 * This bylaws document shall be published on the project’s web site and linked from relevant public channels.
 * Only (P)PMC members are allowed to create new channels. The number of channels shall be limited to #general (user

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ When filing an [issue](https://github.com/apache/polaris/issues), make sure to a
 
 Troubleshooting questions should be posted on: 
 * [Slack](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw)
-* [Zulip](https://polaris-catalog.zulipchat.com/)
 * [dev mailing list](mailto:dev@polaris.apache.org) (you can [subscribe](mailto:dev-subscribe@polaris.apache.org)) instead of the issue tracker. 
 
 Maintainers and community members will answer your questions there or ask you to file an issue if you’ve encountered a bug.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ and [Apache Iceberg REST API doc](https://polaris.apache.org/index.html#tag/Conf
 for contribution guidelines.
 
 [![Slack](https://img.shields.io/badge/chat-on%20Slack-brightgreen.svg?style=for-the-badge)](https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw)
-[![Zulip](https://img.shields.io/badge/Zulip-Chat-blue?color=3d4db3&logo=zulip&style=for-the-badge&logoColor=white)](https://polaris-catalog.zulipchat.com/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/apache/polaris/gradle.yml?branch=main&label=Main%20CI&logo=Github&style=for-the-badge)](https://github.com/apache/polaris/actions/workflows/gradle.yml?query=branch%3Amain)
 
 [dev-list-subscribe]: mailto:dev-subscribe@polaris.apache.org

--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -29,7 +29,7 @@ Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. 
 image::img/Polaris-Catalog-BLOG-symmetrical-subhead.png[Polaris Catalog]
 
 {{< blocks/section color="dark" type="row" >}}
-{{% blocks/feature icon="fa-lightbulb" title="Join the community!" url="https://polaris-catalog.zulipchat.com/" url_text="Chat with us" %}}
+{{% blocks/feature icon="fa-lightbulb" title="Join the community!" url="https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw" url_text="Chat with us" %}}
 Chat with users and project developers!
 {{% /blocks/feature %}}
 {{% blocks/feature icon="fa-brands fa-github" title="Contributions welcome!" url="https://github.com/apache/polaris/pulls" url_text="Polaris Pull Requests" %}}

--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -33,9 +33,6 @@ cascade:
 | link:https://join.slack.com/t/apache-polaris/shared_invite/zt-2y3l3r0fr-VtoW42ltir~nSzCYOrQgfw[Slack]
 | Public chat, open to everybody
 
-| link:https://polaris-catalog.zulipchat.com/[Zulip]
-| Public chat, open to everybody
-
 | link:{{% ref "meetings" %}}[Community Meetings]
 | Upcoming, live and recorded Community Meetings
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -46,10 +46,6 @@ params:
         url: https://apache-polaris.slack.com/
         icon: fa-regular fa-comment-dots
         desc: Chat with other project developers
-      - name: Zulip
-        url: https://polaris-catalog.zulipchat.com/
-        icon: fa-regular fa-comment-dots
-        desc: Chat with other project developers
       - name: Community Meetings
         url: /community/meetings/
         icon: fa-brands fa-square-youtube


### PR DESCRIPTION
As discussed on the mailing list, we have a consensus to "promote" Slack as our main chat service.

This PR removes mention to Zulip in favor of Slack.