### PR TITLE
PySpark Reg Tests Allow Configuring Storage Region Location

### DIFF
--- a/regtests/t_pyspark/src/iceberg_spark.py
+++ b/regtests/t_pyspark/src/iceberg_spark.py
@@ -18,6 +18,7 @@
 #
 
 """Spark connector with different catalog types."""
+import os
 from typing import Any, Dict, List, Optional, Union
 
 from pyspark.errors import PySparkRuntimeError
@@ -43,7 +44,7 @@ class IcebergSparkSession:
       self,
       bearer_token: str = None,
       credentials: str = None,
-      aws_region: str = "us-west-2",
+      aws_region: str = None,
       catalog_name: str = None,
       polaris_url: str = None,
       realm: str = 'POLARIS'
@@ -51,7 +52,8 @@ class IcebergSparkSession:
     """Constructor for Iceberg Spark session. Sets the member variables."""
     self.bearer_token = bearer_token
     self.credentials = credentials
-    self.aws_region = aws_region
+    if aws_region is None:
+      self.aws_region = os.environ.get('AWS_REGION', 'us-west-2')
     self.catalog_name = catalog_name
     self.polaris_url = polaris_url
     self.realm = realm


### PR DESCRIPTION
PySpark Reg Tests Allow Configuring Storage Region Location by taking in the AWS_REGION environment variable if it exists. Else defaulting to us-west-2

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
