### PR TITLE
Add production readiness checks

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkProductionReadinessChecks.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkProductionReadinessChecks.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.extension.persistence.impl.eclipselink;
+
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_URL;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class EclipseLinkProductionReadinessChecks {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(EclipseLinkProductionReadinessChecks.class);
+
+  public void checkJdbcUrl(
+      @Observes StartupEvent event, EclipseLinkConfiguration eclipseLinkConfiguration) {
+    try {
+      var confFile = eclipseLinkConfiguration.configurationFile().map(Path::toString).orElse(null);
+      var persistenceUnitName =
+          confFile != null ? eclipseLinkConfiguration.persistenceUnit() : null;
+      var unit =
+          PolarisEclipseLinkPersistenceUnit.locatePersistenceUnit(confFile, persistenceUnitName);
+      var properties = unit.loadProperties();
+      var jdbcUrl = properties.get(JDBC_URL);
+      if (jdbcUrl != null && jdbcUrl.startsWith("jdbc:h2")) {
+        LOGGER.warn(
+            "The current persistence unit is intended for tests only; do not use it in production "
+                + "(offending configuration option: 'polaris.persistence.eclipselink.configuration-file')");
+      }
+    } catch (IOException e) {
+      LOGGER.error("Failed to check JDBC URL", e);
+    }
+  }
+}

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkProductionReadinessChecks.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkProductionReadinessChecks.java
@@ -46,8 +46,10 @@ public class EclipseLinkProductionReadinessChecks {
       var jdbcUrl = properties.get(JDBC_URL);
       if (jdbcUrl != null && jdbcUrl.startsWith("jdbc:h2")) {
         LOGGER.warn(
-            "The current persistence unit is intended for tests only; do not use it in production "
-                + "(offending configuration option: 'polaris.persistence.eclipselink.configuration-file')");
+            "!!! The current persistence unit (jdbc:h2) is intended for tests only. "
+                + "Do not do this in production! "
+                + "Offending configuration option: 'polaris.persistence.eclipselink.configuration-file'. "
+                + "See https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production/.");
       }
     } catch (IOException e) {
       LOGGER.error("Failed to check JDBC URL", e);

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.spotbugs.annotations)
 
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
   constraints {
     implementation("org.xerial.snappy:snappy-java:1.1.10.7") {
       because("Vulnerability detected in 1.1.8.2")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/ProductionReadinessCheck.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/ProductionReadinessCheck.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.config;
+
+import java.util.List;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+
+/** Represents the result of a production readiness check. */
+@PolarisImmutable
+public interface ProductionReadinessCheck {
+
+  ProductionReadinessCheck OK = ImmutableProductionReadinessCheck.builder().build();
+
+  static ProductionReadinessCheck of(Error... errors) {
+    return ImmutableProductionReadinessCheck.builder().addErrors(errors).build();
+  }
+
+  default boolean ready() {
+    return getErrors().isEmpty();
+  }
+
+  @Value.Parameter(order = 1)
+  List<Error> getErrors();
+
+  @PolarisImmutable
+  interface Error {
+
+    static Error of(String message, String offendingProperty) {
+      return ImmutableError.of(message, offendingProperty);
+    }
+
+    @Value.Parameter(order = 1)
+    String message();
+
+    @Value.Parameter(order = 2)
+    String offendingProperty();
+  }
+}

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
@@ -24,6 +24,7 @@ import jakarta.enterprise.event.Observes;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration;
+import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.RSAKeyPairConfiguration;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.SymmetricKeyConfiguration;
 import org.apache.polaris.service.auth.Authenticator;
 import org.apache.polaris.service.auth.JWTRSAKeyPairFactory;
@@ -64,11 +65,26 @@ public class ProductionReadinessChecks {
       AuthenticationConfiguration configuration,
       TokenBrokerFactory factory) {
     if (factory instanceof JWTRSAKeyPairFactory) {
-      LOGGER.warn(
-          "No public and private key files were provided; these will be generated. "
-              + "Do not do this in production (offending configuration options: "
-              + "'polaris.authentication.token-broker.rsa-key-pair.public-key-file' and "
-              + "'polaris.authentication.token-broker.rsa-key-pair.private-key-file').");
+      if (configuration
+          .tokenBroker()
+          .rsaKeyPair()
+          .map(RSAKeyPairConfiguration::publicKeyFile)
+          .isEmpty()) {
+        LOGGER.warn(
+            "A public key file wasn't provided and will be generated. "
+                + "Do not do this in production (offending configuration option: "
+                + "'polaris.authentication.token-broker.rsa-key-pair.public-key-file').");
+      }
+      if (configuration
+          .tokenBroker()
+          .rsaKeyPair()
+          .map(RSAKeyPairConfiguration::privateKeyFile)
+          .isEmpty()) {
+        LOGGER.warn(
+            "A private key file wasn't provided and will be generated. "
+                + "Do not do this in production (offending configuration option: "
+                + "'polaris.authentication.token-broker.rsa-key-pair.private-key-file').");
+      }
     }
     if (factory instanceof JWTSymmetricKeyFactory) {
       if (configuration

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
@@ -21,7 +21,14 @@ package org.apache.polaris.service.quarkus.config;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Startup;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.config.ProductionReadinessCheck;
+import org.apache.polaris.core.config.ProductionReadinessCheck.Error;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.RSAKeyPairConfiguration;
@@ -47,45 +54,85 @@ public class ProductionReadinessChecks {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProductionReadinessChecks.class);
 
-  public void checkAuthenticator(
-      @Observes Startup event, Authenticator<String, AuthenticatedPolarisPrincipal> authenticator) {
+  /**
+   * A warning sign ⚠ {@code 26A0} with variant selector {@code FE0F}. The sign is preceded by a
+   * null character {@code 0000} to ensure that the warning sign is displayed correctly.
+   */
+  private static final String WARNING_SIGN_WITH_VARIANT_SELECTOR = "\u0000\u26A0\uFE0F";
+
+  /** A simple warning sign displayed when the character set is not UTF-8. */
+  private static final String SIMPLE_WARNING_SIGN = "!!!";
+
+  public void performChecks(@Observes Startup event, Instance<ProductionReadinessCheck> checks) {
+    List<Error> errors =
+        checks.stream()
+            .filter(check -> !check.ready())
+            .flatMap(check -> check.getErrors().stream())
+            .toList();
+    if (!errors.isEmpty()) {
+      String warning =
+          Charset.defaultCharset().equals(StandardCharsets.UTF_8)
+              ? WARNING_SIGN_WITH_VARIANT_SELECTOR
+              : SIMPLE_WARNING_SIGN;
+      LOGGER.warn("{} Production readiness checks failed! Check the warnings below.", warning);
+      errors.forEach(
+          error ->
+              LOGGER.warn(
+                  "- {} Offending configuration option: '{}'.",
+                  error.message(),
+                  error.offendingProperty()));
+      LOGGER.warn(
+          "Refer to https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production for more information.");
+    }
+  }
+
+  @Produces
+  public ProductionReadinessCheck checkAuthenticator(
+      Authenticator<String, AuthenticatedPolarisPrincipal> authenticator) {
     if (authenticator instanceof TestInlineBearerTokenPolarisAuthenticator) {
-      warn(
-          "The current authenticator is intended for tests only.",
-          "polaris.authentication.authenticator.type");
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "The current authenticator is intended for tests only.",
+              "polaris.authentication.authenticator.type"));
     }
+
+    return ProductionReadinessCheck.OK;
   }
 
-  public void checkTokenService(@Observes Startup event, IcebergRestOAuth2ApiService service) {
+  @Produces
+  public ProductionReadinessCheck checkTokenService(IcebergRestOAuth2ApiService service) {
     if (service instanceof TestOAuth2ApiService) {
-      warn(
-          "The current token service is intended for tests only.",
-          "polaris.authentication.token-service.type");
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "The current token service is intended for tests only.",
+              "polaris.authentication.token-service.type"));
     }
+    return ProductionReadinessCheck.OK;
   }
 
-  public void checkTokenBroker(
-      @Observes Startup event,
-      AuthenticationConfiguration configuration,
-      TokenBrokerFactory factory) {
+  @Produces
+  public ProductionReadinessCheck checkTokenBroker(
+      AuthenticationConfiguration configuration, TokenBrokerFactory factory) {
     if (factory instanceof JWTRSAKeyPairFactory) {
       if (configuration
           .tokenBroker()
           .rsaKeyPair()
           .map(RSAKeyPairConfiguration::publicKeyFile)
           .isEmpty()) {
-        warn(
-            "A public key file wasn't provided and will be generated.",
-            "polaris.authentication.token-broker.rsa-key-pair.public-key-file");
+        return ProductionReadinessCheck.of(
+            Error.of(
+                "A public key file wasn't provided and will be generated.",
+                "polaris.authentication.token-broker.rsa-key-pair.public-key-file"));
       }
       if (configuration
           .tokenBroker()
           .rsaKeyPair()
           .map(RSAKeyPairConfiguration::privateKeyFile)
           .isEmpty()) {
-        warn(
-            "A private key file wasn't provided and will be generated.",
-            "polaris.authentication.token-broker.rsa-key-pair.private-key-file");
+        return ProductionReadinessCheck.of(
+            Error.of(
+                "A private key file wasn't provided and will be generated.",
+                "polaris.authentication.token-broker.rsa-key-pair.private-key-file"));
       }
     }
     if (factory instanceof JWTSymmetricKeyFactory) {
@@ -94,42 +141,44 @@ public class ProductionReadinessChecks {
           .symmetricKey()
           .map(SymmetricKeyConfiguration::secret)
           .isPresent()) {
-        warn(
-            "A symmetric key secret was provided through configuration rather than through a secret file.",
-            "polaris.authentication.token-broker.symmetric-key.secret");
+        return ProductionReadinessCheck.of(
+            Error.of(
+                "A symmetric key secret was provided through configuration rather than through a secret file.",
+                "polaris.authentication.token-broker.symmetric-key.secret"));
       }
     }
+    return ProductionReadinessCheck.OK;
   }
 
-  public void checkMetastore(@Observes Startup event, MetaStoreManagerFactory factory) {
+  @Produces
+  public ProductionReadinessCheck checkMetastore(MetaStoreManagerFactory factory) {
     if (factory instanceof InMemoryPolarisMetaStoreManagerFactory) {
-      warn("The current metastore is intended for tests only.", "polaris.persistence.type");
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "The current metastore is intended for tests only.", "polaris.persistence.type"));
     }
+    return ProductionReadinessCheck.OK;
   }
 
-  public void checkRealmResolver(
-      @Observes Startup event, Config config, RealmContextResolver resolver) {
+  @Produces
+  public ProductionReadinessCheck checkRealmResolver(Config config, RealmContextResolver resolver) {
     if (resolver instanceof TestRealmContextResolver) {
-      warn(
-          "The current realm context resolver is intended for tests only.",
-          "polaris.realm-context.type");
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "The current realm context resolver is intended for tests only.",
+              "polaris.realm-context.type"));
     }
     if (resolver instanceof DefaultRealmContextResolver) {
       ConfigValue configValue = config.getConfigValue("polaris.realm-context.require-header");
       boolean userProvided =
           configValue.getSourceOrdinal() > 250; // ordinal for application.properties in classpath
       if ("false".equals(configValue.getValue()) && !userProvided) {
-        warn(
-            "The realm context resolver is configured to map requests without a realm header to the default realm.",
-            "polaris.realm-context.require-header");
+        return ProductionReadinessCheck.of(
+            Error.of(
+                "The realm context resolver is configured to map requests without a realm header to the default realm.",
+                "polaris.realm-context.require-header"));
       }
     }
-  }
-
-  private static void warn(String message, String property) {
-    String fullMessage =
-        "!!! {} Do not do this in production! Offending configuration option: '{}'. "
-            + "See https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production/.";
-    LOGGER.warn(fullMessage, message, property);
+    return ProductionReadinessCheck.OK;
   }
 }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
@@ -18,9 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.config;
 
-import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration;
@@ -48,8 +48,7 @@ public class ProductionReadinessChecks {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProductionReadinessChecks.class);
 
   public void checkAuthenticator(
-      @Observes StartupEvent event,
-      Authenticator<String, AuthenticatedPolarisPrincipal> authenticator) {
+      @Observes Startup event, Authenticator<String, AuthenticatedPolarisPrincipal> authenticator) {
     if (authenticator instanceof TestInlineBearerTokenPolarisAuthenticator) {
       warn(
           "The current authenticator is intended for tests only.",
@@ -57,7 +56,7 @@ public class ProductionReadinessChecks {
     }
   }
 
-  public void checkTokenService(@Observes StartupEvent event, IcebergRestOAuth2ApiService service) {
+  public void checkTokenService(@Observes Startup event, IcebergRestOAuth2ApiService service) {
     if (service instanceof TestOAuth2ApiService) {
       warn(
           "The current token service is intended for tests only.",
@@ -66,7 +65,7 @@ public class ProductionReadinessChecks {
   }
 
   public void checkTokenBroker(
-      @Observes StartupEvent event,
+      @Observes Startup event,
       AuthenticationConfiguration configuration,
       TokenBrokerFactory factory) {
     if (factory instanceof JWTRSAKeyPairFactory) {
@@ -102,14 +101,14 @@ public class ProductionReadinessChecks {
     }
   }
 
-  public void checkMetastore(@Observes StartupEvent event, MetaStoreManagerFactory factory) {
+  public void checkMetastore(@Observes Startup event, MetaStoreManagerFactory factory) {
     if (factory instanceof InMemoryPolarisMetaStoreManagerFactory) {
       warn("The current metastore is intended for tests only.", "polaris.persistence.type");
     }
   }
 
   public void checkRealmResolver(
-      @Observes StartupEvent event, Config config, RealmContextResolver resolver) {
+      @Observes Startup event, Config config, RealmContextResolver resolver) {
     if (resolver instanceof TestRealmContextResolver) {
       warn(
           "The current realm context resolver is intended for tests only.",

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
@@ -56,24 +56,22 @@ public class ProductionReadinessChecks {
 
   /**
    * A warning sign ⚠ {@code 26A0} with variant selector {@code FE0F}. The sign is preceded by a
-   * null character {@code 0000} to ensure that the warning sign is displayed correctly.
+   * null character {@code 0000} to ensure that the warning sign is displayed correctly regardless
+   * of the log pattern (some log patterns seem to interfere with non-ASCII characters).
    */
-  private static final String WARNING_SIGN_WITH_VARIANT_SELECTOR = "\u0000\u26A0\uFE0F";
+  private static final String WARNING_SIGN_UTF_8 = "\u0000\u26A0\uFE0F";
 
   /** A simple warning sign displayed when the character set is not UTF-8. */
-  private static final String SIMPLE_WARNING_SIGN = "!!!";
+  private static final String WARNING_SIGN_PLAIN = "!!!";
 
-  public void performChecks(@Observes Startup event, Instance<ProductionReadinessCheck> checks) {
-    List<Error> errors =
-        checks.stream()
-            .filter(check -> !check.ready())
-            .flatMap(check -> check.getErrors().stream())
-            .toList();
+  public void warnOnFailedChecks(
+      @Observes Startup event, Instance<ProductionReadinessCheck> checks) {
+    List<Error> errors = checks.stream().flatMap(check -> check.getErrors().stream()).toList();
     if (!errors.isEmpty()) {
       String warning =
           Charset.defaultCharset().equals(StandardCharsets.UTF_8)
-              ? WARNING_SIGN_WITH_VARIANT_SELECTOR
-              : SIMPLE_WARNING_SIGN;
+              ? WARNING_SIGN_UTF_8
+              : WARNING_SIGN_PLAIN;
       LOGGER.warn("{} Production readiness checks failed! Check the warnings below.", warning);
       errors.forEach(
           error ->

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.config;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.service.auth.AuthenticationConfiguration;
+import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.SymmetricKeyConfiguration;
+import org.apache.polaris.service.auth.Authenticator;
+import org.apache.polaris.service.auth.JWTRSAKeyPairFactory;
+import org.apache.polaris.service.auth.JWTSymmetricKeyFactory;
+import org.apache.polaris.service.auth.TestInlineBearerTokenPolarisAuthenticator;
+import org.apache.polaris.service.auth.TestOAuth2ApiService;
+import org.apache.polaris.service.auth.TokenBrokerFactory;
+import org.apache.polaris.service.catalog.api.IcebergRestOAuth2ApiService;
+import org.apache.polaris.service.context.DefaultRealmContextResolver;
+import org.apache.polaris.service.context.RealmContextConfiguration;
+import org.apache.polaris.service.context.RealmContextResolver;
+import org.apache.polaris.service.context.TestRealmContextResolver;
+import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class ProductionReadinessChecks {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProductionReadinessChecks.class);
+
+  public void checkAuthenticator(
+      @Observes StartupEvent event,
+      Authenticator<String, AuthenticatedPolarisPrincipal> authenticator) {
+    if (authenticator instanceof TestInlineBearerTokenPolarisAuthenticator) {
+      warnOnTestOnly("authenticator", "polaris.authentication.authenticator.type");
+    }
+  }
+
+  public void checkTokenService(@Observes StartupEvent event, IcebergRestOAuth2ApiService service) {
+    if (service instanceof TestOAuth2ApiService) {
+      warnOnTestOnly("token service", "polaris.authentication.token-service.type");
+    }
+  }
+
+  public void checkTokenBroker(
+      @Observes StartupEvent event,
+      AuthenticationConfiguration configuration,
+      TokenBrokerFactory factory) {
+    if (factory instanceof JWTRSAKeyPairFactory) {
+      LOGGER.warn(
+          "No public and private key files were provided; these will be generated. "
+              + "Do not do this in production (offending configuration options: "
+              + "'polaris.authentication.token-broker.rsa-key-pair.public-key-file' and "
+              + "'polaris.authentication.token-broker.rsa-key-pair.private-key-file').");
+    }
+    if (factory instanceof JWTSymmetricKeyFactory) {
+      if (configuration
+          .tokenBroker()
+          .symmetricKey()
+          .map(SymmetricKeyConfiguration::secret)
+          .isPresent()) {
+        LOGGER.warn(
+            "A symmetric key secret was provided through configuration rather than through a secret file. "
+                + "Do not do this in production (offending configuration option: "
+                + "'polaris.authentication.token-broker.symmetric-key.secret').");
+      }
+    }
+  }
+
+  public void checkMetastore(@Observes StartupEvent event, MetaStoreManagerFactory factory) {
+    if (factory instanceof InMemoryPolarisMetaStoreManagerFactory) {
+      warnOnTestOnly("metastore", "polaris.persistence.type");
+    }
+  }
+
+  public void checkRealmResolver(
+      @Observes StartupEvent event,
+      RealmContextConfiguration configuration,
+      RealmContextResolver resolver) {
+    if (resolver instanceof TestRealmContextResolver) {
+      warnOnTestOnly("realm context resolver", "polaris.realm-context.type");
+    }
+    if (resolver instanceof DefaultRealmContextResolver) {
+      if (!configuration.requireHeader()) {
+        LOGGER.warn(
+            "The realm context resolver is configured to map requests without a realm header to the default realm. "
+                + "Do not do this in production (offending configuration option: 'polaris.realm-context.require-header').");
+      }
+    }
+  }
+
+  private static void warnOnTestOnly(String description, String property) {
+    LOGGER.warn(
+        "The current {} is intended for tests only. Do not use it in production (offending configuration option: '{}').",
+        description,
+        property);
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPairFactory.java
@@ -29,14 +29,10 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration;
 import org.apache.polaris.service.auth.AuthenticationConfiguration.TokenBrokerConfiguration.RSAKeyPairConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 @Identifier("rsa-key-pair")
 public class JWTRSAKeyPairFactory implements TokenBrokerFactory {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(JWTRSAKeyPairFactory.class);
 
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final TokenBrokerConfiguration tokenBrokerConfiguration;
@@ -63,9 +59,6 @@ public class JWTRSAKeyPairFactory implements TokenBrokerFactory {
   }
 
   private RSAKeyPairConfiguration generateKeyPair() {
-    LOGGER.warn(
-        "No public and private key files were provided; these will be generated. "
-            + "This should not be done in production!");
     try {
       Path privateFileLocation = Files.createTempFile("polaris-private", ".pem");
       Path publicFileLocation = Files.createTempFile("polaris-public", ".pem");


### PR DESCRIPTION
You can test this feature with the following commands by observing the warnings in the logs:

```shell
./gradlew run  \
  -Dpolaris.realm-context.type=test \
  -Dpolaris.authentication.token-service.type=test \
  -Dpolaris.authentication.authenticator.type=test

./gradlew run \
  -Dpolaris.authentication.token-broker.type=symmetric-key \
  -Dpolaris.authentication.token-broker.symmetric-key.secret=secret

./gradlew run  \
  -Dpolaris.persistence.type=eclipse-link  \
  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
```