### PR TITLE
don't check for Auth header on a healthcheck endpoint

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/auth/PolarisPrincipalAuthenticatorFilter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/PolarisPrincipalAuthenticatorFilter.java
@@ -48,6 +48,11 @@ public class PolarisPrincipalAuthenticatorFilter implements ContainerRequestFilt
       return;
     }
 
+    // don't check for Auth header on a healthcheck endpoint
+    if (requestContext.getUriInfo().getPath().equals("/healthcheck")) {
+      return;
+    }
+
     String authHeader = requestContext.getHeaderString("Authorization");
 
     if (authHeader == null) {


### PR DESCRIPTION
This change is to bypass `/healthcheck` endpoint going through Authorization header check. I don't think we want `/healthcheck` endpoint to go through the flow of getting Auth header checked before the server returns ok status back. 

This is the error logged on the server

```java
2025-03-12 22:51:52,361 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-0) 127.0.0.1 - - [12/Mar/2025:22:51:52 +0000] "GET /healthcheck HTTP/1.1" 401 88
22:51:57.360 [vert.x-eventloop-thread-0] INFO org.apache.polaris.service.exception.IcebergExceptionMapper -- Handling runtimeException HTTP 401 Unauthorized

jakarta.ws.rs.NotAuthorizedException: HTTP 401 Unauthorized
	at org.apache.polaris.service.auth.PolarisPrincipalAuthenticatorFilter.filter(PolarisPrincipalAuthenticatorFilter.java:54)
	at org.apache.polaris.service.auth.PolarisPrincipalAuthenticatorFilter_ClientProxy.filter(Unknown Source)
	at org.jboss.resteasy.reactive.server.handlers.ResourceRequestFilterHandler.handle(ResourceRequestFilterHandler.java:48)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:131)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at org.jboss.resteasy.reactive.server.handlers.RestInitialHandler.beginProcessing(RestInitialHandler.java:48)
	at org.jboss.resteasy.reactive.server.vertx.ResteasyReactiveVertxHandler.handle(ResteasyReactiveVertxHandler.java:23)
	at org.jboss.resteasy.reactive.server.vertx.ResteasyReactiveVertxHandler.handle(ResteasyReactiveVertxHandler.java:10)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1281)
```
