### PR TITLE
[Spec] Add 'inherited' and 'namespace' Fields to GetApplicablePolicies API Response

### DIFF
--- a/api/polaris-catalog-service/build.gradle.kts
+++ b/api/polaris-catalog-service/build.gradle.kts
@@ -38,6 +38,7 @@ val policyManagementModels =
     "LoadPolicyResponse",
     "PolicyIdentifier",
     "Policy",
+    "ApplicablePolicy",
     "PolicyAttachmentTarget",
     "AttachPolicyRequest",
     "DetachPolicyRequest",

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4012,18 +4012,15 @@ components:
             For policies returned by GetApplicablePolicies, there are 2 additional fields
 
             - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
-            - **namespaces:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+            - **namespace:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
           required:
             - inherited
-            - namespaces
+            - namespace
           properties:
             inherited:
               type: boolean
-            namespace-path:
-              type: array
-              description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
-              items:
-                type: string
+            namespace:
+              $ref: '#/components/schemas/Namespace'
         - $ref: '#/components/schemas/Policy'
     GetApplicablePoliciesResponse:
       type: object

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4005,6 +4005,22 @@ components:
       properties:
         target:
           $ref: '#/components/schemas/PolicyAttachmentTarget'
+    ApplicablePolicy:
+      type: object
+      required:
+        - inherited
+        - namespaces
+        - policy
+      properties:
+        inherited:
+          type: boolean
+        namespaces:
+          type: array
+          description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+          items:
+            type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
     GetApplicablePoliciesResponse:
       type: object
       required:
@@ -4012,11 +4028,11 @@ components:
       properties:
         next-page-token:
           $ref: '#/components/schemas/PageToken'
-        policies:
+        applicable-policies:
           type: array
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Policy'
+            $ref: '#/components/schemas/ApplicablePolicy'
   responses:
     BadRequestErrorResponse:
       description: Indicates a bad request error. It could be caused by an unexpected request body format or other forms of request validation failure, such as invalid json. Usually serves application/json content, although in some cases simple text/plain content might be returned by the server's middleware.

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4019,7 +4019,7 @@ components:
           properties:
             inherited:
               type: boolean
-            namespaces:
+            namespace-path:
               type: array
               description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
               items:

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4011,7 +4011,7 @@ components:
           description: |
             For policies returned by GetApplicablePolicies, there are 2 additional fields
 
-            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
+            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents. For non-inheritable policy, it should always be `false`.
             - **namespace:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
           required:
             - inherited
@@ -4019,6 +4019,7 @@ components:
           properties:
             inherited:
               type: boolean
+              default: false
             namespace:
               $ref: '#/components/schemas/Namespace'
         - $ref: '#/components/schemas/Policy'
@@ -4029,7 +4030,7 @@ components:
       properties:
         next-page-token:
           $ref: '#/components/schemas/PageToken'
-        policies:
+        applicable-policies:
           type: array
           uniqueItems: true
           items:

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4026,7 +4026,7 @@ components:
     GetApplicablePoliciesResponse:
       type: object
       required:
-        - policies
+        - applicable-policies
       properties:
         next-page-token:
           $ref: '#/components/schemas/PageToken'

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -4006,21 +4006,25 @@ components:
         target:
           $ref: '#/components/schemas/PolicyAttachmentTarget'
     ApplicablePolicy:
-      type: object
-      required:
-        - inherited
-        - namespaces
-        - policy
-      properties:
-        inherited:
-          type: boolean
-        namespaces:
-          type: array
-          description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
-          items:
-            type: string
-        policy:
-          $ref: '#/components/schemas/Policy'
+      allOf:
+        - type: object
+          description: |
+            For policies returned by GetApplicablePolicies, there are 2 additional fields
+
+            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
+            - **namespaces:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+          required:
+            - inherited
+            - namespaces
+          properties:
+            inherited:
+              type: boolean
+            namespaces:
+              type: array
+              description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+              items:
+                type: string
+        - $ref: '#/components/schemas/Policy'
     GetApplicablePoliciesResponse:
       type: object
       required:
