### PR TITLE
Rename the Snapshot Retention policy

### DIFF
--- a/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
@@ -2,7 +2,7 @@
   "license": "Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
   "$id": "https://polaris.apache.org/schemas/policies/system/snapshot-expiry/2025-02-03.json",
   "title": "Snapshot Expiry Policy",
-  "description": "Inheritable Polaris policy schema for managing Iceberg table snapshot expiry. This policy allows a table (or its parent) to indicate that snapshot expiry is enabled. It defines how snapshots should be expired. Engines or clients can use this policy to safely remove expired snapshots and delete associated files, helping maintain a clean and efficient table state.",
+  "description": "Inheritable Polaris policy schema for managing Iceberg table snapshot expiry. This policy allows a table (or its parent) to indicate that snapshot expiry is enabled. It also defines how snapshots should be expired. Engines or clients can use this policy to safely remove expired snapshots and delete associated files, helping maintain a clean and efficient table state.",
   "type": "object",
   "properties": {
     "version": {

--- a/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
@@ -1,8 +1,8 @@
 {
   "license": "Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
-  "$id": "https://polaris.apache.org/schemas/policies/system/snapshot-retention/2025-02-03.json",
-  "title": "Snapshot Retention Policy",
-  "description": "Inheritable Polaris policy schema for Iceberg table snapshot retention",
+  "$id": "https://polaris.apache.org/schemas/policies/system/snapshot-expiry/2025-02-03.json",
+  "title": "Snapshot Expiry Policy",
+  "description": "Inheritable Polaris policy schema for Iceberg table snapshot expiry",
   "type": "object",
   "properties": {
     "version": {
@@ -12,7 +12,7 @@
     },
     "enable": {
       "type": "boolean",
-      "description": "Enable or disable snapshot retention."
+      "description": "Enable or disable snapshot expiry."
     },
     "config": {
       "type": "object",

--- a/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
+++ b/polaris-core/src/main/resources/schemas/policies/system/snapshot-expiry/2025-02-03.json
@@ -2,7 +2,7 @@
   "license": "Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
   "$id": "https://polaris.apache.org/schemas/policies/system/snapshot-expiry/2025-02-03.json",
   "title": "Snapshot Expiry Policy",
-  "description": "Inheritable Polaris policy schema for Iceberg table snapshot expiry",
+  "description": "Inheritable Polaris policy schema for managing Iceberg table snapshot expiry. This policy allows a table (or its parent) to indicate that snapshot expiry is enabled. It defines how snapshots should be expired. Engines or clients can use this policy to safely remove expired snapshots and delete associated files, helping maintain a clean and efficient table state.",
   "type": "object",
   "properties": {
     "version": {


### PR DESCRIPTION
I'm proposing to rename the table maintenance policy "snapshot-retention" to "snapshot-expiry". While "snapshot-retention" is a reasonable name, it's a bit too general. I believe "snapshot-expiry" more precisely captures the intent of the policy, which is specifically about removing expired snapshots. 

I think this is the right time to make the change before we include the policy schemas in an upcoming release.

Will change related classes in a followup PR.