### PR TITLE
(fix): Check NodePort Service Type before setting it

### DIFF
--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -90,11 +90,11 @@ spec:
               mountPath: {{ .Values.logging.file.logsDir }}
               readOnly: false
             {{- end }}
-            - name: temp-dir
-              mountPath: /tmp
-              readOnly: false
-            {{- if .Values.extraVolumeMounts }}
-            {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 12 }}
+          ports:
+            {{- range $portName, $port := .Values.service.ports }}
+            - name: {{ $portName }}
+              containerPort: {{ $port.port }}
+              protocol: TCP
             {{- end }}
           {{- include "polaris.containerPorts" . | trim | nindent 10 }}
           livenessProbe:

--- a/helm/polaris/templates/service.yaml
+++ b/helm/polaris/templates/service.yaml
@@ -29,20 +29,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.type | default "ClusterIP" }}
   selector:
     {{- include "polaris.selectorLabels" . | nindent 4 }}
   ports:
-    {{- range .Values.service.ports }}
-    - name: {{ .name }}
-      port: {{ .port }}
-      {{- if .targetPort }}
-      targetPort: {{ .targetPort }}
+    {{- range $portName, $port := .Values.service.ports }}
+    - port: {{ $port.port }}
+      targetPort: {{ $port.port }}
+      {{- if and (eq $.Values.service.type "NodePort") $port.nodePort }}
+      nodePort: {{ $port.nodePort }}
       {{- end }}
-      {{- if .nodePort }}
-      nodePort: {{ .nodePort }}
-      {{- end }}
-      protocol: {{ default "TCP" .protocol }}
+      protocol: TCP
+      name: {{ $portName }}
     {{- end }}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}

--- a/helm/polaris/tests/service_test.yaml
+++ b/helm/polaris/tests/service_test.yaml
@@ -29,7 +29,6 @@ templates:
   - service.yaml
 
 tests:
-
   # metadata.name
   - it: should set service name
     asserts:
@@ -121,9 +120,10 @@ tests:
     set:
       service:
         ports:
-          - port: 18181
-            targetPort: 18181
-            name: polaris-http
+          polaris-service:
+            port: 18181
+          polaris-metrics:
+            port: 18182
     asserts:
       - equal:
           path: spec.ports
@@ -131,38 +131,39 @@ tests:
             - port: 18181
               targetPort: 18181
               protocol: TCP
-              name: polaris-http
-  - it: should set many service ports
+              name: polaris-service
+  - it: should set service nodeports
     set:
       service:
+        type: NodePort
         ports:
-          - port: 18181
-            targetPort: 18181
-            name: polaris-http
-          - port: 28181
-            targetPort: 28181
-            name: polaris-http2
-            nodePort: 28181
-            protocol: UDP
+          polaris-service:
+            port: 18181
+            nodePort: 32181
+          polaris-metrics:
+            port: 18182
+            nodePort: 32182
     asserts:
       - equal:
           path: spec.ports
           value:
+            - port: 18182
+              targetPort: 18182
+              nodePort: 32181
+              protocol: TCP
+              name: polaris-metrics
             - port: 18181
               targetPort: 18181
+              nodePort: 32182
               protocol: TCP
-              name: polaris-http
-            - port: 28181
-              targetPort: 28181
-              name: polaris-http2
-              nodePort: 28181
-              protocol: UDP
+              name: polaris-service
 
   # spec.sessionAffinity
-  - it: should not set service session affinity by default
+  - it: should set service default session affinity
     asserts:
-      - notExists:
+      - equal:
           path: spec.sessionAffinity
+          value: None
   - it: should set service session affinity
     set:
       service.sessionAffinity: ClientIP
@@ -170,84 +171,3 @@ tests:
       - equal:
           path: spec.sessionAffinity
           value: ClientIP
