### PR TITLE
Clear the poetry.lock file during first-time setup of the polaris CLI

### DIFF
--- a/polaris
+++ b/polaris
@@ -21,6 +21,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ ! -d ${SCRIPT_DIR}/polaris-venv ]; then
   echo "Performing first-time setup for the Python client..."
+  rm -f ${SCRIPT_DIR}/poetry.lock
   python3 -m venv ${SCRIPT_DIR}/polaris-venv
   . ${SCRIPT_DIR}/polaris-venv/bin/activate
   pip install -r regtests/requirements.txt


### PR DESCRIPTION
When the polaris CLI script performs first-time setup, it creates `polaris-venv` based on the dependencies configured in poetry. However, if there happens to be an existing poetry.lock file in the directory then the correct dependencies will not get installed. To remedy this, we should clear out any pre-existing poetry.lock file before generating a `polaris-venv` and installing dependencies there.

<hr>

**Without this change:**

```bash
rm -rf polaris-venv
rm -rf poetry.lock
touch poetry.lock
./polaris -h
```

Yields:

```
ModuleNotFoundError: No module named 'pydantic'
```
While

```bash
rm -rf polaris-venv
rm -rf poetry.lock
./polaris -h
```

Yields:

```
First time setup complete.
input: polaris -h
...
```

<hr>

**After this change:**

```bash
rm -rf polaris-venv
rm -rf poetry.lock
./polaris -h
```

Yields:
```
First time setup complete.
input: polaris -h
...
```