### PR TITLE
Add openApiGenerate task as dependency for processResources

### DIFF
--- a/api/iceberg-service/build.gradle.kts
+++ b/api/iceberg-service/build.gradle.kts
@@ -116,3 +116,5 @@ sourceSets {
 }
 
 tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.named("processResources") { dependsOn("openApiGenerate") }

--- a/api/management-model/build.gradle.kts
+++ b/api/management-model/build.gradle.kts
@@ -68,3 +68,5 @@ sourceSets {
 }
 
 tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.named("processResources") { dependsOn("openApiGenerate") }

--- a/api/management-service/build.gradle.kts
+++ b/api/management-service/build.gradle.kts
@@ -77,3 +77,5 @@ sourceSets {
 }
 
 tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.named("processResources") { dependsOn("openApiGenerate") }

--- a/api/polaris-catalog-service/build.gradle.kts
+++ b/api/polaris-catalog-service/build.gradle.kts
@@ -115,3 +115,5 @@ sourceSets {
 }
 
 tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.named("processResources") { dependsOn("openApiGenerate") }


### PR DESCRIPTION
In order to publish artifact to Maven (local or remote), we have to use `processResources` task.

This task has to depend to `openApiGenerate` to be valid.