### PR TITLE
Unblock test `listNamespacesWithEmptyNamespace`

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -391,7 +391,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   public void testEmptyNamespace() {
     IcebergCatalog catalog = catalog();
     TableIdentifier tableInRootNs = TableIdentifier.of("table");
-    String expectedMessage = "Namespace does not exist: ";
+    String expectedMessage = "Namespace does not exist: ''";
 
     ThrowingCallable createEmptyNamespace = () -> catalog.createNamespace(Namespace.empty());
     Assertions.assertThatThrownBy(createEmptyNamespace)

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -164,7 +164,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
       new Schema(
           required(3, "id", Types.IntegerType.get(), "unique ID 🤪"),
           required(4, "data", Types.StringType.get()));
-  protected static final String VIEW_QUERY = "select * from ns1.layer1_table";
+  private static final String VIEW_QUERY = "select * from ns1.layer1_table";
   public static final String CATALOG_NAME = "polaris-catalog";
   public static final String TEST_ACCESS_KEY = "test_access_key";
   public static final String SECRET_ACCESS_KEY = "secret_access_key";
@@ -391,9 +391,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   public void testEmptyNamespace() {
     IcebergCatalog catalog = catalog();
     TableIdentifier tableInRootNs = TableIdentifier.of("table");
+    String expectedMessage = "Namespace does not exist: ";
 
     ThrowingCallable createTable = () -> catalog.createTable(tableInRootNs, SCHEMA);
-    Assertions.assertThatThrownBy(createTable).isInstanceOf(NoSuchNamespaceException.class);
+    Assertions.assertThatThrownBy(createTable)
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining(expectedMessage);
 
     ThrowingCallable createView =
         () ->
@@ -403,13 +406,19 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
                 .withDefaultNamespace(Namespace.empty())
                 .withQuery("spark", VIEW_QUERY)
                 .create();
-    Assertions.assertThatThrownBy(createView).isInstanceOf(NoSuchNamespaceException.class);
+    Assertions.assertThatThrownBy(createView)
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining(expectedMessage);
 
     ThrowingCallable listTables = () -> catalog.listTables(Namespace.empty());
-    Assertions.assertThatThrownBy(listTables).isInstanceOf(NoSuchNamespaceException.class);
+    Assertions.assertThatThrownBy(listTables)
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining(expectedMessage);
 
     ThrowingCallable listViews = () -> catalog.listViews(Namespace.empty());
-    Assertions.assertThatThrownBy(listViews).isInstanceOf(NoSuchNamespaceException.class);
+    Assertions.assertThatThrownBy(listViews)
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining(expectedMessage);
   }
 
   @Test

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -401,12 +401,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     catalog().createNamespace(NS);
 
     Assertions.assertThat(catalog().namespaceExists(Namespace.empty())).isTrue();
-    Assertions.assertThat(catalog().listNamespaces())
-        .contains(NS)
-        .doesNotContain(Namespace.empty());
-    Assertions.assertThat(catalog().listNamespaces(Namespace.empty()))
-        .contains(NS)
-        .doesNotContain(Namespace.empty());
+    Assertions.assertThat(catalog().listNamespaces()).containsExactly(NS);
+    Assertions.assertThat(catalog().listNamespaces(Namespace.empty())).containsExactly(NS);
   }
 
   @Test

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -393,6 +393,16 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     TableIdentifier tableInRootNs = TableIdentifier.of("table");
     String expectedMessage = "Namespace does not exist: ";
 
+    ThrowingCallable createEmptyNamespace = () -> catalog.createNamespace(Namespace.empty());
+    Assertions.assertThatThrownBy(createEmptyNamespace)
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Cannot create root namespace, as it already exists implicitly.");
+
+    ThrowingCallable dropEmptyNamespace = () -> catalog.dropNamespace(Namespace.empty());
+    Assertions.assertThatThrownBy(dropEmptyNamespace)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot drop root namespace");
+
     ThrowingCallable createTable = () -> catalog.createTable(tableInRootNs, SCHEMA);
     Assertions.assertThatThrownBy(createTable)
         .isInstanceOf(NoSuchNamespaceException.class)

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -641,6 +641,9 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
+    if (namespace.isEmpty()) {
+      throw new IllegalArgumentException("Cannot drop root namespace");
+    }
     PolarisResolvedPathWrapper resolvedEntities = resolvedEntityView.getResolvedPath(namespace);
     if (resolvedEntities == null) {
       return false;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -464,7 +464,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   public List<TableIdentifier> listTables(Namespace namespace) {
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
-          "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
+          "Cannot list tables for namespace. Namespace does not exist: '%s'", namespace);
     }
 
     return listTableLike(PolarisEntitySubType.ICEBERG_TABLE, namespace);
@@ -806,7 +806,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   public List<TableIdentifier> listViews(Namespace namespace) {
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
-          "Cannot list views for namespace. Namespace does not exist: %s", namespace);
+          "Cannot list views for namespace. Namespace does not exist: '%s'", namespace);
     }
 
     return listTableLike(PolarisEntitySubType.ICEBERG_VIEW, namespace);
@@ -1257,7 +1257,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       // TODO: Maybe avoid writing metadata if there's definitely a transaction conflict
       if (null == base && !namespaceExists(tableIdentifier.namespace())) {
         throw new NoSuchNamespaceException(
-            "Cannot create table %s. Namespace does not exist: %s",
+            "Cannot create table '%s'. Namespace does not exist: '%s'",
             tableIdentifier, tableIdentifier.namespace());
       }
 
@@ -1498,7 +1498,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       LOGGER.debug("doCommit for view {} with base {}, metadata {}", identifier, base, metadata);
       if (null == base && !namespaceExists(identifier.namespace())) {
         throw new NoSuchNamespaceException(
-            "Cannot create view %s. Namespace does not exist: %s",
+            "Cannot create view '%s'. Namespace does not exist: '%s'",
             identifier, identifier.namespace());
       }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -462,7 +462,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    if (!namespaceExists(namespace) && !namespace.isEmpty()) {
+    if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
           "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
     }
@@ -633,7 +633,10 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public boolean namespaceExists(Namespace namespace) {
-    return resolvedEntityView.getResolvedPath(namespace) != null;
+    return Optional.ofNullable(namespace)
+        .filter(ns -> !ns.isEmpty())
+        .map(resolvedEntityView::getResolvedPath)
+        .isPresent();
   }
 
   @Override
@@ -798,7 +801,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<TableIdentifier> listViews(Namespace namespace) {
-    if (!namespaceExists(namespace) && !namespace.isEmpty()) {
+    if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
           "Cannot list views for namespace. Namespace does not exist: %s", namespace);
     }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

This PR fixes #1272

In Polaris, the empty namespace implicitly exists by default, see [link](https://github.com/apache/polaris/blob/8b5dfa97a8e50a53412d2ded40f2e4db5a40cc42/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java#L490-L493). However, the superclass test assumes that the empty namespace does not exist initially, which causes the test to fail as expected in Polaris. This test was originally introduced in apache/iceberg#9890.

#### Changes in this PR:
- Fix Polaris API including `namespaceExists`, `dropNamespace`, `listTables`, `listViews`

