### PR TITLE
Fix CI error for NotNull import

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatPredicate;
 
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.HashMap;
@@ -56,7 +57,6 @@ import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.task.BatchFileCleanupTaskHandler;
 import org.apache.polaris.service.task.TaskFileIOSupplier;
 import org.apache.polaris.service.task.TaskUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -69,13 +69,13 @@ public class BatchFileCleanupTaskHandlerTest {
         new FileIOFactory() {
           @Override
           public FileIO loadFileIO(
-              @NotNull CallContext callContext,
-              @NotNull String ioImplClassName,
-              @NotNull Map<String, String> properties,
-              @NotNull TableIdentifier identifier,
-              @NotNull Set<String> tableLocations,
-              @NotNull Set<PolarisStorageActions> storageActions,
-              @NotNull PolarisResolvedPathWrapper resolvedEntityPath) {
+              @Nonnull CallContext callContext,
+              @Nonnull String ioImplClassName,
+              @Nonnull Map<String, String> properties,
+              @Nonnull TableIdentifier identifier,
+              @Nonnull Set<String> tableLocations,
+              @Nonnull Set<PolarisStorageActions> storageActions,
+              @Nonnull PolarisResolvedPathWrapper resolvedEntityPath) {
             return fileIO;
           }
         });


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
# Summary 
In #516, incorrect type of NotNull (`org.jetbrains.annotations.NotNull`) was used in the test, which caused errors in CI. This fix PR replaces it with the correct one `jakarta.annotation.Nonnull`
