### PR TITLE
Update usage of polaris.io to apache.polaris.org

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -155,7 +155,7 @@ helm uninstall --namespace polaris polaris
 | cors.accessControlMaxAge | string | `nil` | The `Access-Control-Max-Age` response header value indicating how long the results of a pre-flight request can be cached. Must be a valid duration. |
 | cors.allowedHeaders | list | `[]` | HTTP headers allowed for CORS, ex: X-Custom, Content-Disposition. If this is not set or empty, all requested headers are considered allowed. |
 | cors.allowedMethods | list | `[]` | HTTP methods allowed for CORS, ex: GET, PUT, POST. If this is not set or empty, all requested methods are considered allowed. |
-| cors.allowedOrigins | list | `[]` | Origins allowed for CORS, e.g. http://polaris.io, http://localhost:8181. In case an entry of the list is surrounded by forward slashes, it is interpreted as a regular expression. |
+| cors.allowedOrigins | list | `[]` | Origins allowed for CORS, e.g. https://polaris.apache.org, http://localhost:8181. In case an entry of the list is surrounded by forward slashes, it is interpreted as a regular expression. |
 | cors.exposedHeaders | list | `[]` | HTTP headers exposed to the client, ex: X-Custom, Content-Disposition. The default is an empty list. |
 | extraEnv | list | `[]` | Advanced configuration via Environment Variables. Extra environment variables to add to the Polaris server container. You can pass here any valid EnvVar object: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core This can be useful to get configuration values from Kubernetes secrets or config maps. |
 | extraInitContainers | list | `[]` | Add additional init containers to the polaris pod(s) See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/. |

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -585,7 +585,7 @@ authentication:
 
 # -- Polaris CORS configuration.
 cors:
-  # -- Origins allowed for CORS, e.g. http://polaris.io, http://localhost:8181. In case an entry of the list is surrounded by forward slashes, it is interpreted as a regular expression.
+  # -- Origins allowed for CORS, e.g. https://polaris.apache.org, http://localhost:8181. In case an entry of the list is surrounded by forward slashes, it is interpreted as a regular expression.
   allowedOrigins: []
   # -- HTTP methods allowed for CORS, ex: GET, PUT, POST. If this is not set or empty, all requested methods are considered allowed.
   allowedMethods: []


### PR DESCRIPTION
polaris.io now redirects to apache.polaris.org, so we'd better just update the URL used in docs. Also, this seems to have caused [at least one run of the markdown link checker](https://github.com/apache/polaris/actions/runs/13986872035/job/39162056543?pr=1231) to fail.