@@ -4028,7 +4032,7 @@ components:
       properties:
         next-page-token:
           $ref: '#/components/schemas/PageToken'
-        applicable-policies:
+        policies:
           type: array
           uniqueItems: true
           items:

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -535,7 +535,7 @@ components:
          description: |
             For policies returned by GetApplicablePolicies, there are 2 additional fields
 
-            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
+            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents. For non-inheritable policy, it should always be `false`.
             - **namespace:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
          required:
            - inherited
@@ -543,6 +543,7 @@ components:
          properties:
             inherited:
               type: boolean
+              default: false
             namespace:
               $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/Namespace'
        - $ref: '#/components/schemas/Policy'
@@ -656,7 +657,7 @@ components:
       properties:
         next-page-token:
           $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/PageToken'
-        policies:
+        applicable-policies:
           type: array
           uniqueItems: true
           items:

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -530,21 +530,26 @@ components:
           type: integer
 
     ApplicablePolicy:
-      type: object
-      required:
-        - inherited
-        - namespaces
-        - policy
-      properties:
-        inherited:
-          type: boolean
-        namespaces:
-          type: array
-          description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
-          items:
-            type: string
-        policy:
-          $ref: '#/components/schemas/Policy'
+      allOf:
+       - type: object
+         description: |
+            For policies returned by GetApplicablePolicies, there are 2 additional fields
+
+            - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
+            - **namespaces:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+         required:
+           - inherited
+           - namespaces
+         properties:
+            inherited:
+              type: boolean
+            namespaces:
+              type: array
+              description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+              items:
+                type: string
+       - $ref: '#/components/schemas/Policy'
+       
 
     CreatePolicyRequest:
       type: object
@@ -654,7 +659,7 @@ components:
       properties:
         next-page-token:
           $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/PageToken'
-        applicable-policies:
+        policies:
           type: array
           uniqueItems: true
           items:

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -543,7 +543,7 @@ components:
          properties:
             inherited:
               type: boolean
-            namespaces:
+            namespace-path:
               type: array
               description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
               items:

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -653,7 +653,7 @@ components:
     GetApplicablePoliciesResponse:
       type: object
       required:
-        - policies
+        - applicable-policies
       properties:
         next-page-token:
           $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/PageToken'

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -536,18 +536,15 @@ components:
             For policies returned by GetApplicablePolicies, there are 2 additional fields
 
             - **inherited:** A boolean flag indicating whether the policy is inherited from target's parents
-            - **namespaces:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+            - **namespace:** A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
          required:
            - inherited
-           - namespaces
+           - namespace
          properties:
             inherited:
               type: boolean
-            namespace-path:
-              type: array
-              description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
-              items:
-                type: string
+            namespace:
+              $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/Namespace'
        - $ref: '#/components/schemas/Policy'
        
 

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -529,6 +529,23 @@ components:
         version:
           type: integer
 
+    ApplicablePolicy:
+      type: object
+      required:
+        - inherited
+        - namespaces
+        - policy
+      properties:
+        inherited:
+          type: boolean
+        namespaces:
+          type: array
+          description: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.
+          items:
+            type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
+
     CreatePolicyRequest:
       type: object
       required:
@@ -637,11 +654,11 @@ components:
       properties:
         next-page-token:
           $ref: '../iceberg-rest-catalog-open-api.yaml#/components/schemas/PageToken'
-        policies:
+        applicable-policies:
           type: array
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Policy'
+            $ref: '#/components/schemas/ApplicablePolicy'
 
   responses:
     CreatePolicyResponse:


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Adds two additional fields to the response of the GetApplicablePolicies API (GET /v1/{prefix}/applicablePolicies):

- `inherited`: Boolean indicating whether the applicable policy is directly attached or inherited from a parent entity.
- `namespace`: A list representing the hierarchical parent path to the policy, ordered from higher level namespace to lower.

These fields enable users to determine the origin of a policy, helping them identify when and how to correctly override or update policies.