### PR TITLE
Cleanup: Remove unused class

### DIFF
--- a/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
+++ b/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml
@@ -28,7 +28,6 @@
     <class>org.apache.polaris.jpa.models.ModelEntity</class>
     <class>org.apache.polaris.jpa.models.ModelEntityActive</class>
     <class>org.apache.polaris.jpa.models.ModelEntityChangeTracking</class>
-    <class>org.apache.polaris.jpa.models.ModelEntityDropped</class>
     <class>org.apache.polaris.jpa.models.ModelGrantRecord</class>
     <class>org.apache.polaris.jpa.models.ModelPrincipalSecrets</class>
     <class>org.apache.polaris.jpa.models.ModelSequenceId</class>


### PR DESCRIPTION
### About the change

Remove the unused ModelEntityDropped config from eclipselink reference which was removed as part of https://github.com/apache/polaris/pull/1070/files#diff-66d555be4a9e71a59752d79ee810d7935ab3d10c086b5d580f90db637d477e6e