### PR TITLE
PySpark Reg Test Updates

### DIFF
--- a/regtests/t_pyspark/src/conftest.py
+++ b/regtests/t_pyspark/src/conftest.py
@@ -84,7 +84,8 @@ def aws_bucket_base_location_prefix():
   """
   default_val = 'polaris_test'
   bucket_prefix = os.getenv('AWS_BUCKET_BASE_LOCATION_PREFIX', default_val)
-  return default_val if bucket_prefix == '' else bucket_prefix
+  # Add random string to prefix to prevent base location overlaps
+  return f"{default_val if bucket_prefix == '' else bucket_prefix}_{str(uuid.uuid4())[-5:]}"
 
 @pytest.fixture
 def catalog_client(polaris_catalog_url):

--- a/regtests/t_pyspark/src/conftest.py
+++ b/regtests/t_pyspark/src/conftest.py
@@ -85,7 +85,7 @@ def aws_bucket_base_location_prefix():
   default_val = 'polaris_test'
   bucket_prefix = os.getenv('AWS_BUCKET_BASE_LOCATION_PREFIX', default_val)
   # Add random string to prefix to prevent base location overlaps
-  return f"{default_val if bucket_prefix == '' else bucket_prefix}_{str(uuid.uuid4())[-5:]}"
+  return f"{default_val if bucket_prefix == '' else bucket_prefix}_{str(uuid.uuid4())[:5]}"
 
 @pytest.fixture
 def catalog_client(polaris_catalog_url):

--- a/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
+++ b/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
@@ -366,7 +366,7 @@ def test_spark_creates_table_in_custom_namespace_dir(root_client, snowflake_cata
             f"SELECT file FROM db1.schema.table_in_custom_namespace_location.metadata_log_entries").collect()
         assert namespace_location in entries[0][0]
     finally:
-        spark.sql('drop table table_in_custom_namespace_location PURGE')
+        spark.sql('DROP TABLE table_in_custom_namespace_location PURGE')
 
 
 @pytest.mark.skipif(os.environ.get('AWS_TEST_ENABLED', 'False').lower() != 'true',


### PR DESCRIPTION
Minor Updates to PySpark Reg Tests

Each test directly cleans the artifacts it created.

Optional bucket prefix location has a UUID appended to allow for multiple runs against the same instance not conflicting if a previous run didn't get cleaned up.

For testing - RAN 
`./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache                                                            docker compose -f ./regtests/docker-compose.yml up --build --exit-code-from regtest`
`exported AWS_STORAGE_BUCKET, AWS_BUCKET_BASE_LOCATION_PREFIX, AWS_ROLE_ARN,AWS_TEST_ENABLED`

Saw REG tests complete with exit code 0

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
