### PR TITLE
Expose resetCredentials via api to allow root user to reset credentials for one time use for an existing principal.

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -250,6 +250,13 @@ public class PolarisServiceImpl
     return Response.ok(adminService.rotateCredentials(principalName)).build();
   }
 
+  @Override
+  public Response resetCredentials(
+          String principalName, RealmContext realmContext, SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
+    return Response.ok(adminService.resetCredentials(principalName)).build();
+  }
+
   /** From PolarisPrincipalsApiService */
   @Override
   public Response listPrincipals(RealmContext realmContext, SecurityContext securityContext) {

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -274,13 +274,13 @@ paths:
         createPrincipal and rotateCredentials, that returns the user's credentials. This API is *not* idempotent.
       responses:
         200:
-          description: The principal details along with the newly reset credentials
+          description: The principal details along with the newly reset credentials that require rotating
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PrincipalWithCredentials"
         403:
-          description: "The caller does not have permission to rotate credentials"
+          description: "The caller does not have permission to reset credentials"
         404:
           description: "The principal does not exist"
 

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -242,7 +242,7 @@ paths:
     post:
       operationId: rotateCredentials
       description: Rotate a principal's credentials. The new credentials will be returned in the response. This is the only
-        API, aside from createPrincipal, that returns the user's credentials. This API is *not* idempotent.
+        API, aside from createPrincipal and resetCredentials, that returns the user's credentials. This API is *not* idempotent.
       responses:
         200:
           description: The principal details along with the newly rotated credentials
@@ -268,8 +268,10 @@ paths:
           pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
     post:
       operationId: resetCredentials
-      description: Reset a principal's credentials. The new credentials will be returned in the response. This is the only
-        API, aside from createPrincipal, that returns the user's credentials. This API is *not* idempotent.
+      description:
+        Reset a principal's credentials to a set of credentials that can only be used to rotate the principal's 
+        credentials. The new credentials will be returned in the response. This is the only API, aside from 
+        createPrincipal and rotateCredentials, that returns the user's credentials. This API is *not* idempotent.
       responses:
         200:
           description: The principal details along with the newly reset credentials

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -255,6 +255,33 @@ paths:
         404:
           description: "The principal does not exist"
 
+  /principals/{principalName}/reset:
+    parameters:
+      - name: principalName
+        in: path
+        description: The user name
+        required: true
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+    post:
+      operationId: resetCredentials
+      description: Reset a principal's credentials. The new credentials will be returned in the response. This is the only
+        API, aside from createPrincipal, that returns the user's credentials. This API is *not* idempotent.
+      responses:
+        200:
+          description: The principal details along with the newly reset credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PrincipalWithCredentials"
+        403:
+          description: "The caller does not have permission to rotate credentials"
+        404:
+          description: "The principal does not exist"
+
   /principals/{principalName}/principal-roles:
     parameters:
       - name: principalName


### PR DESCRIPTION
* Exposes the `resetCredentials` operation via the api
* Root principal or an individual principal can now call reset for that principal to obtain a new secret pair that puts PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE on principal's properties
* Principal can only use these credentials to call `rotateCredentials` to obtain new client id and secret that can now be used to exercise normal privileges 
* Needs `ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING` to be set to `true`

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
