### PR TITLE
Update `LICENSE` and `NOTICE` in the distributions (admin and server)

### DIFF
--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -87,8 +87,8 @@ distributions {
     contents {
       from(runScript)
       from(project.layout.buildDirectory.dir("quarkus-app"))
-      from("../../NOTICE")
-      from("../../LICENSE-BINARY-DIST").rename("LICENSE-BINARY-DIST", "LICENSE")
+      from("distribution/NOTICE")
+      from("distribution/LICENSE")
     }
   }
 }

--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -1,0 +1,1725 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact bundles the following projects:
+
+--------------------------------------------------------------------------------
+
+Group: io.github.crac Name: org.crac Version: 0.1.3
+Project URL (from POM): https://github.com/crac/org.crac
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-bootstrap-runner Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-classloader-commons Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-development-mode-spi Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-constraint Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-cpu Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-expression Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-function Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-io Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-net Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-os Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-ref Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logging Name: jboss-logging Version: 3.6.1.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logmanager Name: jboss-logmanager Version: 3.1.2.Final
+Project URL: http://www.jboss.org
+License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.auth0 Name: java-jwt Version: 4.5.0
+Project URL (from POM): https://github.com/auth0/java-jwt
+License (from POM): The MIT License (MIT) - https://raw.githubusercontent.com/auth0/java-jwt/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-core Version: 1.55.3
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-core-http-netty Version: 1.15.11
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-identity Version: 1.15.4
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-json Version: 1.5.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-blob Version: 12.30.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-common Version: 12.29.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-file-datalake Version: 12.23.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-internal-avro Version: 12.15.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-xml Version: 1.2.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module Name: jackson-module-parameter-names Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
+Project URL (from POM): https://github.com/ben-manes/caffeine
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.stephenc.jcip Name: jcip-annotations Version: 1.0-1
+Project URL (from POM): http://stephenc.github.com/jcip-annotations
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.android Name: annotations Version: 4.1.1.4
+Project URL (from POM): http://source.android.com/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api-client Name: google-api-client Version: 2.7.2
+Project URL (from POM): https://github.com/googleapis/google-api-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: api-common Version: 2.46.1
+Project URL (from POM): https://github.com/googleapis/api-common-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax-grpc Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax-httpjson Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-cloud-monitoring-v3 Version: 3.52.0
+Project URL (from POM): https://github.com/googleapis/google-cloud-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-common-protos Version: 2.51.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.49.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250224-2.0.0
+Project URL (from POM): http://www.google.com
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth Name: google-auth-library-credentials Version: 1.33.1
+Project URL (from POM): https://github.com/googleapis/google-auth-library-java
+License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.33.1
+Project URL (from POM): https://github.com/googleapis/google-auth-library-java
+License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auto.value Name: auto-value-annotations Version: 1.11.0
+Project URL (from POM): https://github.com/google/auto
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core-http Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-monitoring Version: 3.52.0
+Project URL (from POM): https://github.com/googleapis/google-cloud-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-storage Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: detector-resources-support Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: exporter-metrics Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: shared-resourcemapping Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.gson Name: gson Version: 2.12.1
+Project URL (from POM): https://github.com/google/gson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.errorprone Name: error_prone_annotations Version: 2.36.0
+Project URL (from POM): https://errorprone.info
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: failureaccess Version: 1.0.1
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: guava Version: 33.4.0-jre
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: listenablefuture Version: 9999.0-empty-to-avoid-conflict-with-guava
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-apache-v2 Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-appengine Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-gson Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-jackson2 Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.j2objc Name: j2objc-annotations Version: 2.8
+Project URL (from POM): https://github.com/google/j2objc/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.oauth-client Name: google-oauth-client Version: 1.37.0
+Project URL (from POM): https://github.com/googleapis/google-oauth-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf Name: protobuf-java Version: 3.25.5
+Project URL (from POM): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf Name: protobuf-java-util Version: 3.25.5
+Project URL (from POM): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.re2j Name: re2j Version: 1.7
+Project URL (from POM): http://github.com/google/re2j
+License (from POM): Go License - https://golang.org/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure Name: msal4j Version: 1.19.1
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure Name: msal4j-persistence-extension Version: 1.3.0
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: content-type Version: 2.3
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: lang-tag Version: 1.7
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: nimbus-jose-jwt Version: 10.0
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: oauth2-oidc-sdk Version: 11.18
+Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.sun.xml.bind Name: jaxb-core Version: 4.0.5
+Project URL: https://eclipse-ee4j.github.io/jaxb-ri/
+License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.sun.xml.bind Name: jaxb-xjc Version: 4.0.5
+Project URL: https://eclipse-ee4j.github.io/jaxb-ri/
+License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec Name: commons-codec Version: 1.18.0
+Project URL (from POM): https://commons.apache.org/proper/commons-codec/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-io Name: commons-io Version: 2.18.0
+Project URL (from POM): https://commons.apache.org/proper/commons-io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: dev.failsafe Name: failsafe Version: 3.3.2
+Project URL (from POM): https://failsafe.dev
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: info.picocli Name: picocli Name: 4.7.6
+Project URL (from POM): https://picocli.info
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.airlift Name: aircompressor Version: 2.0.2
+Project URL (from POM): https://github.com/airlift/aircompressor
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-alts Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-api Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-auth Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-context Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-core Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-googleapis Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-grpclb Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-inprocess Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-protobuf Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-rls Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-services Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-stub Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-util Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-xds Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-commons Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-core Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-observation Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-buffer Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-dns Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-http Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-http2 Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-socks Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-common Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-handler Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-handler-proxy Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-epoll Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus Name: opencensus-api Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus Name: opencensus-contrib-http-util Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-contrib
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-api Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-api-incubator Version: 1.44.1-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-context Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-common Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-logs Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-trace Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.28.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark Name: perfmark-api Version: 0.27.0
+Project URL (from POM): https://github.com/perfmark/perfmark
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.4
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.4
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor Name: reactor-core Version: 3.7.4
+Project URL (from POM): https://github.com/reactor/reactor-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.arc Name: arc Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-arc Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-container-image Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-container-image-docker Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-container-image-docker-common Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-core Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-picocli Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.10.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.10.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-annotations Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-core Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-models Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation Name: jakarta.activation-api Version: 2.1.3
+Project URL (from POM): https://github.com/jakartaee/jaf-api
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.annotation Name: jakarta.annotation-api Version: 3.0.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.ca
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.el Name: jakarta.el-api Version: 5.0.1
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.el
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
+Project URL (from POM): http://cdi-spec.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.lang-model Version: 4.1.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
+Project URL (from POM): https://github.com/eclipse-ee4j/injection-api
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.interceptor Name: jakarta.interceptor-api Version: 2.2.0
+Project URL (from POM): https://github.com/jakartaee/interceptors
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.json Name: jakarta.json-api Version: 2.1.3
+Project URL (from POM): https://github.com/eclipse-ee4j/jsonp
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.persistence Name: jakarta.persistence-api Version: 3.1.0
+Project URL (from POM): https://github.com/eclipse-ee4j/jpa-api
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.servlet Name: jakarta.servlet-api Version: 6.0.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.servlet
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.transaction Name: jakarta.transaction-api Version: 2.0.1
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.jta
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
+Project URL (from POM): https://beanvalidation.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.ws.rs Name: jakarta.ws.rs-api Version: 3.1.0
+Project URL (from POM): https://github.com/eclipse-ee4j/jaxrs-api
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind Name: jakarta.xml.bind-api Version: 4.0.2
+Project URL (from POM): https://github.com/jakartaee/jaxb-api
+License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+javax.ws.rs.jsr311-api-1.1.1.jar
+Project URL (from POM): https://jsr311.dev.java.net
+License (from POM): CDDL License - http://www.opensource.org/licenses/cddl1.php
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna Name: jna Version: 5.8.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna Name: jna-platform Version: 5.8.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev Name: accessors-smart Version: 2.5.1
+Project URL (from POM): https://urielch.github.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev Name: json-smart Version: 2.5.1
+Project URL (from POM): https://urielch.github.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro Name: avro Version: 1.12.0
+Project URL (from POM): https://avro.apache.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-compress Version: 1.27.1
+Project URL (from POM): https://commons.apache.org/proper/commons-compress/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-lang3 Version: 3.17.0
+Project URL (from POM): https://commons.apache.org/proper/commons-lang/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5 Name: httpclient5 Version: 5.4
+Project URL (from POM): https://hc.apache.org/httpcomponents-client-5.4.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5 Name: httpcore5 Version: 5.3
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5 Name: httpcore5-h2 Version: 5.3
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents Name: httpclient Version: 4.5.14
+Project URL (from POM): https://hc.apache.org/httpcomponents-client-4.5.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents Name: httpcore Version: 4.4.16
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-4.4.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-api Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-aws Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-azure Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-bundled-guava Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-common Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-core Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-gcp Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.checkerframework Name: checker-qual Version: 3.49.0
+Project URL (from POM): https://checkerframework.org/
+License (from POM): MIT License - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.mojo Name: animal-sniffer-annotations Version: 1.24
+Project URL (from POM): https://www.mojohaus.org/animal-sniffer
+License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
+Project URL (from POM): https://conscrypt.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.angus Name: angus-activation Version: 2.0.2
+Project URL (from POM): https://github.com/eclipse-ee4j/angus-activation
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
+Project URL (from POM): http://microprofile.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.context-propagation Name: microprofile-context-propagation-api Version: 1.3
+Project URL (from POM): http://microprofile.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.parsson Name: parsson Version: 1.1.7
+Project URL: https://github.com/eclipse-ee4j/parsson
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
+
+--------------------------------------------------------------------------------
+
+org.eclipse.persistence.eclipselink-4.0.5.jar
+Project URL (from POM): http://www.eclipse.org/eclipselink
+License (from POM): Eclipse Public License 2.0 - http://www.eclipse.org/legal/epl-2.0
+License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.hdrhistogram Name: HdrHistogram Version: 2.2.2
+Project URL (from POM): http://hdrhistogram.github.io/HdrHistogram/
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: org.javassist Name: javassist Version: 3.28.0-GA
+Project URL (from POM): http://www.javassist.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logging Name: jboss-logging-annotations Version: 3.0.4.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.slf4j Name: slf4j-jboss-logmanager Version: 2.0.0.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.threads Name: jboss-threads Version: 3.8.0.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jctools Name: jctools-core Version: 4.0.5
+Project URL: https://github.com/JCTools/JCTools
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jspecify Name: jspecify Version: 1.0.0
+Project URL (from POM): http://jspecify.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.latencyutils Name: LatencyUtils Version: 2.0.3
+Project URL (from POM): http://latencyutils.github.io/LatencyUtils/
+License (from POM): Public Domain, per Creative Commons CC0 - http://creativecommons.org/publicdomain/zero/1.0/
+
+--------------------------------------------------------------------------------
+
+Group: org.ow2.asm Name: asm Version: 9.7.1
+Project URL (from POM): http://asm.ow2.io/
+License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+
+--------------------------------------------------------------------------------
+
+Group: org.reactivestreams Name: reactive-streams Version: 1.0.4
+Project URL (from POM): http://www.reactive-streams.org/
+License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+
+--------------------------------------------------------------------------------
+
+Group: org.reflections Name: reflections Version: 0.10.2
+Project URL (from POM): http://github.com/ronmamo/reflections
+License (from POM): WTFPL - http://www.wtfpl.net
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.roaringbitmap Name: RoaringBitmap Version: 1.3.0
+Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.slf4j Name: slf4j-api Version: 2.0.6
+Project URL (from POM): http://www.slf4j.org
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten Name: threetenbp Version: 1.7.0
+Project URL (from POM): https://www.threeten.org/threetenbp
+License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
+Project URL (from POM): https://www.jboss.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.yaml Name: snakeyaml Version: 2.3
+Project URL (from POM): https://bitbucket.org/snakeyaml/snakeyaml
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: annotations Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: arns Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: auth Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: checksums Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: profiles Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: regions Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: retries Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: s3 Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: sts Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: utils Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
+Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------

