### PR TITLE
Helm chart: enforce strong security contexts by default

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -148,7 +148,8 @@ helm uninstall --namespace polaris polaris
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Optional; set to zero or empty to disable. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Optional; set to zero or empty to disable. |
 | configMapLabels | object | `{}` | Additional Labels to apply to polaris configmap. |
-| containerSecurityContext | object | `{}` | Security context for the polaris container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":10000,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| containerSecurityContext.runAsUser | int | `10000` | UID 10000 is compatible with Polaris OSS default images; change this if you are using a different image. |
 | cors | object | `{"accessControlAllowCredentials":null,"accessControlMaxAge":null,"allowedHeaders":[],"allowedMethods":[],"allowedOrigins":[],"exposedHeaders":[]}` | Polaris CORS configuration. |
 | cors.accessControlAllowCredentials | string | `nil` | The `Access-Control-Allow-Credentials` response header. The value of this header will default to `true` if `allowedOrigins` property is set and there is a match with the precise `Origin` header. |
 | cors.accessControlMaxAge | string | `nil` | The `Access-Control-Max-Age` response header value indicating how long the results of a pre-flight request can be cached. Must be a valid duration. |
@@ -230,7 +231,8 @@ helm uninstall --namespace polaris polaris
 | persistence.type | string | `"eclipse-link"` | The type of persistence to use. Two built-in types are supported: in-memory and eclipse-link. |
 | podAnnotations | object | `{}` | Annotations to apply to polaris pods. |
 | podLabels | object | `{}` | Additional Labels to apply to polaris pods. |
-| podSecurityContext | object | `{}` | Security context for the polaris pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| podSecurityContext | object | `{"fsGroup":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| podSecurityContext.fsGroup | int | `10001` | GID 10001 is compatible with Polaris OSS default images; change this if you are using a different image. |
 | rateLimiter | object | `{"tokenBucket":{"requestsPerSecond":9999,"type":"default","window":"PT10S"},"type":"no-op"}` | Polaris rate limiter configuration. |
 | rateLimiter.tokenBucket | object | `{"requestsPerSecond":9999,"type":"default","window":"PT10S"}` | The configuration for the default rate limiter, which uses the token bucket algorithm with one bucket per realm. |
 | rateLimiter.tokenBucket.requestsPerSecond | int | `9999` | The maximum number of requests per second allowed for each realm. |

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -232,19 +232,23 @@ tests:
           value: polaris-sa
 
   # spec.template.spec.securityContext
-  - it: should not set securityContext by default
-    asserts:
-      - notExists:
-          path: spec.template.spec.securityContext
-  - it: should set securityContext
-    set:
-      podSecurityContext:
-        runAsUser: 1000
+  - it: should set securityContext by default
     asserts:
       - isSubset:
           path: spec.template.spec.securityContext
           content:
-            runAsUser: 1000
+            fsGroup: 10001
+            seccompProfile:
+              type: RuntimeDefault
+  - it: should set custom securityContext
+    set:
+      podSecurityContext:
+        fsGroup: 1234
+    asserts:
+      - isSubset:
+          path: spec.template.spec.securityContext
+          content:
+            fsGroup: 1234
 
   # spec.template.spec.containers
   - it: should set container name
@@ -254,19 +258,31 @@ tests:
           value: polaris
 
   # spec.template.spec.containers[0].securityContext
-  - it: should not set container securityContext by default
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].securityContext
-  - it: should set container securityContext
-    set:
-      containerSecurityContext:
-        runAsUser: 1000
+  - it: should set container securityContext by default
     asserts:
       - isSubset:
           path: spec.template.spec.containers[0].securityContext
           content:
-            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 10000
+            capabilities:
+              drop: [ "ALL" ]
+            seccompProfile:
+              type: RuntimeDefault
+  - it: should set custom container securityContext
+    set:
+      containerSecurityContext:
+        allowPrivilegeEscalation: true
+        runAsNonRoot: false
+        runAsUser: 1234
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].securityContext
+          content:
+            allowPrivilegeEscalation: true
+            runAsNonRoot: false
+            runAsUser: 1234
 
   # spec.template.spec.containers[0].image
   - it: should set container image

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -67,18 +67,21 @@ revisionHistoryLimit: ~
 
 # -- Security context for the polaris pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  # -- GID 10001 is compatible with Polaris OSS default images; change this if you are using a different image.
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Security context for the polaris container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 containerSecurityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  # -- UID 10000 is compatible with Polaris OSS default images; change this if you are using a different image.
+  runAsUser: 10000
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Polaris main service settings.
 service:


### PR DESCRIPTION
This change enforces a strong default security context for both the pod and the container. Polaris default Docker images are compatible with such contexts.

Requires #1079 

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
