### PR TITLE
Vend Azure credentials compatible with Iceberg 1.7

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -43,6 +43,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -59,8 +60,6 @@ public class AzureCredentialsStorageIntegration
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AzureCredentialsStorageIntegration.class);
-
-  public static String AZURE_ACCOUNT_HOST_SUFFIX = "dfs.windows.net";
 
   final DefaultAzureCredential defaultAzureCredential;
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -43,7 +43,6 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -60,6 +60,8 @@ public class AzureCredentialsStorageIntegration
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AzureCredentialsStorageIntegration.class);
 
+  public static String AZURE_ACCOUNT_HOST_SUFFIX = "dfs.windows.net";
+
   final DefaultAzureCredential defaultAzureCredential;
 
   public AzureCredentialsStorageIntegration() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -64,13 +64,13 @@ public class StorageCredentialCacheEntry {
 
       // Iceberg 1.7.x may expect the credenetial to _not_ be suffixed with endpoint
       if (host.endsWith(AzureLocation.ADLS_ENDPOINT)) {
-        int suffixIndex = host.lastIndexOf(AzureLocation.ADLS_ENDPOINT);
+        int suffixIndex = host.lastIndexOf(AzureLocation.ADLS_ENDPOINT) - 1;
         String withSuffixStripped = host.substring(0, suffixIndex);
         results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
       }
 
       if (host.endsWith(AzureLocation.BLOB_ENDPOINT)) {
-        int suffixIndex = host.lastIndexOf(AzureLocation.BLOB_ENDPOINT);
+        int suffixIndex = host.lastIndexOf(AzureLocation.BLOB_ENDPOINT) - 1;
         String withSuffixStripped = host.substring(0, suffixIndex);
         results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
       }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -69,7 +69,8 @@ public class StorageCredentialCacheEntry {
               resCredsMap.put(key.getPropertyName() + host, value);
               // Iceberg 1.7.x may expect this to _not_ be suffixed with .dfs.windows.net
               if (host.endsWith(AzureCredentialsStorageIntegration.AZURE_ACCOUNT_HOST_SUFFIX)) {
-                int suffixIndex = host.lastIndexOf(AzureCredentialsStorageIntegration.AZURE_ACCOUNT_HOST_SUFFIX);
+                int suffixIndex =
+                    host.lastIndexOf(AzureCredentialsStorageIntegration.AZURE_ACCOUNT_HOST_SUFFIX);
                 String withSuffixStripped = host.substring(0, suffixIndex);
                 resCredsMap.put(key.getPropertyName() + withSuffixStripped, value);
               }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -62,7 +62,7 @@ public class StorageCredentialCacheEntry {
       String host = credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST);
       results.put(credentialProperty.getPropertyName() + host, value);
 
-      // Iceberg 1.7.x may expect the credenetial to _not_ be suffixed with endpoint
+      // Iceberg 1.7.x may expect the credential key to _not_ be suffixed with endpoint
       if (host.endsWith(AzureLocation.ADLS_ENDPOINT)) {
         int suffixIndex = host.lastIndexOf(AzureLocation.ADLS_ENDPOINT) - 1;
         if (suffixIndex > 0) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.polaris.core.persistence.dao.entity.ScopedCredentialsResult;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
-import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureLocation;
 
 /** A storage credential cached entry. */
@@ -54,13 +53,11 @@ public class StorageCredentialCacheEntry {
   }
 
   /**
-   * Azure needs special handling, the credential key is dynamically generated based on
-   * the storage account endpoint
+   * Azure needs special handling, the credential key is dynamically generated based on the storage
+   * account endpoint
    */
   private void handleAzureCredential(
-      HashMap<String, String> results,
-      PolarisCredentialProperty credentialProperty,
-      String value) {
+      HashMap<String, String> results, PolarisCredentialProperty credentialProperty, String value) {
     if (credentialProperty.equals(PolarisCredentialProperty.AZURE_SAS_TOKEN)) {
       String host = credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST);
       results.put(credentialProperty.getPropertyName() + host, value);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -70,7 +70,8 @@ public class StorageCredentialCacheEntry {
                   value);
               resCredsMap.put(
                   key.getPropertyName()
-                      + credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST) + ".dfs.windows.net",
+                      + credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST)
+                      + ".dfs.windows.net",
                   value);
             } else if (!key.equals(PolarisCredentialProperty.AZURE_ACCOUNT_HOST)) {
               resCredsMap.put(key.getPropertyName(), value);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -68,6 +68,10 @@ public class StorageCredentialCacheEntry {
                   key.getPropertyName()
                       + credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST),
                   value);
+              resCredsMap.put(
+                  key.getPropertyName()
+                      + credsMap.get(PolarisCredentialProperty.AZURE_ACCOUNT_HOST) + ".dfs.windows.net",
+                  value);
             } else if (!key.equals(PolarisCredentialProperty.AZURE_ACCOUNT_HOST)) {
               resCredsMap.put(key.getPropertyName(), value);
             }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -65,14 +65,18 @@ public class StorageCredentialCacheEntry {
       // Iceberg 1.7.x may expect the credenetial to _not_ be suffixed with endpoint
       if (host.endsWith(AzureLocation.ADLS_ENDPOINT)) {
         int suffixIndex = host.lastIndexOf(AzureLocation.ADLS_ENDPOINT) - 1;
-        String withSuffixStripped = host.substring(0, suffixIndex);
-        results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
+        if (suffixIndex > 0) {
+          String withSuffixStripped = host.substring(0, suffixIndex);
+          results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
+        }
       }
 
       if (host.endsWith(AzureLocation.BLOB_ENDPOINT)) {
         int suffixIndex = host.lastIndexOf(AzureLocation.BLOB_ENDPOINT) - 1;
-        String withSuffixStripped = host.substring(0, suffixIndex);
-        results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
+        if (suffixIndex > 0) {
+          String withSuffixStripped = host.substring(0, suffixIndex);
+          results.put(credentialProperty.getPropertyName() + withSuffixStripped, value);
+        }
       }
     }
   }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -440,33 +440,42 @@ public class StorageCredentialCacheTest {
     return Arrays.asList(polarisEntity1, polarisEntity2, polarisEntity3);
   }
 
