### PR TITLE
Remove PolarisMetaStoreSession from FileIOFactory/FileIOUtil in favor of CallContext

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
@@ -76,7 +76,7 @@ class ManifestFileCleanupTaskHandlerTest {
         new FileIOFactory() {
           @Override
           public FileIO loadFileIO(
-              @NotNull RealmContext realmContext,
+              @NotNull CallContext callContext,
               @NotNull String ioImplClassName,
               @NotNull Map<String, String> properties,
               @NotNull TableIdentifier identifier,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -75,7 +75,7 @@ class TableCleanupTaskHandlerTest {
         new FileIOFactory() {
           @Override
           public FileIO loadFileIO(
-              @Nonnull RealmContext realmContext,
+              @Nonnull CallContext callContext,
               @Nonnull String ioImplClassName,
               @Nonnull Map<String, String> properties,
               @Nonnull TableIdentifier identifier,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -836,10 +836,9 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
       return Map.of();
     }
     return FileIOUtil.refreshCredentials(
-        callContext.getRealmContext(),
+        callContext,
         entityManager,
         getCredentialVendor(),
-        callContext.getPolarisCallContext().getMetaStore(),
         callContext.getPolarisCallContext().getConfigurationStore(),
         tableIdentifier,
         getLocationsAllowedToBeAccessed(tableMetadata),
@@ -1614,7 +1613,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
     // Reload fileIO based on table specific context
     FileIO fileIO =
         fileIOFactory.loadFileIO(
-            callContext.getRealmContext(),
+            callContext,
             ioImplClassName,
             tableProperties,
             identifier,
@@ -2077,13 +2076,7 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
         new PolarisResolvedPathWrapper(List.of(resolvedCatalogEntity));
     Set<PolarisStorageActions> storageActions = Set.of(PolarisStorageActions.ALL);
     return fileIOFactory.loadFileIO(
-        callContext.getRealmContext(),
-        ioImpl,
-        properties,
-        identifier,
-        locations,
-        storageActions,
-        resolvedPath);
+        callContext, ioImpl, properties, identifier, locations, storageActions, resolvedPath);
   }
 
   private void blockedUserSpecifiedWriteLocation(Map<String, String> properties) {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfigurationStore;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -70,13 +71,14 @@ public class DefaultFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull RealmContext realmContext,
+      @Nonnull CallContext callContext,
       @Nonnull String ioImplClassName,
       @Nonnull Map<String, String> properties,
       @Nonnull TableIdentifier identifier,
       @Nonnull Set<String> tableLocations,
       @Nonnull Set<PolarisStorageActions> storageActions,
       @Nonnull PolarisResolvedPathWrapper resolvedEntityPath) {
+    RealmContext realmContext = callContext.getRealmContext();
     PolarisEntityManager entityManager =
         realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
     PolarisCredentialVendor credentialVendor =
@@ -93,10 +95,9 @@ public class DefaultFileIOFactory implements FileIOFactory {
             .map(
                 storageInfo ->
                     FileIOUtil.refreshCredentials(
-                        realmContext,
+                        callContext,
                         entityManager,
                         credentialVendor,
-                        metaStoreSession,
                         configurationStore,
                         identifier,
                         tableLocations,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOFactory.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 
@@ -41,7 +41,7 @@ public interface FileIOFactory {
    * <p>This method may obtain subscoped credentials to restrict the FileIO's permissions, ensuring
    * secure and limited access to the table's data and locations.
    *
-   * @param realmContext the realm for which the FileIO is being loaded.
+   * @param callContext the call for which the FileIO is being loaded.
    * @param ioImplClassName the class name of the FileIO implementation to load.
    * @param properties configuration properties for the FileIO.
    * @param identifier the table identifier.
@@ -51,7 +51,7 @@ public interface FileIOFactory {
    * @return a configured FileIO instance.
    */
   FileIO loadFileIO(
-      @Nonnull RealmContext realmContext,
+      @Nonnull CallContext callContext,
       @Nonnull String ioImplClassName,
       @Nonnull Map<String, String> properties,
       @Nonnull TableIdentifier identifier,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
@@ -25,11 +25,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
-import org.apache.polaris.core.persistence.PolarisMetaStoreSession;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisCredentialVendor;
 import org.apache.polaris.core.storage.PolarisStorageActions;
@@ -78,16 +76,14 @@ public class FileIOUtil {
    * </ul>
    */
   public static Map<String, String> refreshCredentials(
-      RealmContext realmContext,
+      CallContext callContext,
       PolarisEntityManager entityManager,
       PolarisCredentialVendor credentialVendor,
-      PolarisMetaStoreSession metaStoreSession,
       PolarisConfigurationStore configurationStore,
       TableIdentifier tableIdentifier,
       Set<String> tableLocations,
       Set<PolarisStorageActions> storageActions,
       PolarisEntity entity) {
-    CallContext callContext = CallContext.getCurrentContext();
 
     boolean skipCredentialSubscopingIndirection =
         configurationStore.getConfiguration(

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisStorageActions;
@@ -52,7 +52,7 @@ public class WasbTranslatingFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull RealmContext realmContext,
+      @Nonnull CallContext callContext,
       @Nonnull String ioImplClassName,
       @Nonnull Map<String, String> properties,
       @Nonnull TableIdentifier identifier,
@@ -61,7 +61,7 @@ public class WasbTranslatingFileIOFactory implements FileIOFactory {
       @Nonnull PolarisResolvedPathWrapper resolvedEntityPath) {
     return new WasbTranslatingFileIO(
         defaultFileIOFactory.loadFileIO(
-            realmContext,
+            callContext,
             ioImplClassName,
             properties,
             identifier,

--- a/service/common/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -73,7 +73,7 @@ public class ManifestFileCleanupTaskHandler implements TaskHandler {
   public boolean handleTask(TaskEntity task, CallContext callContext) {
     ManifestCleanupTask cleanupTask = task.readData(ManifestCleanupTask.class);
     TableIdentifier tableId = cleanupTask.getTableId();
-    try (FileIO authorizedFileIO = fileIOSupplier.apply(task, callContext.getRealmContext())) {
+    try (FileIO authorizedFileIO = fileIOSupplier.apply(task, callContext)) {
       if (task.getTaskType() == AsyncTaskType.MANIFEST_FILE_CLEANUP) {
         ManifestFile manifestFile = decodeManifestData(cleanupTask.getManifestFileData());
         return cleanUpManifestFile(manifestFile, authorizedFileIO, tableId);

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -89,7 +89,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
     // It's likely the cleanupTask has already been completed, but wasn't dropped successfully.
     // Log a
     // warning and move on
-    try (FileIO fileIO = fileIOSupplier.apply(cleanupTask, callContext.getRealmContext())) {
+    try (FileIO fileIO = fileIOSupplier.apply(cleanupTask, callContext)) {
       if (!TaskUtils.exists(tableEntity.getMetadataLocation(), fileIO)) {
         LOGGER
             .atWarn()

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskFileIOSupplier.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskFileIOSupplier.java
@@ -28,7 +28,7 @@ import java.util.function.BiFunction;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TableLikeEntity;
 import org.apache.polaris.core.entity.TaskEntity;
@@ -38,7 +38,7 @@ import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 
 @ApplicationScoped
-public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmContext, FileIO> {
+public class TaskFileIOSupplier implements BiFunction<TaskEntity, CallContext, FileIO> {
   private final FileIOFactory fileIOFactory;
 
   @Inject
@@ -47,7 +47,7 @@ public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmContext, 
   }
 
   @Override
-  public FileIO apply(TaskEntity task, RealmContext realmContext) {
+  public FileIO apply(TaskEntity task, CallContext callContext) {
     Map<String, String> internalProperties = task.getInternalPropertiesAsMap();
     Map<String, String> properties = new HashMap<>(internalProperties);
 
@@ -65,6 +65,6 @@ public class TaskFileIOSupplier implements BiFunction<TaskEntity, RealmContext, 
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.io.ResolvingFileIO");
 
     return fileIOFactory.loadFileIO(
-        realmContext, ioImpl, properties, identifier, locations, storageActions, resolvedPath);
+        callContext, ioImpl, properties, identifier, locations, storageActions, resolvedPath);
   }
 }

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -189,7 +189,7 @@ public class FileIOFactoryTest {
     Assertions.assertThat(tasks).hasSize(1);
     TaskEntity taskEntity = TaskEntity.of(tasks.get(0));
     FileIO fileIO =
-        new TaskFileIOSupplier(testServices.fileIOFactory()).apply(taskEntity, realmContext);
+        new TaskFileIOSupplier(testServices.fileIOFactory()).apply(taskEntity, callContext);
     Assertions.assertThat(fileIO).isNotNull().isInstanceOf(InMemoryFileIO.class);
 
     // 1. BasePolarisCatalog:doCommit: for writing the table during the creation

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.PolarisConfigurationStore;
-import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisStorageActions;
@@ -64,7 +64,7 @@ public class MeasuredFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull RealmContext realmContext,
+      @Nonnull CallContext callContext,
       @Nonnull String ioImplClassName,
       @Nonnull Map<String, String> properties,
       @Nonnull TableIdentifier identifier,
@@ -79,7 +79,7 @@ public class MeasuredFileIOFactory implements FileIOFactory {
     MeasuredFileIO wrapped =
         new MeasuredFileIO(
             defaultFileIOFactory.loadFileIO(
-                realmContext,
+                callContext,
                 ioImplClassName,
                 properties,
                 identifier,


### PR DESCRIPTION
This appeared to be some leaky divergence that occurred after CallContext had been removed, but PolarisMetaStoreSession really is only a low-level implementation detail that should never be handled by BasePolarisCatalog/FileIOFactory.

This plumbs CallContext explicitly into the FileIOFactory and FileIOUtil methods and thus removes a large source of CallContext.getCurrentContext calls; now the threadlocal doesn't have to be set at all in BasePolarisCatalogTest.
