### PR TITLE
Implement service interfaces for policies & generic tables

### DIFF
--- a/service/common/build.gradle.kts
+++ b/service/common/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation(project(":polaris-api-management-model"))
   implementation(project(":polaris-api-management-service"))
   implementation(project(":polaris-api-iceberg-service"))
+  implementation(project(":polaris-api-catalog-service"))
 
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -16,13 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.catalog.generic;
 
 import jakarta.enterprise.context.RequestScoped;
 import org.apache.polaris.service.catalog.api.PolarisCatalogGenericTableApiService;
 
 @RequestScoped
-public class GenericTableCatalogAdapter implements PolarisCatalogGenericTableApiService {
-    
-}
+public class GenericTableCatalogAdapter implements PolarisCatalogGenericTableApiService {}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.generic;
+
+import jakarta.enterprise.context.RequestScoped;
+import org.apache.polaris.service.catalog.api.PolarisCatalogGenericTableApiService;
+
+@RequestScoped
+public class GenericTableCatalogAdapter implements PolarisCatalogGenericTableApiService {
+    
+}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyServiceImpl.java
@@ -16,13 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.catalog.policy;
 
 import jakarta.enterprise.context.RequestScoped;
 import org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApiService;
 
 @RequestScoped
-public class PolicyServiceImpl implements PolarisCatalogPolicyApiService {
-
-}
+public class PolicyServiceImpl implements PolarisCatalogPolicyApiService {}

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyServiceImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.policy;
+
+import jakarta.enterprise.context.RequestScoped;
+import org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApiService;
+
+@RequestScoped
+public class PolicyServiceImpl implements PolarisCatalogPolicyApiService {
+
+}


### PR DESCRIPTION
As part of the generic tables implementation, I added `polaris-api-catalog-service` as a dependency in `polaris-service-common`. What I found was that the interfaces such as `PolarisCatalogPolicyApiService` require scope-annotated implementations or else errors like this will occur during initialization:

```
java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate threw an exception: jakarta.enterprise.inject.spi.DeploymentException: jakarta.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApiService and qualifiers [@Default]
	- injection target: parameter 'service' of org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApi constructor
	- declared on CLASS bean [types=[org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApi, java.lang.Object], qualifiers=[@Default, @Any], target=org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApi]
	The following classes match by type, but have been skipped during discovery:
	- org.apache.polaris.service.catalog.api.impl.PolarisCatalogPolicyApiServiceImpl has no bean defining annotation (scope, stereotype, etc.)
```

This PR adds stubs for these implementations and adds the dependency on `polaris-api-catalog-service`. A real implementation of `GenericTableCatalogAdapter` is slated to immediately follow.