### PR TITLE
populate credentials field for loadTableResponse

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerWrapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerWrapper.java
@@ -639,7 +639,13 @@ public class IcebergCatalogHandlerWrapper implements AutoCloseable {
           if (table instanceof BaseTable baseTable) {
             TableMetadata tableMetadata = baseTable.operations().current();
             return buildLoadTableResponseWithDelegationCredentials(
-                tableIdentifier, tableMetadata, Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE, PolarisStorageActions.LIST)).build();
+                    tableIdentifier,
+                    tableMetadata,
+                    Set.of(
+                        PolarisStorageActions.READ,
+                        PolarisStorageActions.WRITE,
+                        PolarisStorageActions.LIST))
+                .build();
           } else if (table instanceof BaseMetadataTable) {
             // metadata tables are loaded on the client side, return NoSuchTableException for now
             throw new NoSuchTableException("Table does not exist: %s", tableIdentifier.toString());
@@ -737,7 +743,9 @@ public class IcebergCatalogHandlerWrapper implements AutoCloseable {
           LoadTableResponse.Builder responseBuilder =
               LoadTableResponse.builder().withTableMetadata(metadata);
 
-          return buildLoadTableResponseWithDelegationCredentials(ident, metadata, Set.of(PolarisStorageActions.ALL)).build();
+          return buildLoadTableResponseWithDelegationCredentials(
+                  ident, metadata, Set.of(PolarisStorageActions.ALL))
+              .build();
         });
   }
 
@@ -846,7 +854,9 @@ public class IcebergCatalogHandlerWrapper implements AutoCloseable {
 
           if (table instanceof BaseTable baseTable) {
             TableMetadata tableMetadata = baseTable.operations().current();
-            return buildLoadTableResponseWithDelegationCredentials(tableIdentifier, tableMetadata, Set.of(PolarisStorageActions.ALL)).build();
+            return buildLoadTableResponseWithDelegationCredentials(
+                    tableIdentifier, tableMetadata, Set.of(PolarisStorageActions.ALL))
+                .build();
           } else if (table instanceof BaseMetadataTable) {
             // metadata tables are loaded on the client side, return NoSuchTableException for now
             throw new NoSuchTableException("Table does not exist: %s", tableIdentifier.toString());
@@ -857,9 +867,11 @@ public class IcebergCatalogHandlerWrapper implements AutoCloseable {
   }
 
   private LoadTableResponse.Builder buildLoadTableResponseWithDelegationCredentials(
-      TableIdentifier tableIdentifier, TableMetadata tableMetadata, Set<PolarisStorageActions> actions) {
-    LoadTableResponse.Builder responseBuilder = LoadTableResponse.builder()
-        .withTableMetadata(tableMetadata);
+      TableIdentifier tableIdentifier,
+      TableMetadata tableMetadata,
+      Set<PolarisStorageActions> actions) {
+    LoadTableResponse.Builder responseBuilder =
+        LoadTableResponse.builder().withTableMetadata(tableMetadata);
     if (baseCatalog instanceof SupportsCredentialDelegation credentialDelegation) {
       LOGGER
           .atDebug()
@@ -867,8 +879,7 @@ public class IcebergCatalogHandlerWrapper implements AutoCloseable {
           .addKeyValue("tableLocation", tableMetadata.location())
           .log("Fetching client credentials for table");
       Map<String, String> credentialConfig =
-          credentialDelegation.getCredentialConfig(
-              tableIdentifier, tableMetadata, actions);
+          credentialDelegation.getCredentialConfig(tableIdentifier, tableMetadata, actions);
       responseBuilder.addAllConfig(credentialConfig);
       responseBuilder.addCredential(
           ImmutableCredential.builder()


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Previously, we are not populating the `Credentials` field for `LoadTableResponse` and we are using that field to populate the result of `LoadCredentials` endpoint. This PR cleans up the code a bit and populate the configs and credentials.
