### PR TITLE
Harmonize parameters in PolarisMetaStoreManager

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1003,7 +1003,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   public @Nonnull EntityResult renameEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToRename,
+      @Nonnull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @Nonnull PolarisEntity renamedEntity) {
     // get metastore we should be using
@@ -1101,7 +1101,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   public @Nonnull DropEntityResult dropEntityIfExists(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToDrop,
+      @Nonnull PolarisBaseEntity entityToDrop,
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup) {
     // get metastore we should be using

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -252,7 +252,7 @@ public interface PolarisMetaStoreManager
   EntityResult renameEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToRename,
+      @Nonnull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @Nonnull PolarisEntity renamedEntity);
 
@@ -272,7 +272,7 @@ public interface PolarisMetaStoreManager
   DropEntityResult dropEntityIfExists(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToDrop,
+      @Nonnull PolarisBaseEntity entityToDrop,
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup);
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -211,7 +211,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   public EntityResult renameEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToRename,
+      @Nonnull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @Nonnull PolarisEntity renamedEntity) {
     callCtx.getDiagServices().fail("illegal_method_in_transaction_workspace", "renameEntity");
@@ -222,7 +222,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   public DropEntityResult dropEntityIfExists(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToDrop,
+      @Nonnull PolarisBaseEntity entityToDrop,
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup) {
     callCtx.getDiagServices().fail("illegal_method_in_transaction_workspace", "dropEntityIfExists");

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisMetaStoreManagerImpl.java
@@ -1152,7 +1152,7 @@ public class PolarisMetaStoreManagerImpl extends BaseMetaStoreManager {
   }
 
   /**
-   * See {@link PolarisMetaStoreManager#renameEntity(PolarisCallContext, List, PolarisEntityCore,
+   * See {@link PolarisMetaStoreManager#renameEntity(PolarisCallContext, List, PolarisBaseEntity,
    * List, PolarisEntity)}
    */
   private @Nonnull EntityResult renameEntity(
@@ -1264,7 +1264,7 @@ public class PolarisMetaStoreManagerImpl extends BaseMetaStoreManager {
   public @Nonnull EntityResult renameEntity(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToRename,
+      @Nonnull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @Nonnull PolarisEntity renamedEntity) {
     // get metastore we should be using
@@ -1281,13 +1281,14 @@ public class PolarisMetaStoreManagerImpl extends BaseMetaStoreManager {
   /**
    * See
    *
-   * <p>{@link #dropEntityIfExists(PolarisCallContext, List, PolarisEntityCore, Map, boolean)}
+   * <p>{@link #dropEntityIfExists(PolarisCallContext, TransactionalPersistence, List,
+   * PolarisBaseEntity, Map, boolean)}
    */
   private @Nonnull DropEntityResult dropEntityIfExists(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToDrop,
+      @Nonnull PolarisBaseEntity entityToDrop,
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup) {
     // entity cannot be null
@@ -1397,7 +1398,7 @@ public class PolarisMetaStoreManagerImpl extends BaseMetaStoreManager {
   public @Nonnull DropEntityResult dropEntityIfExists(
       @Nonnull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
-      @Nonnull PolarisEntityCore entityToDrop,
+      @Nonnull PolarisBaseEntity entityToDrop,
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup) {
     // get metastore we should be using

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -651,7 +651,7 @@ public class PolarisTestMetaStoreManager {
   }
 
   /** Drop the entity if it exists. */
-  void dropEntity(List<PolarisEntityCore> catalogPath, PolarisEntityCore entityToDrop) {
+  void dropEntity(List<PolarisEntityCore> catalogPath, PolarisBaseEntity entityToDrop) {
     // see if the entity exists
     final boolean exists;
     boolean hasChildren = false;

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -140,7 +139,7 @@ public class TaskExecutorImpl implements TaskExecutor {
           .addKeyValue("handlerClass", handler.getClass())
           .log("Task successfully handled");
       metaStoreManager.dropEntityIfExists(
-          ctx.getPolarisCallContext(), null, PolarisEntity.toCore(taskEntity), Map.of(), false);
+          ctx.getPolarisCallContext(), null, taskEntity, Map.of(), false);
     } else {
       LOGGER
           .atWarn()


### PR DESCRIPTION
* Use `PolarisBaseEntity` for the entity that is acted upon in `renameEntity` and `dropEntityIfExists`

* This is in line with existing parameters for "acted upon" entities in other methods.

* Simplify TaskExecutorImpl (avoid object copy)

* Existing call sites have the required data available.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
