### PR TITLE
Add support for the loadCredentials endpoint

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -1019,10 +1019,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
     Namespace namespace = Namespace.of("ns1");
     TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
 
-    if (requiresNamespaceCreate()) {
-      catalog().createNamespace(namespace);
-    }
-
+    catalog().createNamespace(namespace);
     catalog().buildTable(identifier, SCHEMA).create();
 
     try (Response response =

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -1031,7 +1031,7 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
                      "v1/{cat}/namespaces/{ns}/tables/{table}/credentials",
                      Map.of("cat", currentCatalogName, "ns", namespace.toString(), "table", tableName))
                  .head()) {
-      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+      assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
     }
   }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -1012,4 +1012,26 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
     }
   }
+
+  @Test
+  public void testLoadCredentials() {
+    String tableName = "tbl1";
+    Namespace namespace = Namespace.of("ns1");
+    TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(namespace);
+    }
+
+    catalog().buildTable(identifier, SCHEMA).create();
+
+    try (Response response =
+             catalogApi
+                 .request(
+                     "v1/{cat}/namespaces/{ns}/tables/{table}/credentials",
+                     Map.of("cat", currentCatalogName, "ns", namespace.toString(), "table", tableName))
+                 .head()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+  }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -1026,11 +1026,11 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
     catalog().buildTable(identifier, SCHEMA).create();
 
     try (Response response =
-             catalogApi
-                 .request(
-                     "v1/{cat}/namespaces/{ns}/tables/{table}/credentials",
-                     Map.of("cat", currentCatalogName, "ns", namespace.toString(), "table", tableName))
-                 .head()) {
+        catalogApi
+            .request(
+                "v1/{cat}/namespaces/{ns}/tables/{table}/credentials",
+                Map.of("cat", currentCatalogName, "ns", namespace.toString(), "table", tableName))
+            .head()) {
       assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
     }
   }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -53,6 +53,9 @@ import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
@@ -456,6 +459,22 @@ public class IcebergCatalogAdapter
       SecurityContext securityContext) {
     Namespace ns = decodeNamespace(namespace);
     return Response.ok(newHandlerWrapper(realmContext, securityContext, prefix).listViews(ns))
+        .build();
+  }
+
+  @Override
+  public Response loadCredentials(
+      String prefix,
+      String namespace,
+      String table,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+      Namespace ns = decodeNamespace(namespace);
+      TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
+      LoadTableResponse loadTableResponse = newHandlerWrapper(realmContext, securityContext, prefix)
+          .loadTable(tableIdentifier, "ALL");
+    return Response.ok(
+        ImmutableLoadCredentialsResponse.builder().credentials(loadTableResponse.credentials()).build())
         .build();
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -35,6 +35,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -472,7 +472,7 @@ public class IcebergCatalogAdapter
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     LoadTableResponse loadTableResponse =
         newHandlerWrapper(realmContext, securityContext, prefix)
-            .loadTableWithAccessDelegation(tableIdentifier, "ALL");
+            .loadTableWithAccessDelegation(tableIdentifier, "all");
     return Response.ok(
             ImmutableLoadCredentialsResponse.builder()
                 .credentials(loadTableResponse.credentials())

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -54,7 +54,6 @@ import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
-import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.PolarisConfigurationStore;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -469,12 +468,14 @@ public class IcebergCatalogAdapter
       String table,
       RealmContext realmContext,
       SecurityContext securityContext) {
-      Namespace ns = decodeNamespace(namespace);
-      TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
-      LoadTableResponse loadTableResponse = newHandlerWrapper(realmContext, securityContext, prefix)
-          .loadTable(tableIdentifier, "ALL");
+    Namespace ns = decodeNamespace(namespace);
+    TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
+    LoadTableResponse loadTableResponse =
+        newHandlerWrapper(realmContext, securityContext, prefix).loadTable(tableIdentifier, "ALL");
     return Response.ok(
-        ImmutableLoadCredentialsResponse.builder().credentials(loadTableResponse.credentials()).build())
+            ImmutableLoadCredentialsResponse.builder()
+                .credentials(loadTableResponse.credentials())
+                .build())
         .build();
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -35,9 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-
-import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -471,7 +471,7 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     LoadTableResponse loadTableResponse =
-        newHandlerWrapper(realmContext, securityContext, prefix).loadTable(tableIdentifier, "ALL");
+        newHandlerWrapper(realmContext, securityContext, prefix).loadTableWithAccessDelegation(tableIdentifier, "ALL");
     return Response.ok(
             ImmutableLoadCredentialsResponse.builder()
                 .credentials(loadTableResponse.credentials())

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/IcebergCatalogAdapter.java
@@ -471,7 +471,8 @@ public class IcebergCatalogAdapter
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     LoadTableResponse loadTableResponse =
-        newHandlerWrapper(realmContext, securityContext, prefix).loadTableWithAccessDelegation(tableIdentifier, "ALL");
+        newHandlerWrapper(realmContext, securityContext, prefix)
+            .loadTableWithAccessDelegation(tableIdentifier, "ALL");
     return Response.ok(
             ImmutableLoadCredentialsResponse.builder()
                 .credentials(loadTableResponse.credentials())


### PR DESCRIPTION
We [recently added](https://github.com/apache/polaris/commit/5c3c7d6e80bb13131317a2f4cc7f63369821a997) the loadCredentials endpoint, but it throws a 501. This PR adds support for this endpoint.

Fixes #464 