### PR TITLE
Group application.properties by build time / run time

### DIFF
--- a/quarkus/admin/src/main/resources/application.properties
+++ b/quarkus/admin/src/main/resources/application.properties
@@ -17,6 +17,11 @@
 # under the License.
 #
 
+# ---- Build-time configuration ----
+# Build-time properties take effect when Quarkus processes java classes
+# and creates Polaris jars. These properties cannot be overriden in runtime.
+# Cf. https://quarkus.io/guides/all-config
+
 quarkus.application.name=Apache Polaris Admin Tool (incubating)
 quarkus.banner.path=/org/apache/polaris/admintool/banner.txt
 
@@ -26,5 +31,8 @@ quarkus.container-image.registry=docker.io
 quarkus.container-image.group=apache
 quarkus.container-image.name=polaris-admin-tool
 quarkus.container-image.additional-tags=latest
+
+# ---- Runtime Configuration ----
+# Below are default values for properties that can be changed in runtime.
 
 polaris.persistence.type=eclipse-link

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -17,18 +17,30 @@
 # under the License.
 #
 
+# ---- Build-time configuration ----
+# Build-time properties take effect when Quarkus processes java classes
+# and creates Polaris jars. These properties cannot be overriden in runtime.
+# Cf. https://quarkus.io/guides/all-config
+
 quarkus.banner.path=/org/apache/polaris/service/banner.txt
+quarkus.http.auth.basic=false
+quarkus.http.enable-compression=true
+quarkus.http.enable-decompression=true
+quarkus.http.compress-media-types=application/json,text/html,text/plain
+quarkus.management.enabled=true
+quarkus.micrometer.enabled=true
+quarkus.micrometer.export.prometheus.enabled=true
+quarkus.otel.enabled=true
+
+# ---- Runtime Configuration ----
+# Below are default values for properties that can be changed in runtime.
 
 quarkus.config.mapping.validate-unknown=true
 
-quarkus.http.auth.basic=false
 quarkus.http.access-log.enabled=true
 # quarkus.http.access-log.pattern=common
-quarkus.http.enable-compression=true
-quarkus.http.enable-decompression=true
 quarkus.http.body.handle-file-uploads=false
 quarkus.http.limits.max-body-size=10240K
-quarkus.http.compress-media-types=application/json,text/html,text/plain
 
 quarkus.http.cors.origins=http://localhost:8080
 quarkus.http.cors.methods=PATCH, POST, DELETE, GET, PUT
@@ -57,16 +69,9 @@ quarkus.log.category."org.apache.polaris".level=INFO
 quarkus.log.category."org.apache.iceberg.rest".level=INFO
 quarkus.log.category."io.smallrye.config".level=INFO
 
-quarkus.management.enabled=true
 quarkus.management.port=8182
 quarkus.management.test-port=0
 
-quarkus.micrometer.enabled=true
-quarkus.micrometer.export.prometheus.enabled=true
-
-# quarkus.otel.enabled is a build-time property. If it is disabled at build time, it will not be
-# possible to reset it at runtime, consequently all OTel functionality will be disabled.
-quarkus.otel.enabled=true
 # quarkus.otel.sdk.disabled is set to `true` by default to avoid spuriour errors about
 # trace collector connections being impossible to establish. This setting can be enabled
 # at runtime after configuring other OTel properties for proper trace data collection.

--- a/quarkus/server/src/main/resources/application.properties
+++ b/quarkus/server/src/main/resources/application.properties
@@ -17,6 +17,11 @@
 # under the License.
 #
 
+# ---- Build-time configuration ----
+# Build-time properties take effect when Quarkus processes java classes
+# and creates Polaris jars. These properties cannot be overriden in runtime.
+# Cf. https://quarkus.io/guides/all-config
+
 quarkus.application.name=Apache Polaris Server (incubating)
 
 quarkus.container-image.build=false


### PR DESCRIPTION
As discussed in latest community meeting, having proprties that are settable only at build time can be surprising to Polaris users and contributors.

This change attempts to help with that matter by grouping build time properties into dedicated sections inside application.properties files and adding comments to clarify their usage.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
