### PR TITLE
Fix spark download and add check/cleanup

### DIFF
--- a/regtests/run.sh
+++ b/regtests/run.sh
@@ -20,7 +20,7 @@
 # Run without args to run all tests, or single arg for single test.
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-export SPARK_VERSION=spark-3.5.4
+export SPARK_VERSION=spark-3.5.5
 export SPARK_DISTRIBUTION=${SPARK_VERSION}-bin-hadoop3
 
 if [ -z "${SPARK_HOME}" ]; then

--- a/regtests/run_spark_sql.sh
+++ b/regtests/run_spark_sql.sh
@@ -46,7 +46,7 @@ fi
 REGTEST_HOME=$(dirname $(realpath $0))
 cd ${REGTEST_HOME}
 
-export SPARK_VERSION=spark-3.5.4
+export SPARK_VERSION=spark-3.5.5
 export SPARK_DISTRIBUTION=${SPARK_VERSION}-bin-hadoop3
 export SPARK_LOCAL_HOSTNAME=localhost # avoid VPN messing up driver local IP address binding
 

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -44,12 +44,12 @@ if ! [ -f ${SPARK_HOME}/bin/spark-sql ]; then
   fi
   if ! [ -f ~/${SPARK_DISTRIBUTION}.tgz ]; then
     echo 'Downloading spark distro...'
-    wget -O ~/${SPARK_DISTRIBUTION}.tgz https://dlcdn.apache.org/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
+    wget -O ~/${SPARK_DISTRIBUTION}.tgz https://archive.apache.org/dist/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
     if ! [ -f ~/${SPARK_DISTRIBUTION}.tgz ]; then
       if [[ "${OSTYPE}" == "darwin"* ]]; then
         echo "Detected OS: mac. Running 'brew install wget' to try again."
         brew install wget
-        wget -O ~/${SPARK_DISTRIBUTION}.tgz https://dlcdn.apache.org/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
+        wget -O ~/${SPARK_DISTRIBUTION}.tgz https://archive.apache.org/dist/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
       fi
     fi
   else

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -55,8 +55,19 @@ if ! [ -f ${SPARK_HOME}/bin/spark-sql ]; then
   else
     echo 'Found existing Spark tarball'
   fi
+  # check if the download was successful
+  if ! [ -f ~/${SPARK_DISTRIBUTION}.tgz ]; then
+    echo 'Failed to download Spark distribution. Please check the logs.'
+    exit 1
+  fi
   tar xzvf ~/${SPARK_DISTRIBUTION}.tgz -C ~
-  echo 'Done!'
+  if [ $? -ne 0 ]; then
+    echo 'Failed to extract Spark distribution. Please check the logs.'
+    exit 1
+  else
+    echo 'Extracted Spark distribution.'
+    rm ~/${SPARK_DISTRIBUTION}.tgz
+  fi
   SPARK_HOME=$(realpath ~/${SPARK_DISTRIBUTION})
   SPARK_CONF="${SPARK_HOME}/conf/spark-defaults.conf"
 else


### PR DESCRIPTION
Three changes in this PR:
1. Change download URL for spark distribution
2. Update spark version to 3.5.5 (all other places are changed except this one)
3. Cleanup tarball after extracted and add check after download (in case failed download, abort the regtests)

Explanation for item 1:
Currently it is downloading spark via following link:
```
https://dlcdn.apache.org/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
```

This URL will only return the valid download tgz when the version is latest (as the older version is not accessible from this link...in this case, https://www.apache.org/dyn/closer.lua/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz).

Thus, it is better to download from archive link instead:
```
https://archive.apache.org/dist/spark/${SPARK_VERSION}/${SPARK_DISTRIBUTION}.tgz
```  
