### PR TITLE
Fix: check for slashless metadata paths

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
@@ -1583,4 +1583,13 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     handler.handleTask(taskEntity, realmContext);
     Assertions.assertThat(measured.getNumDeletedFiles()).as("A table was deleted").isGreaterThan(0);
   }
+
+  @Test
+  public void testRegisterTableWithSlashlessMetadataLocation() {
+    BasePolarisCatalog catalog = catalog();
+    Assertions.assertThatThrownBy(
+            () -> catalog.registerTable(TABLE, "metadata_location_without_slashes"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid metadata file location");
+  }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -312,7 +312,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
     int lastSlashIndex = metadataFileLocation.lastIndexOf("/");
     Preconditions.checkArgument(
         lastSlashIndex != -1,
-        "Invalid metadata file location: %s, must be a full path to a file",
+        "Invalid metadata file location; metadata file location must be absolute and contain a '/': %s",
         metadataFileLocation);
 
     // Throw an exception if this table already exists in the catalog.

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -309,12 +309,18 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         metadataFileLocation != null && !metadataFileLocation.isEmpty(),
         "Cannot register an empty metadata file location as a table");
 
+    int lastSlashIndex = metadataFileLocation.lastIndexOf("/");
+    Preconditions.checkArgument(
+        lastSlashIndex != -1,
+        "Invalid metadata file location: %s, must be a full path to a file",
+        metadataFileLocation);
+
     // Throw an exception if this table already exists in the catalog.
     if (tableExists(identifier)) {
       throw new AlreadyExistsException("Table already exists: %s", identifier);
     }
 
-    String locationDir = metadataFileLocation.substring(0, metadataFileLocation.lastIndexOf("/"));
+    String locationDir = metadataFileLocation.substring(0, lastSlashIndex);
 
     TableOperations ops = newTableOps(identifier);
 


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Polaris currently returns a 500 error for the `registerTable` catalog API if the provided metadata file path does not contain any slashes.
- `lastIndexOf("/")` will return `-1`, causing an `Range [0, -1) out of bounds` error when calling `substring()`.
- This change handles this case & returns a 400 instead.