### PR TITLE
Better error message when sibling resolution fails

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1112,9 +1112,11 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                 new ResolverPath(Arrays.asList(ns.levels()), PolarisEntityType.NAMESPACE), ns));
     ResolverStatus status = resolutionManifest.resolveAll();
     if (!status.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
-      throw new IllegalStateException(
-          "Unable to resolve sibling entities to validate location - could not resolve"
-              + status.getFailedToResolvedEntityName());
+      String message = "Unable to resolve sibling entities to validate location - " + status.getStatus();
+      if (status.getStatus().equals(ResolverStatus.StatusEnum.ENTITY_COULD_NOT_BE_RESOLVED)) {
+        message += ". Entity = " + status.getFailedToResolvedEntityName();
+      }
+      throw new IllegalStateException(message);
     }
 
     StorageLocation targetLocation = StorageLocation.of(location);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1115,7 +1115,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       String message =
           "Unable to resolve sibling entities to validate location - " + status.getStatus();
       if (status.getStatus().equals(ResolverStatus.StatusEnum.ENTITY_COULD_NOT_BE_RESOLVED)) {
-        message += ". Entity = " + status.getFailedToResolvedEntityName();
+        message += ". Could not resolve entity: " + status.getFailedToResolvedEntityName();
       }
       throw new IllegalStateException(message);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1112,7 +1112,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                 new ResolverPath(Arrays.asList(ns.levels()), PolarisEntityType.NAMESPACE), ns));
     ResolverStatus status = resolutionManifest.resolveAll();
     if (!status.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
-      String message = "Unable to resolve sibling entities to validate location - " + status.getStatus();
+      String message =
+          "Unable to resolve sibling entities to validate location - " + status.getStatus();
       if (status.getStatus().equals(ResolverStatus.StatusEnum.ENTITY_COULD_NOT_BE_RESOLVED)) {
         message += ". Entity = " + status.getFailedToResolvedEntityName();
       }


### PR DESCRIPTION
An error message that's currently printed during a resolution failure assumes there's an entity that could not be resolved. However, in other code paths such as [this one](https://github.com/apache/polaris/blob/e619a0075bcd13eef1e139f608625c22ab5b50de/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java#L755), the value of `ResolverStatus.getFailedToResolvedEntityName` may be null. Accordingly, this PR fixes some error messages that rely on this value.

[Other places that print a similar error are already resilient to a null being in this field](https://github.com/apache/polaris/blob/e619a0075bcd13eef1e139f608625c22ab5b50de/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java#L260).