### PR TITLE
Remove `@StaticInitSafe` annotation

### DIFF
--- a/extension/persistence/eclipselink/build.gradle.kts
+++ b/extension/persistence/eclipselink/build.gradle.kts
@@ -34,9 +34,6 @@ dependencies {
 
   implementation(libs.eclipselink)
 
-  implementation(platform(libs.quarkus.bom))
-  implementation("io.quarkus:quarkus-core")
-
   implementation(libs.slf4j.api)
 
   val eclipseLinkDeps: String? = project.findProperty("eclipseLinkDeps") as String?
@@ -58,8 +55,8 @@ dependencies {
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)
-  compileOnly("io.smallrye.common:smallrye-common-annotation") // @Identifier
-  compileOnly("io.smallrye.config:smallrye-config-core") // @ConfigMapping
+  compileOnly(libs.smallrye.common.annotation) // @Identifier
+  compileOnly(libs.smallrye.config.core) // @ConfigMapping
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkConfiguration.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkConfiguration.java
@@ -18,13 +18,11 @@
  */
 package org.apache.polaris.extension.persistence.impl.eclipselink;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import java.nio.file.Path;
 import java.util.Optional;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.persistence.eclipselink")
 public interface EclipseLinkConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/auth/QuarkusAuthenticationConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/auth/QuarkusAuthenticationConfiguration.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.auth;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import org.apache.polaris.service.auth.AuthenticationConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.authentication")
 public interface QuarkusAuthenticationConfiguration extends AuthenticationConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/catalog/io/QuarkusFileIOConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/catalog/io/QuarkusFileIOConfiguration.java
@@ -18,10 +18,8 @@
  */
 package org.apache.polaris.service.quarkus.catalog.io;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.file-io")
 public interface QuarkusFileIOConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusBehaviorChangesConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusBehaviorChangesConfiguration.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.quarkus.config;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.polaris.service.config.FeaturesConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.behavior-changes")
 // FIXME: this should extend FeatureConfiguration, but that causes conflicts with
 // QuarkusFeaturesConfiguration

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusFeaturesConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusFeaturesConfiguration.java
@@ -18,12 +18,10 @@
  */
 package org.apache.polaris.service.quarkus.config;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import java.util.Map;
 import org.apache.polaris.service.config.FeaturesConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.features")
 public interface QuarkusFeaturesConfiguration extends FeaturesConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/context/QuarkusRealmContextConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/context/QuarkusRealmContextConfiguration.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.context;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import org.apache.polaris.service.context.RealmContextConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.realm-context")
 public interface QuarkusRealmContextConfiguration extends RealmContextConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/logging/QuarkusLoggingConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/logging/QuarkusLoggingConfiguration.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.logging;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import java.util.Map;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.log")
 public interface QuarkusLoggingConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusMetricsConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/QuarkusMetricsConfiguration.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.metrics;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import java.util.Map;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.metrics")
 public interface QuarkusMetricsConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/persistence/QuarkusPersistenceConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/persistence/QuarkusPersistenceConfiguration.java
@@ -18,10 +18,8 @@
  */
 package org.apache.polaris.service.quarkus.persistence;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.persistence")
 public interface QuarkusPersistenceConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusRateLimiterFilterConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusRateLimiterFilterConfiguration.java
@@ -18,10 +18,8 @@
  */
 package org.apache.polaris.service.quarkus.ratelimiter;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.rate-limiter.filter")
 public interface QuarkusRateLimiterFilterConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusTokenBucketConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/ratelimiter/QuarkusTokenBucketConfiguration.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.service.quarkus.ratelimiter;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import org.apache.polaris.service.ratelimiter.TokenBucketConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.rate-limiter.token-bucket")
 public interface QuarkusTokenBucketConfiguration extends TokenBucketConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/storage/QuarkusStorageConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/storage/QuarkusStorageConfiguration.java
@@ -18,14 +18,12 @@
  */
 package org.apache.polaris.service.quarkus.storage;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithName;
 import java.time.Duration;
 import java.util.*;
 import org.apache.polaris.service.storage.StorageConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.storage")
 public interface QuarkusStorageConfiguration extends StorageConfiguration {
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/task/QuarkusTaskHandlerConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/task/QuarkusTaskHandlerConfiguration.java
@@ -18,12 +18,10 @@
  */
 package org.apache.polaris.service.quarkus.task;
 
-import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import org.apache.polaris.service.task.TaskHandlerConfiguration;
 
-@StaticInitSafe
 @ConfigMapping(prefix = "polaris.tasks")
 public interface QuarkusTaskHandlerConfiguration extends TaskHandlerConfiguration {
 


### PR DESCRIPTION
There was an issue around mapped configurations having the `@StaticInitSafe` annotation that led to _two_ instances (a "static" one and a "somewhet application-scoped" one) - this was fixed in Quarkus 3.21. One bug in smallrye-config is fixed for Quarkus > 3.21.0, another issue however remains.

Since `@StaticInitSafe` annotated configs seem to cause some weird issues, it seems legit to remote that annotation altogether. This approach was [taken in Nessie](https://github.com/projectnessie/nessie/pull/10606) as well. Investigations (via practical experiments) have proven that there's no measurable impact (runtime + heap) when doing this - and that's also been confirmed by Quarkus + Smallrye-config maintainers.

Hence this change remotes that annotation from the code base.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
