### PR TITLE
Make PolarisConfiguration values optional

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -508,9 +508,11 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
     boolean enforceCredentialRotationRequiredState =
-        featureConfig.getConfiguration(
-            CallContext.getCurrentContext().getPolarisCallContext(),
-            FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
+        featureConfig
+            .getConfiguration(
+                CallContext.getCurrentContext().getPolarisCallContext(),
+                FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING)
+            .get();
     if (enforceCredentialRotationRequiredState
         && authenticatedPrincipal
             .getPrincipalEntity()

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
 
   protected BehaviorChangeConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
+      String key, String description, Optional<T> defaultValue, Optional<String> catalogConfig) {
     super(key, description, defaultValue, catalogConfig);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -31,7 +31,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
  */
 public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   protected FeatureConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
+      String key, String description, Optional<T> defaultValue, Optional<String> catalogConfig) {
     super(key, description, defaultValue, catalogConfig);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -47,7 +47,7 @@ public abstract class PolarisConfiguration<T> {
     this.description = description;
     this.defaultValue = defaultValue;
     this.catalogConfigImpl = catalogConfig;
-    this.typ = (Class<T>) defaultValue.getClass();
+    this.typ = (Class<T>) defaultValue.map(c -> c.getClass()).orElse(null);
   }
 
   public boolean hasCatalogConfig() {
@@ -110,14 +110,16 @@ public abstract class PolarisConfiguration<T> {
 
     public FeatureConfiguration<T> buildFeatureConfiguration() {
       if (key == null || description == null || defaultValue == null) {
-        throw new IllegalArgumentException("key, description, and defaultValue / optional are required");
+        throw new IllegalArgumentException(
+            "key, description, and defaultValue / optional are required");
       }
       return new FeatureConfiguration<>(key, description, defaultValue, catalogConfig);
     }
 
     public BehaviorChangeConfiguration<T> buildBehaviorChangeConfiguration() {
       if (key == null || description == null || defaultValue == null) {
-        throw new IllegalArgumentException("key, description, and defaultValue / optional are required");
+        throw new IllegalArgumentException(
+            "key, description, and defaultValue / optional are required");
       }
       if (catalogConfig.isPresent()) {
         throw new IllegalArgumentException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -281,7 +281,8 @@ public class CatalogEntity extends PolarisEntity {
     private void validateMaxAllowedLocations(Collection<String> allowedLocations) {
       int maxAllowedLocations =
           BehaviorChangeConfiguration.loadConfig(
-              BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS).get();
+                  BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS)
+              .get();
       if (maxAllowedLocations != -1 && allowedLocations.size() > maxAllowedLocations) {
         throw new IllegalArgumentException(
             String.format(

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -281,7 +281,7 @@ public class CatalogEntity extends PolarisEntity {
     private void validateMaxAllowedLocations(Collection<String> allowedLocations) {
       int maxAllowedLocations =
           BehaviorChangeConfiguration.loadConfig(
-              BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS);
+              BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS).get();
       if (maxAllowedLocations != -1 && allowedLocations.size() > maxAllowedLocations) {
         throw new IllegalArgumentException(
             String.format(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1476,7 +1476,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                       .getConfiguration(
                           callCtx,
                           PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
+                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS)
+                      .get();
               return taskState == null
                   || taskState.executor == null
                   || callCtx.getClock().millis() - taskState.lastAttemptStartTime > taskAgeTimeout;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -1910,7 +1910,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                       .getConfiguration(
                           callCtx,
                           PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
+                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS)
+                      .get();
               return taskState == null
                   || taskState.executor == null
                   || callCtx.getClock().millis() - taskState.lastAttemptStartTime > taskAgeTimeout;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
@@ -83,6 +83,7 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
                 pc ->
                     pc.getConfigurationStore()
                         .getConfiguration(pc, "ALLOW_WILDCARD_LOCATION", false))
+            .flatMap(o -> o)
             .orElse(false);
 
     if (allowWildcardLocation && allowedLocationStrings.contains("*")) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -168,7 +168,8 @@ public abstract class PolarisStorageConfigurationInfo {
                       .getConfiguration(
                           CallContext.getCurrentContext().getPolarisCallContext(),
                           catalog,
-                          FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION);
+                          FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION)
+                      .get();
               if (!allowEscape
                   && catalog.getCatalogType() != Catalog.TypeEnum.EXTERNAL
                   && baseLocation != null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -73,7 +73,7 @@ public class AwsCredentialsStorageIntegration
                             allowedReadLocations,
                             allowedWriteLocations)
                         .toJson())
-                .durationSeconds(loadConfig(STORAGE_CREDENTIAL_DURATION_SECONDS))
+                .durationSeconds(loadConfig(STORAGE_CREDENTIAL_DURATION_SECONDS).get())
                 .build());
     EnumMap<PolarisCredentialProperty, String> credentialMap =
         new EnumMap<>(PolarisCredentialProperty.class);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -126,7 +126,7 @@ public class AzureCredentialsStorageIntegration
     // clock skew between the client and server,
     OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds =
-        FeatureConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+        FeatureConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS).get();
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -126,7 +126,8 @@ public class AzureCredentialsStorageIntegration
     // clock skew between the client and server,
     OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds =
-        FeatureConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS).get();
+        FeatureConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS)
+            .get();
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -74,9 +74,11 @@ public class StorageCredentialCache {
   private static long maxCacheDurationMs() {
     var cacheDurationSeconds =
         PolarisConfiguration.loadConfig(
-            FeatureConfiguration.STORAGE_CREDENTIAL_CACHE_DURATION_SECONDS);
+                FeatureConfiguration.STORAGE_CREDENTIAL_CACHE_DURATION_SECONDS)
+            .get();
     var credentialDurationSeconds =
-        PolarisConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+        PolarisConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS)
+            .get();
     if (cacheDurationSeconds >= credentialDurationSeconds) {
       throw new IllegalArgumentException(
           String.format(

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -19,11 +19,11 @@
 package org.apache.polaris.core.storage;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.time.Clock;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
@@ -100,8 +100,9 @@ class InMemoryStorageIntegrationTest {
             new PolarisConfigurationStore() {
               @SuppressWarnings("unchecked")
               @Override
-              public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
-                return (T) config.get(configName);
+              public <T> @Nonnull Optional<T> getConfiguration(
+                  PolarisCallContext ctx, String configName) {
+                return Optional.of((T) config.get(configName));
               }
             },
             Clock.systemUTC());

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.polaris.service.storage;
 
-import jakarta.annotation.Nullable;
+import jakarta.annotation.Nonnull;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
@@ -49,10 +50,11 @@ public class PolarisConfigurationStoreTest {
            */
           @SuppressWarnings("unchecked")
           @Override
-          public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
+          public <T> @Nonnull Optional<T> getConfiguration(
+              PolarisCallContext ctx, String configName) {
             for (PolarisConfiguration<?> c : configs) {
               if (c.key.equals(configName)) {
-                return (T) String.valueOf(c.defaultValue);
+                return Optional.ofNullable((T) String.valueOf(c.defaultValue));
               }
             }
 
@@ -81,8 +83,8 @@ public class PolarisConfigurationStoreTest {
         new PolarisConfigurationStore() {
           @SuppressWarnings("unchecked")
           @Override
-          public <T> T getConfiguration(PolarisCallContext ctx, String configName) {
-            return (T) "abc123";
+          public <T> Optional<T> getConfiguration(PolarisCallContext ctx, String configName) {
+            return Optional.of((T) "abc123");
           }
         };
 
@@ -114,7 +116,7 @@ public class PolarisConfigurationStoreTest {
 
     public <T> T consumeConfiguration(
         PolarisConfiguration<Boolean> config, Supplier<T> code, T defaultVal) {
-      if (configurationStore.getConfiguration(polarisCallContext, config)) {
+      if (configurationStore.getConfiguration(polarisCallContext, config).get()) {
         return code.get();
       }
       return defaultVal;

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -54,7 +54,7 @@ public class PolarisConfigurationStoreTest {
               PolarisCallContext ctx, String configName) {
             for (PolarisConfiguration<?> c : configs) {
               if (c.key.equals(configName)) {
-                return Optional.ofNullable((T) String.valueOf(c.defaultValue));
+                return c.defaultValue.map(v -> (T) String.valueOf(v));
               }
             }
 

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -528,7 +528,8 @@ public class PolarisAdminService {
         getCurrentPolarisContext()
             .getConfigurationStore()
             .getConfiguration(
-                getCurrentPolarisContext(), FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
+                getCurrentPolarisContext(), FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS)
+            .get();
 
     if (allowOverlappingCatalogUrls) {
       return false;
@@ -598,7 +599,8 @@ public class PolarisAdminService {
     boolean cleanup =
         polarisCallContext
             .getConfigurationStore()
-            .getConfiguration(polarisCallContext, FeatureConfiguration.CLEANUP_ON_CATALOG_DROP);
+            .getConfiguration(polarisCallContext, FeatureConfiguration.CLEANUP_ON_CATALOG_DROP)
+            .get();
     DropEntityResult dropEntityResult =
         metaStoreManager.dropEntityIfExists(
             getCurrentPolarisContext(), null, entity, Map.of(), cleanup);

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -137,7 +137,8 @@ public class PolarisServiceImpl
         polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
+                polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+            .get();
     if (!allowedStorageTypes.contains(storageConfigInfo.getStorageType().name())) {
       LOGGER
           .atWarn()

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -59,7 +59,7 @@ public class GenericTableCatalogHandler extends CatalogHandler {
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES);
+                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES).get();
     if (!enabled) {
       throw new UnsupportedOperationException("Generic table support is not enabled");
     }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -59,7 +59,8 @@ public class GenericTableCatalogHandler extends CatalogHandler {
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES).get();
+                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES)
+            .get();
     if (!enabled) {
       throw new UnsupportedOperationException("Generic table support is not enabled");
     }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -522,7 +522,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getConfigurationStore()
         .getConfiguration(
             callContext.getPolarisCallContext(),
-            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)
+        .get()) {
       LOGGER.debug("Validating no overlap for {} with sibling tables or namespaces", namespace);
       validateNoLocationOverlap(
           entity.getBaseLocation(), resolvedParent.getRawFullPath(), entity.getName());
@@ -658,7 +659,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                 polarisCallContext
                     .getConfigurationStore()
                     .getConfiguration(
-                        polarisCallContext, FeatureConfiguration.CLEANUP_ON_NAMESPACE_DROP));
+                        polarisCallContext, FeatureConfiguration.CLEANUP_ON_NAMESPACE_DROP)
+                    .get());
 
     if (!dropEntityResult.isSuccess() && dropEntityResult.failedBecauseNotEmpty()) {
       throw new NamespaceNotEmptyException("Namespace %s is not empty", namespace);
@@ -688,7 +690,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getConfigurationStore()
         .getConfiguration(
             callContext.getPolarisCallContext(),
-            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)
+        .get()) {
       LOGGER.debug("Validating no overlap with sibling tables or namespaces");
       validateNoLocationOverlap(
           NamespaceEntity.of(updatedEntity).getBaseLocation(),
@@ -986,7 +989,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                   .getConfigurationStore()
                   .getConfiguration(
                       callContext.getPolarisCallContext(),
-                      FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
+                      FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+                  .get();
           if (!allowedStorageTypes.contains(StorageConfigInfo.StorageTypeEnum.FILE.name())) {
             List<String> invalidLocations =
                 locations.stream()
@@ -1017,7 +1021,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             .getConfigurationStore()
             .getConfiguration(
                 callContext.getPolarisCallContext(),
-                BehaviorChangeConfiguration.VALIDATE_VIEW_LOCATION_OVERLAP);
+                BehaviorChangeConfiguration.VALIDATE_VIEW_LOCATION_OVERLAP)
+            .get();
 
     if (callContext
         .getPolarisCallContext()
@@ -1025,7 +1030,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getConfiguration(
             callContext.getPolarisCallContext(),
             catalog,
-            FeatureConfiguration.ALLOW_TABLE_LOCATION_OVERLAP)) {
+            FeatureConfiguration.ALLOW_TABLE_LOCATION_OVERLAP)
+        .get()) {
       LOGGER.debug("Skipping location overlap validation for identifier '{}'", identifier);
     } else if (validateViewOverlap
         || entity.getSubType().equals(PolarisEntitySubType.ICEBERG_TABLE)) {
@@ -1407,12 +1413,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
+                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION)
+            .get();
     if (!allowEscape
         && !polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
+                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)
+            .get()) {
       LOGGER.debug(
           "Validating base location {} for table {} in metadata file {}",
           metadata.location(),
@@ -1877,7 +1885,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               .getConfiguration(
                   callContext.getPolarisCallContext(),
                   catalogEntity,
-                  FeatureConfiguration.DROP_WITH_PURGE_ENABLED);
+                  FeatureConfiguration.DROP_WITH_PURGE_ENABLED)
+              .get();
       if (!dropWithPurgeEnabled) {
         throw new ForbiddenException(
             String.format(
@@ -2111,7 +2120,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     return callContext
         .getPolarisCallContext()
         .getConfigurationStore()
-        .getConfiguration(callContext.getPolarisCallContext(), configKey, defaultValue);
+        .getConfiguration(callContext.getPolarisCallContext(), configKey, defaultValue)
+        .get();
   }
 
   private int getMaxMetadataRefreshRetries() {
@@ -2119,6 +2129,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getPolarisCallContext()
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getPolarisCallContext(), FeatureConfiguration.MAX_METADATA_REFRESH_RETRIES);
+            callContext.getPolarisCallContext(), FeatureConfiguration.MAX_METADATA_REFRESH_RETRIES)
+        .get();
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -591,10 +591,12 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     if (catalogEntity
             .getCatalogType()
             .equals(org.apache.polaris.core.admin.model.Catalog.TypeEnum.EXTERNAL)
-        && !configurationStore.getConfiguration(
-            callContext.getPolarisCallContext(),
-            catalogEntity,
-            FeatureConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING)) {
+        && !configurationStore
+            .getConfiguration(
+                callContext.getPolarisCallContext(),
+                catalogEntity,
+                FeatureConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING)
+            .get()) {
       throw new ForbiddenException(
           "Access Delegation is not enabled for this catalog. Please consult applicable "
               + "documentation for the catalog config property '%s' to enable this feature",
@@ -820,7 +822,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
                                   .getConfigurationStore()
                                   .getConfiguration(
                                       callContext.getPolarisCallContext(),
-                                      FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+                                      FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)
+                                  .get()) {
                             throw new BadRequestException(
                                 "Unsupported operation: commitTransaction containing SetLocation"
                                     + " for table '%s' and new location '%s'",

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
@@ -86,10 +86,12 @@ public class FileIOUtil {
       PolarisEntity entity) {
 
     boolean skipCredentialSubscopingIndirection =
-        configurationStore.getConfiguration(
-            callContext.getPolarisCallContext(),
-            FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.key,
-            FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.defaultValue);
+        configurationStore
+            .getConfiguration(
+                callContext.getPolarisCallContext(),
+                FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.key,
+                FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.defaultValue)
+            .get();
     if (skipCredentialSubscopingIndirection) {
       LOGGER
           .atDebug()

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -20,10 +20,10 @@ package org.apache.polaris.service.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
@@ -55,14 +55,15 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   }
 
   @Override
-  public <T> @Nullable T getConfiguration(@Nonnull PolarisCallContext ctx, String configName) {
+  public <T> @Nonnull Optional<T> getConfiguration(
+      @Nonnull PolarisCallContext ctx, String configName) {
     String realm = CallContext.getCurrentContext().getRealmContext().getRealmIdentifier();
     @SuppressWarnings("unchecked")
-    T confgValue =
+    T configValue =
         (T)
             realmOverrides
                 .getOrDefault(realm, Map.of())
                 .getOrDefault(configName, defaults.get(configName));
-    return confgValue;
+    return Optional.ofNullable(configValue);
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -210,7 +210,8 @@ public class TableCleanupTaskHandler implements TaskHandler {
     int batchSize =
         polarisCallContext
             .getConfigurationStore()
-            .getConfiguration(polarisCallContext, BATCH_SIZE_CONFIG_KEY, 10);
+            .getConfiguration(polarisCallContext, BATCH_SIZE_CONFIG_KEY, 10)
+            .get();
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {


### PR DESCRIPTION
Created this PR to get **feedback** on an idea I had while trying to add a new configuration where we'd like to distinguish between "set" and "not set" without just setting the default value to `null` (which won't work for some types).

<hr>

I don't love that this implementation requires `get` to be spammed everywhere. With that said, I think the current way of getting configs via the lengthy invocation `callContext.getPolarisCallContext().getConfigurationStore().getConfiguration(callContext.getPolarisCallContext, FeatureConfiguration.FEATURE_NAME)` should probably be made more ergonomic anyway and that adding `get` to the end doesn't make it too much more painful. We could potentially refactor out the `get`s if/when we refactor the rest. I leave them in here so reviewers can get a good sense of the scope of the change.

Critically, this implementation does mean that the caller of `getConfiguration` is expected to know when it's safe to use `get`, i.e. when a config is optional or not. 

An alternative I considered is to make some new type like `OptionalConfiguation` and to provide new overrides of the `getConfiguration`-like methods for this new type. In that way, the caller could be somewhat shielded from having to worry about whether a config is optional. The builder methods like `buildFeatureConfiguration` could be made to return either an `OptionalFeatureConfiguration` or just a `FeatureConfiguration`.

However, the config code is already pretty gnarly with multiple methods & types apparently doing the same thing, and I'm worried about adding more complexity there. 