### PR TITLE
 Use Caffeine's `Expiry.creating` for `StorageCredentialCache`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -51,7 +51,7 @@ public class StorageCredentialCache {
         Caffeine.newBuilder()
             .maximumSize(CACHE_MAX_NUMBER_OF_ENTRIES)
             .expireAfter(
-                Expiry.writing(
+                Expiry.creating(
                     (StorageCredentialCacheKey key, StorageCredentialCacheEntry entry) -> {
                       long expireAfterMillis =
                           Math.max(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -22,10 +22,10 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import jakarta.annotation.Nonnull;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.polaris.core.PolarisCallContext;
@@ -51,39 +51,16 @@ public class StorageCredentialCache {
         Caffeine.newBuilder()
             .maximumSize(CACHE_MAX_NUMBER_OF_ENTRIES)
             .expireAfter(
-                new Expiry<StorageCredentialCacheKey, StorageCredentialCacheEntry>() {
-                  @Override
-                  public long expireAfterCreate(
-                      StorageCredentialCacheKey key,
-                      StorageCredentialCacheEntry entry,
-                      long currentTime) {
-                    long expireAfterMillis =
-                        Math.max(
-                            0,
-                            Math.min(
-                                (entry.getExpirationTime() - System.currentTimeMillis()) / 2,
-                                maxCacheDurationMs()));
-                    return TimeUnit.MILLISECONDS.toNanos(expireAfterMillis);
-                  }
-
-                  @Override
-                  public long expireAfterUpdate(
-                      StorageCredentialCacheKey key,
-                      StorageCredentialCacheEntry entry,
-                      long currentTime,
-                      long currentDuration) {
-                    return currentDuration;
-                  }
-
-                  @Override
-                  public long expireAfterRead(
-                      StorageCredentialCacheKey key,
-                      StorageCredentialCacheEntry entry,
-                      long currentTime,
-                      long currentDuration) {
-                    return currentDuration;
-                  }
-                })
+                Expiry.writing(
+                    (StorageCredentialCacheKey key, StorageCredentialCacheEntry entry) -> {
+                      long expireAfterMillis =
+                          Math.max(
+                              0,
+                              Math.min(
+                                  (entry.getExpirationTime() - System.currentTimeMillis()) / 2,
+                                  maxCacheDurationMs()));
+                      return Duration.ofMillis(expireAfterMillis);
+                    }))
             .build(
                 key -> {
                   // the load happen at getOrGenerateSubScopeCreds()


### PR DESCRIPTION
The `StorageCredentialCache` currently uses a custom `Expiry`. I think that this works correctly.

IMHO using a built-in one that Caffeine provides, like `Expiry.writing` reads better - this is what this PR proposes.
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