-
   @Test
   public void testAzureCredentialFormatting() {
     storageCredentialCache = new StorageCredentialCache();
-    List<ScopedCredentialsResult> mockedScopedCreds = List.of(
-        new ScopedCredentialsResult(
-          new EnumMap<>(
-            ImmutableMap.<PolarisCredentialProperty, String>builder()
-                .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_1")
-                .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account")
-                .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
-                .buildOrThrow())),
-        new ScopedCredentialsResult(
-          new EnumMap<>(
-              ImmutableMap.<PolarisCredentialProperty, String>builder()
-                  .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_2")
-                  .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account." + AzureLocation.ADLS_ENDPOINT)
-                  .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
-                  .buildOrThrow())),
-        new ScopedCredentialsResult(
-        new EnumMap<>(
-            ImmutableMap.<PolarisCredentialProperty, String>builder()
-                .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_3")
-                .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account." + AzureLocation.BLOB_ENDPOINT)
-                .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
-                .buildOrThrow()))
-        );
+    List<ScopedCredentialsResult> mockedScopedCreds =
+        List.of(
+            new ScopedCredentialsResult(
+                new EnumMap<>(
+                    ImmutableMap.<PolarisCredentialProperty, String>builder()
+                        .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_1")
+                        .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account")
+                        .put(
+                            PolarisCredentialProperty.EXPIRATION_TIME,
+                            String.valueOf(Long.MAX_VALUE))
+                        .buildOrThrow())),
+            new ScopedCredentialsResult(
+                new EnumMap<>(
+                    ImmutableMap.<PolarisCredentialProperty, String>builder()
+                        .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_2")
+                        .put(
+                            PolarisCredentialProperty.AZURE_ACCOUNT_HOST,
+                            "some_account." + AzureLocation.ADLS_ENDPOINT)
+                        .put(
+                            PolarisCredentialProperty.EXPIRATION_TIME,
+                            String.valueOf(Long.MAX_VALUE))
+                        .buildOrThrow())),
+            new ScopedCredentialsResult(
+                new EnumMap<>(
+                    ImmutableMap.<PolarisCredentialProperty, String>builder()
+                        .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_3")
+                        .put(
+                            PolarisCredentialProperty.AZURE_ACCOUNT_HOST,
+                            "some_account." + AzureLocation.BLOB_ENDPOINT)
+                        .put(
+                            PolarisCredentialProperty.EXPIRATION_TIME,
+                            String.valueOf(Long.MAX_VALUE))
+                        .buildOrThrow())));
 
     Mockito.when(
             metaStoreManager.getSubscopedCredsForEntity(
@@ -482,36 +491,41 @@ public class StorageCredentialCacheTest {
         .thenReturn(mockedScopedCreds.get(2));
     List<PolarisEntity> entityList = getPolarisEntities();
 
-    Map<String, String> noSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
-        metaStoreManager,
-        callCtx,
-        entityList.get(0),
-        true,
-        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
-        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Map<String, String> noSuffixResult =
+        storageCredentialCache.getOrGenerateSubScopeCreds(
+            metaStoreManager,
+            callCtx,
+            entityList.get(0),
+            true,
+            new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+            new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
     Assertions.assertThat(noSuffixResult.size()).isEqualTo(2);
     Assertions.assertThat(noSuffixResult).containsKey("adls.sas-token.some_account");
 
-    Map<String, String> adlsSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
-        metaStoreManager,
-        callCtx,
-        entityList.get(1),
-        true,
-        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
-        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Map<String, String> adlsSuffixResult =
+        storageCredentialCache.getOrGenerateSubScopeCreds(
+            metaStoreManager,
+            callCtx,
+            entityList.get(1),
+            true,
+            new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+            new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
     Assertions.assertThat(adlsSuffixResult.size()).isEqualTo(3);
     Assertions.assertThat(adlsSuffixResult).containsKey("adls.sas-token.some_account");
-    Assertions.assertThat(adlsSuffixResult).containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
+    Assertions.assertThat(adlsSuffixResult)
+        .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
 
-    Map<String, String> blobSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
-        metaStoreManager,
-        callCtx,
-        entityList.get(2),
-        true,
-        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
-        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Map<String, String> blobSuffixResult =
+        storageCredentialCache.getOrGenerateSubScopeCreds(
+            metaStoreManager,
+            callCtx,
+            entityList.get(2),
+            true,
+            new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+            new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
     Assertions.assertThat(blobSuffixResult.size()).isEqualTo(3);
     Assertions.assertThat(blobSuffixResult).containsKey("adls.sas-token.some_account");
-    Assertions.assertThat(blobSuffixResult).containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
+    Assertions.assertThat(blobSuffixResult)
+        .containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -45,6 +45,7 @@ import org.apache.polaris.core.persistence.transactional.TransactionalPersistenc
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
+import org.apache.polaris.core.storage.azure.AzureLocation;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -437,5 +438,80 @@ public class StorageCredentialCacheTest {
                 3, 2, PolarisEntityType.CATALOG, PolarisEntitySubType.TABLE, 0, "name"));
 
     return Arrays.asList(polarisEntity1, polarisEntity2, polarisEntity3);
+  }
+
+
+  @Test
+  public void testAzureCredentialFormatting() {
+    storageCredentialCache = new StorageCredentialCache();
+    List<ScopedCredentialsResult> mockedScopedCreds = List.of(
+        new ScopedCredentialsResult(
+          new EnumMap<>(
+            ImmutableMap.<PolarisCredentialProperty, String>builder()
+                .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_1")
+                .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account")
+                .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
+                .buildOrThrow())),
+        new ScopedCredentialsResult(
+          new EnumMap<>(
+              ImmutableMap.<PolarisCredentialProperty, String>builder()
+                  .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_2")
+                  .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account." + AzureLocation.ADLS_ENDPOINT)
+                  .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
+                  .buildOrThrow())),
+        new ScopedCredentialsResult(
+        new EnumMap<>(
+            ImmutableMap.<PolarisCredentialProperty, String>builder()
+                .put(PolarisCredentialProperty.AZURE_SAS_TOKEN, "sas_token_azure_3")
+                .put(PolarisCredentialProperty.AZURE_ACCOUNT_HOST, "some_account." + AzureLocation.BLOB_ENDPOINT)
+                .put(PolarisCredentialProperty.EXPIRATION_TIME, String.valueOf(Long.MAX_VALUE))
+                .buildOrThrow()))
+        );
+
+    Mockito.when(
+            metaStoreManager.getSubscopedCredsForEntity(
+                Mockito.any(),
+                Mockito.anyLong(),
+                Mockito.anyLong(),
+                Mockito.any(),
+                Mockito.anyBoolean(),
+                Mockito.anySet(),
+                Mockito.anySet()))
+        .thenReturn(mockedScopedCreds.get(0))
+        .thenReturn(mockedScopedCreds.get(1))
+        .thenReturn(mockedScopedCreds.get(2));
+    List<PolarisEntity> entityList = getPolarisEntities();
+
+    Map<String, String> noSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
+        metaStoreManager,
+        callCtx,
+        entityList.get(0),
+        true,
+        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Assertions.assertThat(noSuffixResult.size()).isEqualTo(2);
+    Assertions.assertThat(noSuffixResult).containsKey("adls.sas-token.some_account");
+
+    Map<String, String> adlsSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
+        metaStoreManager,
+        callCtx,
+        entityList.get(1),
+        true,
+        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Assertions.assertThat(adlsSuffixResult.size()).isEqualTo(3);
+    Assertions.assertThat(adlsSuffixResult).containsKey("adls.sas-token.some_account");
+    Assertions.assertThat(adlsSuffixResult).containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
+
+    Map<String, String> blobSuffixResult = storageCredentialCache.getOrGenerateSubScopeCreds(
+        metaStoreManager,
+        callCtx,
+        entityList.get(2),
+        true,
+        new HashSet<>(Arrays.asList("s3://bucket1/path", "s3://bucket2/path")),
+        new HashSet<>(Arrays.asList("s3://bucket3/path", "s3://bucket4/path")));
+    Assertions.assertThat(blobSuffixResult.size()).isEqualTo(3);
+    Assertions.assertThat(blobSuffixResult).containsKey("adls.sas-token.some_account");
+    Assertions.assertThat(blobSuffixResult).containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
   }
 }


### PR DESCRIPTION
@XJDKC brought it to my attention that [different versions of the Iceberg client expect different credential keys for Azure credentials](https://github.com/apache/iceberg/commit/b07455a940538eda5f27bd4b1b87e49b121346e4#diff-b6b966659def85b3107d8db1f7c3e23ca7c84b9139123114b21dd4df85942664R114). In order to support both variations, Polaris should vend Azure credentials both with and without the host suffixes like `dfs.core.windows.net`.