### PR TITLE
Improve code-containment and efficiency of etag-aware loading

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -531,10 +531,18 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     if (ifNoneMatch != null) {
       // Perform freshness-aware table loading if caller specified ifNoneMatch.
       IcebergTableLikeEntity tableEntity = getTableEntity(tableIdentifier);
-      String tableEntityTag =
-          IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
-      if (ifNoneMatch.anyMatch(tableEntityTag)) {
-        return Optional.empty();
+      if (tableEntity == null || tableEntity.getMetadataLocation() == null) {
+        LOGGER
+            .atWarn()
+            .addKeyValue("tableIdentifier", tableIdentifier)
+            .addKeyValue("tableEntity", tableEntity)
+            .log("Failed to getMetadataLocation to generate ETag when loading table");
+      } else {
+        String tableEntityTag =
+            IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
+        if (ifNoneMatch.anyMatch(tableEntityTag)) {
+          return Optional.empty();
+        }
       }
     }
 
@@ -605,10 +613,18 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     if (ifNoneMatch != null) {
       // Perform freshness-aware table loading if caller specified ifNoneMatch.
       IcebergTableLikeEntity tableEntity = getTableEntity(tableIdentifier);
-      String tableETag =
-          IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
-      if (ifNoneMatch.anyMatch(tableETag)) {
-        return Optional.empty();
+      if (tableEntity == null || tableEntity.getMetadataLocation() == null) {
+        LOGGER
+            .atWarn()
+            .addKeyValue("tableIdentifier", tableIdentifier)
+            .addKeyValue("tableEntity", tableEntity)
+            .log("Failed to getMetadataLocation to generate ETag when loading table");
+      } else {
+        String tableETag =
+            IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
+        if (ifNoneMatch.anyMatch(tableETag)) {
+          return Optional.empty();
+        }
       }
     }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -538,6 +538,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
             .addKeyValue("tableEntity", tableEntity)
             .log("Failed to getMetadataLocation to generate ETag when loading table");
       } else {
+        // TODO: Refactor null-checking into the helper method once we create a more canonical
+        // interface for associate etags with entities.
         String tableEntityTag =
             IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
         if (ifNoneMatch.anyMatch(tableEntityTag)) {
@@ -620,6 +622,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
             .addKeyValue("tableEntity", tableEntity)
             .log("Failed to getMetadataLocation to generate ETag when loading table");
       } else {
+        // TODO: Refactor null-checking into the helper method once we create a more canonical
+        // interface for associate etags with entities.
         String tableETag =
             IcebergHttpUtil.generateETagForMetadataFileLocation(tableEntity.getMetadataLocation());
         if (ifNoneMatch.anyMatch(tableETag)) {

--- a/service/common/src/main/java/org/apache/polaris/service/http/IcebergHttpUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/http/IcebergHttpUtil.java
@@ -32,6 +32,10 @@ public class IcebergHttpUtil {
    * @return the generated ETag
    */
   public static String generateETagForMetadataFileLocation(String metadataFileLocation) {
+    if (metadataFileLocation == null) {
+      metadataFileLocation = "";
+    }
+
     // Use hash of metadata location since we don't want clients to use the ETag to try to extract
     // the metadata file location
     String hashedMetadataFileLocation = DigestUtils.sha256Hex(metadataFileLocation);

--- a/service/common/src/main/java/org/apache/polaris/service/http/IcebergHttpUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/http/IcebergHttpUtil.java
@@ -33,7 +33,8 @@ public class IcebergHttpUtil {
    */
   public static String generateETagForMetadataFileLocation(String metadataFileLocation) {
     if (metadataFileLocation == null) {
-      metadataFileLocation = "";
+      // Throw a more appropriate exception than letting DigestUtils die randomly.
+      throw new IllegalArgumentException("Unable to generate etag for null metadataFileLocation");
     }
 
     // Use hash of metadata location since we don't want clients to use the ETag to try to extract


### PR DESCRIPTION
-Make the hash generation resilient against null metadataLocation
-Use getResolvedPath instead of getPassthroughResolvedPath to avoid redundant persistence round-trip
-Only try to calculate the etag for comparison against ifNoneMatch if the ifNoneMatch is actually provided
