### PR TITLE
Add downloads page on the website

### DIFF
--- a/site/content/downloads.md
+++ b/site/content/downloads.md
@@ -1,0 +1,34 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Downloads
+
+You can find Apache Polaris resources here, including releases.
+
+## Releases
+
+### 0.9.0
+
+Apache Polaris 0.9.0 release is the first Polaris release. Only the source distribution is available for this release.
+
+* https://downloads.apache.org/incubator/polaris/0.9.0-incubating/apache-polaris-0.9.0-incubating.tar.gz
+** [asc](https://downloads.apache.org/incubator/polaris/0.9.0-incubating/apache-polaris-0.9.0-incubating.tar.gz.asc)
+** [sha512](https://downloads.apache.org/incubator/polaris/0.9.0-incubating/apache-polaris-0.9.0-incubating.tar.gz.sha512)
+** [KEYS](https://downloads.apache.org/incubator/polaris/KEYS))
+

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -66,7 +66,7 @@ params:
   active_releases:
     # Mention all active releases here, in semver descending order
     - "1.0.0"
-    - "0.1.0"
+    - "0.9.0"
 
   ui:
     ul_show: 1
@@ -108,6 +108,11 @@ menu:
     - name: "In Development"
       url: "/in-dev/unreleased/"
       parent: "releases"
+
+    - name: "Downloads"
+      identifier: "downloads"
+      url: "/downloads" 
+      weight: 200
 
     - name: "Community"
       identifier: "community"


### PR DESCRIPTION
Add 0.9.0 is a "thin release", I'm adding a downloads page on the website to give visibility and download sources for our users.