### PR TITLE
Support bulk deletion in batch file cleanup task

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -193,7 +193,9 @@ public class BatchFileCleanupTaskHandlerTest {
               .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
               .withData(
                   new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                      tableIdentifier, cleanupFiles, BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
+                      tableIdentifier,
+                      cleanupFiles,
+                      BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
               .setName(UUID.randomUUID().toString())
               .build();
 
@@ -244,7 +246,9 @@ public class BatchFileCleanupTaskHandlerTest {
               .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
               .withData(
                   new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                      tableIdentifier, List.of(statisticsFile.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
+                      tableIdentifier,
+                      List.of(statisticsFile.path()),
+                      BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
               .setName(UUID.randomUUID().toString())
               .build();
 
@@ -316,7 +320,7 @@ public class BatchFileCleanupTaskHandlerTest {
                   new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
                       tableIdentifier,
                       List.of(statisticsFile.path()),
-                          BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
+                      BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
               .setName(UUID.randomUUID().toString())
               .build();
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -260,7 +260,7 @@ public class BatchFileCleanupTaskHandlerTest {
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3})
-  public void testCleanupWithRetries(int retryTime) throws IOException {
+  public void testCleanupWithRetries(int maxRetries) throws IOException {
     PolarisCallContext polarisCallContext =
         new PolarisCallContext(
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
@@ -289,7 +289,7 @@ public class BatchFileCleanupTaskHandlerTest {
                 Boolean isConcurrent,
                 Throwable e,
                 int attempt) {
-              if (attempt <= retryTime) {
+              if (attempt <= maxRetries) {
                 batchRetryCounter.incrementAndGet();
                 return tryDelete(tableId, fileIO, files, type, isConcurrent, e, attempt + 1);
               } else {
@@ -337,7 +337,7 @@ public class BatchFileCleanupTaskHandlerTest {
       future.join();
 
       // Ensure that retries happened as expected
-      assertThat(batchRetryCounter.get()).isEqualTo(retryTime);
+      assertThat(batchRetryCounter.get()).isEqualTo(maxRetries);
 
       // Check if the file was successfully deleted after retries
       assertThat(TaskUtils.exists(statisticsFile.path(), fileIO)).isFalse();

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -180,7 +180,7 @@ class TableCleanupTaskHandlerTest {
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
                             tableIdentifier,
-                            List.of(snapshot.manifestListLocation(), statisticsFile.path())),
+                            List.of(snapshot.manifestListLocation(), statisticsFile.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));
@@ -307,7 +307,7 @@ class TableCleanupTaskHandlerTest {
                     .returns(AsyncTaskType.BATCH_FILE_CLEANUP, TaskEntity::getTaskType)
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                            tableIdentifier, List.of(snapshot.manifestListLocation())),
+                            tableIdentifier, List.of(snapshot.manifestListLocation()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)),
@@ -318,7 +318,7 @@ class TableCleanupTaskHandlerTest {
                     .returns(AsyncTaskType.BATCH_FILE_CLEANUP, TaskEntity::getTaskType)
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                            tableIdentifier, List.of(snapshot.manifestListLocation())),
+                            tableIdentifier, List.of(snapshot.manifestListLocation()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)),
@@ -450,7 +450,7 @@ class TableCleanupTaskHandlerTest {
                                 snapshot.manifestListLocation(),
                                 snapshot2.manifestListLocation(),
                                 statisticsFile1.path(),
-                                statisticsFile2.path())),
+                                statisticsFile2.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));
@@ -627,7 +627,7 @@ class TableCleanupTaskHandlerTest {
                                 statisticsFile1.path(),
                                 statisticsFile2.path(),
                                 partitionStatisticsFile1.path(),
-                                partitionStatisticsFile2.path())),
+                                partitionStatisticsFile2.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -180,7 +180,8 @@ class TableCleanupTaskHandlerTest {
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
                             tableIdentifier,
-                            List.of(snapshot.manifestListLocation(), statisticsFile.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
+                            List.of(snapshot.manifestListLocation(), statisticsFile.path()),
+                            BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));
@@ -307,7 +308,9 @@ class TableCleanupTaskHandlerTest {
                     .returns(AsyncTaskType.BATCH_FILE_CLEANUP, TaskEntity::getTaskType)
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                            tableIdentifier, List.of(snapshot.manifestListLocation()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
+                            tableIdentifier,
+                            List.of(snapshot.manifestListLocation()),
+                            BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)),
@@ -318,7 +321,9 @@ class TableCleanupTaskHandlerTest {
                     .returns(AsyncTaskType.BATCH_FILE_CLEANUP, TaskEntity::getTaskType)
                     .returns(
                         new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                            tableIdentifier, List.of(snapshot.manifestListLocation()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
+                            tableIdentifier,
+                            List.of(snapshot.manifestListLocation()),
+                            BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)),
@@ -450,7 +455,8 @@ class TableCleanupTaskHandlerTest {
                                 snapshot.manifestListLocation(),
                                 snapshot2.manifestListLocation(),
                                 statisticsFile1.path(),
-                                statisticsFile2.path()), BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
+                                statisticsFile2.path()),
+                            BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA),
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));

--- a/service/common/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
@@ -78,7 +78,8 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
       }
 
       CompletableFuture<Void> deleteFutures =
-          tryDelete(tableId, authorizedFileIO, validFiles, cleanupTask.type().getValue(), true, null, 1);
+          tryDelete(
+              tableId, authorizedFileIO, validFiles, cleanupTask.type().getValue(), true, null, 1);
 
       try {
         deleteFutures.join();

--- a/service/common/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.task;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.context.CallContext;
@@ -29,9 +30,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link FileCleanupTaskHandler} responsible for cleaning up files in table tasks. Handles retries
- * for file deletions and skips files that are already missing. Subclasses must implement
- * task-specific logic.
+ * Abstract base class for handling file cleanup tasks within Apache Polaris.
+ *
+ * <p>This class is for performing asynchronous file deletions with retry logic.
+ *
+ * <p>Subclasses must implement {@link #canHandleTask(TaskEntity)} and {@link
+ * #handleTask(TaskEntity, CallContext)} to define task-specific handling logic.
  */
 public abstract class FileCleanupTaskHandler implements TaskHandler {
 
@@ -53,6 +57,19 @@ public abstract class FileCleanupTaskHandler implements TaskHandler {
   @Override
   public abstract boolean handleTask(TaskEntity task, CallContext callContext);
 
+  /**
+   * Attempts to delete a single file with retry logic. If the file does not exist, it logs a
+   * message and does not retry. If an error occurs, it retries up to {@link #MAX_ATTEMPTS} times
+   * before failing.
+   *
+   * @param tableId The identifier of the table associated with the file.
+   * @param fileIO The {@link FileIO} instance used for file operations.
+   * @param baseFile An optional base file associated with the file being deleted (can be null).
+   * @param file The path of the file to be deleted.
+   * @param e The exception from the previous attempt, if any.
+   * @param attempt The current retry attempt count.
+   * @return A {@link CompletableFuture} representing the asynchronous deletion operation.
+   */
   public CompletableFuture<Void> tryDelete(
       TableIdentifier tableId,
       FileIO fileIO,
@@ -99,6 +116,55 @@ public abstract class FileCleanupTaskHandler implements TaskHandler {
                   .addKeyValue("baseFile", baseFile != null ? baseFile : "")
                   .log("Exception caught deleting data file", newEx);
               return tryDelete(tableId, fileIO, baseFile, file, newEx, attempt + 1);
+            },
+            CompletableFuture.delayedExecutor(
+                FILE_DELETION_RETRY_MILLIS, TimeUnit.MILLISECONDS, executorService));
+  }
+
+  /**
+   * Attempts to delete multiple files in a batch operation with retry logic. If an error occurs, it
+   * retries up to {@link #MAX_ATTEMPTS} times before failing.
+   *
+   * @param tableId The identifier of the table associated with the files.
+   * @param fileIO The {@link FileIO} instance used for file operations.
+   * @param files The list of file paths to be deleted.
+   * @param type The type of files being deleted (e.g., data files, metadata files).
+   * @param isConcurrent Whether the deletion should be performed concurrently.
+   * @param e The exception from the previous attempt, if any.
+   * @param attempt The current retry attempt count.
+   * @return A {@link CompletableFuture} representing the asynchronous batch deletion operation.
+   */
+  public CompletableFuture<Void> tryDelete(
+      TableIdentifier tableId,
+      FileIO fileIO,
+      Iterable<String> files,
+      String type,
+      Boolean isConcurrent,
+      Throwable e,
+      int attempt) {
+    if (e != null && attempt <= MAX_ATTEMPTS) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("files", files)
+          .addKeyValue("attempt", attempt)
+          .addKeyValue("error", e.getMessage())
+          .addKeyValue("type", type)
+          .log("Error encountered attempting to delete files");
+    }
+    if (attempt > MAX_ATTEMPTS && e != null) {
+      return CompletableFuture.failedFuture(e);
+    }
+    return CompletableFuture.runAsync(
+            () -> CatalogUtil.deleteFiles(fileIO, files, type, isConcurrent), executorService)
+        .exceptionallyComposeAsync(
+            newEx -> {
+              LOGGER
+                  .atWarn()
+                  .addKeyValue("files", files)
+                  .addKeyValue("tableIdentifier", tableId)
+                  .addKeyValue("type", type)
+                  .log("Exception caught deleting data files", newEx);
+              return tryDelete(tableId, fileIO, files, type, isConcurrent, newEx, attempt + 1);
             },
             CompletableFuture.delayedExecutor(
                 FILE_DELETION_RETRY_MILLIS, TimeUnit.MILLISECONDS, executorService));

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -234,7 +234,9 @@ public class TableCleanupTaskHandler implements TaskHandler {
                   .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
                   .withData(
                       new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                          tableEntity.getTableIdentifier(), metadataBatch, BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
+                          tableEntity.getTableIdentifier(),
+                          metadataBatch,
+                          BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
                   .setInternalProperties(cleanupTask.getInternalPropertiesAsMap())
                   .build();
             });

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -234,7 +234,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
                   .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
                   .withData(
                       new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
-                          tableEntity.getTableIdentifier(), metadataBatch))
+                          tableEntity.getTableIdentifier(), metadataBatch, BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
                   .setInternalProperties(cleanupTask.getInternalPropertiesAsMap())
                   .build();
             });


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
# Summary 
As a follow up improvement for #515 

After introducing batch file clean up, we want to make use of the bulk deletion APIs provided by Iceberg, which essentially utilize the bulk deletion ability of many object storage services (e.g., S3, GCS, Azure Blob Storage) to achieve better performance and lower cost

## Recommended Review Order
1. `FileCleanupTaskHandler.java` 
2. `BatchFileCleanupTaskHandler.java`
3. `TableCleanupTaskHandler.java`
4.  Unit Tests

## Iceberg API Reference
```
// https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/CatalogUtil.java#L194
    public static void deleteFiles(FileIO io, Iterable<String> files, String type, boolean concurrent) {
        if (io instanceof SupportsBulkOperations) {
            try {
                SupportsBulkOperations bulkIO = (SupportsBulkOperations)io;
                bulkIO.deleteFiles(files);
            } catch (RuntimeException e) {
                LOG.warn("Failed to bulk delete {} files", type, e);
            }
        } else if (concurrent) {
            deleteFiles(io, files, type);
        } else {
            files.forEach((file) -> deleteFile(io, file, type));
        }
```