### PR TITLE
Fix behavior change config VALIDATE_VIEW_LOCATION_OVERLAP

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -39,7 +39,7 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
 
   public static final BehaviorChangeConfiguration<Boolean> VALIDATE_VIEW_LOCATION_OVERLAP =
       PolarisConfiguration.<Boolean>builder()
-          .key("STORAGE_CREDENTIAL_CACHE_DURATION_SECONDS")
+          .key("VALIDATE_VIEW_LOCATION_OVERLAP")
           .description("If true, validate that view locations don't overlap when views are created")
           .defaultValue(true)
           .buildBehaviorChangeConfiguration();


### PR DESCRIPTION
The BehaviorChangeConfiguration added in #1124 as an example actually has the wrong config name; this fix is also picked up in #1170 but per [this comment](https://github.com/apache/polaris/pull/1170#discussion_r1999710195) I've opened this PR as a small fix focused on adjusting the config.