### PR TITLE
Fix: Failed to start polaris on UnionTech OS Desktop 20 Pro. 

### DIFF
--- a/aggregated-license-report/build.gradle.kts
+++ b/aggregated-license-report/build.gradle.kts
@@ -62,5 +62,3 @@ val aggregatedLicenseReportsZip by
   }
 
 tasks.register("check")
-
-tasks.register("check")

--- a/aggregated-license-report/build.gradle.kts
+++ b/aggregated-license-report/build.gradle.kts
@@ -62,3 +62,5 @@ val aggregatedLicenseReportsZip by
   }
 
 tasks.register("check")
+
+tasks.register("check")

--- a/site/content/in-dev/unreleased/quickstart.md
+++ b/site/content/in-dev/unreleased/quickstart.md
@@ -98,7 +98,7 @@ To start using Polaris in Docker, launch Polaris while Docker is running:
 ```shell
 cd ~/polaris
 ./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
-docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest
+docker run --privileged -p 8181:8181 -p 8182:8182 apache/polaris:latest
 ```
 
 You should see output for some time as Polaris builds and starts up. Eventually, you won’t see any more logs and should see messages that resemble the following:


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
INFO exec -a "java" java -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar /deployments/quarkus-run.jar 
INFO running in /deployments
[0.005s][warning][os,thread] Failed to start thread "GC Thread#0" - pthread_create failed (EPERM) for attributes: stacksize: 1024k, guardsize: 4k, detached.
[0.005s][error  ][gc,task  ] Failed to create worker thread