### PR TITLE
Avoid adding duplicated projects for Intelij IDE usage

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -37,6 +37,11 @@ plugins {
 
 apply<PublishingHelperPlugin>()
 
+if (project.extra.has("duplicated-project-sources")) {
+  // skip the style check for duplicated projects
+  tasks.withType<Checkstyle>().configureEach { enabled = false }
+}
+
 tasks.withType(JavaCompile::class.java).configureEach {
   options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
   options.errorprone.disableAllWarnings = true

--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -33,11 +33,13 @@ apply<PublishingHelperPlugin>()
 
 apply<CopiedCodeCheckerPlugin>()
 
-spotless {
-  kotlinGradle {
-    ktfmt().googleStyle()
-    licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
-    target("*.gradle.kts", "build-logic/*.gradle.kts", "build-logic/src/**/*.kt*")
+if (!project.extra.has("duplicated-project-sources")) {
+  spotless {
+    kotlinGradle {
+      ktfmt().googleStyle()
+      licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
+      target("*.gradle.kts", "build-logic/*.gradle.kts", "build-logic/src/**/*.kt*")
+    }
   }
 }
 

--- a/build-logic/src/main/kotlin/polaris-spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-spotless.gradle.kts
@@ -25,37 +25,40 @@ import org.gradle.api.GradleException
 
 plugins { id("com.diffplug.spotless") }
 
-spotless {
-  java {
-    target("src/*/java/**/*.java")
-    googleJavaFormat()
-    licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
-    endWithNewline()
-    custom(
-      "disallowWildcardImports",
-      object : Serializable, FormatterFunc {
-        override fun apply(text: String): String {
-          val regex = "~/import .*\\.\\*;/".toRegex()
-          if (regex.matches(text)) {
-            throw GradleException("Wildcard imports disallowed - ${regex.findAll(text)}")
+// skip spotless check for duplicated projects
+if (!project.extra.has("duplicated-project-sources")) {
+  spotless {
+    java {
+      target("src/*/java/**/*.java")
+      googleJavaFormat()
+      licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
+      endWithNewline()
+      custom(
+        "disallowWildcardImports",
+        object : Serializable, FormatterFunc {
+          override fun apply(text: String): String {
+            val regex = "~/import .*\\.\\*;/".toRegex()
+            if (regex.matches(text)) {
+              throw GradleException("Wildcard imports disallowed - ${regex.findAll(text)}")
+            }
+            return text
           }
-          return text
-        }
-      },
-    )
-    toggleOffOn()
-  }
-  kotlinGradle {
-    ktfmt().googleStyle()
-    licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
-    target("*.gradle.kts")
-  }
-  format("xml") {
-    target("src/**/*.xml", "src/**/*.xsd")
-    targetExclude("codestyle/copyright-header.xml")
-    eclipseWtp(com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML)
-      .configFile(rootProject.file("codestyle/org.eclipse.wst.xml.core.prefs"))
-    // getting the license-header delimiter right is a bit tricky.
-    // licenseHeaderFile(rootProject.file("codestyle/copyright-header.xml"), '<^[!?].*$')
+        },
+      )
+      toggleOffOn()
+    }
+    kotlinGradle {
+      ktfmt().googleStyle()
+      licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
+      target("*.gradle.kts")
+    }
+    format("xml") {
+      target("src/**/*.xml", "src/**/*.xsd")
+      targetExclude("codestyle/copyright-header.xml")
+      eclipseWtp(com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML)
+        .configFile(rootProject.file("codestyle/org.eclipse.wst.xml.core.prefs"))
+      // getting the license-header delimiter right is a bit tricky.
+      // licenseHeaderFile(rootProject.file("codestyle/copyright-header.xml"), '<^[!?].*$')
+    }
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -79,8 +79,8 @@ for (sparkVersion in sparkVersions) {
       noSourceChecksProjects.add(":$artifactId")
     }
     // Skip all duplicated spark client projects while using Intelij IDE.
-    // This is to avoid problems during Intelij dependency analysis and sync,
-    // like "Multiple projects in this build have project directory".
+    // This is to avoid problems during dependency analysis and sync when
+    // using Intelij, like "Multiple projects in this build have project directory".
     if (ideaActive) {
       break
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,7 +57,7 @@ loadProperties(file("gradle/projects.main.properties")).forEach { name, director
   polarisProject(name as String, file(directory as String))
 }
 
-val ideActive = System.getProperty("idea.active").toBoolean()
+val ideaActive = System.getProperty("idea.active").toBoolean()
 
 // load the polaris spark plugin projects
 val polarisSparkDir = "plugins/spark"
@@ -78,10 +78,10 @@ for (sparkVersion in sparkVersions) {
     } else {
       noSourceChecksProjects.add(":$artifactId")
     }
-    // skip all duplicated spark client projects in IDE to avoid problems
-    // during Intelij dependency analysis and sync. For example:
-    // "Multiple projects in this build have project directory".
-    if (ideActive) {
+    // Skip all duplicated spark client projects while using Intelij IDE.
+    // This is to avoid problems during Intelij dependency analysis and sync,
+    // like "Multiple projects in this build have project directory".
+    if (ideaActive) {
       break
     }
   }


### PR DESCRIPTION
Intelij gives following warnings during sync 
```
Multiple projects in this build have project directory '/Users/yzou/polaris/plugins/spark/v3.5': [:polaris-spark-3.5_2.12, :polaris-spark-3.5_2.13]
```
And Intelij dependency analysis also fails with same error.
Further more, the stylecheck and spotless check are unnecessary for duplicated projects, and may cause problem.

Here, we fix the problem by only loading one project for the spark plugin during Intelij IDE usage. 

Also manually verified that only one spotless error will be thrown if there is format issue for spark client plugins.