### PR TITLE
Remove unnecessary `clean` and `--no-build-cache` from Gradle invocations

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -99,7 +99,11 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           eval $(minikube -p minikube docker-env)
-          ./gradlew :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+          ./gradlew \
+            :polaris-quarkus-server:assemble \
+            :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+            :polaris-quarkus-admin:assemble \
+            :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
             -Dquarkus.container-image.build=true \
             -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
           minikube image ls

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -45,7 +45,10 @@ jobs:
 
       - name: Image build
         run: |
-          ./gradlew :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true
+          ./gradlew \
+              :polaris-quarkus-server:assemble \
+              :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+              -Dquarkus.container-image.build=true
 
       - name: Regression Test
         env:

--- a/README.md
+++ b/README.md
@@ -76,8 +76,13 @@ select * from db1.table1;
 
 #### Running in Docker
 
-- `./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache` - To 
-  build the image locally.
+- To build the image locally:
+  ```bash
+  ./gradlew \
+    :polaris-quarkus-server:assemble \
+    :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+    -Dquarkus.container-image.build=true
+  ```
 - `docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest` - To run the image.
 
 The Polaris codebase contains some docker compose examples to quickly get started with Polaris,

--- a/getting-started/eclipselink/README.md
+++ b/getting-started/eclipselink/README.md
@@ -25,11 +25,14 @@ This example requires `jq` to be installed on your machine.
    the Postgres JDBC driver:
 
     ```shell
-    ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+    ./gradlew \
+       :polaris-quarkus-server:assemble \
+       :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+       :polaris-quarkus-admin:assemble \
+       :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
        -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
-       -Dquarkus.container-image.build=true \
-       --no-build-cache
+       -Dquarkus.container-image.build=true
     ```
 
 2. Start the docker compose group by running the following command from the root of the repository:

--- a/getting-started/spark/README.md
+++ b/getting-started/spark/README.md
@@ -27,7 +27,10 @@ A Jupyter notebook is used to run PySpark.
 If a Polaris image is not already present locally, build one with the following command:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true
 ```
 
 ## Run the `docker-compose` file

--- a/getting-started/telemetry/README.md
+++ b/getting-started/telemetry/README.md
@@ -24,7 +24,10 @@ This example requires `jq` to be installed on your machine.
 1. Build the Polaris image if it's not already present locally:
 
     ```shell
-    ./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+    ./gradlew \
+      :polaris-quarkus-server:assemble \
+      :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+      -Dquarkus.container-image.build=true
     ```
 
 2. Start the docker compose group by running the following command from the root of the repository:

--- a/getting-started/trino/README.md
+++ b/getting-started/trino/README.md
@@ -24,7 +24,10 @@ This getting started guide provides a `docker-compose` file to set up [Trino](ht
 ## Build Polaris Image
 Build Polaris Image while Docker is running
 ```
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+    :polaris-quarkus-server:assemble \
+    :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+    -Dquarkus.container-image.build=true
 ```
 
 ## Run the `docker-compose` file

--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -86,10 +86,13 @@ If necessary, build and load the Docker images with support for Postgres into Mi
 ```bash
 eval $(minikube -p minikube docker-env)
 
-./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+./gradlew \ 
+    :polaris-quarkus-server:assemble \
+    :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+    :polaris-quarkus-admin:assemble \
+    :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
     -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
-    --no-build-cache
+    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
 ```
 
 ### Installing the chart locally

--- a/helm/polaris/README.md.gotmpl
+++ b/helm/polaris/README.md.gotmpl
@@ -87,10 +87,13 @@ If necessary, build and load the Docker images with support for Postgres into Mi
 ```bash
 eval $(minikube -p minikube docker-env)
 
-./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
+./gradlew \
+    :polaris-quarkus-server:assemble \
+    :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+    :polaris-quarkus-admin:assemble \
+    :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
     -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
-    --no-build-cache
+    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
 ```
 
 ### Installing the chart locally

--- a/quarkus/admin/README.md
+++ b/quarkus/admin/README.md
@@ -47,7 +47,10 @@ java -jar polaris-quarkus-admin-<version>-runner.jar
 To also build the Docker image, you can use the following command:
 
 ```shell
