### PR TITLE
Update EclipseLink doc to 4.0

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkSessionCustomizer.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkSessionCustomizer.java
@@ -25,7 +25,7 @@ import org.eclipse.persistence.sessions.SessionCustomizer;
 /**
  * This pattern of injecting a SessionCustomizer is taken from the EclipseLink guide documentation:
  *
- * <p>https://eclipse.dev/eclipselink/documentation/2.6/dbws/creating_dbws_services002.htm
+ * <p>https://eclipse.dev/eclipselink/documentation/4.0/dbws/dbws.html#performing-intermediate-customization
  */
 public class PolarisEclipseLinkSessionCustomizer implements SessionCustomizer {
   @Override

--- a/site/content/in-dev/0.9.0/metastores.md
+++ b/site/content/in-dev/0.9.0/metastores.md
@@ -34,7 +34,7 @@ metaStoreManager:
   persistence-unit: polaris
 ```
 
-`conf-file` must point to an [EclipseLink configuration file](https://eclipse.dev/eclipselink/documentation/4.0/solutions/solutions.html#TESTINGJPA002)
+`conf-file` must point to an [EclipseLink configuration file](https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm)
 
 By default, `conf-file` points to the embedded resource file `META-INF/persistence.xml` in the `polaris-eclipselink` module.
 
@@ -45,7 +45,7 @@ In order to specify a configuration file outside the classpath, follow these ste
 ## EclipseLink Configuration - persistence.xml
 The configuration file `persistence.xml` is used to set up the database connection properties, which can differ depending on the type of database and its configuration.
 
-Check out the default [persistence.xml](https://github.com/apache/polaris/blob/main/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml) for a complete sample for connecting to the file-based H2 database.
+Check out the default [persistence.xml](https://github.com/apache/polaris/blob/main/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml) for a complete sample for connecting to the file-based H2 database. 
 
 Polaris creates and connects to a separate database for each realm. Specifically, the `{realm}` placeholder in `jakarta.persistence.jdbc.url` is substituted with the actual realm name, allowing the Polaris server to connect to different databases based on the realm.
 
@@ -71,7 +71,7 @@ Polaris creates and connects to a separate database for each realm. Specifically
 </persistence-unit>
 ```
 
-A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/4.0/concepts/concepts.html#APPDEV001). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use `persistence-unit` in the Polaris server configuration to easily switch between persistence units.
+A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/2.6/concepts/app_dev001.htm). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use `persistence-unit` in the Polaris server configuration to easily switch between persistence units.
 
 To build Polaris with the necessary H2 dependency and start the Polaris service, run the following:
 ```bash

--- a/site/content/in-dev/0.9.0/metastores.md
+++ b/site/content/in-dev/0.9.0/metastores.md
@@ -34,7 +34,7 @@ metaStoreManager:
   persistence-unit: polaris
 ```
 
-`conf-file` must point to an [EclipseLink configuration file](https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm)
+`conf-file` must point to an [EclipseLink configuration file](https://eclipse.dev/eclipselink/documentation/4.0/solutions/solutions.html#TESTINGJPA002)
 
 By default, `conf-file` points to the embedded resource file `META-INF/persistence.xml` in the `polaris-eclipselink` module.
 
@@ -45,7 +45,7 @@ In order to specify a configuration file outside the classpath, follow these ste
 ## EclipseLink Configuration - persistence.xml
 The configuration file `persistence.xml` is used to set up the database connection properties, which can differ depending on the type of database and its configuration.
 
-Check out the default [persistence.xml](https://github.com/apache/polaris/blob/main/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml) for a complete sample for connecting to the file-based H2 database. 
+Check out the default [persistence.xml](https://github.com/apache/polaris/blob/main/extension/persistence/eclipselink/src/main/resources/META-INF/persistence.xml) for a complete sample for connecting to the file-based H2 database.
 
 Polaris creates and connects to a separate database for each realm. Specifically, the `{realm}` placeholder in `jakarta.persistence.jdbc.url` is substituted with the actual realm name, allowing the Polaris server to connect to different databases based on the realm.
 
@@ -71,7 +71,7 @@ Polaris creates and connects to a separate database for each realm. Specifically
 </persistence-unit>
 ```
 
-A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/2.6/concepts/app_dev001.htm). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use `persistence-unit` in the Polaris server configuration to easily switch between persistence units.
+A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/4.0/concepts/concepts.html#APPDEV001). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use `persistence-unit` in the Polaris server configuration to easily switch between persistence units.
 
 To build Polaris with the necessary H2 dependency and start the Polaris service, run the following:
 ```bash

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -51,13 +51,13 @@ on the type of database and its configuration.
 
 > Note: You have to locate the `persistence.xml` at least two folders down to the root folder, e.g. `/deployments/config/persistence.xml` is OK, whereas `/deployments/persistence.xml` will cause an infinity loop.
 [Quarkus Configuration Reference]: https://quarkus.io/guides/config-reference
-[EclipseLink configuration file]: https://eclipse.dev/eclipselink/documentation/2.5/solutions/testingjpa002.htm
+[EclipseLink configuration file]: https://eclipse.dev/eclipselink/documentation/4.0/solutions/solutions.html#TESTINGJPA002
 
 Polaris creates and connects to a separate database for each realm. Specifically, the `{realm}` placeholder in `jakarta.persistence.jdbc.url` is substituted with the actual realm name, allowing the Polaris server to connect to different databases based on the realm.
 
 > Note: some database systems such as Postgres don't create databases automatically. Database admins need to create them manually before running Polaris server.
 
-A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/2.6/concepts/app_dev001.htm). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use the `persistence-unit` option in the Polaris server configuration to easily switch between persistence units.
+A single `persistence.xml` can describe multiple [persistence units](https://eclipse.dev/eclipselink/documentation/4.0/concepts/concepts.html#APPDEV001). For example, with both a `polaris-dev` and `polaris` persistence unit defined, you could use a single `persistence.xml` to easily switch between development and production databases. Use the `persistence-unit` option in the Polaris server configuration to easily switch between persistence units.
 
 ### Using H2
 


### PR DESCRIPTION
Currently we are using EclipseLink 4.0.5 but we still ref to 2.5/2.6 version. Since EclipseLink 4.0.x, EclipseLink has changed their doc to Asciidoc format (ref: https://github.com/eclipse-ee4j/eclipselink/pull/1746). The refs we are using in 2.5/2.6 are still valid, but it may contains outdated info as people want to dig deeper into certain settings. 