### PR TITLE
Exclude generated files in regtests/client/python/polaris

### DIFF
--- a/regtests/client/python/.gitignore
+++ b/regtests/client/python/.gitignore
@@ -64,3 +64,9 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Generated Python client files
+client/python/**/*.py
+
+# DON'T ignore api_response.py in both catalog and management service
+!client/python/**/api_response.py


### PR DESCRIPTION
This tries to address - https://github.com/apache/polaris/issues/755