### PR TITLE
Spec: Fix incorrect reference to IcebergErrorResponse in notifications-api.yaml

### DIFF
--- a/site/content/in-dev/unreleased/rest-catalog-open-api.md
+++ b/site/content/in-dev/unreleased/rest-catalog-open-api.md
@@ -17,11 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: 'Apache Polaris and Iceberg Catalog OpenAPI'
-linkTitle: 'Catalog OpenAPI'
+title: 'Apache Iceberg OpenAPI'
+linkTitle: 'Iceberg OpenAPI'
 weight: 900
 params:
   show_page_toc: false
 ---
 
-{{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}
+{{< redoc-polaris "rest-catalog-open-api.yaml" >}}

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,7 +23,7 @@ npm install @redocly/cli -g
 
 ### Generate the Bundle
 ```
-redocly bundle spec/polaris-catalog-open-api.yaml -o spec/generated/generated-polaris-catalog-service.yaml
+redocly bundle spec/polaris-catalog-service.yaml -o spec/generated/bundled-polaris-catalog-service.yaml
 ```
 
 

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -1336,7 +1336,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/responses-IcebergErrorResponse'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -1345,7 +1345,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/responses-IcebergErrorResponse'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example:
                 summary: The timestamp of the received notification is older than or equal to the most recent timestamp Polaris has already processed for the specified table.
                 value:
@@ -3257,17 +3257,6 @@ components:
           $ref: '#/components/schemas/NotificationType'
         payload:
           $ref: '#/components/schemas/TableUpdateNotification'
-    responses-IcebergErrorResponse:
-      description: JSON wrapper for all error responses (non-2xx)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/IcebergErrorResponse'
-          example:
-            error:
-              message: The server does not support this operation
-              type: UnsupportedOperationException
-              code: 406
   responses:
     BadRequestErrorResponse:
       description: Indicates a bad request error. It could be caused by an unexpected request body format or other forms of request validation failure, such as invalid json. Usually serves application/json content, although in some cases simple text/plain content might be returned by the server's middleware.

--- a/spec/polaris-catalog-apis/notifications-api.yaml
+++ b/spec/polaris-catalog-apis/notifications-api.yaml
@@ -68,7 +68,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../rest-catalog-open-api.yaml#/components/responses/IcebergErrorResponse'
+                $ref: '../rest-catalog-open-api.yaml#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '../rest-catalog-open-api.yaml#/components/examples/NoSuchTableError'
@@ -79,7 +79,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../rest-catalog-open-api.yaml#/components/responses/IcebergErrorResponse'
+                $ref: '../rest-catalog-open-api.yaml#/components/schemas/IcebergErrorResponse'
               example:
                 $ref: '#/components/examples/OutOfOrderNotificationError'
         419:


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

In `notification-api.yaml`, the current reference of `IcebergErrorResponse` is pointing to the wrong model. We should use the one defined in `components/schemas` instead of `components/responses` if we want to customize the example of the corresponding error code.

The incorrect reference cause a problematic `responses-IcebergErrorResponse` model be generated in the `bundled-polaris-catalog-service.yaml`, which cause an error in swagger editor. 