### PR TITLE
(fix): Handle lowercase storage types in JSON payload for create cata…

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/config/Serializers.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/Serializers.java
@@ -73,8 +73,18 @@ public final class Serializers {
         throws IOException, JacksonException {
       TreeNode treeNode = p.readValueAsTree();
       if (treeNode.isObject() && ((ObjectNode) treeNode).has("catalog")) {
+        ObjectNode catalogTreeNode = (ObjectNode) treeNode;
+        JsonNode catalogNode = catalogTreeNode.get("catalog");
+        if (catalogNode.has("storageConfigInfo")) {
+          ObjectNode storageConfigNode = (ObjectNode) catalogNode.get("storageConfigInfo");
+          if (storageConfigNode.has("storageType")) {
+            String storageType = storageConfigNode.get("storageType").asText();
+            //ensure the storage type is always serialized as upper case text
+            storageConfigNode.put("storageType", storageType.toUpperCase());
+          }
+        }
         return CreateCatalogRequest.builder()
-            .setCatalog(ctxt.readTreeAsValue((JsonNode) treeNode.get("catalog"), Catalog.class))
+            .setCatalog(ctxt.readTreeAsValue(catalogNode, Catalog.class))
             .build();
       } else {
         return CreateCatalogRequest.builder()

--- a/service/common/src/main/java/org/apache/polaris/service/config/Serializers.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/Serializers.java
@@ -28,6 +28,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
 import org.apache.polaris.core.admin.model.AddGrantRequest;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogRole;
@@ -77,11 +80,13 @@ public final class Serializers {
         JsonNode catalogNode = catalogTreeNode.get("catalog");
         if (catalogNode.has("storageConfigInfo")) {
           ObjectNode storageConfigNode = (ObjectNode) catalogNode.get("storageConfigInfo");
-          if (storageConfigNode.has("storageType")) {
-            String storageType = storageConfigNode.get("storageType").asText();
-            //ensure the storage type is always serialized as upper case text
-            storageConfigNode.put("storageType", storageType.toUpperCase());
-          }
+          List.of("type","storageType").forEach( fieldName -> {
+            if (storageConfigNode.has(fieldName)) {
+              String type = storageConfigNode.get(fieldName).asText();
+              // ensure the field value is always serialized as upper case text
+              storageConfigNode.put(fieldName, type.toUpperCase(Locale.ROOT));
+            }
+          });
         }
         return CreateCatalogRequest.builder()
             .setCatalog(ctxt.readTreeAsValue(catalogNode, Catalog.class))


### PR DESCRIPTION
Handle lowercase storage types in JSON payload for create catalogs. This fix allows the catalog request to be of the form 

```json
{
    "catalog": {
        "name": "my_catalog",
        "type": "INTERNAL",
        "readOnly": false,
        "properties": {
            "default-base-location": "s3://mycatalogs"
        },
        "storageConfigInfo": {
            "storageType": "S3",
            "allowedLocations": ["s3://mycatalogs"]
        }
    }
}
```

(or)

```json
{
    "catalog": {
        "name": "my_catalog",
        "type": "INTERNAL",
        "readOnly": false,
        "properties": {
            "default-base-location": "s3://mycatalogs"
        },
        "storageConfigInfo": {
            "storageType": "s3",
            "allowedLocations": ["s3://mycatalogs"]
        }
    }
}
```

And lowercase storage types will be uppercased for consistency while deser.

Fix: #996 