-
-  # spec.clusterIP
-  - it: should not set service cluster IP by default
-    asserts:
-      - notExists:
-          path: spec.clusterIP
-  - it: should set service cluster IP
-    set:
-      service.clusterIP: 1.2.3.4
-    asserts:
-      - equal:
-          path: spec.clusterIP
-          value: 1.2.3.4
-
-
-  # spec.externalTrafficPolicy
-  - it: should not set service external traffic policy by default
-    asserts:
-      - notExists:
-          path: spec.externalTrafficPolicy
-  - it: should set service external traffic policy if LoadBalancer
-    set:
-      service.externalTrafficPolicy: Local
-      service.type: LoadBalancer
-    asserts:
-      - equal:
-          path: spec.externalTrafficPolicy
-          value: Local
-  - it: should set service external traffic policy if NodePort
-    set:
-      service.externalTrafficPolicy: Local
-      service.type: NodePort
-    asserts:
-      - equal:
-          path: spec.externalTrafficPolicy
-          value: Local
-  - it: should set service external traffic policy if ClusterIP
-    set:
-      service.externalTrafficPolicy: Local
-      service.type: ClusterIP
-    asserts:
-      - notExists:
-          path: spec.externalTrafficPolicy
-
-  # spec.internalTrafficPolicy
-  - it: should not set service internal traffic policy by default
-    asserts:
-      - notExists:
-          path: spec.internalTrafficPolicy
-  - it: should set service internal traffic policy
-    set:
-      service.internalTrafficPolicy: Local
-    asserts:
-      - equal:
-          path: spec.internalTrafficPolicy
-          value: Local
-
-  # spec.trafficDistribution
-  - it: should not set service traffic distribution by default
-    asserts:
-      - notExists:
-          path: spec.trafficDistribution
-  - it: should set service traffic distribution if Kubernetes version >= 1.31
-    capabilities:
-      majorVersion: 1
-      minorVersion: 31
-    set:
-      service.trafficDistribution: Local
-    asserts:
-      - equal:
-          path: spec.trafficDistribution
-          value: Local
-  - it: should not set service traffic distribution if Kubernetes version < 1.31
-    capabilities:
-      majorVersion: 1
-      minorVersion: 30
-    set:
-      service.trafficDistribution: Local
-    asserts:
-      - notExists:
-          path: spec.trafficDistribution

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -42,7 +42,6 @@ image:
 imagePullSecrets: []
 #  - registry-creds
 
-
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true
@@ -51,7 +50,6 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
-
 
 # -- Annotations to apply to polaris pods.
 podAnnotations: {}
@@ -82,30 +80,22 @@ containerSecurityContext:
 
 # -- Polaris main service settings.
 service:
-  # -- The type of service to create. Valid values are: ExternalName, ClusterIP, NodePort, and LoadBalancer.
-  # The default value is ClusterIP.
+  # -- The type of service to create. ClusterIP/NodePort/LoadBalancer
   type: ClusterIP
   # -- The ports the service will listen on.
   # At least one port is required; the first port implicitly becomes the HTTP port that the
   # application will use for serving API requests. By default, it's 8181.
   # Note: port names must be unique and no more than 15 characters long.
   ports:
-      # -- The name of the port. Required.
-    - name: polaris-http
-      # -- The port the service listens on. By default, the HTTP port is 8181.
+    # polaris-server: The port the Polaris server listens on for API requests.
+    polaris-service:
       port: 8181
-      # -- Number or name of the port to access on the pods targeted by the service.
-      # If this is a string, it will be looked up as a named port in the target Pod's container ports.
-      # If this is not specified, the value of the 'port' field is used.
-      targetPort: ~  # polaris-service
-      # -- The port on each node on which this service is exposed when type is NodePort or LoadBalancer.
-      # Usually assigned by the system. If not specified, a port will be allocated if this Service requires one. If this field is specified when creating a Service which does not need it, creation will fail.
-      nodePort: ~  # 30000
-      # -- The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
-      protocol: ~
-    # - name: polaris-https
-    #  port: 18181
-  # -- The session affinity for the service. Valid values are: None, ClientIP. The default value is None.
+      nodePort: ""
+    # polaris-metrics: The port the Polaris server listens on for metrics API requests (health checks, metrics, etc.).
+    polaris-metrics:
+      port: 8182
+      nodePort: ""
+  # -- The session affinity for the service. Valid values are: None, ClientIP.
   # ClientIP enables sticky sessions based on the client's IP address.
   # This is generally beneficial to Polaris deployments, but some testing may be
   # required in order to make sure that the load is distributed evenly among the pods.
@@ -211,9 +201,8 @@ ingress:
   # -- Specifies whether an ingress should be created.
   enabled: false
   # -- Annotations to add to the ingress.
-  annotations: {
-    # nginx.ingress.kubernetes.io/upstream-hash-by: "$binary_remote_addr"
-  }
+  annotations: {}
+  # nginx.ingress.kubernetes.io/upstream-hash-by: "$binary_remote_addr"
   # -- A list of host paths used to configure the ingress.
   hosts:
     - host: chart-example.local
