### PR TITLE
MINOR: Add pydantic and python-dateutil to requirements for ./polaris

### DIFF
--- a/polaris
+++ b/polaris
@@ -28,6 +28,7 @@ if [ ! -d "${dir}"/polaris-venv ]; then
   python3 -m venv "${dir}"/polaris-venv
   . "${dir}"/polaris-venv/bin/activate
   pip install -r regtests/requirements.txt
+  pip install pydantic python-dateutil
 
   cp "${dir}"/client/python/pyproject.toml "${dir}"
   pushd "$dir" && poetry install ; popd


### PR DESCRIPTION
This patch adds a `pip install` for `pydantic` and `python-dateutil` from the `./polaris` executable.

## Motivation

I ran through the quickstart and hit an error with missing both packages on my first `./polaris` invocation.

```
./polaris                                                                                                   
Traceback (most recent call last):
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/cli/polaris_cli.py", line 28, in <module>
    from polaris.management import ApiClient, Configuration
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/__init__.py", line 38, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/api/__init__.py", line 22, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/api/polaris_default_api.py", line 33, in <module>
    from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
ModuleNotFoundError: No module named 'pydantic'
```

```
./polaris                                                                                       
Traceback (most recent call last):
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/cli/polaris_cli.py", line 28, in <module>
    from polaris.management import ApiClient, Configuration
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/__init__.py", line 38, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/api/__init__.py", line 22, in <module>
    from polaris.management.api.polaris_default_api import PolarisDefaultApi
  File "/Users/stanislavkozlovski/tmp/polaris-apache-polaris-0.9.0-incubating/regtests/client/python/polaris/management/api/polaris_default_api.py", line 33, in <module>
    from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
ModuleNotFoundError: No module named 'pydantic'
```