### PR TITLE
Fix inconsistent image build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ select * from db1.table1;
 
 #### Running in Docker
 
-- `./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true` - To 
+- `./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache` - To 
   build the image locally.
 - `docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest` - To run the image.
 

--- a/getting-started/eclipselink/README.md
+++ b/getting-started/eclipselink/README.md
@@ -25,10 +25,11 @@ This example requires `jq` to be installed on your machine.
    the Postgres JDBC driver:
 
     ```shell
-    ./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+    ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
        -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
-       -Dquarkus.container-image.build=true
+       -Dquarkus.container-image.build=true \
+       --no-build-cache
     ```
 
 2. Start the docker compose group by running the following command from the root of the repository:

--- a/getting-started/spark/README.md
+++ b/getting-started/spark/README.md
@@ -27,7 +27,7 @@ A Jupyter notebook is used to run PySpark.
 If a Polaris image is not already present locally, build one with the following command:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
 ```
 
 ## Run the `docker-compose` file

--- a/getting-started/telemetry/README.md
+++ b/getting-started/telemetry/README.md
@@ -24,7 +24,7 @@ This example requires `jq` to be installed on your machine.
 1. Build the Polaris image if it's not already present locally:
 
     ```shell
-    ./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+    ./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
     ```
 
 2. Start the docker compose group by running the following command from the root of the repository:

--- a/getting-started/trino/README.md
+++ b/getting-started/trino/README.md
@@ -24,7 +24,7 @@ This getting started guide provides a `docker-compose` file to set up [Trino](ht
 ## Build Polaris Image
 Build Polaris Image while Docker is running
 ```
-./gradlew :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
 ```
 
 ## Run the `docker-compose` file

--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -89,9 +89,10 @@ If necessary, build and load the Docker images with support for Postgres into Mi
 ```bash
 eval $(minikube -p minikube docker-env)
 
-./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
     -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
+    --no-build-cache
 ```
 
 ### Installing the chart locally

--- a/helm/polaris/README.md.gotmpl
+++ b/helm/polaris/README.md.gotmpl
@@ -90,9 +90,10 @@ If necessary, build and load the Docker images with support for Postgres into Mi
 ```bash
 eval $(minikube -p minikube docker-env)
 
-./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
     -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
+    --no-build-cache
 ```
 
 ### Installing the chart locally

--- a/quarkus/admin/README.md
+++ b/quarkus/admin/README.md
@@ -28,7 +28,7 @@ java -jar polaris-quarkus-admin-<version>-runner.jar
 To also build the Docker image, you can use the following command:
 
 ```shell
-./gradlew :polaris-quarkus-admin:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-admin:assemble -Dquarkus.container-image.build=true --no-build-cache
 ```
 
 ## Running the Admin Tool

--- a/quarkus/server/README.md
+++ b/quarkus/server/README.md
@@ -27,15 +27,16 @@ To also build the Docker image, you can use the following command (a running Doc
 required):
 
 ```shell
-./gradlew :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
 ```
 
 If you need to customize the Docker image, for example to push to a local registry, you can use the
 following command:
 
 ```shell
-./gradlew :polaris-quarkus-server:build -Dquarkus.container-image.build=true \
+./gradlew clean :polaris-quarkus-server:build -Dquarkus.container-image.build=true \
   -Dquarkus.container-image.registry=localhost:5001 \
   -Dquarkus.container-image.group=apache \