@@ -341,8 +330,7 @@ advancedConfig:
 # You can pass here any valid EnvVar object:
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core
 # This can be useful to get configuration values from Kubernetes secrets or config maps.
-extraEnv:
-  []
+extraEnv: []
 #  - name: AWS_STORAGE_BUCKET
 #    value: s3://xxxxx/
 #  - name: AWS_ACCESS_KEY_ID
@@ -538,6 +526,7 @@ fileIo:
     # -- The type of file IO to use. Two built-in types are supported: default and wasb. The wasb one translates WASB paths to ABFS ones.
   type: default
 
+<<<<<<< HEAD
 # -- Storage credentials for the server. If the following properties are unset, default
 # credentials will be used, in which case the pod must have the necessary permissions to access the storage.
 storage:
@@ -553,6 +542,103 @@ storage:
     gcpToken: ~
     # -- The key in the secret to pull the GCP token expiration time from. Only required when using GCP. Must be a valid ISO 8601 duration. The default is PT1H (1 hour).
     gcpTokenLifespan: ~
+||||||| parent of 330f0a30 ((fix): Allow helm chart to support arbitrary nodePort value)
+        #   # The file to which statements will be logged.
+        #   currentLogFilename: ./logs/request.log
+
+        #   #  When the log file rolls over, the file will be archived to requests-2012-03-15.log.gz,
+        #   # requests.log will be truncated, and new statements written to it.
+        #   archivedLogFilenamePattern: ./logs/requests-%d.log.gz
+
+        #   # The maximum number of log files to archive.
+        #   archivedFileCount: 14
+
+        #   # Enable archiving if the request log entries go to the their own file
+        #   archive: true
+
+  featureConfiguration:
+    ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
+    SUPPORTED_CATALOG_STORAGE_TYPES:
+      - S3
+      - GCS
+      - AZURE
+      - FILE
+
+  callContextResolver:
+    type: default
+
+  realmContextResolver:
+    type: default
+
+  defaultRealms:
+    - default-realm
+
+  metaStoreManager:
+    type: in-memory
+    # uncomment below to use eclipse-link as metastore
+    # type: eclipse-link
+    # persistence-unit: polaris
+    # conf-file: /eclipselink-config/conf.jar!/persistence.xml
+
+  io:
+    factoryType: default
+
+  # TODO - avoid duplicating token broker config
+  oauth2:
+    type: test
+  #  type: default # - uncomment to support Auth0 JWT tokens
+# tokenBroker:
+#  type: symmetric-key
+#  secret: polaris
+=======
+        #   # The file to which statements will be logged.
+        #   currentLogFilename: ./logs/request.log
+
+        #   #  When the log file rolls over, the file will be archived to requests-2012-03-15.log.gz,
+        #   # requests.log will be truncated, and new statements written to it.
+        #   archivedLogFilenamePattern: ./logs/requests-%d.log.gz
+
+        #   # The maximum number of log files to archive.
+        #   archivedFileCount: 14
+
+        #   # Enable archiving if the request log entries go to the their own file
+        #   archive: true
+
+  featureConfiguration:
+    ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING: false
+    SUPPORTED_CATALOG_STORAGE_TYPES:
+      - S3
+      - GCS
+      - AZURE
+      - FILE
+
+  callContextResolver:
+    type: default
+
+  realmContextResolver:
+    type: default
+
+  defaultRealms:
+    - default-realm
+
+  metaStoreManager:
+    type: in-memory
+    # uncomment below to use eclipse-link as metastore
+    # type: eclipse-link
+    # persistence-unit: polaris
+    # conf-file: /eclipselink-config/conf.jar!/persistence.xml
+
+  io:
+    factoryType: default
+
+  # TODO - avoid duplicating token broker config
+  oauth2:
+    type: test
+  #  type: default # - uncomment to support Auth0 JWT tokens
+  # tokenBroker:
+  #  type: symmetric-key
+  #  secret: polaris
+>>>>>>> 330f0a30 ((fix): Allow helm chart to support arbitrary nodePort value)
 
 # -- Polaris authentication configuration.
 authentication:
@@ -610,9 +696,104 @@ rateLimiter:
     # -- The time window.
     window: PT10S
 
