### PR TITLE
Generalize bootstrapping in servers

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -118,6 +118,11 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         PrincipalSecretsResult secretsResult =
             bootstrapServiceAndCreatePolarisPrincipalForRealm(
                 realmContext, metaStoreManagerMap.get(realmContext.getRealmIdentifier()));
+
+        if (rootCredentialsSet.credentials().containsKey(realm)) {
+          LOGGER.info("Bootstrapped realm {} using preset credentials.", realm);
+        }
+
         results.put(realmContext.getRealmIdentifier(), secretsResult);
       }
     }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -45,6 +45,7 @@ import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.service.auth.ActiveRolesProvider;
 import org.apache.polaris.service.auth.Authenticator;
@@ -55,7 +56,6 @@ import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.context.RealmContextConfiguration;
 import org.apache.polaris.service.context.RealmContextFilter;
 import org.apache.polaris.service.context.RealmContextResolver;
-import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.apache.polaris.service.quarkus.auth.QuarkusAuthenticationConfiguration;
 import org.apache.polaris.service.quarkus.catalog.io.QuarkusFileIOConfiguration;
 import org.apache.polaris.service.quarkus.context.QuarkusRealmContextConfiguration;
@@ -154,12 +154,14 @@ public class QuarkusProducers {
    * Eagerly initialize the in-memory default realm on startup, so that users can check the
    * credentials printed to stdout immediately.
    */
-  public void maybeInitializeInMemoryRealm(
+  public void maybeBootstrap(
       @Observes StartupEvent event,
       MetaStoreManagerFactory factory,
+      QuarkusPersistenceConfiguration config,
       RealmContextConfiguration realmContextConfiguration) {
-    if (factory instanceof InMemoryPolarisMetaStoreManagerFactory) {
-      ((InMemoryPolarisMetaStoreManagerFactory) factory).onStartup(realmContextConfiguration);
+    if (config.isAutoBootstrap()) {
+      RootCredentialsSet rootCredentialsSet = RootCredentialsSet.fromEnvironment();
+      factory.bootstrapRealms(realmContextConfiguration.realms(), rootCredentialsSet);
     }
   }
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/persistence/QuarkusPersistenceConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/persistence/QuarkusPersistenceConfiguration.java
@@ -20,6 +20,8 @@ package org.apache.polaris.service.quarkus.persistence;
 
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import java.util.Set;
 
 @StaticInitSafe
 @ConfigMapping(prefix = "polaris.persistence")
@@ -30,4 +32,11 @@ public interface QuarkusPersistenceConfiguration {
    * org.apache.polaris.core.persistence.MetaStoreManagerFactory} identifier.
    */
   String type();
+
+  @WithDefault("in-memory")
+  Set<String> autoBootstrapTypes();
+
+  default boolean isAutoBootstrap() {
+    return autoBootstrapTypes().contains(type());
+  }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -32,13 +32,13 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.bootstrap.RootCredentials;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
-import org.apache.polaris.service.context.RealmContextConfiguration;
 
 @ApplicationScoped
 @Identifier("in-memory")
@@ -57,10 +57,6 @@ public class InMemoryPolarisMetaStoreManagerFactory
       PolarisStorageIntegrationProvider storageIntegration, PolarisDiagnostics diagnostics) {
     super(diagnostics);
     this.storageIntegration = storageIntegration;
-  }
-
-  public void onStartup(RealmContextConfiguration realmContextConfiguration) {
-    bootstrapRealmsAndPrintCredentials(realmContextConfiguration.realms());
   }
 
   @Override
@@ -100,10 +96,22 @@ public class InMemoryPolarisMetaStoreManagerFactory
 
   private void bootstrapRealmsAndPrintCredentials(List<String> realms) {
     RootCredentialsSet rootCredentialsSet = RootCredentialsSet.fromEnvironment();
-    Map<String, PrincipalSecretsResult> results = this.bootstrapRealms(realms, rootCredentialsSet);
+    this.bootstrapRealms(realms, rootCredentialsSet);
     bootstrappedRealms.addAll(realms);
+  }
 
+  @Override
+  public Map<String, PrincipalSecretsResult> bootstrapRealms(
+      Iterable<String> realms, RootCredentialsSet rootCredentialsSet) {
+    Map<String, PrincipalSecretsResult> results = super.bootstrapRealms(realms, rootCredentialsSet);
+
+    Map<String, RootCredentials> presetCredentials = rootCredentialsSet.credentials();
     for (String realmId : realms) {
+      if (presetCredentials.containsKey(realmId)) {
+        // Credentials provided in the runtime env... no need to print
+        continue;
+      }
+
       PrincipalSecretsResult principalSecrets = results.get(realmId);
 
       String msg =
@@ -114,5 +122,7 @@ public class InMemoryPolarisMetaStoreManagerFactory
               principalSecrets.getPrincipalSecrets().getMainSecret());
       System.out.println(msg);
     }
+
+    return results;
   }
 }


### PR DESCRIPTION
* Remove `instanceof` checks from `QuarkusProducers`.

* Remove the now unused `onStartup` method from `InMemoryPolarisMetaStoreManagerFactory`.

* Instead, call the good old `bootstrapRealms` method from `QuarkusProducers`.

* Add new config property to control which MetaStore types are bootstrapped automatically (defaults to `in-memory` as before).

* There is no bootstrap behaviour change in this PR, only refactorings to simplify code.

* Add info log message to indicate when a realm is bootstrapped in runtime using preset credentials.

Future enhancements may include pulling preset credentials from a secret manager like Vault for bootstrapping (s discussed in comments on #1228).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
