### PR TITLE
Gradle/Quarkus: make imageBuild task depend on jandex

### DIFF
--- a/build-logic/src/main/kotlin/polaris-quarkus.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-quarkus.gradle.kts
@@ -69,3 +69,5 @@ tasks.named("sourcesJar") { dependsOn("compileQuarkusGeneratedSourcesJava") }
 tasks.named("javadoc") { dependsOn("jandex") }
 
 tasks.named("quarkusDependenciesBuild") { dependsOn("jandex") }
+
+tasks.named("imageBuild") { dependsOn("jandex") }


### PR DESCRIPTION
While the tasks `build` or `assemble` can used for generating the docker images, Quarkus also provides a more specific task, `imageBuild`, that may be convenient sometimes because it runs faster.

However, that task must depend on `jandex` for the build to succeed.