+<<<<<<< HEAD
 # -- Polaris asynchronous task executor configuration.
 tasks:
   # -- The maximum number of concurrent tasks that can be executed at the same time. The default is the number of available cores.
   maxConcurrentTasks: ~  # 100
   # -- The maximum number of tasks that can be queued up for execution. The default is Integer.MAX_VALUE.
   maxQueuedTasks: ~  # 1000
+||||||| parent of 330f0a30 ((fix): Allow helm chart to support arbitrary nodePort value)
+  logging:
+
+    # The default level of all loggers. Can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL.
+    level: INFO
+
+    # Logger-specific levels.
+    loggers:
+      org.apache.iceberg.rest: DEBUG
+      org.apache.polaris: DEBUG
+
+    appenders:
+
+      - type: console
+        # If true, write log statements to stdout.
+        #      enabled: true
+        # Do not display log statements below this threshold to stdout.
+        threshold: ALL
+        # Custom Logback PatternLayout with threadname.
+        logFormat: "%-5p [%d{ISO8601} - %-6r] [%t] [%X{aid}%X{sid}%X{tid}%X{wid}%X{oid}%X{srv}%X{job}%X{rid}] %c{30}: %m %kvp%n%ex"
+
+      # # Settings for logging to a file.
+      # - type: file
+      #   # If true, write log statements to a file.
+      #   #      enabled: true
+      #   # Do not write log statements below this threshold to the file.
+      #   threshold: ALL
+      #   layout:
+      #     type: polaris
+      #     flattenKeyValues: false
+      #     includeKeyValues: true
+
+      #   # The file to which statements will be logged.
+      #   currentLogFilename: ./logs/polaris.log
+      #   #  When the log file rolls over, the file will be archived to polaris-2012-03-15.log.gz,
+      #   # polaris.log will be truncated, and new statements written to it.
+      #   archivedLogFilenamePattern: ./logs/polaris-%d.log.gz
+      #   # The maximum number of log files to archive.
+      #   archivedFileCount: 14
+
+  # Limits the size of request bodies sent to Polaris. -1 means no limit.
+  maxRequestBodyBytes: -1
+
+  # Optional, not specifying a "rateLimiter" section also means no rate limiter
+  rateLimiter:
+    type: no-op
+=======
+  logging:
+    # The default level of all loggers. Can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL.
+    level: INFO
+
+    # Logger-specific levels.
+    loggers:
+      org.apache.iceberg.rest: DEBUG
+      org.apache.polaris: DEBUG
+
+    appenders:
+      - type: console
+        # If true, write log statements to stdout.
+        #      enabled: true
+        # Do not display log statements below this threshold to stdout.
+        threshold: ALL
+        # Custom Logback PatternLayout with threadname.
+        logFormat:
+          "%-5p [%d{ISO8601} - %-6r] [%t]
+          [%X{aid}%X{sid}%X{tid}%X{wid}%X{oid}%X{srv}%X{job}%X{rid}] %c{30}: %m
+          %kvp%n%ex"
+
+      # # Settings for logging to a file.
+      # - type: file
+      #   # If true, write log statements to a file.
+      #   #      enabled: true
+      #   # Do not write log statements below this threshold to the file.
+      #   threshold: ALL
+      #   layout:
+      #     type: polaris
+      #     flattenKeyValues: false
+      #     includeKeyValues: true
+
+      #   # The file to which statements will be logged.
+      #   currentLogFilename: ./logs/polaris.log
+      #   #  When the log file rolls over, the file will be archived to polaris-2012-03-15.log.gz,
+      #   # polaris.log will be truncated, and new statements written to it.
+      #   archivedLogFilenamePattern: ./logs/polaris-%d.log.gz
+      #   # The maximum number of log files to archive.
+      #   archivedFileCount: 14
+
+  # Limits the size of request bodies sent to Polaris. -1 means no limit.
+  maxRequestBodyBytes: -1
+
+  # Optional, not specifying a "rateLimiter" section also means no rate limiter
+  rateLimiter:
+    type: no-op
+>>>>>>> 330f0a30 ((fix): Allow helm chart to support arbitrary nodePort value)


### PR DESCRIPTION
Currently the helm chart does not support specifying arbitrary `nodePort` value for services.   This PR allows the template users to specify the nodePort for the services.  Allowing nodePort helps setting the nodePort for polaris k8s deployment where we it might be a constraint to use any generated nodePort.

fixes: #981