### PR TITLE
File IO UnknownHostException 404

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/FileIOUnknownHostException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/FileIOUnknownHostException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.exceptions;
+
+/**
+ * A {@link PolarisException} implementation for when an UnknownHostException happens during File IO
+ * to S3, GCS, or Azure.
+ */
+public class FileIOUnknownHostException extends PolarisException {
+  public FileIOUnknownHostException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/BasePolarisCatalogTest.java
@@ -110,6 +110,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.BasePolarisCatalog;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
+import org.apache.polaris.service.catalog.io.ExceptionMappingFileIO;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
@@ -473,7 +474,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
 
     // Now also check that despite creating the metadata file, the validation call still doesn't
     // create any namespaces or tables.
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
     fileIO.addFile(
         tableMetadataLocation,
         TableMetadataParser.toJson(createSampleTableMetadata(tableLocation)).getBytes(UTF_8));
@@ -608,7 +609,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -652,7 +653,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -801,7 +802,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
                 PolarisConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
             .build());
     BasePolarisCatalog catalog = catalog();
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -898,7 +899,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         metadataLocation,
@@ -953,7 +954,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     Namespace namespace = Namespace.of("parent", "child1");
     TableIdentifier table = TableIdentifier.of(namespace, "table");
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     // The location of the metadata JSON file specified in the create will be forbidden.
     final String metadataLocation = "http://maliciousdomain.com/metadata.json";
@@ -1031,7 +1032,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1083,7 +1084,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1136,7 +1137,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1174,7 +1175,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(timestamp);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1247,7 +1248,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     // Though the metadata JSON file itself is in an allowed location, make it internally specify
     // a forbidden table location.
@@ -1325,7 +1326,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1377,7 +1378,7 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     update.setTimestamp(230950845L);
     request.setPayload(update);
 
-    InMemoryFileIO fileIO = (InMemoryFileIO) catalog.getIo();
+    InMemoryFileIO fileIO = getInMemoryIo(catalog);
 
     fileIO.addFile(
         tableMetadataLocation,
@@ -1448,7 +1449,9 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
                     metaStoreManagerFactory,
                     configurationStore))
             .apply(taskEntity, callContext);
-    Assertions.assertThat(fileIO).isNotNull().isInstanceOf(InMemoryFileIO.class);
+    Assertions.assertThat(fileIO).isNotNull().isInstanceOf(ExceptionMappingFileIO.class);
+    Assertions.assertThat(((ExceptionMappingFileIO) fileIO).getInnerIo())
+        .isInstanceOf(InMemoryFileIO.class);
   }
 
   @Test