--- a/quarkus/admin/distribution/NOTICE
+++ b/quarkus/admin/distribution/NOTICE
@@ -1,0 +1,1221 @@
+Apache Polaris (incubating)
+Copyright 2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The initial code for the Polaris project was donated
+to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+
+--------------------------------------------------------------------------------
+
+This binary artifact bundles the following projects with NOTICE:
+
+--------------------------------------------------------------------------------
+
+Group: info.picocli Name: picocli Name: 4.7.6
+
+NOTICE:
+| This project includes one or more documentation files from OpenJDK, licensed under GPL v2 with Classpath Exception.
+| 
+| These files are included in the source distributions, not in the binary distributions of this project.
+| 
+| The GNU General Public License (GPL)
+| 
+| Version 2, June 1991
+| 
+| Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+| 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+| 
+| Everyone is permitted to copy and distribute verbatim copies of this license
+| document, but changing it is not allowed.
+| 
+| Preamble
+| 
+| The licenses for most software are designed to take away your freedom to share
+| and change it.  By contrast, the GNU General Public License is intended to
+| guarantee your freedom to share and change free software--to make sure the
+| software is free for all its users.  This General Public License applies to
+| most of the Free Software Foundation's software and to any other program whose
+| authors commit to using it.  (Some other Free Software Foundation software is
+| covered by the GNU Library General Public License instead.) You can apply it to
+| your programs, too.
+| 
+| When we speak of free software, we are referring to freedom, not price.  Our
+| General Public Licenses are designed to make sure that you have the freedom to
+| distribute copies of free software (and charge for this service if you wish),
+| that you receive source code or can get it if you want it, that you can change
+| the software or use pieces of it in new free programs; and that you know you
+| can do these things.
+| 
+| To protect your rights, we need to make restrictions that forbid anyone to deny
+| you these rights or to ask you to surrender the rights.  These restrictions
+| translate to certain responsibilities for you if you distribute copies of the
+| software, or if you modify it.
+| 
+| For example, if you distribute copies of such a program, whether gratis or for
+| a fee, you must give the recipients all the rights that you have.  You must
+| make sure that they, too, receive or can get the source code.  And you must
+| show them these terms so they know their rights.
+| 
+| We protect your rights with two steps: (1) copyright the software, and (2)
+| offer you this license which gives you legal permission to copy, distribute
+| and/or modify the software.
+| 
+| Also, for each author's protection and ours, we want to make certain that
+| everyone understands that there is no warranty for this free software.  If the
+| software is modified by someone else and passed on, we want its recipients to
+| know that what they have is not the original, so that any problems introduced
+| by others will not reflect on the original authors' reputations.
+| 
+| Finally, any free program is threatened constantly by software patents.  We
+| wish to avoid the danger that redistributors of a free program will
+| individually obtain patent licenses, in effect making the program proprietary.
+| To prevent this, we have made it clear that any patent must be licensed for
+| everyone's free use or not licensed at all.
+| 
+| The precise terms and conditions for copying, distribution and modification
+| follow.
+| 
+| TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+| 
+| 0. This License applies to any program or other work which contains a notice
+| placed by the copyright holder saying it may be distributed under the terms of
+| this General Public License.  The "Program", below, refers to any such program
+| or work, and a "work based on the Program" means either the Program or any
+| derivative work under copyright law: that is to say, a work containing the
+| Program or a portion of it, either verbatim or with modifications and/or
+| translated into another language.  (Hereinafter, translation is included
+| without limitation in the term "modification".) Each licensee is addressed as
+| "you".
+| 
+| Activities other than copying, distribution and modification are not covered by
+| this License; they are outside its scope.  The act of running the Program is
+| not restricted, and the output from the Program is covered only if its contents
+| constitute a work based on the Program (independent of having been made by
+| running the Program).  Whether that is true depends on what the Program does.
+| 
+| 1. You may copy and distribute verbatim copies of the Program's source code as
+| you receive it, in any medium, provided that you conspicuously and
+| appropriately publish on each copy an appropriate copyright notice and
+| disclaimer of warranty; keep intact all the notices that refer to this License
+| and to the absence of any warranty; and give any other recipients of the
+| Program a copy of this License along with the Program.
+| 
+| You may charge a fee for the physical act of transferring a copy, and you may
+| at your option offer warranty protection in exchange for a fee.
+| 
+| 2. You may modify your copy or copies of the Program or any portion of it, thus
+| forming a work based on the Program, and copy and distribute such modifications
+| or work under the terms of Section 1 above, provided that you also meet all of
+| these conditions:
+| 
+|     a) You must cause the modified files to carry prominent notices stating
+|     that you changed the files and the date of any change.
+| 
+|     b) You must cause any work that you distribute or publish, that in whole or
+|     in part contains or is derived from the Program or any part thereof, to be
+|     licensed as a whole at no charge to all third parties under the terms of
+|     this License.
+| 
+|     c) If the modified program normally reads commands interactively when run,
+|     you must cause it, when started running for such interactive use in the
+|     most ordinary way, to print or display an announcement including an
+|     appropriate copyright notice and a notice that there is no warranty (or
+|     else, saying that you provide a warranty) and that users may redistribute
+|     the program under these conditions, and telling the user how to view a copy
+|     of this License.  (Exception: if the Program itself is interactive but does
+|     not normally print such an announcement, your work based on the Program is
+|     not required to print an announcement.)
+| 
+| These requirements apply to the modified work as a whole.  If identifiable
+| sections of that work are not derived from the Program, and can be reasonably
+| considered independent and separate works in themselves, then this License, and
+| its terms, do not apply to those sections when you distribute them as separate
+| works.  But when you distribute the same sections as part of a whole which is a
+| work based on the Program, the distribution of the whole must be on the terms
+| of this License, whose permissions for other licensees extend to the entire
+| whole, and thus to each and every part regardless of who wrote it.
+| 
+| Thus, it is not the intent of this section to claim rights or contest your
+| rights to work written entirely by you; rather, the intent is to exercise the
+| right to control the distribution of derivative or collective works based on
+| the Program.
+| 
+| In addition, mere aggregation of another work not based on the Program with the
+| Program (or with a work based on the Program) on a volume of a storage or
+| distribution medium does not bring the other work under the scope of this
+| License.
+| 
+| 3. You may copy and distribute the Program (or a work based on it, under
+| Section 2) in object code or executable form under the terms of Sections 1 and
+| 2 above provided that you also do one of the following:
+| 
+|     a) Accompany it with the complete corresponding machine-readable source
+|     code, which must be distributed under the terms of Sections 1 and 2 above
+|     on a medium customarily used for software interchange; or,
+| 
+|     b) Accompany it with a written offer, valid for at least three years, to
+|     give any third party, for a charge no more than your cost of physically
+|     performing source distribution, a complete machine-readable copy of the
+|     corresponding source code, to be distributed under the terms of Sections 1
+|     and 2 above on a medium customarily used for software interchange; or,
+| 
+|     c) Accompany it with the information you received as to the offer to
+|     distribute corresponding source code.  (This alternative is allowed only
+|     for noncommercial distribution and only if you received the program in
+|     object code or executable form with such an offer, in accord with
+|     Subsection b above.)
+| 
+| The source code for a work means the preferred form of the work for making
+| modifications to it.  For an executable work, complete source code means all
+| the source code for all modules it contains, plus any associated interface
+| definition files, plus the scripts used to control compilation and installation
+| of the executable.  However, as a special exception, the source code
+| distributed need not include anything that is normally distributed (in either
+| source or binary form) with the major components (compiler, kernel, and so on)
+| of the operating system on which the executable runs, unless that component
+| itself accompanies the executable.
+| 
+| If distribution of executable or object code is made by offering access to copy
+| from a designated place, then offering equivalent access to copy the source
+| code from the same place counts as distribution of the source code, even though
+| third parties are not compelled to copy the source along with the object code.
+| 
+| 4. You may not copy, modify, sublicense, or distribute the Program except as
+| expressly provided under this License.  Any attempt otherwise to copy, modify,
+| sublicense or distribute the Program is void, and will automatically terminate
+| your rights under this License.  However, parties who have received copies, or
+| rights, from you under this License will not have their licenses terminated so
+| long as such parties remain in full compliance.
+| 
+| 5. You are not required to accept this License, since you have not signed it.
+| However, nothing else grants you permission to modify or distribute the Program
+| or its derivative works.  These actions are prohibited by law if you do not
+| accept this License.  Therefore, by modifying or distributing the Program (or
+| any work based on the Program), you indicate your acceptance of this License to
+| do so, and all its terms and conditions for copying, distributing or modifying
+| the Program or works based on it.
+| 
+| 6. Each time you redistribute the Program (or any work based on the Program),
+| the recipient automatically receives a license from the original licensor to
+| copy, distribute or modify the Program subject to these terms and conditions.
+| You may not impose any further restrictions on the recipients' exercise of the
+| rights granted herein.  You are not responsible for enforcing compliance by
+| third parties to this License.
+| 
+| 7. If, as a consequence of a court judgment or allegation of patent
+| infringement or for any other reason (not limited to patent issues), conditions
+| are imposed on you (whether by court order, agreement or otherwise) that
+| contradict the conditions of this License, they do not excuse you from the
+| conditions of this License.  If you cannot distribute so as to satisfy
+| simultaneously your obligations under this License and any other pertinent
+| obligations, then as a consequence you may not distribute the Program at all.
+| For example, if a patent license would not permit royalty-free redistribution
+| of the Program by all those who receive copies directly or indirectly through
+| you, then the only way you could satisfy both it and this License would be to
+| refrain entirely from distribution of the Program.
+| 
+| If any portion of this section is held invalid or unenforceable under any
+| particular circumstance, the balance of the section is intended to apply and
+| the section as a whole is intended to apply in other circumstances.
+| 
+| It is not the purpose of this section to induce you to infringe any patents or
+| other property right claims or to contest validity of any such claims; this
+| section has the sole purpose of protecting the integrity of the free software
+| distribution system, which is implemented by public license practices.  Many
+| people have made generous contributions to the wide range of software
+| distributed through that system in reliance on consistent application of that
+| system; it is up to the author/donor to decide if he or she is willing to
+| distribute software through any other system and a licensee cannot impose that
+| choice.
+| 
+| This section is intended to make thoroughly clear what is believed to be a
+| consequence of the rest of this License.
+| 
+| 8. If the distribution and/or use of the Program is restricted in certain
+| countries either by patents or by copyrighted interfaces, the original
+| copyright holder who places the Program under this License may add an explicit
+| geographical distribution limitation excluding those countries, so that
+| distribution is permitted only in or among countries not thus excluded.  In
+| such case, this License incorporates the limitation as if written in the body
+| of this License.
+| 
+| 9. The Free Software Foundation may publish revised and/or new versions of the
+| General Public License from time to time.  Such new versions will be similar in
+| spirit to the present version, but may differ in detail to address new problems
+| or concerns.
+| 
+| Each version is given a distinguishing version number.  If the Program
+| specifies a version number of this License which applies to it and "any later
+| version", you have the option of following the terms and conditions either of
+| that version or of any later version published by the Free Software Foundation.
+| If the Program does not specify a version number of this License, you may
+| choose any version ever published by the Free Software Foundation.
+| 
+| 10. If you wish to incorporate parts of the Program into other free programs
+| whose distribution conditions are different, write to the author to ask for
+| permission.  For software which is copyrighted by the Free Software Foundation,
+| write to the Free Software Foundation; we sometimes make exceptions for this.
+| Our decision will be guided by the two goals of preserving the free status of
+| all derivatives of our free software and of promoting the sharing and reuse of
+| software generally.
+| 
+| NO WARRANTY
+| 
+| 11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+| THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE
+| STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+| PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+| INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+| FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND
+| PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE,
+| YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+| 
+| 12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+| ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+| PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+| GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+| INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
+| BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+| FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+| OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+| 
+| END OF TERMS AND CONDITIONS
+| 
+| How to Apply These Terms to Your New Programs
+| 
+| If you develop a new program, and you want it to be of the greatest possible
+| use to the public, the best way to achieve this is to make it free software
+| which everyone can redistribute and change under these terms.
+| 
+| To do so, attach the following notices to the program.  It is safest to attach
+| them to the start of each source file to most effectively convey the exclusion
+| of warranty; and each file should have at least the "copyright" line and a
+| pointer to where the full notice is found.
+| 
+|     One line to give the program's name and a brief idea of what it does.
+| 
+|     Copyright (C) <year> <name of author>
+| 
+|     This program is free software; you can redistribute it and/or modify it
+|     under the terms of the GNU General Public License as published by the Free
+|     Software Foundation; either version 2 of the License, or (at your option)
+|     any later version.
+| 
+|     This program is distributed in the hope that it will be useful, but WITHOUT
+|     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+|     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+|     more details.
+| 
+|     You should have received a copy of the GNU General Public License along
+|     with this program; if not, write to the Free Software Foundation, Inc., 59
+|     Temple Place, Suite 330, Boston, MA 02111-1307 USA
+| 
+| Also add information on how to contact you by electronic and paper mail.
+| 
+| If the program is interactive, make it output a short notice like this when it
+| starts in an interactive mode:
+| 
+|     Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+|     with ABSOLUTELY NO WARRANTY; for details type 'show w'.  This is free
+|     software, and you are welcome to redistribute it under certain conditions;
+|     type 'show c' for details.
+| 
+| The hypothetical commands 'show w' and 'show c' should show the appropriate
+| parts of the General Public License.  Of course, the commands you use may be
+| called something other than 'show w' and 'show c'; they could even be
+| mouse-clicks or menu items--whatever suits your program.
+| 
+| You should also get your employer (if you work as a programmer) or your school,
+| if any, to sign a "copyright disclaimer" for the program, if necessary.  Here
+| is a sample; alter the names:
+| 
+|     Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+|     'Gnomovision' (which makes passes at compilers) written by James Hacker.
+| 
+|     signature of Ty Coon, 1 April 1989
+| 
+|     Ty Coon, President of Vice
+| 
+| This General Public License does not permit incorporating your program into
+| proprietary programs.  If your program is a subroutine library, you may
+| consider it more useful to permit linking proprietary applications with the
+| library.  If this is what you want to do, use the GNU Library General Public
+| License instead of this License.
+| 
+| 
+| "CLASSPATH" EXCEPTION TO THE GPL
+| 
+| Certain source files distributed by Oracle America and/or its affiliates are
+| subject to the following clarification and special exception to the GPL, but
+| only where Oracle has expressly included in the particular source file's header
+| the words "Oracle designates this particular file as subject to the "Classpath"
+| exception as provided by Oracle in the LICENSE file that accompanied this code."
+| 
+|     Linking this library statically or dynamically with other modules is making
+|     a combined work based on this library.  Thus, the terms and conditions of
+|     the GNU General Public License cover the whole combination.
+| 
+|     As a special exception, the copyright holders of this library give you
+|     permission to link this library with independent modules to produce an
+|     executable, regardless of the license terms of these independent modules,
+|     and to copy and distribute the resulting executable under terms of your
+|     choice, provided that you also meet, for each linked independent module,
+|     the terms and conditions of the license of that module.  An independent
+|     module is a module which is not derived from or based on this library.  If
+|     you modify this library, you may extend this exception to your version of
+|     the library, but you are not obligated to do so.  If you do not wish to do
+|     so, delete this exception statement from your version.
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-alts Version: 1.69.1
+Group: io.grpc Name: grpc-api Version: 1.69.1
+Group: io.grpc Name: grpc-auth Version: 1.69.1
+Group: io.grpc Name: grpc-context Version: 1.69.1
+Group: io.grpc Name: grpc-core Version: 1.69.1
+Group: io.grpc Name: grpc-googleapis Version: 1.69.1
+Group: io.grpc Name: grpc-grpclb Version: 1.69.1
+Group: io.grpc Name: grpc-inprocess Version: 1.69.1
+Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
+Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
+Group: io.grpc Name: grpc-protobuf Version: 1.69.1
+Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
+Group: io.grpc Name: grpc-rls Version: 1.69.1
+Group: io.grpc Name: grpc-services Version: 1.69.1
+Group: io.grpc Name: grpc-stub Version: 1.69.1
+Group: io.grpc Name: grpc-util Version: 1.69.1
+Group: io.grpc Name: grpc-xds Version: 1.69.1
+
+NOTICE:
+| Copyright 2014 The gRPC Authors
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'OkHttp', an open source
+| HTTP & SPDY client for Android and Java applications, which can be obtained
+| at:
+| 
+|   * LICENSE:
+|     * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/square/okhttp
+|   * LOCATION_IN_GRPC:
+|     * okhttp/third_party/okhttp
+| 
+| This product contains a modified portion of 'Envoy', an open source
+| cloud-native high-performance edge/middle/service proxy, which can be
+| obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/envoy/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|     * xds/third_party/envoy/NOTICE
+|   * HOMEPAGE:
+|     * https://www.envoyproxy.io
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/envoy
+| 
+| This product contains a modified portion of 'protoc-gen-validate (PGV)',
+| an open source protoc plugin to generate polyglot message validators,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|       * xds/third_party/protoc-gen-validate/NOTICE
+|   * HOMEPAGE:
+|     * https://github.com/envoyproxy/protoc-gen-validate
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/protoc-gen-validate
+| 
+| This product contains a modified portion of 'udpa',
+| an open source universal data plane API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/udpa/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/cncf/udpa
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/udpa
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-commons Version: 1.14.5
+Group: io.micrometer Name: micrometer-core Version: 1.14.5
+Group: io.micrometer Name: micrometer-observation Version: 1.14.5
+
+NOTICE:
+| Micrometer
+| 
+| Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|    https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -------------------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'io.netty.util.internal.logging',
+| in the Netty/Common library distributed by The Netty Project:
+| 
+|   * Copyright 2013 The Netty Project
+|   * License: Apache License v2.0
+|   * Homepage: https://netty.io
+| 
+| This product contains a modified portion of 'StringUtils.isBlank()',
+| in the Commons Lang library distributed by The Apache Software Foundation:
+| 
+|   * Copyright 2001-2019 The Apache Software Foundation
+|   * License: Apache License v2.0
+|   * Homepage: https://commons.apache.org/proper/commons-lang/
+| 
+| This product contains a modified portion of 'JsonUtf8Writer',
+| in the Moshi library distributed by Square, Inc:
+| 
+|   * Copyright 2010 Google Inc.
+|   * License: Apache License v2.0
+|   * Homepage: https://github.com/square/moshi
+| 
+| This product contains a modified portion of the 'org.springframework.lang'
+| package in the Spring Framework library, distributed by VMware, Inc:
+| 
+|   * Copyright 2002-2019 the original author or authors.
+|   * License: Apache License v2.0
+|   * Homepage: https://spring.io/projects/spring-framework
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-buffer Version: 4.1.118.Final
+Group: io.netty Name: netty-codec Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-dns Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-haproxy Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-http Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-http2 Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-socks Version: 4.1.118.Final
+Group: io.netty Name: netty-common Version: 4.1.118.Final
+Group: io.netty Name: netty-handler Version: 4.1.118.Final
+Group: io.netty Name: netty-handler-proxy Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.118.Final
+Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
+Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
+Group: io.netty Name: netty-transport Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-epoll Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.118.Final
+
+NOTICE:
+| 
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * https://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.zstd-jni.txt (BSD)
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|     
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+| 
+| 
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| 
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+| 
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| 
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+|   * HOMEPAGE:
+|     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| 
+| This product optionally depends on 'Brotli4j', Brotli compression and
+| decompression for Java., which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/hyperxpro/Brotli4j
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark Name: perfmark-api Version: 0.27.0
+
+NOTICE:
+| 
+| Copyright 2019 Google LLC
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'Catapult', an open source
+| Trace Event viewer for Chome, Linux, and Android applications, which can 
+| be obtained at:
+| 
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/catapult/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/catapult-project/catapult
+| 
+| This product contains a modified portion of 'Polymer', a library for Web
+| Components, which can be obtained at:
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/polymer/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/Polymer/polymer
+| 
+| 
+| This product contains a modified portion of 'ASM', an open source
+| Java Bytecode library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * agent/src/main/resources/io/perfmark/agent/third_party/asm/LICENSE (BSD style License)
+|   * HOMEPAGE:
+|     * https://asm.ow2.io/
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config Version: 3.11.4
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.11.4
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.11.4
+
+NOTICE:
+| Copyright 2009-2017 Mark Struberg
+| Copyright 2018 Red Hat, inc.
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-annotations Version: 1.6.15
+Group: io.swagger Name: swagger-core Version: 1.6.15
+Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
+Group: io.swagger Name: swagger-models Version: 1.6.15
+
+NOTICE:
+| Swagger Core - ${pom.name}
+| Copyright (c) 2015. SmartBear Software Inc.
+| Swagger Core - ${pom.name}  is licensed under Apache 2.0 license.
+| Copy of the Apache 2.0 license can be found in `LICENSE` file.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+| 
+| ## FastDoubleParser
+| 
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+|  
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+| 
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson components are licensed under Apache (Software) License, version 2.0,
+| as per accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jdk8 Version: 2.18.2
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
+Group: com.fasterxml.jackson.module Name: jackson-module-parameter-names Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson components are licensed under Apache (Software) License, version 2.0,
+| as per accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
+Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
+
+NOTICE:
+| # Notices for Jakarta Contexts and Dependency Injection
+| 
+| This content is produced and maintained by the Jakarta Contexts and Dependency Injection
+| project.
+| 
+| * Project home: https://projects.eclipse.org/projects/ee4j.cdi
+| 
+| ## Trademarks
+| 
+| Jakarta Contexts and Dependency Injection is a trademark of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License v. 2.0 which is available at
+| http://www.apache.org/licenses/LICENSE-2.0
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+| * https://github.com/jakartaee/cdi
+| * https://github.com/jakartaee/cdi-tck
+| * https://github.com/jakartaee/inject
+| * https://github.com/jakartaee/inject-spec
+| * https://github.com/jakartaee/inject-tck
+| 
+| The project also maintains the following legacy CPL licensed source code repositories:
+| 
+| * https://github.com/eclipse-ee4j/cdi-cpl
+| * https://github.com/eclipse-ee4j/cdi-tck-cpl
+| 
+| ## Third-party Content
+| 
+| ## Cryptography
+| 
+| Content may contain encryption software. The country in which you are currently
+| may have restrictions on the import, possession, and use, and/or re-export to
+| another country, of encryption software. BEFORE using any encryption software,
+| please check the country's laws, regulations and policies concerning the import,
+| possession, or use, and re-export of encryption software, to see if this is
+| permitted.
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
+
+NOTICE:
+| # Notices for Eclipse Jakarta Validation
+| 
+| This content is produced and maintained by the Eclipse Jakarta Validation
+| project.
+| 
+| * Project home: https://projects.eclipse.org/projects/ee4j.validation
+| 
+| ## Trademarks
+| 
+|  Jakarta Validation is a trademark of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License, Version 2.0 which is available at
+| https://www.apache.org/licenses/LICENSE-2.0.
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+| * [The specification repository](https://github.com/jakartaee/validation-spec)
+| * [The API repository](https://github.com/jakartaee/validation)
+| * [The TCK repository](https://github.com/jakartaee/validation-tck)
+| 
+| ## Third-party Content
+| 
+| This project leverages the following third party content.
+| 
+| Test dependencies:
+| 
+|  * [TestNG](https://github.com/cbeust/testng) - Apache License 2.0
+|  * [JCommander](https://github.com/cbeust/jcommander) - Apache License 2.0
+|  * [SnakeYAML](https://bitbucket.org/asomov/snakeyaml/src) - Apache License 2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
+
+NOTICE:
+| Copyright 2016 The Android Open Source Project
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|      http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| This product contains a modified portion of `Netty`, a configurable network
+| stack in Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.netty.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://netty.io/
+| 
+| This product contains a modified portion of `Apache Harmony`, modular Java runtime,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://harmony.apache.org/
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
+
+NOTICE:
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for Microprofile Config                  ==
+| =========================================================================
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+| 
+| Portions of this software were originally based on the following:
+| * Apache DeltaSpike Config
+|   https://deltaspike.apache.org
+|   under Apache License, v2.0
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse Microprofile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Mark Struberg struberg@apache.org,
+| Gerhard Petracek gpetracek@apache.org,
+| Romain Manni-Bucau rmannibucau@apache.org,
+| Ron Smeral rsmeral@apache.org,
+| Emily Jiang emijiang@uk.ibm.com,
+| Ondrej Mihalyi ondrej.mihalyi@gmail.com,
+| Gunnar Morling gunnar@hibernate.org
+| </text>
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.11
+Group: software.amazon.awssdk Name: arns Version: 2.31.11
+Group: software.amazon.awssdk Name: auth Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.11
+Group: software.amazon.awssdk Name: checksums Version: 2.31.11
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.11
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.11
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.11
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.11
+Group: software.amazon.awssdk Name: profiles Version: 2.31.11
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.11
+Group: software.amazon.awssdk Name: regions Version: 2.31.11
+Group: software.amazon.awssdk Name: retries Version: 2.31.11
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: s3 Version: 2.31.11
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.11
+Group: software.amazon.awssdk Name: sts Version: 2.31.11
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.11
+Group: software.amazon.awssdk Name: utils Version: 2.31.11
+
+NOTICE:
+| AWS SDK for Java
+| Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+| 
+| This product includes software developed by
+| Amazon Technologies, Inc (http://www.amazon.com/).
+| 
+| **********************
+| THIRD PARTY COMPONENTS
+| **********************
+| This software includes third party software subject to the following copyrights:
+| - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+| - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+| 
+| The licenses for these third party components are included in LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
+
+NOTICE:
+| AWS EventStream for Java
+| Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+
+--------------------------------------------------------------------------------

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -87,8 +87,8 @@ distributions {
     contents {
       from(runScript)
       from(project.layout.buildDirectory.dir("quarkus-app"))
-      from("../../NOTICE")
-      from("../../LICENSE-BINARY-DIST").rename("LICENSE-BINARY-DIST", "LICENSE")
+      from("distribution/NOTICE")
+      from("distribution/LICENSE")
       exclude("lib/main/io.quarkus.quarkus-container-image*")
     }
   }

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -1,0 +1,2482 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact bundles the following projects:
+
+--------------------------------------------------------------------------------
+
+Group: io.github.crac Name: org.crac Version: 0.1.3
+Project URL (from POM): https://github.com/crac/org.crac
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-bootstrap-runner Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-classloader-commons Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-development-mode-spi Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-vertx-latebound-mdc-provider Version: 3.19.4
+Project URL: https://quarkus.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-constraint Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-cpu Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-expression Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-function Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-io Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-net Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-os Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-ref Version: 2.10.0
+Project URL: https://smallrye.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.json Name: jakarta.json-api Version: 2.1.3
+Project URL (from POM): https://github.com/eclipse-ee4j/jsonp
+License (from POM): Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://projects.eclipse.org/license/secondary-gpl-2.0-cp
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.parsson Name: parsson Version: 1.1.7
+Project URL: https://github.com/eclipse-ee4j/parsson
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logging Name: jboss-logging Version: 3.6.1.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logmanager Name: jboss-logmanager Version: 3.1.2.Final
+Project URL: http://www.jboss.org
+License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.aayushatharva.brotli4j Name: brotli4j Version: 1.16.0
+Project URL: https://github.com/hyperxpro/Brotli4j
+License: Apache License 2.0 - https://github.com/hyperxpro/Brotli4j/blob/v1.16.0/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.aayushatharva.brotli4j Name: service Version: 1.16.0
+Project URL: https://github.com/hyperxpro/Brotli4j
+License: Apache License 2.0 - https://github.com/hyperxpro/Brotli4j/blob/v1.16.0/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.auth0 Name: java-jwt Version: 4.5.0
+Project URL (from POM): https://github.com/auth0/java-jwt
+License (from POM): The MIT License (MIT) - https://raw.githubusercontent.com/auth0/java-jwt/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-core Version: 1.55.3
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-core-http-netty Version: 1.15.11
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-identity Version: 1.15.4
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-json Version: 1.5.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-blob Version: 12.30.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-common Version: 12.29.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-file-datalake Version: 12.23.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-storage-internal-avro Version: 12.15.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure Name: azure-xml Version: 1.2.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml Name: classmate Version: 1.7.0
+Project URL (from POM): https://github.com/FasterXML/java-classmate
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jdk8 Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module Name: jackson-module-parameter-names Version: 2.18.2
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.woodstox Name: woodstox-core Version: 5.4.0
+Project URL (from POM): https://github.com/FasterXML/woodstox
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
+Project URL (from POM): https://github.com/ben-manes/caffeine
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.stephenc.jcip Name: jcip-annotations Version: 1.0-1
+Project URL (from POM): http://stephenc.github.com/jcip-annotations
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.android Name: annotations Version: 4.1.1.4
+Project URL (from POM): http://source.android.com/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api-client Name: google-api-client Version: 2.7.2
+Project URL (from POM): https://github.com/googleapis/google-api-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: api-common Version: 2.46.1
+Project URL (from POM): https://github.com/googleapis/api-common-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax-grpc Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api Name: gax-httpjson Version: 2.63.1
+Project URL (from POM): https://github.com/googleapis/gax-java
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-cloud-monitoring-v3 Version: 3.52.0
+Project URL (from POM): https://github.com/googleapis/google-cloud-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-common-protos Version: 2.51.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.49.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250224-2.0.0
+Project URL (from POM): http://www.google.com
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth Name: google-auth-library-credentials Version: 1.33.1
+Project URL (from POM): https://github.com/googleapis/google-auth-library-java
+License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.33.1
+Project URL (from POM): https://github.com/googleapis/google-auth-library-java
+License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auto.value Name: auto-value-annotations Version: 1.11.0
+Project URL (from POM): https://github.com/google/auto
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-core-http Version: 2.53.1
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-monitoring Version: 3.52.0
+Project URL (from POM): https://github.com/googleapis/google-cloud-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud Name: google-cloud-storage Version: 2.50.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: detector-resources-support Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: exporter-metrics Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud.opentelemetry Name: shared-resourcemapping Version: 0.33.0
+Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.gson Name: gson Version: 2.12.1
+Project URL (from POM): https://github.com/google/gson
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.errorprone Name: error_prone_annotations Version: 2.36.0
+Project URL (from POM): https://errorprone.info
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: failureaccess Version: 1.0.1
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: guava Version: 33.4.0-jre
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava Name: listenablefuture Version: 9999.0-empty-to-avoid-conflict-with-guava
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-apache-v2 Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-appengine Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-gson Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client Name: google-http-client-jackson2 Version: 1.46.1
+Project URL (from POM): https://github.com/googleapis/google-http-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.j2objc Name: j2objc-annotations Version: 2.8
+Project URL (from POM): https://github.com/google/j2objc/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.oauth-client Name: google-oauth-client Version: 1.37.0
+Project URL (from POM): https://github.com/googleapis/google-oauth-java-client
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf Name: protobuf-java Version: 3.25.5
+Project URL (from POM): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf Name: protobuf-java-util Version: 3.25.5
+Project URL (from POM): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.re2j Name: re2j Version: 1.7
+Project URL (from POM): http://github.com/google/re2j
+License (from POM): Go License - https://golang.org/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.jcraft Name: jsch Version: 0.1.55
+Project URL (from POM): http://www.jcraft.com/jsch/
+License (from POM): BSD License - http://www.jcraft.com/jsch/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure Name: msal4j Version: 1.19.1
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure Name: msal4j-persistence-extension Version: 1.3.0
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: content-type Version: 2.3
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: lang-tag Version: 1.7
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: nimbus-jose-jwt Version: 10.0
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds Name: oauth2-oidc-sdk Version: 11.18
+Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-beanutils Name: commons-beanutils Version: 1.9.4
+Project URL (from POM): https://commons.apache.org/proper/commons-beanutils/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-cli Name: commons-cli Version: 1.5.0
+Project URL (from POM): https://commons.apache.org/proper/commons-cli/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec Name: commons-codec Version: 1.18.0
+Project URL (from POM): https://commons.apache.org/proper/commons-codec/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-collections Name: commons-collections Version: 3.2.2
+Project URL (from POM): http://commons.apache.org/collections/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-io Name: commons-io Version: 2.18.0
+Project URL (from POM): https://commons.apache.org/proper/commons-io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-logging Name: commons-logging Version: 1.3.2
+Project URL (from POM): https://commons.apache.org/proper/commons-logging/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-net Name: commons-net Version: 3.9.0
+Project URL (from POM): https://commons.apache.org/proper/commons-net/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: dev.failsafe Name: failsafe Version: 3.3.2
+Project URL (from POM): https://failsafe.dev
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: dnsjava Name: dnsjava Version: 3.6.1
+Project URL (from POM): https://github.com/dnsjava/dnsjava
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: io.airlift Name: aircompressor Version: 2.0.2
+Project URL (from POM): https://github.com/airlift/aircompressor
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-alts Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-api Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-auth Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-context Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-core Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-googleapis Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-grpclb Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-inprocess Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-netty Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-protobuf Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-rls Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-services Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-stub Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-util Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-xds Version: 1.69.1
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-commons Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-core Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-observation Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.5
+Project URL (from POM): https://github.com/micrometer-metrics/micrometer
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-buffer Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-dns Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-haproxy Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-http Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-http2 Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-codec-socks Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-common Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-handler Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-handler-proxy Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-epoll Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.118.Final
+Project URL (from POM): https://netty.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus Name: opencensus-api Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus Name: opencensus-contrib-http-util Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-contrib
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-annotations Version: 2.10.0
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-annotations-support Version: 2.10.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-api Version: 2.10.0
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-api-incubator Version: 2.10.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-runtime-telemetry-java17 Version: 2.10.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.instrumentation Name: opentelemetry-runtime-telemetry-java8 Version: 2.10.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-api Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-api-incubator Version: 1.44.1-alpha
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-context Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-exporter-common Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-exporter-otlp Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-exporter-otlp-common Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-exporter-sender-okhttp Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-common Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-logs Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry Name: opentelemetry-sdk-trace Version: 1.44.1
+Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.28.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opentelemetry.semconv Name: opentelemetry-semconv-incubating Version: 1.29.0-alpha
+Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark Name: perfmark-api Version: 0.27.0
+Project URL (from POM): https://github.com/perfmark/perfmark
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.4
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.4
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor Name: reactor-core Version: 3.7.4
+Project URL (from POM): https://github.com/reactor/reactor-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient Version: 0.16.0
+Project URL (from POM): http://github.com/prometheus/client_java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient_common Version: 0.16.0
+Project URL (from POM): http://github.com/prometheus/client_java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient_tracer_common Version: 0.16.0
+Project URL (from POM): http://github.com/prometheus/client_java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient_tracer_otel Version: 0.16.0
+Project URL (from POM): http://github.com/prometheus/client_java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient_tracer_otel_agent Version: 0.16.0
+Project URL (from POM): http://github.com/prometheus/client_java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.arc Name: arc Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-arc Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-core Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-credentials Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-grpc-common Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-hibernate-validator Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-jackson Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-jsonp Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-logging-json Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-micrometer Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-micrometer-registry-prometheus Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-mutiny Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-netty Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-opentelemetry Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-reactive-routes Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-rest Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-rest-common Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-rest-jackson Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-rest-jackson-common Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-security-runtime-spi Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-smallrye-context-propagation Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-smallrye-health Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-tls-registry Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-vertx Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-vertx-http Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus Name: quarkus-virtual-threads Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.resteasy Name: reactive.resteasy-reactive Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common-types Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-jackson Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-vertx Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.security Name: quarkus-security Version: 2.2.1
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.quarkus.vertx.utils Name: quarkus-vertx-utils Version: 3.19.4
+Project URL (from POM): https://quarkus.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.certs Name: smallrye-private-key-pem-parser Version: 0.9.2
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.10.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.10.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.common Name: smallrye-common-vertx-context Version: 2.10.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config-validator Version: 3.11.4
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: mutiny-smallrye-context-propagation Version: 2.8.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: mutiny-zero-flow-adapters Version: 1.1.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-auth-common Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-bridge-common Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-core Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-runtime Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-uri-template Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web-common Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.reactive Name: vertx-mutiny-generator Version: 3.18.1
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-context-propagation Version: 2.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-context-propagation-api Version: 2.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-context-propagation-storage Version: 2.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-fault-tolerance-vertx Version: 6.9.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-health Version: 4.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-health-api Version: 4.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye Name: smallrye-health-provided-checks Version: 4.2.0
+Project URL (from POM): https://smallrye.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-annotations Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-core Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-models Version: 1.6.15
+Project URL (from POM): https://github.com/swagger-api/swagger-core
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-auth-common Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-bridge-common Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-codegen Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-core Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-grpc Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-grpc-client Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-grpc-common Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-grpc-server Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-uri-template Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-web Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: io.vertx Name: vertx-web-common Version: 4.5.13
+Project URL: https://vertx.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation Name: jakarta.activation-api Version: 2.1.3
+Project URL (from POM): https://github.com/jakartaee/jaf-api
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.annotation Name: jakarta.annotation-api Version: 3.0.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.ca
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.el Name: jakarta.el-api Version: 5.0.1
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.el
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
+Project URL (from POM): http://cdi-spec.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.lang-model Version: 4.1.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
+Project URL (from POM): https://github.com/eclipse-ee4j/injection-api
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.interceptor Name: jakarta.interceptor-api Version: 2.2.0
+Project URL (from POM): https://github.com/jakartaee/interceptors
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.servlet Name: jakarta.servlet-api Version: 6.0.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.servlet
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.transaction Name: jakarta.transaction-api Version: 2.0.1
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j.jta
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
+Project URL (from POM): https://beanvalidation.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.ws.rs Name: jakarta.ws.rs-api Version: 3.1.0
+Project URL (from POM): https://github.com/eclipse-ee4j/jaxrs-api
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind Name: jakarta.xml.bind-api Version: 4.0.2
+Project URL (from POM): https://github.com/jakartaee/jaxb-api
+License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet Name: javax.servlet-api Version: 3.1.0
+Project URL (from POM): http://servlet-spec.java.net
+License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet.jsp Name: jsp-api Version: 2.1
+Project URL (from POM): http://servlet-spec.java.net
+License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.validation Name: validation-api Version: 1.1.0.Final
+Project URL (from POM): https://beanvalidation.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: javax.ws.rs Name: jsr311-api Version: 1.1.1
+Project URL (from POM): https://jsr311.dev.java.net
+License (from POM): CDDL License - http://www.opensource.org/licenses/cddl1.php
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna Name: jna Version: 5.8.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna Name: jna-platform Version: 5.8.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev Name: accessors-smart Version: 2.5.1
+Project URL (from POM): https://urielch.github.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev Name: json-smart Version: 2.5.1
+Project URL (from POM): https://urielch.github.io/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro Name: avro Version: 1.12.0
+Project URL (from POM): https://avro.apache.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-compress Version: 1.27.1
+Project URL (from POM): https://commons.apache.org/proper/commons-compress/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-configuration2 Version: 2.11.0
+Project URL (from POM): https://commons.apache.org/proper/commons-configuration/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-lang3 Version: 3.17.0
+Project URL (from POM): https://commons.apache.org/proper/commons-lang/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-math3 Version: 3.6.1
+Project URL (from POM): http://commons.apache.org/proper/commons-math/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons Name: commons-text Version: 1.13.0
+Project URL (from POM): https://commons.apache.org/proper/commons-text
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator Name: curator-client Version: 5.2.0
+Project URL (from POM): http://curator.apache.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator Name: curator-framework Version: 5.2.0
+Project URL (from POM): http://curator.apache.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator Name: curator-recipes Version: 5.2.0
+Project URL (from POM): http://curator.apache.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-annotations Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-auth Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-client-api Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-client-runtime Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-common Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop Name: hadoop-hdfs-client Version: 3.4.1
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty Name: hadoop-shaded-guava Version: 1.3.0
+Project URL (from POM): https://hadoop.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5 Name: httpclient5 Version: 5.4
+Project URL (from POM): https://hc.apache.org/httpcomponents-client-5.4.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5 Name: httpcore5 Version: 5.3
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5 Name: httpcore5-h2 Version: 5.3
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents Name: httpclient Version: 4.5.14
+Project URL (from POM): https://hc.apache.org/httpcomponents-client-4.5.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents Name: httpcore Version: 4.4.16
+Project URL (from POM): https://hc.apache.org/httpcomponents-core-4.4.x/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-api Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-aws Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-azure Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-bundled-guava Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-common Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-core Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.iceberg Name: iceberg-gcp Version: 1.7.1
+Project URL (from POM): https://iceberg.apache.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerb-core Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerb-crypto Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerb-util Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerby-asn1 Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerby-config Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerby-pkix Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby Name: kerby-util Version: 2.0.3
+Project URL (from POM): https://directory.apache.org/kerby/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.bouncycastle Name: bcprov-jdk18on Version: 1.80
+Project URL (from POM): https://www.bouncycastle.org/download/bouncy-castle-java/
+License (from POM): Bouncy Castle Licence - https://www.bouncycastle.org/licence.html
+
+--------------------------------------------------------------------------------
+
+Group: org.checkerframework Name: checker-qual Version: 3.49.0
+Project URL (from POM): https://checkerframework.org/
+License (from POM): MIT License - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.jettison Name: jettison Version: 1.5.4
+Project URL (from POM): https://github.com/jettison-json/jettison
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.mojo Name: animal-sniffer-annotations Version: 1.24
+Project URL (from POM): https://www.mojohaus.org/animal-sniffer
+License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.woodstox Name: stax2-api Version: 4.2.1
+Project URL (from POM): http://github.com/FasterXML/stax2-api
+License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
+Project URL (from POM): https://conscrypt.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-http Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-io Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-security Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-server Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-servlet Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-util Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-util-ajax Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-webapp Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-xml Version: 9.4.53.v20231009
+Project URL (from POM): https://eclipse.org/jetty
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
+Project URL (from POM): http://microprofile.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.context-propagation Name: microprofile-context-propagation-api Version: 1.3
+Project URL (from POM): http://microprofile.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.health Name: microprofile-health-api Version: 4.0.1
+Project URL (from POM): http://microprofile.io
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.glassfish.expressly Name: expressly Version: 5.0.0
+Project URL (from POM): https://projects.eclipse.org/projects/ee4j
+License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: org.hdrhistogram Name: HdrHistogram Version: 2.2.2
+Project URL (from POM): http://hdrhistogram.github.io/HdrHistogram/
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: org.hibernate.validator Name: hibernate-validator Version: 8.0.2.Final
+Project URL (from POM): http://hibernate.org/validator
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.javassist Name: javassist Version: 3.28.0-GA
+Project URL (from POM): http://www.javassist.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logging Name: commons-logging-jboss-logging Version: 1.0.0.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.logging Name: jboss-logging-annotations Version: 3.0.4.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.slf4j Name: slf4j-jboss-logmanager Version: 2.0.0.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jboss.threads Name: jboss-threads Version: 3.8.0.Final
+Project URL (from POM): http://www.jboss.org
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jctools Name: jctools-core Version: 4.0.5
+Project URL: https://github.com/JCTools/JCTools
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jspecify Name: jspecify Version: 1.0.0
+Project URL (from POM): http://jspecify.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.latencyutils Name: LatencyUtils Version: 2.0.3
+Project URL (from POM): http://latencyutils.github.io/LatencyUtils/
+License (from POM): Public Domain, per Creative Commons CC0 - http://creativecommons.org/publicdomain/zero/1.0/
+
+--------------------------------------------------------------------------------
+
+Group: org.ow2.asm Name: asm Version: 9.7.1
+Project URL (from POM): http://asm.ow2.io/
+License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+
+--------------------------------------------------------------------------------
+
+Group: org.reactivestreams Name: reactive-streams Version: 1.0.4
+Project URL (from POM): http://www.reactive-streams.org/
+License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+
+--------------------------------------------------------------------------------
+
+Group: org.reflections Name: reflections Version: 0.10.2
+Project URL (from POM): http://github.com/ronmamo/reflections
+License (from POM): WTFPL - http://www.wtfpl.net
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.roaringbitmap Name: RoaringBitmap Version: 1.3.0
+Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.slf4j Name: slf4j-api Version: 2.0.6
+Project URL (from POM): http://www.slf4j.org
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten Name: threetenbp Version: 1.7.0
+Project URL (from POM): https://www.threeten.org/threetenbp
+License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
+Project URL (from POM): https://www.jboss.org/
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.xerial.snappy Name: snappy-java Version: 1.1.10.5
+Project URL (from POM): https://github.com/xerial/snappy-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.yaml Name: snakeyaml Version: 2.3
+Project URL (from POM): https://bitbucket.org/snakeyaml/snakeyaml
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: annotations Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: arns Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: auth Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: checksums Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: profiles Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: regions Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: retries Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: s3 Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: sts Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: utils Version: 2.31.11
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
+Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------

--- a/quarkus/server/distribution/NOTICE
+++ b/quarkus/server/distribution/NOTICE
@@ -1,0 +1,1090 @@
+Apache Polaris (incubating)
+Copyright 2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The initial code for the Polaris project was donated
+to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+
+--------------------------------------------------------------------------------
+
+This binary artifact bundles the following projects with NOTICE:
+
+--------------------------------------------------------------------------------
+
+Group: com.aayushatharva.brotli4j Name: brotli4j Version: 1.16.0
+Group: com.aayushatharva.brotli4j Name: service Version: 1.16.0
+
+NOTICE:
+| =============== Brotli4j ===============
+| 
+| Copyright 2021, Aayush Atharva
+| 
+|   Brotli4j licenses this file to you under the
+|   Apache License, Version 2.0 (the "License");
+|   you may not use this file except in compliance with the License.
+|   You may obtain a copy of the License at
+|   
+|        http://www.apache.org/licenses/LICENSE-2.0
+|        
+|   Unless required by applicable law or agreed to in writing, software
+|   distributed under the License is distributed on an "AS IS" BASIS,
+|   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|   See the License for the specific language governing permissions and
+|   limitations under the License.
+| 
+| =========================================
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'LICENSES' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| ---------------------------------
+| This product depends on 'Google Brotli'. License for the same can be obtained at:
+| 
+|   * LICENSE:
+|     * LICENSES/LICENSE.googlebrotli.txt (MIT License)
+| 
+| ---------------------------------
+| This product depends on 'Netty ByteBuf'. License for the same can be obtained at:
+| 
+|   * LICENSE:
+|     * LICENSES/LICENSE.netty.txt (Apache License 2.0)
+| 
+| ---------------------------------
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc Name: grpc-alts Version: 1.69.1
+Group: io.grpc Name: grpc-api Version: 1.69.1
+Group: io.grpc Name: grpc-auth Version: 1.69.1
+Group: io.grpc Name: grpc-context Version: 1.69.1
+Group: io.grpc Name: grpc-core Version: 1.69.1
+Group: io.grpc Name: grpc-googleapis Version: 1.69.1
+Group: io.grpc Name: grpc-grpclb Version: 1.69.1
+Group: io.grpc Name: grpc-inprocess Version: 1.69.1
+Group: io.grpc Name: grpc-netty Version: 1.69.1
+Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
+Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
+Group: io.grpc Name: grpc-protobuf Version: 1.69.1
+Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
+Group: io.grpc Name: grpc-rls Version: 1.69.1
+Group: io.grpc Name: grpc-services Version: 1.69.1
+Group: io.grpc Name: grpc-stub Version: 1.69.1
+Group: io.grpc Name: grpc-util Version: 1.69.1
+Group: io.grpc Name: grpc-xds Version: 1.69.1
+
+NOTICE:
+| Copyright 2014 The gRPC Authors
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'OkHttp', an open source
+| HTTP & SPDY client for Android and Java applications, which can be obtained
+| at:
+| 
+|   * LICENSE:
+|     * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/square/okhttp
+|   * LOCATION_IN_GRPC:
+|     * okhttp/third_party/okhttp
+| 
+| This product contains a modified portion of 'Envoy', an open source
+| cloud-native high-performance edge/middle/service proxy, which can be
+| obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/envoy/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|     * xds/third_party/envoy/NOTICE
+|   * HOMEPAGE:
+|     * https://www.envoyproxy.io
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/envoy
+| 
+| This product contains a modified portion of 'protoc-gen-validate (PGV)',
+| an open source protoc plugin to generate polyglot message validators,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|       * xds/third_party/protoc-gen-validate/NOTICE
+|   * HOMEPAGE:
+|     * https://github.com/envoyproxy/protoc-gen-validate
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/protoc-gen-validate
+| 
+| This product contains a modified portion of 'udpa',
+| an open source universal data plane API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/udpa/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/cncf/udpa
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/udpa
+
+--------------------------------------------------------------------------------
+
+Group: io.micrometer Name: micrometer-commons Version: 1.14.5
+Group: io.micrometer Name: micrometer-core Version: 1.14.5
+Group: io.micrometer Name: micrometer-observation Version: 1.14.5
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.5
+
+NOTICE:
+| Micrometer
+| 
+| Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|    https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -------------------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'io.netty.util.internal.logging',
+| in the Netty/Common library distributed by The Netty Project:
+| 
+|   * Copyright 2013 The Netty Project
+|   * License: Apache License v2.0
+|   * Homepage: https://netty.io
+| 
+| This product contains a modified portion of 'StringUtils.isBlank()',
+| in the Commons Lang library distributed by The Apache Software Foundation:
+| 
+|   * Copyright 2001-2019 The Apache Software Foundation
+|   * License: Apache License v2.0
+|   * Homepage: https://commons.apache.org/proper/commons-lang/
+| 
+| This product contains a modified portion of 'JsonUtf8Writer',
+| in the Moshi library distributed by Square, Inc:
+| 
+|   * Copyright 2010 Google Inc.
+|   * License: Apache License v2.0
+|   * Homepage: https://github.com/square/moshi
+| 
+| This product contains a modified portion of the 'org.springframework.lang'
+| package in the Spring Framework library, distributed by VMware, Inc:
+| 
+|   * Copyright 2002-2019 the original author or authors.
+|   * License: Apache License v2.0
+|   * Homepage: https://spring.io/projects/spring-framework
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty-buffer Version: 4.1.118.Final
+Group: io.netty Name: netty-codec Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-dns Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-haproxy Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-http Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-http2 Version: 4.1.118.Final
+Group: io.netty Name: netty-codec-socks Version: 4.1.118.Final
+Group: io.netty Name: netty-common Version: 4.1.118.Final
+Group: io.netty Name: netty-handler Version: 4.1.118.Final
+Group: io.netty Name: netty-handler-proxy Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.118.Final
+Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.118.Final
+Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
+Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
+Group: io.netty Name: netty-transport Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-epoll Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.118.Final
+Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.118.Final
+
+NOTICE:
+| 
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * https://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.zstd-jni.txt (BSD)
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|     
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+| 
+| 
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| 
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+| 
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| 
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+|   * HOMEPAGE:
+|     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| 
+| This product optionally depends on 'Brotli4j', Brotli compression and
+| decompression for Java., which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/hyperxpro/Brotli4j
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark Name: perfmark-api Version: 0.27.0
+
+NOTICE:
+| 
+| Copyright 2019 Google LLC
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'Catapult', an open source
+| Trace Event viewer for Chome, Linux, and Android applications, which can 
+| be obtained at:
+| 
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/catapult/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/catapult-project/catapult
+| 
+| This product contains a modified portion of 'Polymer', a library for Web
+| Components, which can be obtained at:
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/polymer/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/Polymer/polymer
+| 
+| 
+| This product contains a modified portion of 'ASM', an open source
+| Java Bytecode library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * agent/src/main/resources/io/perfmark/agent/third_party/asm/LICENSE (BSD style License)
+|   * HOMEPAGE:
+|     * https://asm.ow2.io/
+
+--------------------------------------------------------------------------------
+
+Group: io.prometheus Name: simpleclient Version: 0.16.0
+Group: io.prometheus Name: simpleclient_common Version: 0.16.0
+Group: io.prometheus Name: simpleclient_tracer_common Version: 0.16.0
+Group: io.prometheus Name: simpleclient_tracer_otel Version: 0.16.0
+Group: io.prometheus Name: simpleclient_tracer_otel_agent Version: 0.16.0
+
+NOTICE:
+| Prometheus instrumentation library for JVM applications
+| Copyright 2012-2015 The Prometheus Authors
+| 
+| This product includes software developed at
+| Boxever Ltd. (http://www.boxever.com/).
+| 
+| This product includes software developed at
+| SoundCloud Ltd. (http://soundcloud.com/).
+| 
+| This product includes software developed as part of the
+| Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
+
+--------------------------------------------------------------------------------
+
+Group: io.smallrye.config Name: smallrye-config Version: 3.11.4
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.11.4
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.11.4
+Group: io.smallrye.config Namee: smallrye-config-validator Version: 3.11.4
+
+NOTICE:
+| Copyright 2009-2017 Mark Struberg
+| Copyright 2018 Red Hat, inc.
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+Group: io.swagger Name: swagger-annotations Version: 1.6.15
+Group: io.swagger Name: swagger-core Version: 1.6.15
+Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
+Group: io.swagger Name: swagger-models Version: 1.6.15
+
+NOTICE:
+| Swagger Core - ${pom.name}
+| Copyright (c) 2015. SmartBear Software Inc.
+| Swagger Core - ${pom.name}  is licensed under Apache 2.0 license.
+| Copy of the Apache 2.0 license can be found in `LICENSE` file.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+| 
+| ## FastDoubleParser
+| 
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+|  
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+| 
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
+| ## Licensing
+| 
+| Jackson components are licensed under Apache (Software) License, version 2.0,
+| as per accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jdk8 Version: 2.18.2
+Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
+Group: com.fasterxml.jackson.module Name: jackson-module-parameter-names Version: 2.18.2
+
+NOTICE:
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson components are licensed under Apache (Software) License, version 2.0,
+| as per accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
+Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
+
+NOTICE:
+| # Notices for Jakarta Contexts and Dependency Injection
+| 
+| This content is produced and maintained by the Jakarta Contexts and Dependency Injection
+| project.
+| 
+| * Project home: https://projects.eclipse.org/projects/ee4j.cdi
+| 
+| ## Trademarks
+| 
+| Jakarta Contexts and Dependency Injection is a trademark of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License v. 2.0 which is available at
+| http://www.apache.org/licenses/LICENSE-2.0
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+| * https://github.com/jakartaee/cdi
+| * https://github.com/jakartaee/cdi-tck
+| * https://github.com/jakartaee/inject
+| * https://github.com/jakartaee/inject-spec
+| * https://github.com/jakartaee/inject-tck
+| 
+| The project also maintains the following legacy CPL licensed source code repositories:
+| 
+| * https://github.com/eclipse-ee4j/cdi-cpl
+| * https://github.com/eclipse-ee4j/cdi-tck-cpl
+| 
+| ## Third-party Content
+| 
+| ## Cryptography
+| 
+| Content may contain encryption software. The country in which you are currently
+| may have restrictions on the import, possession, and use, and/or re-export to
+| another country, of encryption software. BEFORE using any encryption software,
+| please check the country's laws, regulations and policies concerning the import,
+| possession, or use, and re-export of encryption software, to see if this is
+| permitted.
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
+Group: javax.validation Name: validation-api Version: 1.1.0.Final
+
+NOTICE:
+| # Notices for Eclipse Jakarta Validation
+| 
+| This content is produced and maintained by the Eclipse Jakarta Validation
+| project.
+| 
+| * Project home: https://projects.eclipse.org/projects/ee4j.validation
+| 
+| ## Trademarks
+| 
+|  Jakarta Validation is a trademark of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License, Version 2.0 which is available at
+| https://www.apache.org/licenses/LICENSE-2.0.
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+| * [The specification repository](https://github.com/jakartaee/validation-spec)
+| * [The API repository](https://github.com/jakartaee/validation)
+| * [The TCK repository](https://github.com/jakartaee/validation-tck)
+| 
+| ## Third-party Content
+| 
+| This project leverages the following third party content.
+| 
+| Test dependencies:
+| 
+|  * [TestNG](https://github.com/cbeust/testng) - Apache License 2.0
+|  * [JCommander](https://github.com/cbeust/jcommander) - Apache License 2.0
+|  * [SnakeYAML](https://bitbucket.org/asomov/snakeyaml/src) - Apache License 2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
+
+NOTICE:
+| Copyright 2016 The Android Open Source Project
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|      http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| This product contains a modified portion of `Netty`, a configurable network
+| stack in Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.netty.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://netty.io/
+| 
+| This product contains a modified portion of `Apache Harmony`, modular Java runtime,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://harmony.apache.org/
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty Name: jetty-http Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-io Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-security Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-server Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-servlet Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-util Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-util-ajax Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-webapp Version: 9.4.53.v20231009
+Group: org.eclipse.jetty Name: jetty-xml Version: 9.4.53.v20231009
+
+NOTICE:
+| Notices for Eclipse Jetty
+| =========================
+| This content is produced and maintained by the Eclipse Jetty project.
+| 
+| Project home: https://jetty.org/
+| 
+| Trademarks
+| ----------
+| Eclipse Jetty, and Jetty are trademarks of the Eclipse Foundation.
+| 
+| Copyright
+| ---------
+| All contributions are the property of the respective authors or of
+| entities to which copyright has been assigned by the authors (eg. employer).
+| 
+| Declared Project Licenses
+| -------------------------
+| This artifacts of this project are made available under the terms of:
+| 
+|   * the Eclipse Public License v2.0
+|     https://www.eclipse.org/legal/epl-2.0
+|     SPDX-License-Identifier: EPL-2.0
+| 
+|   or
+| 
+|   * the Apache License, Version 2.0
+|     https://www.apache.org/licenses/LICENSE-2.0
+|     SPDX-License-Identifier: Apache-2.0
+| 
+| The following dependencies are EPL.
+|  * org.eclipse.jetty.orbit:org.eclipse.jdt.core
+| 
+| The following dependencies are EPL and ASL2.
+|  * org.eclipse.jetty.orbit:javax.security.auth.message
+| 
+| The following dependencies are EPL and CDDL 1.0.
+|  * org.eclipse.jetty.orbit:javax.mail.glassfish
+| 
+| The following dependencies are CDDL + GPLv2 with classpath exception.
+| https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+| 
+|  * jakarta.servlet:jakarta.servlet-api
+|  * javax.annotation:javax.annotation-api
+|  * javax.transaction:javax.transaction-api
+|  * javax.websocket:javax.websocket-api
+| 
+| The following dependencies are licensed by the OW2 Foundation according to the
+| terms of http://asm.ow2.org/license.html
+| 
+|  * org.ow2.asm:asm-commons
+|  * org.ow2.asm:asm
+| 
+| The following dependencies are ASL2 licensed.
+| 
+|  * org.apache.taglibs:taglibs-standard-spec
+|  * org.apache.taglibs:taglibs-standard-impl
+| 
+| The following dependencies are ASL2 licensed.  Based on selected classes from
+| following Apache Tomcat jars, all ASL2 licensed.
+| 
+|  * org.mortbay.jasper:apache-jsp
+|  * org.apache.tomcat:tomcat-jasper
+|  * org.apache.tomcat:tomcat-juli
+|  * org.apache.tomcat:tomcat-jsp-api
+|  * org.apache.tomcat:tomcat-el-api
+|  * org.apache.tomcat:tomcat-jasper-el
+|  * org.apache.tomcat:tomcat-api
+|  * org.apache.tomcat:tomcat-util-scan
+|  * org.apache.tomcat:tomcat-util
+|  * org.mortbay.jasper:apache-el
+|  * org.apache.tomcat:tomcat-jasper-el
+|  * org.apache.tomcat:tomcat-el-api
+| 
+| The following artifacts are CDDL + GPLv2 with classpath exception.
+| https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+| 
+|  * org.eclipse.jetty.toolchain:jetty-schemas
+| 
+| Cryptography
+| ------------
+| Content may contain encryption software. The country in which you are currently
+| may have restrictions on the import, possession, and use, and/or re-export to
+| another country, of encryption software. BEFORE using any encryption software,
+| please check the country's laws, regulations and policies concerning the import,
+| possession, or use, and re-export of encryption software, to see if this is
+| permitted.
+| 
+| The UnixCrypt.java code implements the one way cryptography used by
+| Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
+| modified April 2001  by Iris Van den Broeke, Daniel Deville.
+| Permission to use, copy, modify and distribute UnixCrypt
+| for non-commercial or commercial purposes and without fee is
+| granted provided that the copyright notice appears in all copies.
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
+
+NOTICE:
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for Microprofile Config                  ==
+| =========================================================================
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+| 
+| Portions of this software were originally based on the following:
+| * Apache DeltaSpike Config
+|   https://deltaspike.apache.org
+|   under Apache License, v2.0
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse Microprofile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Mark Struberg struberg@apache.org,
+| Gerhard Petracek gpetracek@apache.org,
+| Romain Manni-Bucau rmannibucau@apache.org,
+| Ron Smeral rsmeral@apache.org,
+| Emily Jiang emijiang@uk.ibm.com,
+| Ondrej Mihalyi ondrej.mihalyi@gmail.com,
+| Gunnar Morling gunnar@hibernate.org
+| </text>
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.health Name: microprofile-health-api Version: 4.0.1
+
+NOTICE:
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for Microprofile Health                  ==
+| =========================================================================
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+| 
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse Microprofile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Heiko Braun hbraun@redhat.com
+| </text>
+
+--------------------------------------------------------------------------------
+
+Group: org.xerial.snappy Name: snappy-java Version: 1.1.10.5
+
+NOTICE:
+| This product includes software developed by Google
+|  Snappy: http://code.google.com/p/snappy/ (New BSD License)
+| 
+| This product includes software developed by Apache
+|  PureJavaCrc32C from apache-hadoop-common http://hadoop.apache.org/
+|  (Apache 2.0 license)
+| 
+| This library contains statically linked libstdc++. This inclusion is allowed by 
+| "GCC Runtime Library Exception" 
+| http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+| 
+| == Contributors ==
+|   * Tatu Saloranta  
+|     * Providing benchmark suite
+|   * Alec Wysoker
+|     * Performance and memory usage improvement
+| 
+| Third-Party Notices and Licenses:
+| 
+| - Hadoop: Apache Hadoop is used as a dependency
+|   License: Apache License 2.0
+|   Source/Reference: https://github.com/apache/hadoop/blob/trunk/NOTICE.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.11
+Group: software.amazon.awssdk Name: arns Version: 2.31.11
+Group: software.amazon.awssdk Name: auth Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.11
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.11
+Group: software.amazon.awssdk Name: checksums Version: 2.31.11
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.11
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.11
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.11
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.11
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.11
+Group: software.amazon.awssdk Name: profiles Version: 2.31.11
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.11
+Group: software.amazon.awssdk Name: regions Version: 2.31.11
+Group: software.amazon.awssdk Name: retries Version: 2.31.11
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.11
+Group: software.amazon.awssdk Name: s3 Version: 2.31.11
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.11
+Group: software.amazon.awssdk Name: sts Version: 2.31.11
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.11
+Group: software.amazon.awssdk Name: utils Version: 2.31.11
+
+NOTICE:
+| AWS SDK for Java
+| Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+| 
+| This product includes software developed by
+| Amazon Technologies, Inc (http://www.amazon.com/).
+| 
+| **********************
+| THIRD PARTY COMPONENTS
+| **********************
+| This software includes third party software subject to the following copyrights:
+| - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+| - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+| 
+| The licenses for these third party components are included in LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
+
+NOTICE:
+| AWS EventStream for Java
+| Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
The distributions (admin and server) will be published in the next release (both on dist.apache.org and Nexus).

As for all distributed artifacts, they have to contain complete and accurate `LICENSE` and `NOTICE` files.

This PR updates `LICENSE` and `NOTICE` in server and admin distributions.