### PR TITLE
Treat headers as case-insensitive during RealmContext resolution

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.context;
 
 import java.util.Map;
 import java.util.function.Function;
-
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.polaris.core.context.RealmContext;
 
@@ -38,6 +37,7 @@ public interface RealmContextResolver {
   default RealmContext resolveRealmContext(
       String requestURL, String method, String path, Map<String, String> headers) {
     CaseInsensitiveMap caseInsensitiveMap = new CaseInsensitiveMap(headers);
-    return resolveRealmContext(requestURL, method, path, (key) -> (String)caseInsensitiveMap.get(key));
+    return resolveRealmContext(
+        requestURL, method, path, (key) -> (String) caseInsensitiveMap.get(key));
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
@@ -20,6 +20,8 @@ package org.apache.polaris.service.context;
 
 import java.util.Map;
 import java.util.function.Function;
+
+import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.polaris.core.context.RealmContext;
 
 public interface RealmContextResolver {
@@ -35,6 +37,7 @@ public interface RealmContextResolver {
 
   default RealmContext resolveRealmContext(
       String requestURL, String method, String path, Map<String, String> headers) {
-    return resolveRealmContext(requestURL, method, path, headers::get);
+    CaseInsensitiveMap caseInsensitiveMap = new CaseInsensitiveMap(headers);
+    return resolveRealmContext(requestURL, method, path, (key) -> (String)caseInsensitiveMap.get(key));
   }
 }

--- a/service/common/src/test/java/org/apache/polaris/service/context/DefaultRealmIdResolverTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/context/DefaultRealmIdResolverTest.java
@@ -82,4 +82,17 @@ class DefaultRealmContextResolverTest {
         .isInstanceOf(UnresolvableRealmContextException.class)
         .hasMessage("Missing required realm header: Polaris-Header");
   }
+
+  @Test
+  void headerCaseInsensitive() {
+    DefaultRealmContextResolver resolver = new DefaultRealmContextResolver(config);
+    RealmContext RealmContext1 =
+        resolver.resolveRealmContext(
+            "requestURL", "method", "path", Map.of("POLARIS-HEADER", "realm1"));
+    assertThat(RealmContext1.getRealmIdentifier()).isEqualTo("realm1");
+    RealmContext RealmContext2 =
+        resolver.resolveRealmContext(
+            "requestURL", "method", "path", Map.of("polaris-header", "realm2"));
+    assertThat(RealmContext2.getRealmIdentifier()).isEqualTo("realm2");
+  }
 }


### PR DESCRIPTION
According to the RFC, HTTP headers should be case-insensitive. To support this, we need to avoiding doing string comparison against a case-sensitive map.
