### PR TITLE
Let 'spotless' run on all java source directories

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -152,7 +152,7 @@ tasks.withType(Jar::class).configureEach {
 
 spotless {
   java {
-    target("src/main/java/**/*.java", "src/testFixtures/java/**/*.java", "src/test/java/**/*.java")
+    target("src/*/java/**/*.java")
     googleJavaFormat()
     licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
     endWithNewline()

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusManagementServiceIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusManagementServiceIT.java
@@ -22,5 +22,4 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
 
 @QuarkusIntegrationTest
-public class QuarkusManagementServiceIT
-    extends PolarisManagementServiceIntegrationTest {}
+public class QuarkusManagementServiceIT extends PolarisManagementServiceIntegrationTest {}

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAwsIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAwsIT.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class QuarkusRestCatalogViewAwsIT
-    extends PolarisRestCatalogViewAwsIntegrationTest {
+public class QuarkusRestCatalogViewAwsIT extends PolarisRestCatalogViewAwsIntegrationTest {
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAzureIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewAzureIT.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class QuarkusRestCatalogViewAzureIT
-    extends PolarisRestCatalogViewAzureIntegrationTest {
+public class QuarkusRestCatalogViewAzureIT extends PolarisRestCatalogViewAzureIntegrationTest {
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIT.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class QuarkusRestCatalogViewFileIT
-    extends PolarisRestCatalogViewFileIntegrationTest {
+public class QuarkusRestCatalogViewFileIT extends PolarisRestCatalogViewFileIntegrationTest {
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewGcpIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewGcpIT.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class QuarkusRestCatalogViewGcpIT
-    extends PolarisRestCatalogViewGcpIntegrationTest {
+public class QuarkusRestCatalogViewGcpIT extends PolarisRestCatalogViewGcpIntegrationTest {
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
+++ b/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
@@ -19,8 +19,8 @@
 package org.apache.polaris.version;
 
 import static java.lang.String.format;
-import static org.apache.polaris.version.PolarisVersion.getBuildGitTag;
 import static org.apache.polaris.version.PolarisVersion.getBuildGitHead;
+import static org.apache.polaris.version.PolarisVersion.getBuildGitTag;
 import static org.apache.polaris.version.PolarisVersion.getBuildJavaVersion;
 import static org.apache.polaris.version.PolarisVersion.getBuildReleasedVersion;
 import static org.apache.polaris.version.PolarisVersion.getBuildSystem;
@@ -108,6 +108,7 @@ public class TestPolarisVersion {
     return Stream.of(
         Arguments.arguments("NOTICE", (Supplier<String>) PolarisVersion::readNoticeFile),
         Arguments.arguments("LICENSE", (Supplier<String>) PolarisVersion::readSourceLicenseFile));
-        //Arguments.arguments(//   "LICENSE-BINARY-DIST", (Supplier<String>) PolarisVersion::readBinaryLicenseFile));
+    // Arguments.arguments(//   "LICENSE-BINARY-DIST", (Supplier<String>)
+    // PolarisVersion::readBinaryLicenseFile));
   }
 }


### PR DESCRIPTION
Only runs on 'main', 'test', 'testFixtures', but not on others like 'intTest'. This change fixes this.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