-./gradlew clean :polaris-quarkus-admin:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+  :polaris-quarkus-admin:assemble \
+  :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true
 ```
 
 ## Running the Admin Tool

--- a/quarkus/server/README.md
+++ b/quarkus/server/README.md
@@ -46,16 +46,21 @@ To also build the Docker image, you can use the following command (a running Doc
 required):
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true
 ```
 
 If you need to customize the Docker image, for example to push to a local registry, you can use the
 following command:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:build -Dquarkus.container-image.build=true \
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true \
   -Dquarkus.container-image.registry=localhost:5001 \
   -Dquarkus.container-image.group=apache \
-  -Dquarkus.container-image.name=polaris-local \
-  --no-build-cache
+  -Dquarkus.container-image.name=polaris-local
 ```

--- a/regtests/README.md
+++ b/regtests/README.md
@@ -39,7 +39,10 @@ Tests can be run with docker-compose using the provided `./regtests/docker-compo
 follows:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true
 docker compose -f ./regtests/docker-compose.yml up --build --exit-code-from regtest
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -52,10 +52,12 @@ sh ./kind-registry.sh
 
 # Build and deploy the server image
 echo "Building polaris image..."
-./gradlew clean :polaris-quarkus-server:build $ECLIPSE_LINK_DEPS \
+./gradlew \
+  :polaris-quarkus-server:build \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  $ECLIPSE_LINK_DEPS \
   -Dquarkus.container-image.build=true \
-  -Dquarkus.container-image.registry=localhost:5001 \
-  --no-build-cache
+  -Dquarkus.container-image.registry=localhost:5001
 
 echo "Pushing polaris image..."
 docker push localhost:5001/apache/polaris

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -28,10 +28,11 @@ The tool must be built with the necessary JDBC drivers to access the metastore d
 example, to build the tool with support for Postgres, run the following:
 
 ```shell
-./gradlew clean :polaris-quarkus-admin:build \
+./gradlew \
+  :polaris-quarkus-admin:assemble \
+  :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
   -Dquarkus.container-image.build=true \
-  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
-  --no-build-cache
+  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
 ```
 
 The above command will generate:

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -92,7 +92,10 @@ your H2 configuration using the persistence unit template below:
 To build Polaris with the necessary H2 dependency and start the Polaris service, run the following:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -PeclipseLinkDeps=com.h2database:h2:2.3.232
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -PeclipseLinkDeps=com.h2database:h2:2.3.232
 java -Dpolaris.persistence.type=eclipse-link \
      -Dpolaris.persistence.eclipselink.configuration-file=/path/to/persistence.xml \
      -Dpolaris.persistence.eclipselink.persistence-unit=polaris \
@@ -130,7 +133,10 @@ The following shows a sample configuration for integrating Polaris with Postgres
 To build Polaris with the necessary Postgres dependency and start the Polaris service, run the following:
 
 ```shell
-./gradlew clean :polaris-quarkus-server:assemble -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
 java -Dpolaris.persistence.type=eclipse-link \
      -Dpolaris.persistence.eclipselink.configuration-file=/path/to/persistence.xml \
      -Dpolaris.persistence.eclipselink.persistence-unit=polaris \

--- a/site/content/in-dev/unreleased/quickstart.md
+++ b/site/content/in-dev/unreleased/quickstart.md
@@ -105,7 +105,10 @@ To start using Polaris in Docker, launch Polaris while Docker is running:
 
 ```shell
 cd ~/polaris
-./gradlew clean :polaris-quarkus-server:assemble -Dquarkus.container-image.build=true --no-build-cache
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+  -Dquarkus.container-image.build=true
 docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest
 ```
 
@@ -125,7 +128,9 @@ The easiest way to run Polaris locally is to start the Polaris server from the
 ```shell
 cd ~/polaris
 # Build the server
-./gradlew clean :polaris-quarkus-server:assemble
+./gradlew \
+  :polaris-quarkus-server:assemble \
+  :polaris-quarkus-server:quarkusAppPartsBuild --rerun
 # Start the server
 java -jar quarkus/server/build/quarkus-app/quarkus-run.jar
 ```


### PR DESCRIPTION
`quarkusAppPartsBuild --rerun` is the right way to force a Docker image build.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
