### PR TITLE
Add Identifier annotation to DefaultActiveRolesProvider

### DIFF
--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -116,6 +116,8 @@ polaris.rate-limiter.token-bucket.type=default
 polaris.rate-limiter.token-bucket.requests-per-second=9999
 polaris.rate-limiter.token-bucket.window=PT10S
 
+polaris.active-roles-provider.type=default
+
 polaris.authentication.authenticator.type=default
 polaris.authentication.token-service.type=default
 polaris.authentication.token-broker.type=rsa-key-pair

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -47,6 +47,7 @@ import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.cache.EntityCache;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.auth.ActiveRolesProvider;
 import org.apache.polaris.service.auth.Authenticator;
 import org.apache.polaris.service.auth.TokenBrokerFactory;
 import org.apache.polaris.service.catalog.api.IcebergRestOAuth2ApiService;
@@ -64,6 +65,7 @@ import org.apache.polaris.service.quarkus.ratelimiter.QuarkusTokenBucketConfigur
 import org.apache.polaris.service.ratelimiter.RateLimiter;
 import org.apache.polaris.service.ratelimiter.TokenBucketFactory;
 import org.apache.polaris.service.task.TaskHandlerConfiguration;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 
@@ -237,6 +239,13 @@ public class QuarkusProducers {
       StorageCredentialCache credentialCache,
       EntityCache entityCache) {
     return new PolarisEntityManager(polarisMetaStoreManager, credentialCache, entityCache);
+  }
+
+  @Produces
+  public ActiveRolesProvider activeRolesProvider(
+      @ConfigProperty(name = "quarkus.active-roles-provider.type") String persistenceType,
+      @Any Instance<ActiveRolesProvider> activeRolesProviders) {
+    return activeRolesProviders.select(Identifier.Literal.of(persistenceType)).get();
   }
 
   public void closeTaskExecutor(@Disposes @Identifier("task-executor") ManagedExecutor executor) {

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -243,7 +243,7 @@ public class QuarkusProducers {
 
   @Produces
   public ActiveRolesProvider activeRolesProvider(
-      @ConfigProperty(name = "quarkus.active-roles-provider.type") String persistenceType,
+      @ConfigProperty(name = "polaris.active-roles-provider.type") String persistenceType,
       @Any Instance<ActiveRolesProvider> activeRolesProviders) {
     return activeRolesProviders.select(Identifier.Literal.of(persistenceType)).get();
   }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.auth;
 
+import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
  * available roles are active for this request.
  */
 @RequestScoped
+@Identifier("default")
 public class DefaultActiveRolesProvider implements ActiveRolesProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultActiveRolesProvider.class);
 


### PR DESCRIPTION
When debugging with Quarkus, @RichardLiu2001 and I noticed that `DefaultActiveRolesProvider` doesn't have an `Identifier` currently. This means that if we add a new implementation of `ActiveRolesProvider`, the runtime can fail with:

```
jakarta.enterprise.inject.AmbiguousResolutionException: Ambiguous dependencies for type org.apache.polaris.service.auth.ActiveRolesProvider and qualifiers [@Default]
```