### PR TITLE
Allow MetaStore manager to declare whether bulk reload is necessary

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -376,4 +376,14 @@ public interface PolarisMetaStoreManager
       @Nonnull PolarisEntityType entityType,
       long entityCatalogId,
       long entityId);
+
+  /**
+   * Indicates whether this metastore manager implementation requires entities to be reloaded via
+   * {@link #loadEntitiesChangeTracking} in order to ensure the most recent versions are obtained.
+   *
+   * <p>Generally this flag is {@code true} when entity caching is used.
+   */
+  default boolean requiresEntityReload() {
+    return true;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -517,6 +517,10 @@ public class Resolver {
    * @return true if none of the entities has changed
    */
   private boolean bulkValidate(List<ResolvedPolarisEntity> toValidate) {
+    if (!polarisMetaStoreManager.requiresEntityReload()) {
+      return true;
+    }
+
     // assume everything is good
     boolean validationStatus = true;
 


### PR DESCRIPTION
This change is in anticipation of NoSQL persistence implementations.

A MetaStore manager does not have to use entity caching and provide fresh results from all load method, thus making the `bulkValidate` call redundant in `Resolver`.

This change does not alter existing behaviour, but enables future optimizations.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
