### PR TITLE
Add proxy option for CLI

### DIFF
--- a/regtests/client/python/cli/constants.py
+++ b/regtests/client/python/cli/constants.py
@@ -136,6 +136,7 @@ class Arguments:
     LOCATION = 'location'
     REGION = 'region'
     PROFILE = 'profile'
+    PROXY = 'proxy'
 
 
 class Hints:

--- a/regtests/client/python/cli/options/parser.py
+++ b/regtests/client/python/cli/options/parser.py
@@ -44,6 +44,7 @@ class Parser(object):
         Argument(Arguments.CLIENT_SECRET, str, hint='client secret for token-based authentication'),
         Argument(Arguments.ACCESS_TOKEN, str, hint='access token for token-based authentication'),
         Argument(Arguments.PROFILE, str, hint='profile for token-based authentication'),
+        Argument(Arguments.PROXY, str, hint='proxy URL'),
     ]
 
     @staticmethod

--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -144,20 +144,23 @@ class PolarisCli:
             polaris_catalog_url = f'http://{host}:{port}/api/catalog/v1'
 
         builder = None
+        config = Configuration(host=polaris_management_url) 
+        if options.proxy:
+            config.proxy = options.proxy
         if has_access_token:
-            builder = lambda: ApiClient(
-                Configuration(host=polaris_management_url, access_token=options.access_token),
-            )
+            config.access_token = options.access_token
+            builder = lambda: ApiClient(config)
         elif has_client_secret:
-            builder = lambda: ApiClient(
-                Configuration(host=polaris_management_url, username=client_id, password=client_secret),
-            )
+            config.username = client_id
+            config.password = client_secret
+            builder = lambda: ApiClient(config)
 
         if not has_access_token and not PolarisCli.DIRECT_AUTHENTICATION_ENABLED:
             token = PolarisCli._get_token(builder(), polaris_catalog_url, client_id, client_secret)
-            builder = lambda: ApiClient(
-                Configuration(host=polaris_management_url, access_token=token),
-            )
+            config.username = None
+            config.password = None
+            config.access_token = token
+            builder = lambda: ApiClient(config)
         return builder
 
 

--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -143,25 +143,21 @@ class PolarisCli:
             polaris_management_url = f'http://{host}:{port}/api/management/v1'
             polaris_catalog_url = f'http://{host}:{port}/api/catalog/v1'
 
-        builder = None
-        config = Configuration(host=polaris_management_url) 
-        if options.proxy:
-            config.proxy = options.proxy
+        config = Configuration(host=polaris_management_url)
+        config.proxy = options.proxy
         if has_access_token:
             config.access_token = options.access_token
-            builder = lambda: ApiClient(config)
         elif has_client_secret:
             config.username = client_id
             config.password = client_secret
-            builder = lambda: ApiClient(config)
 
         if not has_access_token and not PolarisCli.DIRECT_AUTHENTICATION_ENABLED:
-            token = PolarisCli._get_token(builder(), polaris_catalog_url, client_id, client_secret)
+            token = PolarisCli._get_token(ApiClient(config), polaris_catalog_url, client_id, client_secret)
             config.username = None
             config.password = None
             config.access_token = token
-            builder = lambda: ApiClient(config)
-        return builder
+
+        return lambda: ApiClient(config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This feature is requested from https://github.com/apache/polaris/issues/1113. Currently we don't support pass in proxy info. 

Here is how this PR is being validated:
Terminal 1:
```
# Setup mitmproxy
(venv) yong@DESKTOP:~/k8s/polaris(main)$ pip install mitmproxy
# Start mitmproxy
(venv) yong@DESKTOP:~/k8s/polaris(proxy_support)$ mitmproxy
```

# Terminal 2:
```
# Start polaris service
yong@DESKTOP:~/k8s/polaris(main)$ ./gradlew run
```

# Terminal 3:
```
# List catalog without proxy
yong@DESKTOP:~/k8s/polaris(proxy_support)$ ./polaris --profile dev catalogs list
yong@DESKTOP:~/k8s/polaris(proxy_support)$ echo $?
0
# List catalog with proxy
yong@DESKTOP:~/k8s/polaris(proxy_support)$ ./polaris --profile dev --proxy http://localhost:8080 catalogs list
yong@DESKTOP:~/k8s/polaris(proxy_support)$ echo $?
0
```

Now here is the output from terminal 1:
![image](https://github.com/user-attachments/assets/2f1469a7-9b64-418b-9170-5176b1c097f5)
