### PR TITLE
Move realm header tests out of the integration tests module

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
@@ -102,6 +102,10 @@ public final class PolarisClient implements AutoCloseable {
         client, endpoints, obtainToken(credentials), endpoints.catalogApiEndpoint());
   }
 
+  public CatalogApi catalogApiPlain() {
+    return new CatalogApi(client, endpoints, null, endpoints.catalogApiEndpoint());
+  }
+
   /**
    * Requests an access token from the Polaris server for the client ID/secret pair that is part of
    * the given principal data object.

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -27,7 +27,6 @@ import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -57,14 +56,12 @@ import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
-import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogProperties;
 import org.apache.polaris.core.admin.model.CatalogRole;
-import org.apache.polaris.core.admin.model.Catalogs;
 import org.apache.polaris.core.admin.model.ExternalCatalog;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
@@ -88,8 +85,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @implSpec This test expects the server to be configured with the following features configured:
@@ -649,64 +644,6 @@ public class PolarisApplicationIntegrationTest {
                   // asserts that one of those things happens.
                 }
               });
-    }
-  }
-
-  @Test
-  public void testNoRealmHeader() {
-    try (Response response =
-        managementApi
-            .request(
-                "v1/catalogs", Map.of(), Map.of(), Map.of("Authorization", "Bearer " + authToken))
-            .get()) {
-      assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
-      Catalogs roles = response.readEntity(Catalogs.class);
-      assertThat(roles.getCatalogs()).extracting(Catalog::getName).contains(internalCatalogName);
-    }
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"POLARIS", "OTHER"})
-  public void testRealmHeaderValid(String realmId) {
-    String catalogName = client.newEntityName("testRealmHeaderValid" + realmId);
-    createCatalog(catalogName, Catalog.TypeEnum.INTERNAL, principalRoleName);
-    try (Response response =
-        managementApi
-            .request(
-                "v1/catalogs",
-                Map.of(),
-                Map.of(),
-                Map.of(
-                    "Authorization", "Bearer " + authToken, endpoints.realmHeaderName(), realmId))
-            .get()) {
-      assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
-      Catalogs catalogsList = response.readEntity(Catalogs.class);
-      if ("POLARIS".equals(realmId)) {
-        assertThat(catalogsList.getCatalogs()).extracting(Catalog::getName).contains(catalogName);
-      } else {
-        assertThat(catalogsList.getCatalogs()).isEmpty();
-      }
-    }
-  }
-
-  @Test
-  public void testRealmHeaderInvalid() {
-    try (Response response =
-        managementApi
-            .request(
-                "v1/catalogs",
-                Map.of(),
-                Map.of(),
-                Map.of(
-                    "Authorization", "Bearer " + authToken, endpoints.realmHeaderName(), "INVALID"))
-            .get()) {
-      assertThat(response.getStatus()).isEqualTo(Status.NOT_FOUND.getStatusCode());
-      assertThat(response.readEntity(ErrorResponse.class))
-          .extracting(ErrorResponse::code, ErrorResponse::type, ErrorResponse::message)
-          .containsExactly(
-              Status.NOT_FOUND.getStatusCode(),
-              "UnresolvableRealmContextException",
-              "Unknown realm: INVALID");
     }
   }
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/RealmHeaderTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/RealmHeaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.polaris.service.it.env.PolarisApiEndpoints;
+import org.apache.polaris.service.it.env.PolarisClient;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RealmHeaderTest.Profile.class)
+public class RealmHeaderTest {
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.realm-context.header-name",
+          REALM_HEADER,
+          "polaris.realm-context.realms",
+          "realm1,realm2",
+          "polaris.bootstrap.credentials",
+          "realm1,client1,secret1;realm2,client2,secret2");
+    }
+  }
+
+  private static final String REALM_HEADER = "test-header-r123";
+
+  private static final URI baseUri =
+      URI.create(
+          "http://localhost:"
+              + Objects.requireNonNull(
+                  Integer.getInteger("quarkus.http.test-port"),
+                  "System property not set correctly: quarkus.http.test-port"));
+
+  private Response request(String realm, String header, String clientId, String secret) {
+    try (PolarisClient client =
+        PolarisClient.polarisClient(new PolarisApiEndpoints(baseUri, realm, header))) {
+      return client
+          .catalogApiPlain()
+          .request("v1/oauth/tokens")
+          .post(
+              Entity.form(
+                  new MultivaluedHashMap<>(
+                      Map.of(
+                          "grant_type",
+                          "client_credentials",
+                          "scope",
+                          "PRINCIPAL_ROLE:ALL",
+                          "client_id",
+                          clientId,
+                          "client_secret",
+                          secret))));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testInvalidRealmHeaderValue() {
+    try (Response response = request("INVALID", REALM_HEADER, "dummy", "dummy")) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+      assertThat(response.readEntity(ErrorResponse.class))
+          .extracting(ErrorResponse::code, ErrorResponse::type, ErrorResponse::message)
+          .containsExactly(
+              Response.Status.NOT_FOUND.getStatusCode(),
+              "UnresolvableRealmContextException",
+              "Unknown realm: INVALID");
+    }
+  }
+
+  @Test
+  public void testNoRealmHeader() {
+    try (Response response = request("fake-realm", "irrelevant-header", "client2", "secret2")) {
+      // The default realm is "realm2" so the second pair of secrets is not valid without
+      // an explicit header
+      assertThat(response.getStatus()).isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode());
+    }
+  }
+
+  @Test
+  public void testDefaultRealm() {
+    try (Response response = request("fake-realm", "irrelevant-header", "client1", "secret1")) {
+      // The default realm is "realm1", now credentials match
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+  }
+
+  @Test
+  public void testValidRealmHeaderDefaultRealm() {
+    try (Response response = request("realm2", REALM_HEADER, "client2", "secret2")) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+  }
+}


### PR DESCRIPTION
* The `integration-test` module was not designed for multi-realm usage, therefore assumptions that root credentials from the test environment are valid for all realms does not necessarily hold.

* Move the realm header tests to a new class that controls the Polaris server by bootstrapping (in-memory) under a specific Quarkus test profile.

* Use different client ID/secret values to validate realm header parsing This is simpler than listing catalogs because credentials are required for all operations anyway.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