@@ -1761,5 +1764,9 @@ public class BasePolarisCatalogTest extends CatalogTests<BasePolarisCatalog> {
     Assertions.assertThatThrownBy(() -> update.commit())
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("conflict_table");
+  }
+
+  private static InMemoryFileIO getInMemoryIo(BasePolarisCatalog catalog) {
+    return (InMemoryFileIO) ((ExceptionMappingFileIO) catalog.getIo()).getInnerIo();
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -114,6 +114,7 @@ public class DefaultFileIOFactory implements FileIOFactory {
   @VisibleForTesting
   FileIO loadFileIOInternal(
       @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
-    return CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration());
+    return new ExceptionMappingFileIO(
+        CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration()));
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.io;
+
+import java.net.UnknownHostException;
+import java.util.Map;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
+
+/** A {@link FileIO} implementation that wraps an existing FileIO and re-maps exceptions */
+public class ExceptionMappingFileIO implements FileIO {
+  private final FileIO io;
+
+  public ExceptionMappingFileIO(FileIO io) {
+    this.io = io;
+  }
+
+  private void handleException(RuntimeException e) {
+    for (Throwable t : ExceptionUtils.getThrowables(e)) {
+      // UnknownHostException isn't a RuntimeException so it's always wrapped
+      if (t instanceof UnknownHostException) {
+        throw new FileIOUnknownHostException("UnknownHostException during File IO", t);
+      }
+    }
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    try {
+      return io.newInputFile(path);
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    try {
+      return io.newOutputFile(path);
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    try {
+      io.deleteFile(path);
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    try {
+      return io.properties();
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    try {
+      io.initialize(properties);
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      io.close();
+    } catch (RuntimeException e) {
+      handleException(e);
+      throw e;
+    }
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.catalog.io;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.net.UnknownHostException;
 import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -41,6 +42,11 @@ public class ExceptionMappingFileIO implements FileIO {
         throw new FileIOUnknownHostException("UnknownHostException during File IO", t);
       }
     }
+  }
+
+  @VisibleForTesting
+  public FileIO getInnerIo() {
+    return io;
   }
 
   @Override

--- a/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -30,7 +30,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
@@ -57,6 +56,7 @@ import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -173,6 +173,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
       case NoSuchTableException e -> Status.NOT_FOUND.getStatusCode();
       case NoSuchViewException e -> Status.NOT_FOUND.getStatusCode();
       case NotFoundException e -> Status.NOT_FOUND.getStatusCode();
+      case FileIOUnknownHostException e -> Status.NOT_FOUND.getStatusCode();
       case AlreadyExistsException e -> Status.CONFLICT.getStatusCode();
       case CommitFailedException e -> Status.CONFLICT.getStatusCode();
       case UnprocessableEntityException e -> 422;
@@ -221,12 +222,6 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
    *     Optional.empty() otherwise.
    */
   static Optional<Integer> mapCloudExceptionToResponseCode(Throwable t) {
-    // UnknownHostException isn't a RuntimeException so it's always wrapped
-    if (t instanceof UnknownHostException && t.getMessage().contains(AZURE_STORAGE_URL_SUFFIX)) {
-      return Optional.of(
-          Status.NOT_FOUND.getStatusCode()); // Return a 404 to be consistent with S3/GCS
-    }
-
     if (!(t instanceof S3Exception
         || t instanceof AzureException
         || t instanceof StorageException)) {

--- a/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -213,6 +213,13 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
     };
   }
 
+  /**
+   * Tries mapping a cloud exception to the HTTP code that Polaris should return
+   *
+   * @param t the throwable/exception
+   * @return the HTTP code Polaris should return, if it was possible to return a suitable mapping.
+   *     Optional.empty() otherwise.
+   */
   static Optional<Integer> mapCloudExceptionToResponseCode(Throwable t) {
     // UnknownHostException isn't a RuntimeException so it's always wrapped
     if (t instanceof UnknownHostException && t.getMessage().contains(AZURE_STORAGE_URL_SUFFIX)) {

--- a/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -68,7 +68,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
   /** Signifies that we could not extract an HTTP code from a given cloud exception */
   public static final int UNKNOWN_CLOUD_HTTP_CODE = -1;
 
-  @VisibleForTesting public static final String AZURE_STORAGE_URL_SUFFIX = ".blob.core.windows.net";
+  private static final String AZURE_STORAGE_URL_SUFFIX = ".windows.net";
 
   public static final Set<Integer> RETRYABLE_AZURE_HTTP_CODES =
       Set.of(

--- a/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -68,8 +68,6 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
   /** Signifies that we could not extract an HTTP code from a given cloud exception */
   public static final int UNKNOWN_CLOUD_HTTP_CODE = -1;
 
-  private static final String AZURE_STORAGE_URL_SUFFIX = ".windows.net";
-
   public static final Set<Integer> RETRYABLE_AZURE_HTTP_CODES =
       Set.of(
           Response.Status.REQUEST_TIMEOUT.getStatusCode(),

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIOTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIOTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.io;
+
+import java.net.UnknownHostException;
+import java.util.Map;
+import org.apache.iceberg.io.FileIO;
+import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** Unit tests for ExceptionMappingFileIO */
+public class ExceptionMappingFileIOTest {
+  private static final String PATH = "x/y/z";
+  private static final Map<String, String> PROPERTIES = Map.of("k", "v");
+
+  @Test
+  void testProxiesMethodCalls() {
+    try (var io = Mockito.mock(FileIO.class)) {
+      var wrappedIO = new ExceptionMappingFileIO(io);
+
+      wrappedIO.newInputFile(PATH);
+      Mockito.verify(io, Mockito.times(1)).newInputFile(PATH);
+
+      wrappedIO.newOutputFile(PATH);
+      Mockito.verify(io, Mockito.times(1)).newOutputFile(PATH);
+
+      wrappedIO.deleteFile(PATH);
+      Mockito.verify(io, Mockito.times(1)).deleteFile(PATH);
+
+      wrappedIO.properties();
+      Mockito.verify(io, Mockito.times(1)).properties();
+
+      wrappedIO.initialize(PROPERTIES);
+      Mockito.verify(io, Mockito.times(1)).initialize(PROPERTIES);
+
+      wrappedIO.close();
+      Mockito.verify(io, Mockito.times(1)).close();
+    }
+  }
+
+  @Test
+  void testExceptionRemapping() {
+    try (var io = Mockito.mock(FileIO.class)) {
+      Mockito.doThrow(new RuntimeException(new UnknownHostException())).when(io).newInputFile(PATH);
+
+      var wrappedIO = new ExceptionMappingFileIO(io);
+      Assertions.assertThrows(FileIOUnknownHostException.class, () -> wrappedIO.newInputFile(PATH));
+    }
+  }
+}

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -190,7 +190,9 @@ public class FileIOFactoryTest {
     TaskEntity taskEntity = TaskEntity.of(tasks.get(0));
     FileIO fileIO =
         new TaskFileIOSupplier(testServices.fileIOFactory()).apply(taskEntity, callContext);
-    Assertions.assertThat(fileIO).isNotNull().isInstanceOf(InMemoryFileIO.class);
+    Assertions.assertThat(fileIO).isNotNull().isInstanceOf(ExceptionMappingFileIO.class);
+    Assertions.assertThat(((ExceptionMappingFileIO) fileIO).getInnerIo())
+        .isInstanceOf(InMemoryFileIO.class);
 
     // 1. BasePolarisCatalog:doCommit: for writing the table during the creation
     // 2. BasePolarisCatalog:doRefresh: for reading the table during the drop

--- a/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.exception;
 
-import static org.apache.polaris.service.exception.IcebergExceptionMapper.AZURE_STORAGE_URL_SUFFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.core.exception.AzureException;
@@ -68,8 +67,7 @@ public class IcebergExceptionMapperTest {
             Arguments.of(
                 new RuntimeException(
                     new UnknownHostException(
-                        String.format(
-                            "mybucket%s: Name or service not known", AZURE_STORAGE_URL_SUFFIX))),
+                        "mybucket.blob.core.windows.net: Name or service not known")),
                 404)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(

--- a/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.exception;
 
+import static org.apache.polaris.service.exception.IcebergExceptionMapper.UNPROCESSABLE_CONTENT_HTTP_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.core.exception.AzureException;
@@ -25,6 +26,7 @@ import com.azure.core.exception.HttpResponseException;
 import com.google.cloud.storage.StorageException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -44,7 +46,7 @@ public class IcebergExceptionMapperTest {
             // RuntimeIOExceptions,
             // which is what the Iceberg SDK sometimes wraps them with if the error happens during
             // IO.
-            302, 422,
+            302, UNPROCESSABLE_CONTENT_HTTP_CODE,
             400, 400,
             401, 403,
             403, 403,
@@ -62,7 +64,9 @@ public class IcebergExceptionMapperTest {
             Arguments.of(new AzureException("Not Authorized"), 403),
             Arguments.of(new AzureException("Access Denied"), 403),
             Arguments.of(S3Exception.builder().message("Access denied").build(), 403),
-            Arguments.of(new StorageException(1, "access denied"), 403)),
+            Arguments.of(new StorageException(1, "access denied"), 403),
+            Arguments.of(
+                new RuntimeException(new UnknownHostException()), UNPROCESSABLE_CONTENT_HTTP_CODE)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(
                 entry ->

--- a/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.exception;
 
-import static org.apache.polaris.service.exception.IcebergExceptionMapper.UNPROCESSABLE_CONTENT_HTTP_CODE;
+import static org.apache.polaris.service.exception.IcebergExceptionMapper.AZURE_STORAGE_URL_SUFFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.core.exception.AzureException;
@@ -46,7 +46,7 @@ public class IcebergExceptionMapperTest {
             // RuntimeIOExceptions,
             // which is what the Iceberg SDK sometimes wraps them with if the error happens during
             // IO.
-            302, UNPROCESSABLE_CONTENT_HTTP_CODE,
+            302, 422,
             400, 400,
             401, 403,
             403, 403,
@@ -66,7 +66,11 @@ public class IcebergExceptionMapperTest {
             Arguments.of(S3Exception.builder().message("Access denied").build(), 403),
             Arguments.of(new StorageException(1, "access denied"), 403),
             Arguments.of(
-                new RuntimeException(new UnknownHostException()), UNPROCESSABLE_CONTENT_HTTP_CODE)),
+                new RuntimeException(
+                    new UnknownHostException(
+                        String.format(
+                            "mybucket%s: Name or service not known", AZURE_STORAGE_URL_SUFFIX))),
+                404)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(
                 entry ->

--- a/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -29,6 +29,7 @@ import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -65,9 +66,9 @@ public class IcebergExceptionMapperTest {
             Arguments.of(S3Exception.builder().message("Access denied").build(), 403),
             Arguments.of(new StorageException(1, "access denied"), 403),
             Arguments.of(
-                new RuntimeException(
-                    new UnknownHostException(
-                        "mybucket.blob.core.windows.net: Name or service not known")),
+                new FileIOUnknownHostException(
+                    "mybucket.blob.core.windows.net: Name or service not known",
+                    new RuntimeException(new UnknownHostException())),
                 404)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(


### PR DESCRIPTION
Typically when a S3/GCS bucket isn't found, you'll get a 404. Azure seems to be unique, in that it provisions a subdomain for each "blob container", so non-existence manifests as a DNS resolution failure instead. This makes the Polaris return code consistent.