### PR TITLE
Introduce MetaStoreManagerFactory.initializeForService

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.nio.file.Path;
+import java.util.List;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
@@ -53,6 +54,10 @@ public class EclipseLinkPolarisMetaStoreManagerFactory
   protected EclipseLinkPolarisMetaStoreManagerFactory(PolarisDiagnostics diagnostics) {
     super(diagnostics);
   }
+
+  @Override
+  public void initializeForService(
+      @Nonnull List<String> realmIds, @Nonnull String defaultRealmId) {}
 
   @Override
   protected PolarisEclipseLinkStore createBackingStore(@Nonnull PolarisDiagnostics diagnostics) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.persistence;
 
+import jakarta.annotation.Nonnull;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.polaris.core.context.RealmContext;
@@ -43,4 +45,6 @@ public interface MetaStoreManagerFactory {
 
   /** Purge all metadata for the realms provided */
   Map<String, BaseResult> purgeRealms(Iterable<String> realms);
+
+  void initializeForService(@Nonnull List<String> realmIds, @Nonnull String defaultRealmId);
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -27,6 +27,7 @@ import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
@@ -286,6 +287,10 @@ public class GenericTableCatalogTest {
       public EntityCache getOrCreateEntityCache(RealmContext realmContext) {
         return new EntityCache(metaStoreManager);
       }
+
+      @Override
+      public void initializeForService(
+          @Nonnull List<String> realmIds, @Nonnull String defaultRealmId) {}
 
       @Override
       public Map<String, PrincipalSecretsResult> bootstrapRealms(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -374,6 +374,10 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
       }
 
       @Override
+      public void initializeForService(
+          @Nonnull List<String> realmIds, @Nonnull String defaultRealmId) {}
+
+      @Override
       public Map<String, PrincipalSecretsResult> bootstrapRealms(
           Iterable<String> realms, RootCredentialsSet rootCredentialsSet) {
         throw new NotImplementedException("Bootstrapping realms is not supported");

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -26,6 +26,7 @@ import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
@@ -298,6 +299,12 @@ public class PolicyCatalogTest {
       @Override
       public Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
         throw new NotImplementedException("Purging realms is not supported");
+      }
+
+      @Override
+      public void initializeForService(
+          @Nonnull List<String> realmIds, @Nonnull String defaultRealmId) {
+        throw new NotImplementedException("Bootstrapping realms is not supported");
       }
     };
   }

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -38,7 +38,6 @@ import org.apache.polaris.core.persistence.transactional.TransactionalPersistenc
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
-import org.apache.polaris.service.context.RealmContextConfiguration;
 
 @ApplicationScoped
 @Identifier("in-memory")
@@ -59,8 +58,9 @@ public class InMemoryPolarisMetaStoreManagerFactory
     this.storageIntegration = storageIntegration;
   }
 
-  public void onStartup(RealmContextConfiguration realmContextConfiguration) {
-    bootstrapRealmsAndPrintCredentials(realmContextConfiguration.realms());
+  @Override
+  public void initializeForService(@Nonnull List<String> realmIds, @Nonnull String defaultRealmId) {
+    bootstrapRealmsAndPrintCredentials(realmIds);
   }
 
   @Override


### PR DESCRIPTION
This is to let meta-store-manager-factories be notified when those are started up for the Polaris service, instead of the `if (mf instanceof InMemoryPolarisMetaStoreManagerFactory)` in `QuarkusProducers`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
