### PR TITLE
Fix overzealous check in the Polaris CLI

### DIFF
--- a/client/python/cli/polaris_cli.py
+++ b/client/python/cli/polaris_cli.py
@@ -118,7 +118,7 @@ class PolarisCli:
         # Validates
         has_access_token = options.access_token is not None
         has_client_secret = client_id is not None and client_secret is not None
-        if options.client_id and options.client_secret:
+        if has_access_token and (options.client_id or options.client_secret):
             raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
                             f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
                             f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}, but not both')
@@ -128,7 +128,6 @@ class PolarisCli:
                             f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}.'
                             f' Alternatively, you may set the environment variables {CLIENT_ID_ENV} &'
                             f' {CLIENT_SECRET_ENV}.')
-        # Authenticate accordingly
         if options.base_url:
             if options.host is not None or options.port is not None:
                 raise Exception(f'Please provide either {Argument.to_flag_name(Arguments.BASE_URL)} or'

--- a/client/python/cli/polaris_cli.py
+++ b/client/python/cli/polaris_cli.py
@@ -128,6 +128,7 @@ class PolarisCli:
                             f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}.'
                             f' Alternatively, you may set the environment variables {CLIENT_ID_ENV} &'
                             f' {CLIENT_SECRET_ENV}.')
+        # Authenticate accordingly
         if options.base_url:
             if options.host is not None or options.port is not None:
                 raise Exception(f'Please provide either {Argument.to_flag_name(Arguments.BASE_URL)} or'

--- a/client/python/cli/polaris_cli.py
+++ b/client/python/cli/polaris_cli.py
@@ -118,7 +118,7 @@ class PolarisCli:
         # Validates
         has_access_token = options.access_token is not None
         has_client_secret = client_id is not None and client_secret is not None
-        if has_access_token and has_client_secret:
+        if options.client_id and options.client_secret:
             raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
                             f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
                             f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}, but not both')


### PR DESCRIPTION
When running a command like this in the Polaris CLI:

```
./polaris \
	--access-token 'principal:root;realm:default-realm' \
        --client-id abc \
        --client-secret xyz \
	catalogs \
	create test_catalog \
	--storage-type file \
	--default-base-location 'file:///tmp/polaris'
```

We reject the invocation because it's ambiguous whether the user would like to use the access token or the client ID & secret.

However, it's also possible for the user to specify client ID & secret via environment variables. In that case, we reject commands even like this:

```
./polaris \
	--access-token 'principal:root;realm:default-realm' \
	catalogs \
	create test_catalog \
	--storage-type file \
	--default-base-location 'file:///tmp/polaris'
```

I believe that we should allow situations where the user explicitly provides one set of credentials rather than failing due to the implicit inclusion of another set of credentials via the environment variables.