### PR TITLE
Handle restart cases and add more logging to Eclipselink

### DIFF
--- a/getting-started/assets/eclipselink/persistence.xml
+++ b/getting-started/assets/eclipselink/persistence.xml
@@ -26,7 +26,6 @@
     <class>org.apache.polaris.jpa.models.ModelEntity</class>
     <class>org.apache.polaris.jpa.models.ModelEntityActive</class>
     <class>org.apache.polaris.jpa.models.ModelEntityChangeTracking</class>
-    <class>org.apache.polaris.jpa.models.ModelEntityDropped</class>
     <class>org.apache.polaris.jpa.models.ModelGrantRecord</class>
     <class>org.apache.polaris.jpa.models.ModelPrincipalSecrets</class>
     <class>org.apache.polaris.jpa.models.ModelSequenceId</class>
@@ -40,6 +39,8 @@
       <property name="eclipselink.persistence-context.flush-mode" value="auto"/>
       <property name="eclipselink.session.customizer" value="org.apache.polaris.extension.persistence.impl.eclipselink.PolarisEclipseLinkSessionCustomizer"/>
       <property name="eclipselink.transaction.join-existing" value="true"/>
+      <property name="eclipselink.logging.level.sql" value="FINE"/>
+      <property name="eclipselink.logging.parameters" value="true"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/getting-started/eclipselink/docker-compose.yml
+++ b/getting-started/eclipselink/docker-compose.yml
@@ -49,10 +49,27 @@ services:
       timeout: 10s
       retries: 10
 
+  polaris-purge:
+    # IMPORTANT: the image MUST contain the Postgres JDBC driver and EclipseLink dependencies, see README for instructions
+    image: apache/polaris-admin-tool:postgres-latest
+    depends_on:
+      postgres:
+        condition: service_started
+    environment:
+      polaris.persistence.type: eclipse-link
+      polaris.persistence.eclipselink.configuration-file: /deployments/config/eclipselink/persistence.xml
+    volumes:
+      - ../assets/eclipselink/:/deployments/config/eclipselink
+    command:
+      - "purge"
+      - "--realm=POLARIS"
+
   polaris-bootstrap:
     # IMPORTANT: the image MUST contain the Postgres JDBC driver and EclipseLink dependencies, see README for instructions
     image: apache/polaris-admin-tool:postgres-latest
     depends_on:
+      polaris-purge:
+        condition: service_started
       postgres:
         condition: service_healthy
     environment:


### PR DESCRIPTION
### About the change 

1. Add the ecpliselink getting started to capture SQL queries in server logs to enable debugging 
2. Fix the case when the docker images is restarted again by purging the realm first before starting 
a/ we can do alterantive as well before stopping purge the realm.



