### PR TITLE
Maven publication: Produce correct `<scm><tag>` in `pom.xml`

### DIFF
--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -103,7 +103,10 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
               connection.set("scm:git:$codeRepo")
               developerConnection.set("scm:git:$codeRepo")
               url.set("$codeRepo/tree/main")
-              tag.set("main")
+              val version = project.version.toString()
+              if (!version.endsWith("-SNAPSHOT")) {
+                tag.set("apache-polaris-$version")
+              }
             }
             issueManagement { url.set(projectPeople.bugDatabase) }
 


### PR DESCRIPTION
`project.scm.tag` in a Maven pom is intended to refer to the SCM (Git) tag. We currently publish `main`, which is incorrect.

This change omits the SCM tag for snapshot builds, but emits the Git tag for releases.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
