### PR TITLE
Policy Store: PolicyMappingRecord with Persistence Impl

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -53,6 +53,7 @@ import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.PrincipalSecretsGenerator;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
 import org.apache.polaris.core.persistence.transactional.AbstractTransactionalPersistence;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -60,6 +61,7 @@ import org.apache.polaris.jpa.models.ModelEntity;
 import org.apache.polaris.jpa.models.ModelEntityActive;
 import org.apache.polaris.jpa.models.ModelEntityChangeTracking;
 import org.apache.polaris.jpa.models.ModelGrantRecord;
+import org.apache.polaris.jpa.models.ModelPolicyMappingRecord;
 import org.apache.polaris.jpa.models.ModelPrincipalSecrets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -662,6 +664,90 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
     PolarisStorageConfigurationInfo storageConfig =
         BaseMetaStoreManager.extractStorageConfiguration(callCtx, entity);
     return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void writeToPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+
+    this.store.writeToPolicyMappingRecords(localSession.get(), record);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteFromPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    this.store.deleteFromPolicyMappingRecords(localSession.get(), record);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore entity,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+    this.store.deleteAllEntityPolicyMappingRecords(localSession.get(), entity);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  public PolarisPolicyMappingRecord lookupPolicyMappingRecordInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    return ModelPolicyMappingRecord.toPolicyMappingRecord(
+        this.store.lookupPolicyMappingRecord(
+            localSession.get(),
+            targetCatalogId,
+            targetId,
+            policyTypeCode,
+            policyCatalogId,
+            policyId));
+  }
+
+  /** {@inheritDoc} */
+  @Nonnull
+  @Override
+  public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByTypeInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode) {
+    return this.store
+        .loadPoliciesOnTargetByType(localSession.get(), targetCatalogId, targetId, policyTypeCode)
+        .stream()
+        .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
+        .toList();
+  }
+
+  /** {@inheritDoc} */
+  @Nonnull
+  @Override
+  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnTargetInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+    return this.store
+        .loadAllPoliciesOnTarget(localSession.get(), targetCatalogId, targetId)
+        .stream()
+        .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
+        .toList();
+  }
+
+  /** {@inheritDoc} */
+  @Nonnull
+  @Override
+  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+    return this.store
+        .loadAllPoliciesOnPolicy(localSession.get(), policyCatalogId, policyId)
+        .stream()
+        .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
+        .toList();
   }
 
   @Override

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -741,10 +741,10 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   /** {@inheritDoc} */
   @Nonnull
   @Override
-  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+  public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     return this.store
-        .loadAllPoliciesOnPolicy(localSession.get(), policyCatalogId, policyId)
+        .loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId)
         .stream()
         .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
         .toList();

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -743,9 +743,7 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   @Override
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
-    return this.store
-        .loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId)
-        .stream()
+    return this.store.loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId).stream()
         .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
         .toList();
   }

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -443,8 +443,7 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    loadAllTargetsOnPolicy(session, entity.getCatalogId(), entity.getId())
-        .forEach(session::remove);
+    loadAllTargetsOnPolicy(session, entity.getCatalogId(), entity.getId()).forEach(session::remove);
     loadAllPoliciesOnTarget(session, entity.getCatalogId(), entity.getId())
         .forEach(session::remove);
   }

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -35,10 +35,12 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.jpa.models.ModelEntity;
 import org.apache.polaris.jpa.models.ModelEntityActive;
 import org.apache.polaris.jpa.models.ModelEntityChangeTracking;
 import org.apache.polaris.jpa.models.ModelGrantRecord;
+import org.apache.polaris.jpa.models.ModelPolicyMappingRecord;
 import org.apache.polaris.jpa.models.ModelPrincipalSecrets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -409,6 +411,121 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(modelPrincipalSecrets != null, "principal_secretes_not_found");
 
     session.remove(modelPrincipalSecrets);
