### PR TITLE
Allow MetaStoreManagerFactory to produce `null` `EntityCache`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -64,7 +64,7 @@ public class Resolver {
   private final @Nonnull PolarisMetaStoreManager polarisMetaStoreManager;
 
   // the cache of entities
-  private final EntityCache cache;
+  @Nullable private final EntityCache cache;
 
   // the id of the principal making the call or 0 if unknown
   private final @Nonnull AuthenticatedPolarisPrincipal polarisPrincipal;

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -44,7 +44,6 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.cache.EntityCache;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.service.auth.ActiveRolesProvider;
@@ -52,6 +51,7 @@ import org.apache.polaris.service.auth.Authenticator;
 import org.apache.polaris.service.auth.TokenBrokerFactory;
 import org.apache.polaris.service.catalog.api.IcebergRestOAuth2ApiService;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
+import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.context.RealmContextConfiguration;
 import org.apache.polaris.service.context.RealmContextFilter;
 import org.apache.polaris.service.context.RealmContextResolver;
@@ -213,13 +213,6 @@ public class QuarkusProducers {
 
   @Produces
   @RequestScoped
-  public EntityCache entityCache(
-      RealmContext realmContext, MetaStoreManagerFactory metaStoreManagerFactory) {
-    return metaStoreManagerFactory.getOrCreateEntityCache(realmContext);
-  }
-
-  @Produces
-  @RequestScoped
   public PolarisMetaStoreManager polarisMetaStoreManager(
       RealmContext realmContext, MetaStoreManagerFactory metaStoreManagerFactory) {
     return metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
@@ -235,10 +228,8 @@ public class QuarkusProducers {
   @Produces
   @RequestScoped
   public PolarisEntityManager polarisEntityManager(
-      PolarisMetaStoreManager polarisMetaStoreManager,
-      StorageCredentialCache credentialCache,
-      EntityCache entityCache) {
-    return new PolarisEntityManager(polarisMetaStoreManager, credentialCache, entityCache);
+      RealmContext realmContext, RealmEntityManagerFactory factory) {
+    return factory.getOrCreateEntityManager(realmContext);
   }
 
   @Produces


### PR DESCRIPTION
Following up on #1055, this refactoring does not remove `EntityCache`, but allows it to be `null` in principle, should a particular MetaStoreManagerFactory implementation choose not to use an `EntityCache`.

* Remove bean producer for `EntityCache` (beans cannot be `null`).

* Harmonize all `PolarisEntityManager` producers (explicit and CDI) to go through `RealmEntityManagerFactory` (tangential to the cache being null, but related).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
