### PR TITLE
CLI: add subcommand access for principals

### DIFF
--- a/regtests/client/python/cli/constants.py
+++ b/regtests/client/python/cli/constants.py
@@ -80,6 +80,7 @@ class Subcommands:
     VIEW = 'view'
     GRANT = 'grant'
     REVOKE = 'revoke'
+    ACCESS = 'access'
 
 
 class Actions:

--- a/regtests/client/python/cli/options/option_tree.py
+++ b/regtests/client/python/cli/options/option_tree.py
@@ -123,7 +123,8 @@ class OptionTree:
                 Option(Subcommands.UPDATE, args=[
                     Argument(Arguments.SET_PROPERTY, str, Hints.SET_PROPERTY, allow_repeats=True),
                     Argument(Arguments.REMOVE_PROPERTY, str, Hints.REMOVE_PROPERTY, allow_repeats=True),
-                ], input_name=Arguments.PRINCIPAL)
+                ], input_name=Arguments.PRINCIPAL),
+                Option(Subcommands.ACCESS, input_name=Arguments.PRINCIPAL),
             ]),
             Option(Commands.PRINCIPAL_ROLES, 'manage principal roles', children=[
                 Option(Subcommands.CREATE, args=[

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -388,7 +388,7 @@ options:
 ##### Examples
 
 ```
-polaris --profile dev principals access quickstart_user
+polaris principals access quickstart_user
 ```
 
 ### Principal Roles

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -256,6 +256,7 @@ The `principals` command is used to manage principals within Polaris.
 4. list
 5. rotate-credentials
 6. update
+7. access
 
 #### create
 
@@ -370,6 +371,24 @@ options:
 polaris principals update --property key=value --property other_key=other_value some_user
 
 polaris principals update --property are_other_keys_removed=yes some_user
+```
+
+#### access
+
+The `access` subcommand retrieves entities relation about a principal.
+
+```
+input: polaris principals access --help
+options:
+  access
+    Positional arguments:
+      principal
+```
+
+##### Examples
+
+```
+polaris --profile dev principals access quickstart_user
 ```
 
 ### Principal Roles


### PR DESCRIPTION
This is one of the purposed CLI option in https://github.com/apache/polaris/issues/989 (item 1). This new subcommand will display the entities relation a given principal has.

Here is a sample output for quickstart_user based on our example:
```json
{
  "principal": "quickstart_user",
  "principal_roles": [
    {
      "name": "quickstart_user_role",
      "catalog_roles": [
        {
          "name": "quickstart_catalog_role",
          "catalog": "quickstart_catalog",
          "privileges": [
            {
              "type": "catalog",
              "privilege": "CATALOG_MANAGE_CONTENT"
            }
          ]
        }
      ]
    }
  ]
}
```

Here is another example for the same user but with additional access, principal roles, and catalogs:
```json
{
  "principal": "quickstart_user",
  "principal_roles": [
    {
      "name": "demo_user_role",
      "catalog_roles": [
        {
          "name": "demo_catalog_role",
          "catalog": "demo_catalog",
          "privileges": [
            {
              "type": "catalog",
              "privilege": "CATALOG_MANAGE_CONTENT"
            },
            {
              "type": "namespace",
              "namespace": [
                "default"
              ],
              "privilege": "NAMESPACE_LIST"
            },
            {
              "type": "table",
              "namespace": [
                "default"
              ],
              "tableName": "test",
              "privilege": "TABLE_READ_PROPERTIES"
            },
            {
              "type": "table",
              "namespace": [
                "default"
              ],
              "tableName": "test",
              "privilege": "TABLE_READ_DATA"
            }
          ]
        }
      ]
    },
    {
      "name": "demo_user_empty_role",
      "catalog_roles": []
    },
    {
      "name": "quickstart_user_role",
      "catalog_roles": [
        {
          "name": "quickstart_catalog_role",
          "catalog": "quickstart_catalog",
          "privileges": [
            {
              "type": "catalog",
              "privilege": "CATALOG_MANAGE_CONTENT"
            }
          ]
        }
      ]
    }
  ]
}
```

Here is an sample output for a user with zero reference:
```json
{
  "principal": "test",
  "principal_roles": []
}
``` 