### PR TITLE
Renovate: Group all Quarkus dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,18 @@
       extends: ["schedule:weekly"],
     },
 
+    // Quarkus platform + plugin together
+    {
+      groupName: "Quarkus Platform and Group",
+      matchManagers: ["gradle"],
+      matchPackageNames: [
+        "io.quarkus.platform:quarkus-bom",
+        "io.quarkus.platform:quarkus-amazon-services-bom",
+        "io.quarkus.platform:quarkus-google-cloud-services-bom",
+        "io.quarkus:io.quarkus.gradle.plugin",
+      ],
+    },
+
     // Turn off major & minor version updates on version-branches
     {
       matchBaseBranches: ["/^release/.*/"],


### PR DESCRIPTION
Quarkus-platform releases happen some time after the "actual" Quarkus release, which causes "broken" CI for Renovate PRs against for example the Quarkus Gradle plugin.

This change groups all Quarkus dependencies together to consistently bump all Quarkus-platform dependencies at once.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
