### PR TITLE
Build/Release: Add digest for Quarkus distributables

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -49,12 +49,6 @@ constructor(objectFactory: ObjectFactory, project: Project) {
     objectFactory
       .fileProperty()
       .convention(project.provider { distributionDir.get().file("${baseName.get()}.tar.gz") })
-  val sourceTarballDigest =
-    objectFactory
-      .fileProperty()
-      .convention(
-        project.provider { distributionDir.get().file("${baseName.get()}.tar.gz.sha512") }
-      )
 
   val mailingLists = objectFactory.listProperty(String::class.java).convention(emptyList())
 

--- a/build-logic/src/main/kotlin/publishing/digest-task.kt
+++ b/build-logic/src/main/kotlin/publishing/digest-task.kt
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package publishing
+
+import java.security.MessageDigest
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault
+abstract class GenerateDigest @Inject constructor(objectFactory: ObjectFactory) : DefaultTask() {
+
+  @get:InputFile val file = objectFactory.fileProperty()
+  @get:Input val algorithm = objectFactory.property(String::class.java).convention("SHA-512")
+  @get:OutputFile
+  val outputFile =
+    objectFactory.fileProperty().convention {
+      val input = file.get().asFile
+      val algo = algorithm.get()
+      input.parentFile.resolve("${input.name}-${algo.replace("-", "").lowercase()}")
+    }
+
+  @TaskAction
+  fun generate() {
+    val input = file.get().asFile
+    val digestFile = outputFile.get().asFile
+    val md = MessageDigest.getInstance(algorithm.get())
+    input.inputStream().use {
+      val buffered = it.buffered(8192)
+      val buf = ByteArray(8192)
+      var rd: Int
+      while (true) {
+        rd = buffered.read(buf)
+        if (rd == -1) break
+        md.update(buf, 0, rd)
+      }
+
+      digestFile.writeText(
+        md.digest().joinToString(separator = "") { eachByte -> "%02x".format(eachByte) } +
+          "  ${input.name}"
+      )
+    }
+  }
+}

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -61,27 +61,28 @@ internal fun configureOnRootProject(project: Project) =
       workingDir(project.projectDir)
     }
 
-    val digestSourceTarball = tasks.register("digestSourceTarball")
-    digestSourceTarball.configure {
-      mustRunAfter(sourceTarball)
-
-      doFirst {
-        val e = project.extensions.getByType(PublishingHelperExtension::class.java)
-        generateDigest(e.sourceTarball.get().asFile, e.sourceTarballDigest.get().asFile, "SHA-512")
+    val digestSourceTarball =
+      tasks.register<GenerateDigest>("digestSourceTarball") {
+        description = "Generate the source tarball digest"
+        mustRunAfter(sourceTarball)
+        file.set {
+          val e = project.extensions.getByType(PublishingHelperExtension::class.java)
+          e.sourceTarball.get().asFile
+        }
       }
-    }
 
     sourceTarball.configure { finalizedBy(digestSourceTarball) }
 
     if (isSigning) {
-      val signSourceTarball = tasks.register<Sign>("signSourceTarball")
-      signSourceTarball.configure {
-        mustRunAfter(sourceTarball)
-        doFirst {
-          val e = project.extensions.getByType(PublishingHelperExtension::class.java)
-          sign(e.sourceTarball.get().asFile)
+      val signSourceTarball =
+        tasks.register<Sign>("signSourceTarball") {
+          description = "Sign the source tarball"
+          mustRunAfter(sourceTarball)
+          doFirst {
+            val e = project.extensions.getByType(PublishingHelperExtension::class.java)
+            sign(e.sourceTarball.get().asFile)
+          }
         }
-      }
       sourceTarball.configure { finalizedBy(signSourceTarball) }
     }
 

--- a/build-logic/src/main/kotlin/publishing/util.kt
+++ b/build-logic/src/main/kotlin/publishing/util.kt
@@ -23,10 +23,8 @@ import groovy.json.JsonException
 import groovy.json.JsonSlurper
 import groovy.util.Node
 import groovy.util.NodeList
-import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
-import java.security.MessageDigest
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.DependencyResult
@@ -56,25 +54,6 @@ internal fun xmlNode(node: Node?, child: String): Node? {
     }
   }
   return null
-}
-
-internal fun generateDigest(input: File, output: File, algorithm: String) {
-  val md = MessageDigest.getInstance(algorithm)
-  input.inputStream().use {
-    val buffered = it.buffered(8192)
-    val buf = ByteArray(8192)
-    var rd: Int
-    while (true) {
-      rd = buffered.read(buf)
-      if (rd == -1) break
-      md.update(buf, 0, rd)
-    }
-
-    output.writeText(
-      md.digest().joinToString(separator = "") { eachByte -> "%02x".format(eachByte) } +
-        "  ${input.name}"
-    )
-  }
 }
 
 internal fun <T : Any> unsafeCast(o: Any?): T {

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import io.quarkus.gradle.tasks.QuarkusBuild
 import io.quarkus.gradle.tasks.QuarkusRun
+import publishing.GenerateDigest
 
 plugins {
   alias(libs.plugins.quarkus)
@@ -109,6 +110,31 @@ val distZip =
     inputs.files(runScript)
   }
 
+val digestDistTar =
+  tasks.register<GenerateDigest>("digestDistTar") {
+    description = "Generate the distribution tar digest"
+    mustRunAfter(distTar)
+    file.set { distTar.get().archiveFile.get().asFile }
+  }
+
+val digestDistZip =
+  tasks.register<GenerateDigest>("digestDistZip") {
+    description = "Generate the distribution zip digest"
+    mustRunAfter(distZip)
+    file.set { distZip.get().archiveFile.get().asFile }
+  }
+
+distTar.configure { finalizedBy(digestDistTar) }
+
+distZip.configure { finalizedBy(digestDistZip) }
+
+if (project.hasProperty("release") || project.hasProperty("signArtifacts")) {
+  signing {
+    sign(distTar.get())
+    sign(distZip.get())
+  }
+}
+
 // Expose runnable jar via quarkusRunner configuration for integration-tests that require the
 // server.
 artifacts {
@@ -116,7 +142,9 @@ artifacts {
     builtBy(quarkusBuild)
   }
   add(distributionTar.name, provider { distTar.get().archiveFile }) { builtBy(distTar) }
+  add(distributionTar.name, provider { digestDistTar.get().outputFile }) { builtBy(digestDistTar) }
   add(distributionZip.name, provider { distZip.get().archiveFile }) { builtBy(distZip) }
+  add(distributionZip.name, provider { digestDistZip.get().outputFile }) { builtBy(digestDistZip) }
 }
 
 afterEvaluate {


### PR DESCRIPTION
Ensure that digest and signature are generated for both Polaris-Server and admin tar/zip distribution. This actually _adds_ a SHA-512 digest for the tar/zip files, which can (and should) be published along those on download pages.

The Quarkus zip/tar distributables would already be published to Nexus as well, which implies a digest and signature. However this change makes the digest and signature available in a way that enables us to publish those along the zip/tar to download servers.

NB: This change moves the existing "generate digest" functionality to a reusable Gradle task implementation.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
