### PR TITLE
Doc: Remove lines that are not no longer needed

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -62,9 +62,6 @@ root:
 helm unittest helm/polaris
 ```
 
-Note: the `grep` command is used to filter out the annoying warning messages about symbolic links;
-see https://github.com/helm/helm/issues/7019.
-
 ### Running locally with a Kind cluster
 
 The below instructions assume Kind and Helm are installed.

--- a/helm/polaris/README.md.gotmpl
+++ b/helm/polaris/README.md.gotmpl
@@ -63,9 +63,6 @@ root:
 helm unittest helm/polaris
 ```
 
-Note: the `grep` command is used to filter out the annoying warning messages about symbolic links;
-see https://github.com/helm/helm/issues/7019.
-
 ### Running locally with a Kind cluster
 
 The below instructions assume Kind and Helm are installed.


### PR DESCRIPTION
This is is no longer needed (nor make sense) as we are not longer using grep command to filter out the verbose messages (as the issue got fixed with LICENSE file that is not a soft link)