### PR TITLE
IcebergCatalogAdapter: close underlying catalog consistently

### DIFF
--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -177,9 +177,6 @@ public record TestServices(
               callContextFactory,
               entityManager,
               metaStoreManager,
-              metaStoreSession,
-              configurationStore,
-              polarisDiagnostics,
               authorizer,
               new DefaultCatalogPrefixParser());
 


### PR DESCRIPTION
With the revert of b84f4624db8d0bd5b8920b0df719bcc15666008f by ccf25df7b055e9d232b88a3f6fe8b4e0a2ab035a, we lost an extra benefit that was included in the reverted commit: a fix for the fact that `IcebergCatalogHandlerWrapper` does not always close its underlying `Catalog`, thus relying on `CallContext` to play the role of the "sweeper car" and close everything that was left unclosed at the end of the request processing.

This PR re-applies that fix again.

If this change gets accepted, we could envisage removing `CallContext.closeables()` – as the main purpose of this method is to close unclosed catalogs.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
