### PR TITLE
Poetry version upgrade and pyproject.toml update

### DIFF
--- a/regtests/client/python/pyproject.toml
+++ b/regtests/client/python/pyproject.toml
@@ -29,6 +29,9 @@ keywords = ["Polaris", "Polaris Management Service"]
 include = ["polaris.management/py.typed"]
 package-mode = true
 
+[[tool.poetry.packages]]
+include = "."
+
 [tool.poetry.dependencies]
 python = "^3.8"
 

--- a/regtests/requirements.txt
+++ b/regtests/requirements.txt
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-poetry==1.8.5
+poetry==2.1.1


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
The first error message:
  ItemNotFoundException

  Item does not exist!

  at polaris-venv/lib/python3.9/site-packages/secretstorage/util.py:52 in send_and_get_reply
       48│                 raise DBusErrorResponse(resp_msg)
       49│             return resp_msg.body
       50│         except DBusErrorResponse as resp:
       51│             if resp.name in (DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT):
    →  52│                 raise ItemNotFoundException('Item does not exist!') from resp
       53│             elif resp.name in (DBUS_SERVICE_UNKNOWN, DBUS_EXEC_FAILED,
       54│                                DBUS_NO_REPLY):
       55│                 data = resp.data
       56│                 if isinstance(data, tuple):

Cannot install annotated-types.

  - Installing exceptiongroup (1.2.2)
  - Installing iniconfig (2.0.0)
  - Installing mccabe (0.7.0)
  - Installing mypy-extensions (1.0.0)
  - Installing pluggy (1.5.0)
  - Installing pycodestyle (2.12.1)
  - Installing pydantic-core (2.27.2)
  - Installing pyflakes (3.2.0)
  - Installing s3transfer (0.11.2)
/media/user_DdGiX601V/DataDisk/workspace/openresource/polaris
First time setup complete.
Traceback (most recent call last):
  File "/media/user_DdGiX601V/DataDisk/workspace/openresource/polaris/regtests/client/python/cli/polaris_cli.py", line 28, in <module>
    from polaris.management import ApiClient, Configuration
  File "/media/user_DdGiX601V/DataDisk/workspace/openresource/polaris/regtests/client/python/polaris/management/__init__.py", line 38, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/media/user_DdGiX601V/DataDisk/workspace/openresource/polaris/regtests/client/python/polaris/management/api/__init__.py", line 22, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/media/user_DdGiX601V/DataDisk/workspace/openresource/polaris/regtests/client/python/polaris/management/api/polaris_default_api.py", line 33, in <module>
    from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
ModuleNotFoundError: No module named 'pydantic'

The second error message:
Installing the current project: polaris (1.0.0)
Error: The current project could not be installed: No file/folder found for package polaris
If you do not want to install the current project use --no-root.                                                                             
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.                                                                                                                 
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
