### PR TITLE
Integration tests: improve support for temporary folders

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -29,13 +29,13 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionData;
@@ -87,6 +87,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -109,7 +110,6 @@ public class PolarisApplicationIntegrationTest {
 
   public static final String PRINCIPAL_ROLE_ALL = "PRINCIPAL_ROLE:ALL";
 
-  private static Path testDir;
   private static String realm;
 
   private static RestApi managementApi;
@@ -118,25 +118,26 @@ public class PolarisApplicationIntegrationTest {
   private static ClientCredentials clientCredentials;
   private static ClientPrincipal admin;
   private static String authToken;
+  private static URI baseLocation;
 
   private String principalRoleName;
   private String internalCatalogName;
 
   @BeforeAll
-  public static void setup(PolarisApiEndpoints apiEndpoints, ClientPrincipal adminCredentials)
-      throws IOException {
+  public static void setup(
+      PolarisApiEndpoints apiEndpoints, ClientPrincipal adminCredentials, @TempDir Path tempDir) {
     endpoints = apiEndpoints;
     client = polarisClient(endpoints);
     realm = endpoints.realmId();
     admin = adminCredentials;
     clientCredentials = adminCredentials.credentials();
     authToken = client.obtainToken(clientCredentials);
-
-    testDir = Path.of("build/test_data/iceberg/" + realm);
-    FileUtils.deleteQuietly(testDir.toFile());
-    Files.createDirectories(testDir);
-
     managementApi = client.managementApi(clientCredentials);
+    baseLocation =
+        Optional.ofNullable(System.getenv("INTEGRATION_TEST_TEMP_DIR"))
+            .map(URI::create)
+            .orElse(tempDir.toUri())
+            .resolve(realm + "/");
   }
 
   @AfterAll
@@ -443,9 +444,9 @@ public class PolarisApplicationIntegrationTest {
         Catalog.TypeEnum.EXTERNAL,
         principalRoleName,
         FileStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.FILE)
-            .setAllowedLocations(List.of("file://" + testDir.toFile().getAbsolutePath()))
+            .setAllowedLocations(List.of(baseLocation.toString()))
             .build(),
-        "file://" + testDir.toFile().getAbsolutePath());
+        baseLocation.toString());
     try (RESTSessionCatalog sessionCatalog = newSessionCatalog(catalogName);
         HadoopFileIO fileIo = new HadoopFileIO(new Configuration())) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
@@ -453,9 +454,7 @@ public class PolarisApplicationIntegrationTest {
       sessionCatalog.createNamespace(sessionContext, ns);
       TableIdentifier tableIdentifier = TableIdentifier.of(ns, "the_table");
       String location =
-          "file://"
-              + testDir.toFile().getAbsolutePath()
-              + "/testIcebergRegisterTableInExternalCatalog";
+          baseLocation.resolve("testIcebergRegisterTableInExternalCatalog").toString();
       String metadataLocation = location + "/metadata/000001-494949494949494949.metadata.json";
 
       TableMetadata tableMetadata =
@@ -489,19 +488,16 @@ public class PolarisApplicationIntegrationTest {
         Catalog.TypeEnum.EXTERNAL,
         principalRoleName,
         FileStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.FILE)
-            .setAllowedLocations(List.of("file://" + testDir.toFile().getAbsolutePath()))
+            .setAllowedLocations(List.of(baseLocation.toString()))
             .build(),
-        "file://" + testDir.toFile().getAbsolutePath());
+        baseLocation.toString());
     try (RESTSessionCatalog sessionCatalog = newSessionCatalog(catalogName);
         HadoopFileIO fileIo = new HadoopFileIO(new Configuration())) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
       Namespace ns = Namespace.of("db1");
       sessionCatalog.createNamespace(sessionContext, ns);
       TableIdentifier tableIdentifier = TableIdentifier.of(ns, "the_table");
-      String location =
-          "file://"
-              + testDir.toFile().getAbsolutePath()
-              + "/testIcebergUpdateTableInExternalCatalog";
+      String location = baseLocation.resolve("testIcebergUpdateTableInExternalCatalog").toString();
       String metadataLocation = location + "/metadata/000001-494949494949494949.metadata.json";
 
       Types.NestedField col1 = Types.NestedField.of(1, false, "col1", Types.StringType.get());
@@ -541,20 +537,16 @@ public class PolarisApplicationIntegrationTest {
         Catalog.TypeEnum.EXTERNAL,
         principalRoleName,
         FileStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.FILE)
-            .setAllowedLocations(List.of("file://" + testDir.toFile().getAbsolutePath()))
+            .setAllowedLocations(List.of(baseLocation.toString()))
             .build(),
-        "file://" + testDir.toFile().getAbsolutePath());
+        baseLocation.toString());
     try (RESTSessionCatalog sessionCatalog = newSessionCatalog(catalogName);
         HadoopFileIO fileIo = new HadoopFileIO(new Configuration())) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
       Namespace ns = Namespace.of("db1");
       sessionCatalog.createNamespace(sessionContext, ns);
       TableIdentifier tableIdentifier = TableIdentifier.of(ns, "the_table");
