### PR TITLE
Docker images: use runtime openjdk base image

### DIFF
--- a/quarkus/admin/src/main/docker/Dockerfile.jvm
+++ b/quarkus/admin/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.21-3.1739376165
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1.1733995527
 
 LABEL org.opencontainers.image.source=https://github.com/apache/polaris
 LABEL org.opencontainers.image.description="Apache Polaris (incubating) Admin Tool"

--- a/quarkus/server/src/main/docker/Dockerfile.jvm
+++ b/quarkus/server/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.21-3.1739376165
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1.1733995527
 
 LABEL org.opencontainers.image.source=https://github.com/apache/polaris
 LABEL org.opencontainers.image.description="Apache Polaris (incubating)"


### PR DESCRIPTION
The `ubi9/openjdk-21` image contains the Java compiler and other tools for building Java apps. This is excessive; the `ubi9/openjdk-21-runtime` image should be used instead.

Additionally, using `ubi9/openjdk-21` might be preventing K8s deployments from using security contexts including `capabilities: { drop: [ "ALL" ] }`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
