### PR TITLE
Remove jetbrains-annotations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,6 @@ jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version 
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "3.1.1" }
 jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "4.0.0" }
 javax-servlet-api = { module = "javax.servlet:javax.servlet-api", version = "4.0.1" }
-jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.2" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.12.1" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.17" }
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version = "1.14.5" }

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
   implementation(libs.commons.codec1)
   implementation(libs.guava)
   implementation(libs.slf4j.api)
-  compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.spotbugs.annotations)
 
   compileOnly(project(":polaris-immutables"))

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisDefaultDiagServiceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisDefaultDiagServiceImpl.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
-import org.jetbrains.annotations.Contract;
 
 /** Default implementation of the PolarisDiagServices. */
 public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
@@ -67,7 +66,6 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
    * @return the non-null reference that was validated
    * @throws RuntimeException if `reference` is null
    */
-  @Contract("null, _ -> fail")
   @Override
   public <T> T checkNotNull(final T reference, final String signature) {
     return Preconditions.checkNotNull(reference, signature);
@@ -85,7 +83,6 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
    * @return the non-null reference that was validated
    * @throws RuntimeException if `reference` is null
    */
-  @Contract("null, _, _, _ -> fail")
   @Override
   public <T> T checkNotNull(
       final T reference,
@@ -104,7 +101,6 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
    *     like "path_cannot_be_null"
    * @throws RuntimeException if `condition` is not true
    */
-  @Contract("false, _ -> fail")
   @Override
   public void check(final boolean expression, final String signature) {
     Preconditions.checkState(expression, signature);
@@ -121,7 +117,6 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
    * @param extraInfoArgs extra information arguments
    * @throws RuntimeException if condition` is not true
    */
-  @Contract("false, _, _, _ -> fail")
   @Override
   public void check(
       final boolean expression,

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisDiagnostics.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisDiagnostics.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.core;
 
-import org.jetbrains.annotations.Contract;
-
 public interface PolarisDiagnostics {
 
   /**
@@ -31,7 +29,6 @@ public interface PolarisDiagnostics {
    *     pairs: "id={} fileName={}"
    * @param extraInfoArgs extra information arguments
    */
-  @Contract("_, _, _ -> fail")
   RuntimeException fail(
       final String signature, final String extraInfoFormat, final Object... extraInfoArgs);
 
@@ -45,7 +42,6 @@ public interface PolarisDiagnostics {
    *     pairs: "id={} fileName={}"
    * @param extraInfoArgs extra information arguments
    */
-  @Contract("_, _, _, _ -> fail")
   RuntimeException fail(
       final String signature,
       final Throwable cause,
@@ -61,7 +57,6 @@ public interface PolarisDiagnostics {
    * @return the non-null reference that was validated
    * @throws RuntimeException if `reference` is null
    */
-  @Contract("null, _ -> fail")
   <T> T checkNotNull(final T reference, final String signature);
 
   /**
@@ -76,7 +71,6 @@ public interface PolarisDiagnostics {
    * @return the non-null reference that was validated
    * @throws RuntimeException if `reference` is null
    */
-  @Contract("null, _, _, _ -> fail")
   <T> T checkNotNull(
       final T reference,
       final String signature,
@@ -91,7 +85,6 @@ public interface PolarisDiagnostics {
    *     like "path_cannot_be_null"
    * @throws RuntimeException if `condition` is not true
    */
-  @Contract("false, _ -> fail")
   void check(final boolean expression, final String signature);
 
   /**
@@ -105,7 +98,6 @@ public interface PolarisDiagnostics {
    * @param extraInfoArgs extra information arguments
    * @throws RuntimeException if `condition` is not true
    */
-  @Contract("false, _, _, _ -> fail")
   void check(
       final boolean expression,
       final String signature,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -21,6 +21,7 @@ package org.apache.polaris.core.storage.cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import java.time.Duration;
 import java.util.Map;
@@ -35,7 +36,6 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.dao.entity.ScopedCredentialsResult;
 import org.apache.polaris.core.storage.PolarisCredentialVendor;
-import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
The main intention of this change is to avoid confusion between Jetbrains' `@NotNull` and Jakarta's `@Nonnull` (the latter is standard in the Polaris codebase).

As a side effect `@Contract` is no longer available. However, its value is realised only in tools that support it and Polaris builds do not rely on it for producing artifacts. For a human being the value of `@Contract` appears to be negligible compared to javadoc. Therefore, in the interest of keeping annotation dependencies concise, `@Contract` lines are removed.

Jetbrains' `@VisibleForTesting` is converted to the same annotation from Guava (which is also standard in the Polaris codebase).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
