### PR TITLE
Quarkus-Build: ignore split-packages + add jandex indexes

### DIFF
--- a/quarkus/admin/src/main/resources/application.properties
+++ b/quarkus/admin/src/main/resources/application.properties
@@ -36,3 +36,16 @@ quarkus.container-image.additional-tags=latest
 # Below are default values for properties that can be changed in runtime.
 
 polaris.persistence.type=eclipse-link
+
+quarkus.arc.ignored-split-packages=\
+  org.apache.polaris.admintool.config,\
+  org.apache.polaris.admintool
+
+## Quarkus required setting for third party indexing
+# fixed at buildtime
+quarkus.index-dependency.avro.group-id=org.apache.avro
+quarkus.index-dependency.avro.artifact-id=avro
+quarkus.index-dependency.guava.group-id=com.google.guava
+quarkus.index-dependency.guava.artifact-id=guava
+quarkus.index-dependency.protobuf.group-id=com.google.protobuf
+quarkus.index-dependency.protobuf.artifact-id=protobuf-java

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -132,3 +132,28 @@ polaris.authentication.token-broker.max-token-generation=PT1H
 # polaris.storage.aws.secret-key=secretKey
 # polaris.storage.gcp.token=token
 # polaris.storage.gcp.lifespan=PT1H
+
+quarkus.arc.ignored-split-packages=\
+  org.apache.polaris.service.quarkus.metrics,\
+  org.apache.polaris.service.quarkus.config,\
+  org.apache.polaris.service.quarkus.auth,\
+  org.apache.polaris.service.quarkus.task,\
+  org.apache.polaris.service.quarkus.storage,\
+  org.apache.polaris.service.quarkus.tracing,\
+  org.apache.polaris.service.quarkus.ratelimiter,\
+  org.apache.polaris.service.quarkus.catalog.io,\
+  org.apache.polaris.service.quarkus.legacy,\
+  org.apache.polaris.service.quarkus.context,\
+  org.apache.polaris.service.quarkus.persistence,\
+  org.apache.polaris.service.quarkus.logging,\
+  org.apache.polaris.admintool.config,\
+  org.apache.polaris.admintool
+
+## Quarkus required setting for third party indexing
+# fixed at buildtime
+quarkus.index-dependency.avro.group-id=org.apache.avro
+quarkus.index-dependency.avro.artifact-id=avro
+quarkus.index-dependency.guava.group-id=com.google.guava
+quarkus.index-dependency.guava.artifact-id=guava
+quarkus.index-dependency.protobuf.group-id=com.google.protobuf
+quarkus.index-dependency.protobuf.artifact-id=protobuf-java


### PR DESCRIPTION
Eliminates a bunch of Quarkus-build warnings about split packages and "add jandex index" recommendations.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