+  }
+
+  void writeToPolicyMappingRecords(
+      EntityManager session, PolarisPolicyMappingRecord mappingRecord) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    session.persist(ModelPolicyMappingRecord.fromPolicyMappingRecord(mappingRecord));
+  }
+
+  void deleteFromPolicyMappingRecords(
+      EntityManager session, PolarisPolicyMappingRecord mappingRecord) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    ModelPolicyMappingRecord lookupPolicyMappingRecord =
+        lookupPolicyMappingRecord(
+            session,
+            mappingRecord.getTargetCatalogId(),
+            mappingRecord.getTargetId(),
+            mappingRecord.getPolicyTypeCode(),
+            mappingRecord.getPolicyCatalogId(),
+            mappingRecord.getPolicyId());
+
+    diagnosticServices.check(lookupPolicyMappingRecord != null, "policy_mapping_record_not_found");
+    session.remove(lookupPolicyMappingRecord);
+  }
+
+  void deleteAllEntityPolicyMappingRecords(EntityManager session, PolarisEntityCore entity) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    loadAllPoliciesOnPolicy(session, entity.getCatalogId(), entity.getId())
+        .forEach(session::remove);
+    loadAllPoliciesOnTarget(session, entity.getCatalogId(), entity.getId())
+        .forEach(session::remove);
+  }
+
+  ModelPolicyMappingRecord lookupPolicyMappingRecord(
+      EntityManager session,
+      long targetCatalogId,
+      long targetId,
+      long policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    return session
+        .createQuery(
+            "SELECT m from ModelPolicyMappingRecord m "
+                + "where m.targetCatalogId=:targetCatalogId "
+                + "and m.targetId=:targetId "
+                + "and m.policyTypeCode=:policyTypeCode "
+                + "and m.policyCatalogId=:policyCatalogId "
+                + "and m.policyId=:policyId",
+            ModelPolicyMappingRecord.class)
+        .setParameter("targetCatalogId", targetCatalogId)
+        .setParameter("targetId", targetId)
+        .setParameter("policyTypeCode", policyTypeCode)
+        .setParameter("policyCatalogId", policyCatalogId)
+        .setParameter("policyId", policyId)
+        .getResultStream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  List<ModelPolicyMappingRecord> loadPoliciesOnTargetByType(
+      EntityManager session, long targetCatalogId, long targetId, int policyTypeCode) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    return session
+        .createQuery(
+            "SELECT m from ModelPolicyMappingRecord m "
+                + "where m.targetCatalogId=:targetCatalogId "
+                + "and m.targetId=:targetId "
+                + "and m.policyTypeCode=:policyTypeCode",
+            ModelPolicyMappingRecord.class)
+        .setParameter("targetCatalogId", targetCatalogId)
+        .setParameter("targetId", targetId)
+        .setParameter("policyTypeCode", policyTypeCode)
+        .getResultList();
+  }
+
+  List<ModelPolicyMappingRecord> loadAllPoliciesOnTarget(
+      EntityManager session, long targetCatalogId, long targetId) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    return session
+        .createQuery(
+            "SELECT m from ModelPolicyMappingRecord m "
+                + " where m.targetCatalogId=:targetCatalogId "
+                + "and m.targetId=:targetId",
+            ModelPolicyMappingRecord.class)
+        .setParameter("targetCatalogId", targetCatalogId)
+        .setParameter("targetId", targetId)
+        .getResultList();
+  }
+
+  List<ModelPolicyMappingRecord> loadAllPoliciesOnPolicy(
+      EntityManager session, long policyCatalogId, long policyId) {
+    diagnosticServices.check(session != null, "session_is_null");
+    checkInitialized();
+
+    return session
+        .createQuery(
+            "SELECT m from ModelPolicyMappingRecord m "
+                + "where  m.policyCatalogId=:policyCatalogId "
+                + "and m.policyId=:policyId",
+            ModelPolicyMappingRecord.class)
+        .setParameter("policyCatalogId", policyCatalogId)
+        .setParameter("policyId", policyId)
+        .getResultList();
   }
 
   private void checkInitialized() {

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -443,7 +443,7 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    loadAllPoliciesOnPolicy(session, entity.getCatalogId(), entity.getId())
+    loadAllTargetsOnPolicy(session, entity.getCatalogId(), entity.getId())
         .forEach(session::remove);
     loadAllPoliciesOnTarget(session, entity.getCatalogId(), entity.getId())
         .forEach(session::remove);
@@ -512,7 +512,7 @@ public class PolarisEclipseLinkStore {
         .getResultList();
   }
 
-  List<ModelPolicyMappingRecord> loadAllPoliciesOnPolicy(
+  List<ModelPolicyMappingRecord> loadAllTargetsOnPolicy(
       EntityManager session, long policyCatalogId, long policyId) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();

--- a/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
+++ b/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
@@ -29,6 +29,7 @@
     <class>org.apache.polaris.jpa.models.ModelEntityActive</class>
     <class>org.apache.polaris.jpa.models.ModelEntityChangeTracking</class>
     <class>org.apache.polaris.jpa.models.ModelGrantRecord</class>
+    <class>org.apache.polaris.jpa.models.ModelPolicyMappingRecord</class>
     <class>org.apache.polaris.jpa.models.ModelPrincipalSecrets</class>
     <class>org.apache.polaris.jpa.models.ModelSequenceId</class>
     <shared-cache-mode>NONE</shared-cache-mode>

--- a/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
+++ b/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.jpa.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+
+@Entity
+@Table(
+    name = "POLICY_MAPPING_RECORDS",
+    indexes = {
+      @Index(
+          name = "POLICY_MAPPING_RECORDS_BY_POLICY_INDEX",
+          columnList = "policyCatalogId,policyId,targetCatalogId,targetId")
+    })
+public class ModelPolicyMappingRecord {
+  // id of the catalog where target entity resides
+  @Id private long targetCatalogId;
+
+  // id of the target entity
+  @Id private long targetId;
+
+  // id associated to the policy type
+  @Id private int policyTypeCode;
+
+  // id of the catalog where the policy entity resides
+  @Id private long policyCatalogId;
+
+  // id of the policy
+  @Id private long policyId;
+
+  // additional parameters of the mapping
+  private String parameters;
+
+  // Used for Optimistic Locking to handle concurrent reads and updates
+  @Version private long version;
+
+  public long getTargetCatalogId() {
+    return targetCatalogId;
+  }
+
+  public long getTargetId() {
+    return targetId;
+  }
+
+  public int getPolicyTypeCode() {
+    return policyTypeCode;
+  }
+
+  public long getPolicyCatalogId() {
+    return policyCatalogId;
+  }
+
+  public long getPolicyId() {
+    return policyId;
+  }
+
+  public String getParameters() {
+    return parameters;
+  }
+
+  public static ModelPolicyMappingRecord.Builder builder() {
+    return new ModelPolicyMappingRecord.Builder();
+  }
+
+  public static final class Builder {
+    private final ModelPolicyMappingRecord policyMappingRecord;
+
+    private Builder() {
+      policyMappingRecord = new ModelPolicyMappingRecord();
+    }
+
+    public Builder targetCatalogId(long targetCatalogId) {
+      policyMappingRecord.targetCatalogId = targetCatalogId;
+      return this;
+    }
+
+    public Builder targetId(long targetId) {
+      policyMappingRecord.targetId = targetId;
+      return this;
+    }
+
+    public Builder policyTypeCode(int policyTypeCode) {
+      policyMappingRecord.policyTypeCode = policyTypeCode;
+      return this;
+    }
+
+    public Builder policyCatalogId(long policyCatalogId) {
+      policyMappingRecord.policyCatalogId = policyCatalogId;
+      return this;
+    }
+
+    public Builder policyId(long policyId) {
+      policyMappingRecord.policyId = policyId;
+      return this;
+    }
+
+    public Builder parameters(String parameters) {
+      policyMappingRecord.parameters = parameters;
+      return this;
+    }
+
+    public ModelPolicyMappingRecord build() {
+      return policyMappingRecord;
+    }
+  }
+
+  public static ModelPolicyMappingRecord fromPolicyMappingRecord(
+      PolarisPolicyMappingRecord record) {
+    if (record == null) return null;
+
+    return ModelPolicyMappingRecord.builder()
+        .targetCatalogId(record.getTargetCatalogId())
+        .targetId(record.getTargetId())
+        .policyTypeCode(record.getPolicyTypeCode())
+        .policyCatalogId(record.getPolicyCatalogId())
+        .policyId(record.getPolicyId())
+        .parameters(record.getParameters())
+        .build();
+  }
+
+  public static PolarisPolicyMappingRecord toPolicyMappingRecord(ModelPolicyMappingRecord model) {
+    if (model == null) return null;
+
+    return new PolarisPolicyMappingRecord(
+        model.getTargetCatalogId(),
+        model.getTargetId(),
+        model.getPolicyCatalogId(),
+        model.getPolicyId(),
+        model.getPolicyTypeCode(),
+        model.getParameters());
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1884,7 +1884,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
         ms.loadAllPoliciesOnTarget(callCtx, target.getCatalogId(), target.getId());
 
-    List<PolicyEntity> policyEntities =
+    List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
     return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
   }
@@ -1908,7 +1908,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         ms.loadPoliciesOnTargetByType(
             callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
 
-    List<PolicyEntity> policyEntities =
+    List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
     return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
   }
@@ -1962,7 +1962,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
    * @param policyMappingRecords a list of policy mapping records
    * @return a list of policy entities
    */
-  private List<PolicyEntity> loadPoliciesFromMappingRecords(
+  private List<PolarisBaseEntity> loadPoliciesFromMappingRecords(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull BasePersistence ms,
       @Nonnull List<PolarisPolicyMappingRecord> policyMappingRecords) {
@@ -1975,8 +1975,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyId()))
             .distinct()
             .collect(Collectors.toList());
-    return ms.lookupEntities(callCtx, policyEntityIds).stream()
-        .map(PolicyEntity::of)
-        .collect(Collectors.toList());
+    return ms.lookupEntities(callCtx, policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -56,6 +56,8 @@ import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.dao.entity.ListEntitiesResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
@@ -1826,7 +1828,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   }
 
   @Override
-  public @Nonnull AttachmentResult attachPolicyToEntity(
+  public @Nonnull PolicyAttachmentResult attachPolicyToEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
       @Nonnull PolarisEntityCore target,
@@ -1839,7 +1841,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     PolicyType policyType = PolicyType.fromCode(policy.getPolicyTypeCode());
     if (policyType == null) {
       // This should never happen
-      return new AttachmentResult(
+      return new PolicyAttachmentResult(
           BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
     }
 
@@ -1850,13 +1852,13 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
           ms.loadPoliciesOnTargetByType(
               callCtx, target.getCatalogId(), target.getId(), policy.getPolicyTypeCode());
       if (existingRecordsOfSameType.size() > 1) {
-        return new AttachmentResult(
+        return new PolicyAttachmentResult(
             BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
       } else if (existingRecordsOfSameType.size() == 1) {
         PolarisPolicyMappingRecord existingRecord = existingRecordsOfSameType.get(0);
         if (existingRecord.getPolicyId() != policy.getId()
             || existingRecord.getPolicyCatalogId() != policy.getCatalogId()) {
-          return new AttachmentResult(
+          return new PolicyAttachmentResult(
               BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
         }
       }
@@ -1864,11 +1866,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     PolarisPolicyMappingRecord mappingRecord =
         this.persistNewPolicyMappingRecord(callCtx, ms, target, policy, parameters);
-    return new AttachmentResult(mappingRecord);
+    return new PolicyAttachmentResult(mappingRecord);
   }
 
   @Override
-  public @Nonnull AttachmentResult detachPolicyFromEntity(
+  public @Nonnull PolicyAttachmentResult detachPolicyFromEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> catalogPath,
       @Nonnull PolarisEntityCore target,
@@ -1886,12 +1888,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             policy.getCatalogId(),
             policy.getId());
     if (mappingRecord == null) {
-      return new AttachmentResult(BaseResult.ReturnStatus.POLICY_MAPPING_NOT_FOUND, null);
+      return new PolicyAttachmentResult(BaseResult.ReturnStatus.POLICY_MAPPING_NOT_FOUND, null);
     }
 
     ms.deleteFromPolicyMappingRecords(callCtx, mappingRecord);
 
-    return new AttachmentResult(mappingRecord);
+    return new PolicyAttachmentResult(mappingRecord);
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1933,7 +1933,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     }
 
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
-        ms.loadAllPoliciesOnTarget(callCtx, target.getCatalogId(), target.getId());
+        ms.loadPoliciesOnTargetByType(
+            callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
 
     List<PolicyEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1838,35 +1838,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    PolicyType policyType = PolicyType.fromCode(policy.getPolicyTypeCode());
-    if (policyType == null) {
-      // This should never happen
-      return new PolicyAttachmentResult(
-          BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
-    }
-
-    // TODO: this may make it necessary to push down this logic to policy persistence layer
-    if (policyType.isInheritable()) {
-      // Verify that there is no other mapping of the same type but different entity
-      List<PolarisPolicyMappingRecord> existingRecordsOfSameType =
-          ms.loadPoliciesOnTargetByType(
-              callCtx, target.getCatalogId(), target.getId(), policy.getPolicyTypeCode());
-      if (existingRecordsOfSameType.size() > 1) {
-        return new PolicyAttachmentResult(
-            BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
-      } else if (existingRecordsOfSameType.size() == 1) {
-        PolarisPolicyMappingRecord existingRecord = existingRecordsOfSameType.get(0);
-        if (existingRecord.getPolicyId() != policy.getId()
-            || existingRecord.getPolicyCatalogId() != policy.getCatalogId()) {
-          return new PolicyAttachmentResult(
-              BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
-        }
-      }
-    }
-
-    PolarisPolicyMappingRecord mappingRecord =
-        this.persistNewPolicyMappingRecord(callCtx, ms, target, policy, parameters);
-    return new PolicyAttachmentResult(mappingRecord);
+    return this.persistNewPolicyMappingRecord(callCtx, ms, target, policy, parameters);
   }
 
   @Override
@@ -1951,7 +1923,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
    * @param parameters optional parameters
    * @return new policy mapping record which was created and persisted
    */
-  private @Nonnull PolarisPolicyMappingRecord persistNewPolicyMappingRecord(
+  private @Nonnull PolicyAttachmentResult persistNewPolicyMappingRecord(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull BasePersistence ms,
       @Nonnull PolarisEntityCore target,
@@ -1968,10 +1940,18 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             policy.getId(),
             policy.getPolicyTypeCode(),
             parameters);
+    try {
+      ms.writeToPolicyMappingRecords(callCtx, mappingRecord);
+    } catch (IllegalArgumentException e) {
+      return new PolicyAttachmentResult(
+          BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
+    } catch (PolicyMappingAlreadyExistsException e) {
+      return new PolicyAttachmentResult(
+          BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS,
+          e.getExistingRecord().getPolicyTypeCode());
+    }
 
-    ms.writeToPolicyMappingRecords(callCtx, mappingRecord);
-
-    return mappingRecord;
+    return new PolicyAttachmentResult(mappingRecord);
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1874,9 +1874,9 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    int grantRecordVersion =
-        ms.lookupEntityGrantRecordsVersion(callCtx, target.getCatalogId(), target.getId());
-    if (grantRecordVersion == 0) {
+    PolarisBaseEntity entity =
+        ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+    if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
@@ -1897,9 +1897,9 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    int grantRecordVersion =
-        ms.lookupEntityGrantRecordsVersion(callCtx, target.getCatalogId(), target.getId());
-    if (grantRecordVersion == 0) {
+    PolarisBaseEntity entity =
+        ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+    if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -68,7 +68,6 @@ import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1827,12 +1826,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   }
 
   @Override
-  public @NotNull AttachmentResult attachPolicyToEntity(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull List<PolarisEntityCore> targetCatalogPath,
-      @NotNull PolarisEntityCore target,
-      @NotNull List<PolarisEntityCore> policyCatalogPath,
-      @NotNull PolicyEntity policy,
+  public @Nonnull AttachmentResult attachPolicyToEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy,
       Map<String, String> parameters) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
@@ -1869,12 +1868,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   }
 
   @Override
-  public @NotNull AttachmentResult detachPolicyFromEntity(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull List<PolarisEntityCore> catalogPath,
-      @NotNull PolarisEntityCore target,
-      @NotNull List<PolarisEntityCore> policyCatalogPath,
-      @NotNull PolicyEntity policy) {
+  public @Nonnull AttachmentResult detachPolicyFromEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
@@ -1896,8 +1895,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   }
 
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntity(
-      @NotNull PolarisCallContext callCtx, @NotNull PolarisEntityCore target) {
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntity(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
@@ -1917,10 +1916,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   }
 
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull PolarisEntityCore target,
-      @NotNull PolicyType policyType) {
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyType policyType) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1877,7 +1877,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     PolarisBaseEntity entity =
         ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
-      // Target entity does not exists
+      // Target entity does not exist
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
 
@@ -1900,7 +1900,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     PolarisBaseEntity entity =
         ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
-      // Target entity does not exists
+      // Target entity does not exist
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
@@ -31,6 +31,7 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
+import org.apache.polaris.core.policy.PolicyMappingPersistence;
 
 /**
  * Interface to the Polaris persistence backend, with which to persist and retrieve all the data
@@ -41,7 +42,7 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
  * the underlying data store. The goal is to make it really easy to back this using databases like
  * Postgres or simpler KV store.
  */
-public interface BasePersistence {
+public interface BasePersistence extends PolicyMappingPersistence {
   /**
    * The returned id must be fully unique within a realm and never reused once generated, whether or
    * not anything ends up committing an entity with the generated id.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -42,6 +42,7 @@ import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.ListEntitiesResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
+import org.apache.polaris.core.policy.PolarisPolicyMappingManager;
 import org.apache.polaris.core.storage.PolarisCredentialVendor;
 
 /**
@@ -49,7 +50,10 @@ import org.apache.polaris.core.storage.PolarisCredentialVendor;
  * authorization. It uses the underlying persistent metastore to store and retrieve Polaris metadata
  */
 public interface PolarisMetaStoreManager
-    extends PolarisSecretsManager, PolarisGrantManager, PolarisCredentialVendor {
+    extends PolarisSecretsManager,
+        PolarisGrantManager,
+        PolarisCredentialVendor,
+        PolarisPolicyMappingManager {
 
   /**
    * Bootstrap the Polaris service, creating the root catalog, root principal, and associated

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+
+/**
+ * Exception raised when an existing policy mapping preveents the attempted creation of a new policy
+ * mapping record.
+ */
+public class PolicyMappingAlreadyExistsException extends RuntimeException {
+  private PolarisPolicyMappingRecord existingRecord;
+
+  /**
+   * @param existingRecord The conflicting record that caused creation to fail.
+   */
+  public PolicyMappingAlreadyExistsException(PolarisPolicyMappingRecord existingRecord) {
+    super("Existing Policy Mapping Record: " + existingRecord);
+    this.existingRecord = existingRecord;
+  }
+
+  public PolarisPolicyMappingRecord getExistingRecord() {
+    return this.existingRecord;
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -44,6 +44,8 @@ import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.ListEntitiesResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
@@ -398,7 +400,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @Nonnull AttachmentResult attachPolicyToEntity(
+  public @Nonnull PolicyAttachmentResult attachPolicyToEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
       @Nonnull PolarisEntityCore target,
@@ -412,7 +414,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @Nonnull AttachmentResult detachPolicyFromEntity(
+  public @Nonnull PolicyAttachmentResult detachPolicyFromEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> catalogPath,
       @Nonnull PolarisEntityCore target,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -49,7 +49,10 @@ import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.apache.polaris.core.persistence.dao.entity.ScopedCredentialsResult;
 import org.apache.polaris.core.persistence.dao.entity.ValidateAccessResult;
+import org.apache.polaris.core.policy.PolicyEntity;
+import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Wraps an existing impl of PolarisMetaStoreManager and delegates expected "read" operations
@@ -392,6 +395,53 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "refreshResolvedEntity");
+    return null;
+  }
+
+  @Override
+  public @NotNull AttachmentResult attachPolicyToEntity(
+      @NotNull PolarisCallContext callCtx,
+      @NotNull List<PolarisEntityCore> targetCatalogPath,
+      @NotNull PolarisEntityCore target,
+      @NotNull List<PolarisEntityCore> policyCatalogPath,
+      @NotNull PolicyEntity policy,
+      Map<String, String> parameters) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "attachPolicyToEntity");
+    return null;
+  }
+
+  @Override
+  public @NotNull AttachmentResult detachPolicyFromEntity(
+      @NotNull PolarisCallContext callCtx,
+      @NotNull List<PolarisEntityCore> catalogPath,
+      @NotNull PolarisEntityCore target,
+      @NotNull List<PolarisEntityCore> policyCatalogPath,
+      @NotNull PolicyEntity policy) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "detachPolicyFromEntity");
+    return null;
+  }
+
+  @Override
+  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntity(
+      @NotNull PolarisCallContext callCtx, @NotNull PolarisEntityCore target) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "loadPoliciesOnEntity");
+    return null;
+  }
+
+  @Override
+  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+      @NotNull PolarisCallContext callCtx,
+      @NotNull PolarisEntityCore target,
+      @NotNull PolicyType policyType) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "loadPoliciesOnEntityByType");
     return null;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -52,7 +52,6 @@ import org.apache.polaris.core.persistence.dao.entity.ValidateAccessResult;
 import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.core.storage.PolarisStorageActions;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Wraps an existing impl of PolarisMetaStoreManager and delegates expected "read" operations
@@ -399,12 +398,12 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @NotNull AttachmentResult attachPolicyToEntity(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull List<PolarisEntityCore> targetCatalogPath,
-      @NotNull PolarisEntityCore target,
-      @NotNull List<PolarisEntityCore> policyCatalogPath,
-      @NotNull PolicyEntity policy,
+  public @Nonnull AttachmentResult attachPolicyToEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy,
       Map<String, String> parameters) {
     callCtx
         .getDiagServices()
@@ -413,12 +412,12 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @NotNull AttachmentResult detachPolicyFromEntity(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull List<PolarisEntityCore> catalogPath,
-      @NotNull PolarisEntityCore target,
-      @NotNull List<PolarisEntityCore> policyCatalogPath,
-      @NotNull PolicyEntity policy) {
+  public @Nonnull AttachmentResult detachPolicyFromEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy) {
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "detachPolicyFromEntity");
@@ -426,8 +425,8 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntity(
-      @NotNull PolarisCallContext callCtx, @NotNull PolarisEntityCore target) {
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntity(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target) {
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "loadPoliciesOnEntity");
@@ -435,10 +434,10 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
-      @NotNull PolarisCallContext callCtx,
-      @NotNull PolarisEntityCore target,
-      @NotNull PolicyType policyType) {
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyType policyType) {
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "loadPoliciesOnEntityByType");

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
@@ -111,6 +111,7 @@ public class BaseResult {
 
     // error caught while sub-scoping credentials. Error message will be returned
     SUBSCOPE_CREDS_ERROR(13),
+
     // policy mapping not found
     POLICY_MAPPING_NOT_FOUND(14),
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
@@ -111,6 +111,11 @@ public class BaseResult {
 
     // error caught while sub-scoping credentials. Error message will be returned
     SUBSCOPE_CREDS_ERROR(13),
+    // policy mapping not found
+    POLICY_MAPPING_NOT_FOUND(14),
+
+    // policy mapping of same type already exists
+    POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS(15),
     ;
 
     // code for the enum

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/LoadPolicyMappingsResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/LoadPolicyMappingsResult.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence.dao.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+import org.apache.polaris.core.policy.PolicyEntity;
+
+/** result of a load policy mapping call */
+public class LoadPolicyMappingsResult extends BaseResult {
+  // null if not success. Else set of policy mapping records on a target or from a policy
+  private final List<PolarisPolicyMappingRecord> mappingRecords;
+
+  // null if not success. Else set of policy entities in the mapping records.
+  private final List<PolicyEntity> policyEntities;
+
+  /**
+   * Constructor for an error
+   *
+   * @param errorCode error code, cannot be SUCCESS
+   * @param extraInformation extra information
+   */
+  public LoadPolicyMappingsResult(
+      @Nonnull ReturnStatus errorCode, @Nullable String extraInformation) {
+    super(errorCode, extraInformation);
+    this.mappingRecords = null;
+    this.policyEntities = null;
+  }
+
+  /**
+   * Constructor for success
+   *
+   * @param mappingRecords policy mapping records
+   * @param policyEntities policy entities
+   */
+  public LoadPolicyMappingsResult(
+      @Nonnull List<PolarisPolicyMappingRecord> mappingRecords,
+      @Nonnull List<PolicyEntity> policyEntities) {
+    super(ReturnStatus.SUCCESS);
+    this.mappingRecords = mappingRecords;
+    this.policyEntities = policyEntities;
+  }
+
+  @JsonCreator
+  private LoadPolicyMappingsResult(
+      @JsonProperty("returnStatus") @Nonnull ReturnStatus returnStatus,
+      @JsonProperty("extraInformation") String extraInformation,
+      @JsonProperty("policyMappingRecords") List<PolarisPolicyMappingRecord> mappingRecords,
+      @JsonProperty("policyEntities") List<PolicyEntity> policyEntities) {
+    super(returnStatus, extraInformation);
+    this.mappingRecords = mappingRecords;
+    this.policyEntities = policyEntities;
+  }
+
+  public List<PolarisPolicyMappingRecord> getPolicyMappingRecords() {
+    return mappingRecords;
+  }
+
+  public List<PolicyEntity> getPolicyEntities() {
+    return policyEntities;
+  }
+
+  @JsonIgnore
+  public Map<Long, PolicyEntity> getPolicyEntitiesAsMap() {
+    return policyEntities == null
+        ? null
+        : policyEntities.stream().collect(Collectors.toMap(PolicyEntity::getId, entity -> entity));
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/LoadPolicyMappingsResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/LoadPolicyMappingsResult.java
@@ -26,16 +26,16 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
-import org.apache.polaris.core.policy.PolicyEntity;
 
 /** result of a load policy mapping call */
 public class LoadPolicyMappingsResult extends BaseResult {
   // null if not success. Else set of policy mapping records on a target or from a policy
   private final List<PolarisPolicyMappingRecord> mappingRecords;
 
-  // null if not success. Else set of policy entities in the mapping records.
-  private final List<PolicyEntity> policyEntities;
+  // null if not success. Else, for each policy mapping record, list of target or policy entities
+  private final List<PolarisBaseEntity> entities;
 
   /**
    * Constructor for an error
@@ -47,21 +47,21 @@ public class LoadPolicyMappingsResult extends BaseResult {
       @Nonnull ReturnStatus errorCode, @Nullable String extraInformation) {
     super(errorCode, extraInformation);
     this.mappingRecords = null;
-    this.policyEntities = null;
+    this.entities = null;
   }
 
   /**
    * Constructor for success
    *
    * @param mappingRecords policy mapping records
-   * @param policyEntities policy entities
+   * @param entities policy entities
    */
   public LoadPolicyMappingsResult(
       @Nonnull List<PolarisPolicyMappingRecord> mappingRecords,
-      @Nonnull List<PolicyEntity> policyEntities) {
+      @Nonnull List<PolarisBaseEntity> entities) {
     super(ReturnStatus.SUCCESS);
     this.mappingRecords = mappingRecords;
-    this.policyEntities = policyEntities;
+    this.entities = entities;
   }
 
   @JsonCreator
@@ -69,24 +69,34 @@ public class LoadPolicyMappingsResult extends BaseResult {
       @JsonProperty("returnStatus") @Nonnull ReturnStatus returnStatus,
       @JsonProperty("extraInformation") String extraInformation,
       @JsonProperty("policyMappingRecords") List<PolarisPolicyMappingRecord> mappingRecords,
-      @JsonProperty("policyEntities") List<PolicyEntity> policyEntities) {
+      @JsonProperty("policyEntities") List<PolarisBaseEntity> entities) {
     super(returnStatus, extraInformation);
     this.mappingRecords = mappingRecords;
-    this.policyEntities = policyEntities;
+    this.entities = entities;
   }
 
   public List<PolarisPolicyMappingRecord> getPolicyMappingRecords() {
     return mappingRecords;
   }
 
-  public List<PolicyEntity> getPolicyEntities() {
-    return policyEntities;
+  public List<PolarisBaseEntity> getEntities() {
+    return entities;
   }
 
   @JsonIgnore
-  public Map<Long, PolicyEntity> getPolicyEntitiesAsMap() {
-    return policyEntities == null
+  public Map<Long, PolarisBaseEntity> getEntitiesAsMap() {
+    return entities == null
         ? null
-        : policyEntities.stream().collect(Collectors.toMap(PolicyEntity::getId, entity -> entity));
+        : entities.stream().collect(Collectors.toMap(PolarisBaseEntity::getId, entity -> entity));
+  }
+
+  @Override
+  public String toString() {
+    return "LoadPolicyMappingsResult{"
+        + "mappingRecords="
+        + mappingRecords
+        + ", entities="
+        + entities
+        + '}';
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/PolicyAttachmentResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/PolicyAttachmentResult.java
@@ -32,12 +32,23 @@ public class PolicyAttachmentResult extends BaseResult {
   /**
    * Constructor for an error
    *
-   * @param errorCode error code, cannot be SUCCESS
+   * @param errorStatus error code, cannot be SUCCESS
    * @param extraInformation extra information
    */
   public PolicyAttachmentResult(
-      @Nonnull ReturnStatus errorCode, @Nullable String extraInformation) {
-    super(errorCode, extraInformation);
+      @Nonnull ReturnStatus errorStatus, @Nullable String extraInformation) {
+    super(errorStatus, extraInformation);
+    this.mappingRecord = null;
+  }
+
+  /**
+   * Constructor for an error
+   *
+   * @param errorStatus error code, cannot be SUCCESS
+   * @param policyTypeCode existing policy mapping record's policy type code
+   */
+  public PolicyAttachmentResult(@Nonnull ReturnStatus errorStatus, int policyTypeCode) {
+    super(errorStatus, Integer.toString(policyTypeCode));
     this.mappingRecord = null;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/PolicyAttachmentResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/PolicyAttachmentResult.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence.dao.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+
+/** result of an attach/detach operation */
+public class PolicyAttachmentResult extends BaseResult {
+  // null if not success
+  private final PolarisPolicyMappingRecord mappingRecord;
+
+  /**
+   * Constructor for an error
+   *
+   * @param errorCode error code, cannot be SUCCESS
+   * @param extraInformation extra information
+   */
+  public PolicyAttachmentResult(
+      @Nonnull ReturnStatus errorCode, @Nullable String extraInformation) {
+    super(errorCode, extraInformation);
+    this.mappingRecord = null;
+  }
+
+  /**
+   * Constructor for success
+   *
+   * @param mappingRecord policy mapping record being attached/detached
+   */
+  public PolicyAttachmentResult(@Nonnull PolarisPolicyMappingRecord mappingRecord) {
+    super(ReturnStatus.SUCCESS);
+    this.mappingRecord = mappingRecord;
+  }
+
+  @JsonCreator
+  private PolicyAttachmentResult(
+      @JsonProperty("returnStatus") @Nonnull ReturnStatus returnStatus,
+      @JsonProperty("extraInformation") String extraInformation,
+      @JsonProperty("policyMappingRecord") PolarisPolicyMappingRecord mappingRecord) {
+    super(returnStatus, extraInformation);
+    this.mappingRecord = mappingRecord;
+  }
+
+  public PolarisPolicyMappingRecord getPolicyMappingRecord() {
+    return mappingRecord;
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -774,7 +774,6 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     return this.runInReadTransaction(
-        callCtx,
-        () -> this.loadAllTargetsOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
+        callCtx, () -> this.loadAllTargetsOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -771,10 +771,10 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   /** {@inheritDoc} */
   @Override
   @Nonnull
-  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicy(
+  public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     return this.runInReadTransaction(
         callCtx,
-        () -> this.loadAllPoliciesOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
+        () -> this.loadAllTargetsOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -35,6 +35,7 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 
@@ -659,5 +660,87 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
     PolarisEntitiesActiveKey entityActiveKey =
         new PolarisEntitiesActiveKey(catalogId, parentId, typeCode, name);
     return this.lookupEntityActiveInCurrentTxn(callCtx, entityActiveKey);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void writeToPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    this.runActionInTransaction(
+        callCtx, () -> this.writeToPolicyMappingRecordsInCurrentTxn(callCtx, record));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteFromPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    this.runActionInTransaction(
+        callCtx, () -> this.deleteFromPolicyMappingRecordsInCurrentTxn(callCtx, record));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteAllEntityPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore entity,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+    this.runActionInTransaction(
+        callCtx,
+        () ->
+            this.deleteAllEntityPolicyMappingRecordsInCurrentTxn(
+                callCtx, entity, mappingOnTarget, mappingOnPolicy));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @Nullable
+  public PolarisPolicyMappingRecord lookupPolicyMappingRecord(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    return this.runInReadTransaction(
+        callCtx,
+        () ->
+            this.lookupPolicyMappingRecordInCurrentTxn(
+                callCtx, targetCatalogId, targetId, policyTypeCode, policyCatalogId, policyId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @Nonnull
+  public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode) {
+    return this.runInReadTransaction(
+        callCtx,
+        () ->
+            this.loadPoliciesOnTargetByTypeInCurrentTxn(
+                callCtx, targetCatalogId, targetId, policyTypeCode));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @Nonnull
+  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnTarget(
+      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+    return this.runInReadTransaction(
+        callCtx,
+        () -> this.loadAllPoliciesOnTargetInCurrentTxn(callCtx, targetCatalogId, targetId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @Nonnull
+  public List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicy(
+      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+    return this.runInReadTransaction(
+        callCtx,
+        () -> this.loadAllPoliciesOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -62,10 +62,14 @@ import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.apache.polaris.core.persistence.dao.entity.ScopedCredentialsResult;
 import org.apache.polaris.core.persistence.dao.entity.ValidateAccessResult;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+import org.apache.polaris.core.policy.PolicyEntity;
+import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2315,5 +2319,247 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                 entityType,
                 entityCatalogId,
                 entityId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @NotNull AttachmentResult attachPolicyToEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy,
+      Map<String, String> parameters) {
+    // get metastore we should be using
+    TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
+
+    return ms.runInTransaction(
+        callCtx,
+        () ->
+            this.doAttachPolicyToEntity(
+                callCtx, ms, target, targetCatalogPath, policy, policyCatalogPath, parameters));
+  }
+
+  /**
+   * See {@link #attachPolicyToEntity(PolarisCallContext, List, PolarisEntityCore, List,
+   * PolicyEntity, Map)}
+   */
+  private @Nonnull AttachmentResult doAttachPolicyToEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolicyEntity policy,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      Map<String, String> parameters) {
+    PolarisEntityResolver targetResolver =
+        new PolarisEntityResolver(callCtx, ms, targetCatalogPath, target);
+    PolarisEntityResolver policyResolver =
+        new PolarisEntityResolver(callCtx, ms, policyCatalogPath, policy);
+    if (targetResolver.isFailure() || policyResolver.isFailure()) {
+      return new AttachmentResult(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED, null);
+    }
+
+    PolicyType policyType = PolicyType.fromCode(policy.getPolicyTypeCode());
+    if (policyType == null) {
+      // This should never happen
+      return new AttachmentResult(
+          BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
+    }
+
+    if (policyType.isInheritable()) {
+      // Verify that there is no other mapping of the same type but different entity
+      List<PolarisPolicyMappingRecord> existingRecordsOfSameType =
+          ms.loadPoliciesOnTargetByTypeInCurrentTxn(
+              callCtx, target.getCatalogId(), target.getId(), policy.getPolicyTypeCode());
+      if (existingRecordsOfSameType.size() > 1) {
+        return new AttachmentResult(
+            BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
+      } else if (existingRecordsOfSameType.size() == 1) {
+        PolarisPolicyMappingRecord existingRecord = existingRecordsOfSameType.get(0);
+        if (existingRecord.getPolicyId() != policy.getId()
+            || existingRecord.getPolicyCatalogId() != policy.getCatalogId()) {
+          return new AttachmentResult(
+              BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS, null);
+        }
+      }
+    }
+
+    PolarisPolicyMappingRecord mappingRecord =
+        this.persistNewPolicyMappingRecord(callCtx, ms, target, policy, parameters);
+    return new AttachmentResult(mappingRecord);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @Nonnull AttachmentResult detachPolicyFromEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy) {
+    TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
+    return ms.runInTransaction(
+        callCtx,
+        () ->
+            this.doDetachPolicyFromEntity(
+                callCtx, ms, target, targetCatalogPath, policy, policyCatalogPath));
+  }
+
+  /**
+   * See {@link #detachPolicyFromEntity(PolarisCallContext, List, PolarisEntityCore,
+   * List,PolicyEntity)}
+   */
+  private AttachmentResult doDetachPolicyFromEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolicyEntity policy,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath) {
+    PolarisEntityResolver targetResolver =
+        new PolarisEntityResolver(callCtx, ms, targetCatalogPath, target);
+    PolarisEntityResolver policyResolver =
+        new PolarisEntityResolver(callCtx, ms, policyCatalogPath, policy);
+    if (targetResolver.isFailure() || policyResolver.isFailure()) {
+      return new AttachmentResult(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED, null);
+    }
+
+    PolarisPolicyMappingRecord mappingRecord =
+        ms.lookupPolicyMappingRecordInCurrentTxn(
+            callCtx,
+            target.getCatalogId(),
+            target.getId(),
+            policy.getPolicyTypeCode(),
+            policy.getCatalogId(),
+            policy.getId());
+    if (mappingRecord == null) {
+      return new AttachmentResult(BaseResult.ReturnStatus.POLICY_MAPPING_NOT_FOUND, null);
+    }
+
+    ms.deleteFromPolicyMappingRecordsInCurrentTxn(callCtx, mappingRecord);
+
+    return new AttachmentResult(mappingRecord);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntity(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target) {
+    TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
+    return ms.runInReadTransaction(callCtx, () -> this.doLoadPoliciesOnEntity(callCtx, ms, target));
+  }
+
+  /** See {@link #loadPoliciesOnEntity(PolarisCallContext, PolarisEntityCore)} */
+  private LoadPolicyMappingsResult doLoadPoliciesOnEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull PolarisEntityCore target) {
+    int grantRecordVersion =
+        ms.lookupEntityGrantRecordsVersionInCurrentTxn(
+            callCtx, target.getCatalogId(), target.getId());
+    if (grantRecordVersion == 0) {
+      // Target entity does not exists
+      return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
+    }
+
+    final List<PolarisPolicyMappingRecord> policyMappingRecords =
+        ms.loadAllPoliciesOnTargetInCurrentTxn(callCtx, target.getCatalogId(), target.getId());
+
+    List<PolicyEntity> policyEntities =
+        loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
+    return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyType policyType) {
+    TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
+    return ms.runInReadTransaction(
+        callCtx, () -> this.doLoadPoliciesOnEntityByType(callCtx, ms, target, policyType));
+  }
+
+  /** See {@link #loadPoliciesOnEntityByType(PolarisCallContext, PolarisEntityCore, PolicyType)} */
+  public LoadPolicyMappingsResult doLoadPoliciesOnEntityByType(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyType policyType) {
+    int grantRecordVersion =
+        ms.lookupEntityGrantRecordsVersionInCurrentTxn(
+            callCtx, target.getCatalogId(), target.getId());
+    if (grantRecordVersion == 0) {
+      // Target entity does not exists
+      return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
+    }
+
+    final List<PolarisPolicyMappingRecord> policyMappingRecords =
+        ms.loadPoliciesOnTargetByTypeInCurrentTxn(
+            callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
+    List<PolicyEntity> policyEntities =
+        loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
+    return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
+  }
+
+  /**
+   * Create and persist a new policy mapping record
+   *
+   * @param callCtx call context
+   * @param ms meta store in read/write mode
+   * @param target target
+   * @param policy policy
+   * @param parameters optional parameters
+   * @return new policy mapping record which was created and persisted
+   */
+  private @Nonnull PolarisPolicyMappingRecord persistNewPolicyMappingRecord(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyEntity policy,
+      Map<String, String> parameters) {
+    callCtx.getDiagServices().checkNotNull(target, "unexpected_null_target");
+    callCtx.getDiagServices().checkNotNull(policy, "unexpected_null_policy");
+
+    PolarisPolicyMappingRecord mappingRecord =
+        new PolarisPolicyMappingRecord(
+            target.getCatalogId(),
+            target.getId(),
+            policy.getCatalogId(),
+            policy.getId(),
+            policy.getPolicyTypeCode(),
+            parameters);
+
+    ms.writeToPolicyMappingRecordsInCurrentTxn(callCtx, mappingRecord);
+
+    return mappingRecord;
+  }
+
+  /**
+   * Load policies from a list of policy mapping records
+   *
+   * @param callCtx call context
+   * @param ms meta store
+   * @param policyMappingRecords a list of policy mapping records
+   * @return a list of policy entities
+   */
+  private List<PolicyEntity> loadPoliciesFromMappingRecords(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull TransactionalPersistence ms,
+      @Nonnull List<PolarisPolicyMappingRecord> policyMappingRecords) {
+    List<PolarisEntityId> policyEntityIds =
+        policyMappingRecords.stream()
+            .map(
+                policyMappingRecord ->
+                    new PolarisEntityId(
+                        policyMappingRecord.getPolicyCatalogId(),
+                        policyMappingRecord.getPolicyId()))
+            .distinct()
+            .collect(Collectors.toList());
+    return ms.lookupEntitiesInCurrentTxn(callCtx, policyEntityIds).stream()
+        .map(PolicyEntity::of)
+        .collect(Collectors.toList());
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2336,7 +2336,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         callCtx,
         () ->
             this.doAttachPolicyToEntity(
-                callCtx, ms, target, targetCatalogPath, policy, policyCatalogPath, parameters));
+                callCtx, ms, targetCatalogPath, target, policyCatalogPath, policy, parameters));
   }
 
   /**
@@ -2346,10 +2346,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   private @Nonnull AttachmentResult doAttachPolicyToEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
-      @Nonnull PolarisEntityCore target,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
-      @Nonnull PolicyEntity policy,
+      @Nonnull PolarisEntityCore target,
       @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy,
       Map<String, String> parameters) {
     PolarisEntityResolver targetResolver =
         new PolarisEntityResolver(callCtx, ms, targetCatalogPath, target);
@@ -2402,7 +2402,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         callCtx,
         () ->
             this.doDetachPolicyFromEntity(
-                callCtx, ms, target, targetCatalogPath, policy, policyCatalogPath));
+                callCtx, ms, targetCatalogPath, target, policyCatalogPath, policy));
   }
 
   /**
@@ -2412,10 +2412,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   private AttachmentResult doDetachPolicyFromEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
-      @Nonnull PolarisEntityCore target,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
-      @Nonnull PolicyEntity policy,
-      @Nonnull List<PolarisEntityCore> policyCatalogPath) {
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy) {
     PolarisEntityResolver targetResolver =
         new PolarisEntityResolver(callCtx, ms, targetCatalogPath, target);
     PolarisEntityResolver policyResolver =

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -69,7 +69,6 @@ import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2323,7 +2322,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
   /** {@inheritDoc} */
   @Override
-  public @NotNull AttachmentResult attachPolicyToEntity(
+  public @Nonnull AttachmentResult attachPolicyToEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
       @Nonnull PolarisEntityCore target,
@@ -2444,7 +2443,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
   /** {@inheritDoc} */
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntity(
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntity(
       @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target) {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
     return ms.runInReadTransaction(callCtx, () -> this.doLoadPoliciesOnEntity(callCtx, ms, target));
@@ -2473,7 +2472,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
   /** {@inheritDoc} */
   @Override
-  public @NotNull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+  public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntityByType(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyType policyType) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2440,7 +2440,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
         ms.loadAllPoliciesOnTargetInCurrentTxn(callCtx, target.getCatalogId(), target.getId());
 
-    List<PolicyEntity> policyEntities =
+    List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
     return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
   }
@@ -2473,7 +2473,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
         ms.loadPoliciesOnTargetByTypeInCurrentTxn(
             callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
-    List<PolicyEntity> policyEntities =
+    List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
     return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
   }
@@ -2529,7 +2529,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
    * @param policyMappingRecords a list of policy mapping records
    * @return a list of policy entities
    */
-  private List<PolicyEntity> loadPoliciesFromMappingRecords(
+  private List<PolarisBaseEntity> loadPoliciesFromMappingRecords(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       @Nonnull List<PolarisPolicyMappingRecord> policyMappingRecords) {
@@ -2542,8 +2542,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyId()))
             .distinct()
             .collect(Collectors.toList());
-    return ms.lookupEntitiesInCurrentTxn(callCtx, policyEntityIds).stream()
-        .map(PolicyEntity::of)
-        .collect(Collectors.toList());
+    return ms.lookupEntitiesInCurrentTxn(callCtx, policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2429,10 +2429,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       @Nonnull PolarisEntityCore target) {
-    int grantRecordVersion =
-        ms.lookupEntityGrantRecordsVersionInCurrentTxn(
-            callCtx, target.getCatalogId(), target.getId());
-    if (grantRecordVersion == 0) {
+    PolarisBaseEntity entity =
+        ms.lookupEntityInCurrentTxn(
+            callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+    if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
@@ -2462,10 +2462,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull TransactionalPersistence ms,
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyType policyType) {
-    int grantRecordVersion =
-        ms.lookupEntityGrantRecordsVersionInCurrentTxn(
-            callCtx, target.getCatalogId(), target.getId());
-    if (grantRecordVersion == 0) {
+    PolarisBaseEntity entity =
+        ms.lookupEntityInCurrentTxn(
+            callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+    if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
@@ -36,6 +36,7 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.IntegrationPersistence;
+import org.apache.polaris.core.policy.TransactionalPolicyMappingPersistence;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 
@@ -44,7 +45,8 @@ import org.apache.polaris.core.storage.PolarisStorageIntegration;
  * which can support a runInTransaction semantic, while providing default implementations of some of
  * the BasePersistence methods in terms of lower-level methods that subclasses must implement.
  */
-public interface TransactionalPersistence extends BasePersistence, IntegrationPersistence {
+public interface TransactionalPersistence
+    extends BasePersistence, IntegrationPersistence, TransactionalPolicyMappingPersistence {
 
   /**
    * Run the specified transaction code (a Supplier lambda type) in a database read/write

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -628,7 +628,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
 
   /** {@inheritDoc} */
   @Override
-  public @Nonnull List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+  public @Nonnull List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     return this.store
         .getSlicePolicyMappingRecordsByPolicy()

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -38,6 +38,7 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.PrincipalSecretsGenerator;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -550,5 +551,87 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
   @Override
   public void rollback() {
     this.store.rollback();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void writeToPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    this.store.getSlicePolicyMappingRecords().write(record);
+    this.store.getSlicePolicyMappingRecordsByPolicy().write(record);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteFromPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    this.store.getSlicePolicyMappingRecords().delete(record);
+    this.store.getSlicePolicyMappingRecordsByPolicy().delete(record);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore entity,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+    // build composite prefix key and delete policy mapping records on the indexed side of each
+    // mapping table
+    String prefix = this.store.buildPrefixKeyComposite(entity.getCatalogId(), entity.getId());
+    this.store.getSlicePolicyMappingRecords().deleteRange(prefix);
+    this.store.getSlicePolicyMappingRecordsByPolicy().deleteRange(prefix);
+
+    // also delete the other side. We need to delete these mapping one at a time versus doing a
+    // range delete
+    mappingOnTarget.forEach(record -> this.store.getSlicePolicyMappingRecords().delete(record));
+    mappingOnPolicy.forEach(
+        record -> this.store.getSlicePolicyMappingRecordsByPolicy().delete(record));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @Nullable PolarisPolicyMappingRecord lookupPolicyMappingRecordInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    return this.store
+        .getSlicePolicyMappingRecords()
+        .read(
+            this.store.buildKeyComposite(
+                targetCatalogId, targetId, policyTypeCode, policyCatalogId, policyId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @Nonnull List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByTypeInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode) {
+    return this.store
+        .getSlicePolicyMappingRecords()
+        .readRange(this.store.buildPrefixKeyComposite(targetCatalogId, targetId, policyTypeCode));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @Nonnull List<PolarisPolicyMappingRecord> loadAllPoliciesOnTargetInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+    return this.store
+        .getSlicePolicyMappingRecords()
+        .readRange(this.store.buildPrefixKeyComposite(targetCatalogId, targetId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public @Nonnull List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+    return this.store
+        .getSlicePolicyMappingRecordsByPolicy()
+        .readRange(this.store.buildPrefixKeyComposite(policyCatalogId, policyId));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingManager.java
@@ -18,17 +18,13 @@
  */
 package org.apache.polaris.core.policy;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisEntityCore;
-import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
 
 public interface PolarisPolicyMappingManager {
 
@@ -50,7 +46,7 @@ public interface PolarisPolicyMappingManager {
    *     attached and the policy is inheritable.
    */
   @Nonnull
-  AttachmentResult attachPolicyToEntity(
+  PolicyAttachmentResult attachPolicyToEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> targetCatalogPath,
       @Nonnull PolarisEntityCore target,
@@ -71,7 +67,7 @@ public interface PolarisPolicyMappingManager {
    *     be found
    */
   @Nonnull
-  AttachmentResult detachPolicyFromEntity(
+  PolicyAttachmentResult detachPolicyFromEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisEntityCore> catalogPath,
       @Nonnull PolarisEntityCore target,
@@ -104,108 +100,4 @@ public interface PolarisPolicyMappingManager {
       @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyType policyType);
-
-  /** result of an attach/detach operation */
-  class AttachmentResult extends BaseResult {
-    // null if not success
-    private final PolarisPolicyMappingRecord mappingRecord;
-
-    /**
-     * Constructor for an error
-     *
-     * @param errorCode error code, cannot be SUCCESS
-     * @param extraInformation extra information
-     */
-    public AttachmentResult(
-        @Nonnull BaseResult.ReturnStatus errorCode, @Nullable String extraInformation) {
-      super(errorCode, extraInformation);
-      this.mappingRecord = null;
-    }
-
-    /**
-     * Constructor for success
-     *
-     * @param mappingRecord policy mapping record being attached/detached
-     */
-    public AttachmentResult(@Nonnull PolarisPolicyMappingRecord mappingRecord) {
-      super(BaseResult.ReturnStatus.SUCCESS);
-      this.mappingRecord = mappingRecord;
-    }
-
-    @JsonCreator
-    private AttachmentResult(
-        @JsonProperty("returnStatus") @Nonnull BaseResult.ReturnStatus returnStatus,
-        @JsonProperty("extraInformation") String extraInformation,
-        @JsonProperty("policyMappingRecord") PolarisPolicyMappingRecord mappingRecord) {
-      super(returnStatus, extraInformation);
-      this.mappingRecord = mappingRecord;
-    }
-
-    public PolarisPolicyMappingRecord getPolicyMappingRecord() {
-      return mappingRecord;
-    }
-  }
-
-  /** result of a load policy mapping call */
-  class LoadPolicyMappingsResult extends BaseResult {
-    // null if not success. Else set of policy mapping records on a target or from a policy
-    private final List<PolarisPolicyMappingRecord> mappingRecords;
-
-    // null if not success. Else set of policy entities in the mapping records.
-    private final List<PolicyEntity> policyEntities;
-
-    /**
-     * Constructor for an error
-     *
-     * @param errorCode error code, cannot be SUCCESS
-     * @param extraInformation extra information
-     */
-    public LoadPolicyMappingsResult(
-        @Nonnull BaseResult.ReturnStatus errorCode, @Nullable String extraInformation) {
-      super(errorCode, extraInformation);
-      this.mappingRecords = null;
-      this.policyEntities = null;
-    }
-
-    /**
-     * Constructor for success
-     *
-     * @param mappingRecords policy mapping records
-     * @param policyEntities policy entities
-     */
-    public LoadPolicyMappingsResult(
-        @Nonnull List<PolarisPolicyMappingRecord> mappingRecords,
-        @Nonnull List<PolicyEntity> policyEntities) {
-      super(BaseResult.ReturnStatus.SUCCESS);
-      this.mappingRecords = mappingRecords;
-      this.policyEntities = policyEntities;
-    }
-
-    @JsonCreator
-    private LoadPolicyMappingsResult(
-        @JsonProperty("returnStatus") @Nonnull BaseResult.ReturnStatus returnStatus,
-        @JsonProperty("extraInformation") String extraInformation,
-        @JsonProperty("policyMappingRecords") List<PolarisPolicyMappingRecord> mappingRecords,
-        @JsonProperty("policyEntities") List<PolicyEntity> policyEntities) {
-      super(returnStatus, extraInformation);
-      this.mappingRecords = mappingRecords;
-      this.policyEntities = policyEntities;
-    }
-
-    public List<PolarisPolicyMappingRecord> getPolicyMappingRecords() {
-      return mappingRecords;
-    }
-
-    public List<PolicyEntity> getPolicyEntities() {
-      return policyEntities;
-    }
-
-    @JsonIgnore
-    public Map<Long, PolicyEntity> getPolicyEntitiesAsMap() {
-      return policyEntities == null
-          ? null
-          : policyEntities.stream()
-              .collect(Collectors.toMap(PolicyEntity::getId, entity -> entity));
-    }
-  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingManager.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+
+public interface PolarisPolicyMappingManager {
+
+  /**
+   * Attach a policy to a target entity, for example attach a policy to a table.
+   *
+   * <p>For inheritable policy, only one policy of the same type can be attached to the target. For
+   * non-inheritable policy, multiple policies of the same type can be attached to the target.
+   *
+   * @param callCtx call context
+   * @param targetCatalogPath path to the target entity
+   * @param target target entity
+   * @param policyCatalogPath path to the policy entity
+   * @param policy policy entity
+   * @param parameters additional parameters for the attachment
+   * @return The policy mapping record we created for this attachment. Will return ENTITY_NOT_FOUND
+   *     if the specified target or policy does not exist. Will return
+   *     POLICY_OF_SAME_TYPE_ALREADY_ATTACHED if the target already has a policy of the same type
+   *     attached and the policy is inheritable.
+   */
+  @Nonnull
+  AttachmentResult attachPolicyToEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> targetCatalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy,
+      Map<String, String> parameters);
+
+  /**
+   * Detach a policy from a target entity
+   *
+   * @param callCtx call context
+   * @param catalogPath path to the target entity
+   * @param target target entity
+   * @param policyCatalogPath path to the policy entity
+   * @param policy policy entity
+   * @return The policy mapping record we detached. Will return ENTITY_NOT_FOUND if the specified
+   *     target or policy does not exist. Will return POLICY_MAPPING_NOT_FOUND if the mapping cannot
+   *     be found
+   */
+  @Nonnull
+  AttachmentResult detachPolicyFromEntity(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull List<PolarisEntityCore> policyCatalogPath,
+      @Nonnull PolicyEntity policy);
+
+  /**
+   * Load all policies attached to a target entity
+   *
+   * @param callCtx call context
+   * @param target target entity
+   * @return the list of policy mapping records on the target entity. Will return ENTITY_NOT_FOUND
+   *     if the specified target does not exist.
+   */
+  @Nonnull
+  LoadPolicyMappingsResult loadPoliciesOnEntity(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target);
+
+  /**
+   * Load all policies of a specific type attached to a target entity
+   *
+   * @param callCtx call context
+   * @param target target entity
+   * @param policyType the type of policy
+   * @return the list of policy mapping records on the target entity. Will return ENTITY_NOT_FOUND
+   *     if the specified target does not exist.
+   */
+  @Nonnull
+  LoadPolicyMappingsResult loadPoliciesOnEntityByType(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore target,
+      @Nonnull PolicyType policyType);
+
+  /** result of an attach/detach operation */
+  class AttachmentResult extends BaseResult {
+    // null if not success
+    private final PolarisPolicyMappingRecord mappingRecord;
+
+    /**
+     * Constructor for an error
+     *
+     * @param errorCode error code, cannot be SUCCESS
+     * @param extraInformation extra information
+     */
+    public AttachmentResult(
+        @Nonnull BaseResult.ReturnStatus errorCode, @Nullable String extraInformation) {
+      super(errorCode, extraInformation);
+      this.mappingRecord = null;
+    }
+
+    /**
+     * Constructor for success
+     *
+     * @param mappingRecord policy mapping record being attached/detached
+     */
+    public AttachmentResult(@Nonnull PolarisPolicyMappingRecord mappingRecord) {
+      super(BaseResult.ReturnStatus.SUCCESS);
+      this.mappingRecord = mappingRecord;
+    }
+
+    @JsonCreator
+    private AttachmentResult(
+        @JsonProperty("returnStatus") @Nonnull BaseResult.ReturnStatus returnStatus,
+        @JsonProperty("extraInformation") String extraInformation,
+        @JsonProperty("policyMappingRecord") PolarisPolicyMappingRecord mappingRecord) {
+      super(returnStatus, extraInformation);
+      this.mappingRecord = mappingRecord;
+    }
+
+    public PolarisPolicyMappingRecord getPolicyMappingRecord() {
+      return mappingRecord;
+    }
+  }
+
+  /** result of a load policy mapping call */
+  class LoadPolicyMappingsResult extends BaseResult {
+    // null if not success. Else set of policy mapping records on a target or from a policy
+    private final List<PolarisPolicyMappingRecord> mappingRecords;
+
+    // null if not success. Else set of policy entities in the mapping records.
+    private final List<PolicyEntity> policyEntities;
+
+    /**
+     * Constructor for an error
+     *
+     * @param errorCode error code, cannot be SUCCESS
+     * @param extraInformation extra information
+     */
+    public LoadPolicyMappingsResult(
+        @Nonnull BaseResult.ReturnStatus errorCode, @Nullable String extraInformation) {
+      super(errorCode, extraInformation);
+      this.mappingRecords = null;
+      this.policyEntities = null;
+    }
+
+    /**
+     * Constructor for success
+     *
+     * @param mappingRecords policy mapping records
+     * @param policyEntities policy entities
+     */
+    public LoadPolicyMappingsResult(
+        @Nonnull List<PolarisPolicyMappingRecord> mappingRecords,
+        @Nonnull List<PolicyEntity> policyEntities) {
+      super(BaseResult.ReturnStatus.SUCCESS);
+      this.mappingRecords = mappingRecords;
+      this.policyEntities = policyEntities;
+    }
+
+    @JsonCreator
+    private LoadPolicyMappingsResult(
+        @JsonProperty("returnStatus") @Nonnull BaseResult.ReturnStatus returnStatus,
+        @JsonProperty("extraInformation") String extraInformation,
+        @JsonProperty("policyMappingRecords") List<PolarisPolicyMappingRecord> mappingRecords,
+        @JsonProperty("policyEntities") List<PolicyEntity> policyEntities) {
+      super(returnStatus, extraInformation);
+      this.mappingRecords = mappingRecords;
+      this.policyEntities = policyEntities;
+    }
+
+    public List<PolarisPolicyMappingRecord> getPolicyMappingRecords() {
+      return mappingRecords;
+    }
+
+    public List<PolicyEntity> getPolicyEntities() {
+      return policyEntities;
+    }
+
+    @JsonIgnore
+    public Map<Long, PolicyEntity> getPolicyEntitiesAsMap() {
+      return policyEntities == null
+          ? null
+          : policyEntities.stream()
+              .collect(Collectors.toMap(PolicyEntity::getId, entity -> entity));
+    }
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class PolarisPolicyMappingRecord {
+  // to serialize/deserialize properties
+  public static final String EMPTY_MAP_STRING = "{}";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // id of the catalog where target entity resides
+  private long targetCatalogId;
+
+  // id of the target entity
+  private long targetId;
+
+  // id of the catalog where the policy entity resides
+  private long policyCatalogId;
+
+  // id of the policy
+  private long policyId;
+
+  // id associated to the policy type
+  private int policyTypeCode;
+
+  // additional parameters of the mapping
+  private String parameters;
+
+  public PolarisPolicyMappingRecord() {}
+
+  public long getTargetCatalogId() {
+    return targetCatalogId;
+  }
+
+  public void setTargetCatalogId(long targetCatalogId) {
+    this.targetCatalogId = targetCatalogId;
+  }
+
+  public long getTargetId() {
+    return targetId;
+  }
+
+  public void setTargetId(long targetId) {
+    this.targetId = targetId;
+  }
+
+  public long getPolicyId() {
+    return policyId;
+  }
+
+  public void setPolicyId(long policyId) {
+    this.policyId = policyId;
+  }
+
+  public int getPolicyTypeCode() {
+    return policyTypeCode;
+  }
+
+  public void setPolicyTypeCode(int policyTypeCode) {
+    this.policyTypeCode = policyTypeCode;
+  }
+
+  public long getPolicyCatalogId() {
+    return policyCatalogId;
+  }
+
+  public void setPolicyCatalogId(long policyCatalogId) {
+    this.policyCatalogId = policyCatalogId;
+  }
+
+  public String getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(String parameters) {
+    this.parameters = parameters;
+  }
+
+  public Map<String, String> getParametersAsMap() {
+    if (parameters == null) {
+      return new HashMap<>();
+    }
+    try {
+      return MAPPER.readValue(parameters, new TypeReference<>() {});
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException(
+          String.format("Failed to deserialize json. parameters %s", parameters), ex);
+    }
+  }
+
+  public void setParametersAsMap(Map<String, String> parameters) {
+    try {
+      this.parameters =
+          parameters == null ? EMPTY_MAP_STRING : MAPPER.writeValueAsString(parameters);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException(
+          String.format("Failed to serialize json. properties %s", parameters), ex);
+    }
+  }
+
+  /**
+   * Constructor
+   *
+   * @param targetCatalogId id of the catalog where target entity resides
+   * @param targetId id of the target entity
+   * @param policyCatalogId id of the catalog where the policy entity resides
+   * @param policyId id of the policy
+   * @param policyTypeCode id associated to the policy type
+   * @param parameters additional parameters of the mapping
+   */
+  @JsonCreator
+  public PolarisPolicyMappingRecord(
+      @JsonProperty("targetCatalogId") long targetCatalogId,
+      @JsonProperty("targetId") long targetId,
+      @JsonProperty("policyCatalogId") long policyCatalogId,
+      @JsonProperty("policyId") long policyId,
+      @JsonProperty("policyTypeCode") int policyTypeCode,
+      @JsonProperty("parameters") String parameters) {
+    this.targetCatalogId = targetCatalogId;
+    this.targetId = targetId;
+    this.policyCatalogId = policyCatalogId;
+    this.policyId = policyId;
+    this.policyTypeCode = policyTypeCode;
+    this.parameters = parameters;
+  }
+
+  public PolarisPolicyMappingRecord(
+      long targetCatalogId,
+      long targetId,
+      long policyCatalogId,
+      long policyId,
+      int policyTypeCode,
+      Map<String, String> parameters) {
+    this.targetCatalogId = targetCatalogId;
+    this.targetId = targetId;
+    this.policyCatalogId = policyCatalogId;
+    this.policyId = policyId;
+    this.policyTypeCode = policyTypeCode;
+    this.setParametersAsMap(parameters);
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param policyMappingRecord policy mapping rec to copy
+   */
+  public PolarisPolicyMappingRecord(PolarisPolicyMappingRecord policyMappingRecord) {
+    this.targetCatalogId = policyMappingRecord.getTargetCatalogId();
+    this.targetId = policyMappingRecord.getTargetId();
+    this.policyCatalogId = policyMappingRecord.getPolicyCatalogId();
+    this.policyId = policyMappingRecord.getPolicyId();
+    this.policyTypeCode = policyMappingRecord.getPolicyTypeCode();
+    this.parameters = policyMappingRecord.getParameters();
+  }
+
+  @Override
+  public String toString() {
+    return "PolarisPolicyMappingRec{"
+        + "targetCatalogId="
+        + targetCatalogId
+        + ", targetId="
+        + targetId
+        + ", policyCatalogId="
+        + policyCatalogId
+        + ", policyId="
+        + policyId
+        + ", policyType='"
+        + policyTypeCode
+        + ", parameters='"
+        + parameters
+        + "}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PolarisPolicyMappingRecord that = (PolarisPolicyMappingRecord) o;
+    return targetCatalogId == that.targetCatalogId
+        && targetId == that.targetId
+        && policyCatalogId == that.policyCatalogId
+        && policyId == that.policyId
+        && policyTypeCode == that.policyTypeCode
+        && Objects.equals(parameters, that.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(targetId, policyId, policyCatalogId, policyTypeCode, parameters);
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -31,7 +31,7 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
  *
  * <p>Note that APIs to the actual persistence store are very basic, often point read or write to
  * the underlying data store. The goal is to make it really easy to back this using databases like
- * Postgres or simpler KV store.
+ * Postgres or simpler KV store. Each API in this interface need to be atomic.
  */
 public interface PolicyMappingPersistence {
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -144,7 +144,7 @@ public interface PolicyMappingPersistence {
    * @return the list of policy mapping records for the specified policy entity
    */
   @Nonnull
-  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicy(
+  default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     throw new UnsupportedOperationException("Not Implemented");
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+
+/**
+ * Interface for interacting with the Polaris persistence backend for Policy Mapping operations.
+ * This interface provides methods to persist and retrieve policy mapping records, which define the
+ * relationships between policies and target entities in Polaris.
+ *
+ * <p>Note that APIs to the actual persistence store are very basic, often point read or write to
+ * the underlying data store. The goal is to make it really easy to back this using databases like
+ * Postgres or simpler KV store.
+ */
+public interface PolicyMappingPersistence {
+
+  /**
+   * Write the specified policyMappingRecord to the policy_mapping_records table. If there is a
+   * conflict (existing record with the same PK), all attributes of the new record will replace the
+   * existing one.
+   *
+   * @param callCtx call context
+   * @param record policy mapping record to write, potentially replacing an existing policy mapping
+   *     with the same key
+   */
+  default void writeToPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Delete the specified policyMappingRecord to the policy_mapping_records table.
+   *
+   * @param callCtx call context
+   * @param record policy mapping record to delete.
+   */
+  default void deleteFromPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Delete the all policy mapping records in the policy_mapping_records table for the specified
+   * entity. This method will delete all policy mapping records on the entity
+   *
+   * @param callCtx call context
+   * @param entity entity whose policy mapping records should be deleted
+   * @param mappingOnTarget all mappings on that target entity. Empty list if that entity is not a
+   *     target
+   * @param mappingOnPolicy all mappings on that policy entity. Empty list if that entity is not a
+   *     policy
+   */
+  default void deleteAllEntityPolicyMappingRecords(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore entity,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Look up the specified policy mapping record from the policy_mapping_records table. Return NULL
+   * if not found
+   *
+   * @param callCtx call context
+   * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
+   * @param targetId id of the target entity
+   * @param policyTypeCode type code of the policy entity
+   * @param policyCatalogId catalog id of the policy entity
+   * @param policyId id of the policy entity
+   * @return the policy mapping record if found, NULL if not found
+   */
+  @Nullable
+  default PolarisPolicyMappingRecord lookupPolicyMappingRecord(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Get all policies on the specified target entity with specified policy type.
+   *
+   * @param callCtx call context
+   * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
+   * @param targetId id of the target entity
+   * @param policyTypeCode type code of the policy entity
+   * @return the list of policy mapping records for the specified target entity with the specified
+   *     policy type
+   */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Get all policies on the specified target entity.
+   *
+   * @param callCtx call context
+   * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
+   * @param targetId id of the target entity
+   * @return the list of policy mapping records for the specified target entity
+   */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnTarget(
+      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /**
+   * Get all targets of the specified policy entity
+   *
+   * @param callCtx call context
+   * @param policyCatalogId catalog id of the policy entity, NULL_ID if the entity is top-level
+   * @param policyId id of the policy entity
+   * @return the list of policy mapping records for the specified policy entity
+   */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicy(
+      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -89,9 +89,9 @@ public interface TransactionalPolicyMappingPersistence {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
-  /** See {@link PolicyMappingPersistence#loadAllPoliciesOnPolicy} */
+  /** See {@link PolicyMappingPersistence#loadAllTargetsOnPolicy} */
   @Nonnull
-  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+  default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
     throw new UnsupportedOperationException("Not Implemented");
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+
+public interface TransactionalPolicyMappingPersistence extends PolicyMappingPersistence {
+  /** See {@link PolicyMappingPersistence#writeToPolicyMappingRecords} */
+  default void writeToPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#deleteFromPolicyMappingRecords} */
+  default void deleteFromPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#deleteAllEntityPolicyMappingRecords} */
+  default void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull PolarisEntityCore entity,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#lookupPolicyMappingRecord} */
+  @Nullable
+  default PolarisPolicyMappingRecord lookupPolicyMappingRecordInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#loadPoliciesOnTargetByType} */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByTypeInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#loadAllPoliciesOnTarget} */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnTargetInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  /** See {@link PolicyMappingPersistence#loadAllPoliciesOnPolicy} */
+  @Nonnull
+  default List<PolarisPolicyMappingRecord> loadAllPoliciesOnPolicyInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -31,6 +31,20 @@ public interface TransactionalPolicyMappingPersistence {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
+  /**
+   * Helpers to check conditions for writing new PolicyMappingRecords in current transaction.
+   *
+   * <p>It should throw a PolicyMappingAlreadyExistsException if the new record conflicts with an
+   * exising record with same policy type but different policy.
+   *
+   * @param callCtx call context
+   * @param record policy mapping record to write.
+   */
+  default void checkConditionsForWriteToPolicyMappingRecordsInCurrentTxn(
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+    throw new UnsupportedOperationException("Not Implemented");
+  }
+
   /** See {@link PolicyMappingPersistence#deleteFromPolicyMappingRecords} */
   default void deleteFromPolicyMappingRecordsInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 
-public interface TransactionalPolicyMappingPersistence extends PolicyMappingPersistence {
+public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#writeToPolicyMappingRecords} */
   default void writeToPolicyMappingRecordsInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -280,6 +280,12 @@ public abstract class BasePolarisMetaStoreManagerTest {
     polarisTestMetaStoreManager.testEntityCache();
   }
 
+  /** Test that attaching/detaching policies works well */
+  @Test
+  void testPolicyMapping() {
+    polarisTestMetaStoreManager.testPolicyMapping();
+  }
+
   @Test
   void testLoadTasks() {
     for (int i = 0; i < 20; i++) {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -1074,7 +1074,7 @@ public class PolarisTestMetaStoreManager {
   void validateLoadedPolicyMappings(LoadPolicyMappingsResult loadPolicyMappingRecords) {
     Assertions.assertThat(loadPolicyMappingRecords).isNotNull();
 
-    Map<Long, PolicyEntity> policyEntities = loadPolicyMappingRecords.getPolicyEntitiesAsMap();
+    Map<Long, PolarisBaseEntity> policyEntities = loadPolicyMappingRecords.getEntitiesAsMap();
     Assertions.assertThat(policyEntities).isNotNull();
 
     for (PolarisPolicyMappingRecord policyMappingRecord :
@@ -2684,8 +2684,8 @@ public class PolarisTestMetaStoreManager {
         polarisMetaStoreManager.loadPoliciesOnEntityByType(
             polarisCallContext, N1_N2_T1, PredefinedPolicyTypes.DATA_COMPACTION);
     Assertions.assertThat(loadPolicyMappingsResult.isSuccess()).isTrue();
-    Assertions.assertThat(loadPolicyMappingsResult.getPolicyEntities()).hasSize(1);
-    PolicyEntity policyEntity = loadPolicyMappingsResult.getPolicyEntities().get(0);
+    Assertions.assertThat(loadPolicyMappingsResult.getEntities()).hasSize(1);
+    PolicyEntity policyEntity = PolicyEntity.of(loadPolicyMappingsResult.getEntities().get(0));
     Assertions.assertThat(policyEntity.getId()).isEqualTo(N1_P1.getId());
     Assertions.assertThat(policyEntity.getPolicyType())
         .isEqualTo(PredefinedPolicyTypes.DATA_COMPACTION);

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2650,7 +2650,7 @@ public class PolarisTestMetaStoreManager {
     PolarisBaseEntity N1_N2_T1 =
         this.ensureExistsByName(
             List.of(catalog, N1, N1_N2),
-            PolarisEntityType.ICEBERG_TABLE_LIKE,
+            PolarisEntityType.TABLE_LIKE,
             PolarisEntitySubType.ANY_SUBTYPE,
             "T1");
 

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2650,7 +2650,7 @@ public class PolarisTestMetaStoreManager {
     PolarisBaseEntity N1_N2_T1 =
         this.ensureExistsByName(
             List.of(catalog, N1, N1_N2),
-            PolarisEntityType.TABLE_LIKE,
+            PolarisEntityType.ICEBERG_TABLE_LIKE,
             PolarisEntitySubType.ANY_SUBTYPE,
             "T1");
 

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -48,8 +48,9 @@ import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.dao.entity.DropEntityResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
-import org.apache.polaris.core.policy.PolarisPolicyMappingManager;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.core.policy.PolicyType;
@@ -1005,7 +1006,7 @@ public class PolarisTestMetaStoreManager {
                 .getEntity());
     Assertions.assertThat(policy).isNotNull();
 
-    PolarisPolicyMappingManager.LoadPolicyMappingsResult loadPolicyMappingsResult =
+    LoadPolicyMappingsResult loadPolicyMappingsResult =
         polarisMetaStoreManager.loadPoliciesOnEntity(this.polarisCallContext, target);
 
     validateLoadedPolicyMappings(loadPolicyMappingsResult);
@@ -1014,7 +1015,7 @@ public class PolarisTestMetaStoreManager {
         loadPolicyMappingsResult.getPolicyMappingRecords(), target, policy);
 
     // also try load by specific type
-    PolarisPolicyMappingManager.LoadPolicyMappingsResult loadPolicyMappingsResultByType =
+    LoadPolicyMappingsResult loadPolicyMappingsResultByType =
         polarisMetaStoreManager.loadPoliciesOnEntityByType(
             this.polarisCallContext, target, policy.getPolicyType());
     validateLoadedPolicyMappings(loadPolicyMappingsResultByType);
@@ -1047,7 +1048,7 @@ public class PolarisTestMetaStoreManager {
                 .getEntity());
     Assertions.assertThat(policy).isNotNull();
 
-    PolarisPolicyMappingManager.LoadPolicyMappingsResult loadPolicyMappingsResult =
+    LoadPolicyMappingsResult loadPolicyMappingsResult =
         polarisMetaStoreManager.loadPoliciesOnEntity(this.polarisCallContext, target);
 
     validateLoadedPolicyMappings(loadPolicyMappingsResult);
@@ -1056,7 +1057,7 @@ public class PolarisTestMetaStoreManager {
         loadPolicyMappingsResult.getPolicyMappingRecords(), target, policy);
 
     // also try load by specific type
-    PolarisPolicyMappingManager.LoadPolicyMappingsResult loadPolicyMappingsResultByType =
+    LoadPolicyMappingsResult loadPolicyMappingsResultByType =
         polarisMetaStoreManager.loadPoliciesOnEntityByType(
             this.polarisCallContext, target, policy.getPolicyType());
     validateLoadedPolicyMappings(loadPolicyMappingsResultByType);
@@ -1070,8 +1071,7 @@ public class PolarisTestMetaStoreManager {
    * @param loadPolicyMappingRecords return from calling
    *     loadPoliciesOnEntity()/LoadPoliciesOnEntityByType()
    */
-  void validateLoadedPolicyMappings(
-      PolarisPolicyMappingManager.LoadPolicyMappingsResult loadPolicyMappingRecords) {
+  void validateLoadedPolicyMappings(LoadPolicyMappingsResult loadPolicyMappingRecords) {
     Assertions.assertThat(loadPolicyMappingRecords).isNotNull();
 
     Map<Long, PolicyEntity> policyEntities = loadPolicyMappingRecords.getPolicyEntitiesAsMap();
@@ -2667,7 +2667,7 @@ public class PolarisTestMetaStoreManager {
     attachPolicyToTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N5), N5_P3);
 
     // attach a different policy of same inheritable type to the same target, should fail
-    PolarisPolicyMappingManager.AttachmentResult attachmentResult =
+    PolicyAttachmentResult policyAttachmentResult =
         polarisMetaStoreManager.attachPolicyToEntity(
             polarisCallContext,
             List.of(catalog, N1, N1_N2),
@@ -2676,8 +2676,8 @@ public class PolarisTestMetaStoreManager {
             N1_P2,
             null);
 
-    Assertions.assertThat(attachmentResult.isSuccess()).isFalse();
-    Assertions.assertThat(attachmentResult.getReturnStatus())
+    Assertions.assertThat(policyAttachmentResult.isSuccess()).isFalse();
+    Assertions.assertThat(policyAttachmentResult.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS);
     detachPolicyFromTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N1), N1_P1);
     detachPolicyFromTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N5), N5_P3);

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2679,6 +2679,17 @@ public class PolarisTestMetaStoreManager {
     Assertions.assertThat(policyAttachmentResult.isSuccess()).isFalse();
     Assertions.assertThat(policyAttachmentResult.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS);
+
+    LoadPolicyMappingsResult loadPolicyMappingsResult =
+        polarisMetaStoreManager.loadPoliciesOnEntityByType(
+            polarisCallContext, N1_N2_T1, PredefinedPolicyTypes.DATA_COMPACTION);
+    Assertions.assertThat(loadPolicyMappingsResult.isSuccess()).isTrue();
+    Assertions.assertThat(loadPolicyMappingsResult.getPolicyEntities()).hasSize(1);
+    PolicyEntity policyEntity = loadPolicyMappingsResult.getPolicyEntities().get(0);
+    Assertions.assertThat(policyEntity.getId()).isEqualTo(N1_P1.getId());
+    Assertions.assertThat(policyEntity.getPolicyType())
+        .isEqualTo(PredefinedPolicyTypes.DATA_COMPACTION);
+
     detachPolicyFromTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N1), N1_P1);
     detachPolicyFromTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N5), N5_P3);
   }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Depends on #1133 

Policy Store in Polaris allow user to attach a policy to a target entity (e.g. table). To represent and persist this information, we introduces PolicyMappingRecords which is similar to GrantRecords that represent a single attachment from a policy to a target entity.

This PR introduces new persistence interfaces and impl for PolicyMappingRecords for supporting Policy Store in Polaris, as discussed in [apache/polaris#1059](https://github.com/apache/polaris/issues/1059).

Key Additions:
- PolarisPolicyMappingRecord – Stores the mapping between a policy and a target entity. For example, when a user attaches a policy to a table, a new record will be created and persisted.
- PolicyMappingPersistence:  Interface for interacting with the Polaris persistence backend for Policy Mapping operations
- PolarisPolicyMappingManager: Interfaces for managing policy mapping in Polaris (attach/detach/lookup mappings)

Persistence Implementation:
- InMemory: PolarisTreeMapStoreSessionImpl
- SQL: PolarisEclipseLinkMetaStoreSessionImpl

cc: @flyrain 