### PR TITLE
Update .asf.yaml adding dismiss_stale_reviews to true and require_last_push_approval to false

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,8 @@ github:
     main:
       required_pull_request_reviews:
         require_code_owner_reviews: false
+        dismiss_stale_reviews: true
+        require_last_push_approval: false
         required_approving_review_count: 1
 
       required_linear_history: true


### PR DESCRIPTION
With https://github.com/apache/infrastructure-asfyaml/pull/55 I added the `require_last_push_approval` option to `.asf.yaml` (it was not possible to change it before).

This PR updates `.asf.yaml` with:
* `dismiss_stale_reviews: true`
* `require_last_push_approval: false`

See https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#branch-protection for details.