-  -Dquarkus.container-image.name=polaris-local
+  -Dquarkus.container-image.name=polaris-local \
+  --no-build-cache
 ```

--- a/regtests/README.md
+++ b/regtests/README.md
@@ -39,7 +39,7 @@ Tests can be run with docker-compose using the provided `./regtests/docker-compo
 follows:
 
 ```shell
-./gradlew :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
 docker compose -f ./regtests/docker-compose.yml up --build --exit-code-from regtest
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -52,9 +52,10 @@ sh ./kind-registry.sh
 
 # Build and deploy the server image
 echo "Building polaris image..."
-./gradlew :polaris-quarkus-server:build $ECLIPSE_LINK_DEPS \
+./gradlew clean :polaris-quarkus-server:build $ECLIPSE_LINK_DEPS \
   -Dquarkus.container-image.build=true \
-  -Dquarkus.container-image.registry=localhost:5001
+  -Dquarkus.container-image.registry=localhost:5001 \
+  --no-build-cache
 
 echo "Pushing polaris image..."
 docker push localhost:5001/apache/polaris

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -30,7 +30,8 @@ example, to build the tool with support for Postgres, run the following:
 ```shell
 ./gradlew clean :polaris-quarkus-admin:build \
   -Dquarkus.container-image.build=true \
-  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
+  --no-build-cache
 ```
 
 The above command will generate:

--- a/site/content/in-dev/unreleased/quickstart.md
+++ b/site/content/in-dev/unreleased/quickstart.md
@@ -105,7 +105,7 @@ To start using Polaris in Docker, launch Polaris while Docker is running:
 
 ```shell
 cd ~/polaris
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
 docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest
 ```
 


### PR DESCRIPTION
This PR fixed inconsistent image build issue after a successful build is made already. It contains two changes:
1. add `clean` to the build command
2. disable gradle build cache when building image

Here are the test:

# Happy path (first time building)
```
➜  polaris git:(main) docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
➜  polaris git:(main) ./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
    -Dquarkus.container-image.build=true \
    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
...
BUILD SUCCESSFUL in 38s
115 actionable tasks: 98 executed, 17 up-to-date
➜  polaris git:(main) docker images
REPOSITORY                  TAG                         IMAGE ID       CREATED          SIZE
apache/polaris-admin-tool   1.0.0-incubating-SNAPSHOT   4162495a3d93   29 seconds ago   535MB
apache/polaris-admin-tool   latest                      4162495a3d93   29 seconds ago   535MB
apache/polaris              1.0.0-incubating-SNAPSHOT   1d48a4908017   29 seconds ago   633MB
apache/polaris              latest                      1d48a4908017   29 seconds ago   633MB
```

# Un-happy paths
## users removed the images then reran the same command to get images back
```
➜  polaris git:(main) ./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
    -Dquarkus.container-image.build=true \
    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
...
BUILD SUCCESSFUL in 2s
96 actionable tasks: 96 up-to-date
➜  polaris git:(main) docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
```

## users removed the images then reran the same command to get images back with clean option
```
➜  polaris git:(main) ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
    -Dquarkus.container-image.build=true \
    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
...
BUILD SUCCESSFUL in 13s
115 actionable tasks: 72 executed, 26 from cache, 17 up-to-date
➜  polaris git:(main) docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
➜  polaris git:(main)
```

## users removed the images then reran the same command to get images back with no-cache option
```
➜  polaris git:(main) ./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
    -Dquarkus.container-image.build=true \
    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
    --no-build-cache
...
BUILD SUCCESSFUL in 2s
96 actionable tasks: 96 up-to-date
➜  polaris git:(main) docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
```

# With the purposed change:
```
➜  polaris git:(main) ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
    -Dquarkus.container-image.build=true \
    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
    --no-build-cache
...
BUILD SUCCESSFUL in 32s
115 actionable tasks: 98 executed, 17 up-to-date
➜  polaris git:(main) docker images
REPOSITORY                  TAG                         IMAGE ID       CREATED          SIZE
apache/polaris-admin-tool   1.0.0-incubating-SNAPSHOT   e771063a0c2b   10 seconds ago   535MB
apache/polaris-admin-tool   latest                      e771063a0c2b   10 seconds ago   535MB
apache/polaris              1.0.0-incubating-SNAPSHOT   78de7f511dcd   16 seconds ago   633MB
apache/polaris              latest                      78de7f511dcd   16 seconds ago   633MB
```
