### PR TITLE
Add fix from 1092 to helm

### DIFF
--- a/helm/polaris/ci/fixtures/persistence.yaml
+++ b/helm/polaris/ci/fixtures/persistence.yaml
@@ -49,6 +49,8 @@ stringData:
           <property name="eclipselink.connection-pool.default.initial" value="1" />
           <property name="eclipselink.connection-pool.default.min" value="1" />
           <property name="eclipselink.connection-pool.default.max" value="1" />
+          <property name="eclipselink.session.customizer" value="org.apache.polaris.extension.persistence.impl.eclipselink.PolarisEclipseLinkSessionCustomizer" />
+          <property name="eclipselink.transaction.join-existing" value="true" />
         </properties>
       </persistence-unit>
     </persistence>


### PR DESCRIPTION
From https://github.com/apache/polaris/pull/1092/files, we added `eclipselink.session.customizer` and `eclipselink.transaction.join-existing` in persistence.yaml, this PR added the same for helm setup.