-      String location =
-          "file://"
-              + testDir.toFile().getAbsolutePath()
-              + "/"
-              + "testIcebergDropTableInExternalCatalog";
+      String location = baseLocation.resolve("testIcebergDropTableInExternalCatalog").toString();
       String metadataLocation = location + "/metadata/000001-494949494949494949.metadata.json";
 
       TableMetadata tableMetadata =

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -29,6 +29,8 @@ import jakarta.ws.rs.core.Response;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +94,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
@@ -108,9 +111,9 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
   private static final String TEST_ROLE_ARN =
       Optional.ofNullable(System.getenv("INTEGRATION_TEST_ROLE_ARN"))
           .orElse("arn:aws:iam::123456789012:role/my-role");
-  private static final String S3_BUCKET_BASE =
-      Optional.ofNullable(System.getenv("INTEGRATION_TEST_S3_PATH"))
-          .orElse("file:///tmp/buckets/my-bucket");
+
+  private static URI s3BucketBase;
+  private static URI externalCatalogBase;
 
   protected static final String VIEW_QUERY = "select * from ns1.layer1_table";
   private static String principalRoleName;
@@ -125,7 +128,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
   private String currentCatalogName;
 
   private final String catalogBaseLocation =
-      S3_BUCKET_BASE + "/" + System.getenv("USER") + "/path/to/data";
+      s3BucketBase + "/" + System.getenv("USER") + "/path/to/data";
 
   private static final String[] DEFAULT_CATALOG_PROPERTIES = {
     "allow.unstructured.table.location", "true",
@@ -148,7 +151,8 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
   }
 
   @BeforeAll
-  static void setup(PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
+  static void setup(
+      PolarisApiEndpoints apiEndpoints, ClientCredentials credentials, @TempDir Path tempDir) {
     adminCredentials = credentials;
     endpoints = apiEndpoints;
     client = polarisClient(endpoints);
@@ -157,6 +161,20 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
     principalRoleName = client.newEntityName("rest-admin");
     principalCredentials = managementApi.createPrincipalWithRole(principalName, principalRoleName);
     catalogApi = client.catalogApi(principalCredentials);
+    URI testRootUri =
+        Optional.ofNullable(System.getenv("INTEGRATION_TEST_TEMP_DIR"))
+            .map(URI::create)
+            .orElse(tempDir.toUri());
+    s3BucketBase =
+        Optional.ofNullable(System.getenv("INTEGRATION_TEST_S3_PATH"))
+            .map(URI::create)
+            .orElse(testRootUri)
+            .resolve("my-bucket");
+    externalCatalogBase =
+        Optional.ofNullable(System.getenv("INTEGRATION_TEST_S3_PATH"))
+            .map(URI::create)
+            .orElse(testRootUri)
+            .resolve("external-catalog");
   }
 
   @AfterAll
@@ -192,7 +210,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
     for (int i = 0; i < properties.length; i += 2) {
       catalogPropsBuilder.addProperty(properties[i], properties[i + 1]);
     }
-    if (!S3_BUCKET_BASE.startsWith("file:/")) {
+    if (!s3BucketBase.getScheme().equals("file")) {
       catalogPropsBuilder.addProperty(
           CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:");
     }
@@ -202,7 +220,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
             .setName(currentCatalogName)
             .setProperties(catalogPropsBuilder.build())
             .setStorageConfigInfo(
-                S3_BUCKET_BASE.startsWith("file:/")
+                s3BucketBase.getScheme().equals("file")
                     ? new FileStorageConfigInfo(
                         StorageConfigInfo.StorageTypeEnum.FILE, List.of("file://"))
                     : awsConfigModel)
@@ -541,12 +559,12 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.of(1, false, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            "file:///tmp/ns1/my_table",
+            externalCatalogBase + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       resolvingFileIO.initialize(Map.of());
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = "file:///tmp/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {
@@ -576,12 +594,12 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.of(1, false, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            "file:///tmp/ns1/my_table",
+            externalCatalogBase + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       resolvingFileIO.initialize(Map.of());
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = "file:///tmp/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {
@@ -610,12 +628,12 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.of(1, false, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            "file:///tmp/ns1/my_table",
+            externalCatalogBase + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       resolvingFileIO.initialize(Map.of());
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = "file:///tmp/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {


### PR DESCRIPTION
3 integration tests currently require a temporary folder for various purposes. The folders are generally hard-coded to some local filesystem location, which makes those tests impossible to execute against a remote Polaris instance.

This PR aims at fixing this situation by leveraging a new optional environment variable that points to a location that is accessible by both the server and the client running the tests. This would typically be an S3 bucket, for example, but could also be a shared volume mounted on both machines at the same mount point. If this environment variable is not present, then local execution is assumed and a temporary directory managed by JUnit is used instead.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
