### PR TITLE
Use correct link format for adoc and update menu title for proposals

### DIFF
--- a/site/content/community/proposals.adoc
+++ b/site/content/community/proposals.adoc
@@ -17,20 +17,18 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-linkTitle: 'Proposals & Roadmap'
+linkTitle: Proposals & Roadmap
 title: 'Apache Polaris Proposals & Roadmap'
 weight: 200
 type: docs
-toc_hide: false
-hide_summary: true
 ---
 
 == Proposals
 
-* [Active](https://github.com/apache/polaris/issues?q=is%3Aissue%20state%3Aopen%20label%3Aproposal)
-* [Past](https://github.com/apache/polaris/issues?q=is%3Aissue%20state%3Aclosed%20label%3Aproposal)
+* https://github.com/apache/polaris/issues?q=is%3Aissue%20state%3Aopen%20label%3Aproposal[Active]
+* https://github.com/apache/polaris/issues?q=is%3Aissue%20state%3Aclosed%20label%3Aproposal[Past]
 
 
 == Polaris Roadmap
 
-* [Discussed Roadmap](https://github.com/apache/polaris/discussions/1028)
+* https://github.com/apache/polaris/discussions/1028[Discussed Roadmap]

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -120,7 +120,7 @@ menu:
       parent: "community"
       url: "/community/meetings"
       weight: 20
-    - name: "Proposals"
+    - name: "Proposals & Roadmap"
       parent: "community"
       url: "/community/proposals"
       weight: 30


### PR DESCRIPTION
Proposals page is a adoc file. So this PR uses the right links format for adoc.