### PR TITLE
Surface failed BaseResults to the caller more often

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
@@ -22,14 +22,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.Optional;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
-
-import java.util.Optional;
 
 /** Base result class for any call to the persistence layer */
 public class BaseResult {
@@ -74,10 +73,11 @@ public class BaseResult {
   }
 
   /**
-   * If this result is not a successful one, this builds an exception from the failed result
-   * which the exception mapper can use to provide the caller some useful information about
-   * the failure. The message relies on `extraInformation`.
+   * If this result is not a successful one, this builds an exception from the failed result which
+   * the exception mapper can use to provide the caller some useful information about the failure.
+   * The message relies on `extraInformation`.
    */
+  @SuppressWarnings("FormatStringAnnotation")
   public Optional<RuntimeException> getException() {
     // TODO use a switch expression if the Java version here is ever raised
     if (this.returnStatusCode == ReturnStatus.SUCCESS.getCode()) {
@@ -98,7 +98,8 @@ public class BaseResult {
       return Optional.of(new NamespaceNotEmptyException(this.extraInformation));
     } else if (this.returnStatusCode == ReturnStatus.CATALOG_NOT_EMPTY.getCode()) {
       return Optional.of(new BadRequestException(this.extraInformation));
-    } else if (this.returnStatusCode == ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED.getCode()) {
+    } else if (this.returnStatusCode
+        == ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED.getCode()) {
       return Optional.of(new CommitFailedException(this.extraInformation));
     } else if (this.returnStatusCode == ReturnStatus.ENTITY_CANNOT_BE_RENAMED.getCode()) {
       return Optional.of(new BadRequestException(this.extraInformation));
@@ -106,7 +107,8 @@ public class BaseResult {
       return Optional.of(new UnprocessableEntityException(this.extraInformation));
     } else if (this.returnStatusCode == ReturnStatus.POLICY_MAPPING_NOT_FOUND.getCode()) {
       return Optional.of(new NotFoundException(this.extraInformation));
-    } else if (this.returnStatusCode == ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS.getCode()) {
+    } else if (this.returnStatusCode
+        == ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS.getCode()) {
       return Optional.of(new AlreadyExistsException(this.extraInformation));
     } else {
       return Optional.of(new RuntimeException(this.extraInformation));
@@ -114,16 +116,16 @@ public class BaseResult {
   }
 
   /**
-   * If this result is failed, this should throw the appropriate exception which corresponds
-   * to the result status. See {@link BaseResult#getException} for details.
+   * If this result is failed, this should throw the appropriate exception which corresponds to the
+   * result status. See {@link BaseResult#getException} for details.
    */
   public void maybeThrowException() throws RuntimeException {
     if (this.getException().isPresent()) {
-        throw this.getException().get();
+      throw this.getException().get();
     }
   }
 
-    /** Possible return code for the various API calls. */
+  /** Possible return code for the various API calls. */
   public enum ReturnStatus {
     // all good
     SUCCESS(1),

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -603,18 +603,7 @@ public class PolarisAdminService {
         metaStoreManager.dropEntityIfExists(
             getCurrentPolarisContext(), null, entity, Map.of(), cleanup);
 
-    // at least some handling of error
-    if (!dropEntityResult.isSuccess()) {
-      if (dropEntityResult.failedBecauseNotEmpty()) {
-        throw new BadRequestException(
-            "Catalog '%s' cannot be dropped, it is not empty", entity.getName());
-      } else {
-        throw new BadRequestException(
-            "Catalog '%s' cannot be dropped, concurrent modification detected. Please try "
-                + "again",
-            entity.getName());
-      }
-    }
+    dropEntityResult.maybeThrowException();
   }
 
   public @Nonnull CatalogEntity getCatalog(String name) {
@@ -804,16 +793,7 @@ public class PolarisAdminService {
         metaStoreManager.dropEntityIfExists(
             getCurrentPolarisContext(), null, entity, Map.of(), false);
 
-    // at least some handling of error
-    if (!dropEntityResult.isSuccess()) {
-      if (dropEntityResult.isEntityUnDroppable()) {
-        throw new BadRequestException("Root principal cannot be dropped");
-      } else {
-        throw new BadRequestException(
-            "Root principal cannot be dropped, concurrent modification "
-                + "detected. Please try again");
-      }
-    }
+    dropEntityResult.maybeThrowException();
   }
 
   public @Nonnull PrincipalEntity getPrincipal(String name) {
@@ -963,21 +943,11 @@ public class PolarisAdminService {
     PolarisEntity entity =
         findPrincipalRoleByName(name)
             .orElseThrow(() -> new NotFoundException("PrincipalRole %s not found", name));
-    // TODO: Handle return value in case of concurrent modification
     DropEntityResult dropEntityResult =
         metaStoreManager.dropEntityIfExists(
             getCurrentPolarisContext(), null, entity, Map.of(), true); // cleanup grants
 
-    // at least some handling of error
-    if (!dropEntityResult.isSuccess()) {
-      if (dropEntityResult.isEntityUnDroppable()) {
-        throw new BadRequestException("Polaris service admin principal role cannot be dropped");
-      } else {
-        throw new BadRequestException(
-            "Polaris service admin principal role cannot be dropped, "
-                + "concurrent modification detected. Please try again");
-      }
-    }
+    dropEntityResult.maybeThrowException();
   }
 
   public @Nonnull PrincipalRoleEntity getPrincipalRole(String name) {
@@ -1088,16 +1058,7 @@ public class PolarisAdminService {
             Map.of(),
             true); // cleanup grants
 
-    // at least some handling of error
-    if (!dropEntityResult.isSuccess()) {
-      if (dropEntityResult.isEntityUnDroppable()) {
-        throw new BadRequestException("Catalog admin role cannot be dropped");
-      } else {
-        throw new BadRequestException(
-            "Catalog admin role cannot be dropped, concurrent "
-                + "modification detected. Please try again");
-      }
-    }
+    dropEntityResult.maybeThrowException();
   }
 
   public @Nonnull CatalogRoleEntity getCatalogRole(String catalogName, String name) {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalog.java
@@ -158,6 +158,7 @@ public class GenericTableCatalog {
             Map.of(),
             false);
 
+    dropEntityResult.maybeThrowException();
     return dropEntityResult.isSuccess();
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1691,7 +1691,6 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                 PolarisEntity.toCoreList(newCatalogPath),
                 toEntity);
 
-
     // handle error
     if (returnedEntityResult.getException().isPresent()) {
       LOGGER.debug(
@@ -1709,16 +1708,23 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             if (existingEntitySubType == null) {
               // this code path is unexpected
               throw new AlreadyExistsException(
-                  returnedEntityException, "Cannot rename %s to %s. Object already exists", from, to);
+                  returnedEntityException,
+                  "Cannot rename %s to %s. Object already exists",
+                  from,
+                  to);
             } else if (existingEntitySubType == PolarisEntitySubType.ICEBERG_TABLE) {
               throw new AlreadyExistsException(
-                  returnedEntityException, "Cannot rename %s to %s. Table already exists", from, to);
+                  returnedEntityException,
+                  "Cannot rename %s to %s. Table already exists",
+                  from,
+                  to);
             } else if (existingEntitySubType == PolarisEntitySubType.ICEBERG_VIEW) {
               throw new AlreadyExistsException(
                   returnedEntityException, "Cannot rename %s to %s. View already exists", from, to);
             }
             throw new IllegalStateException(
-                String.format("Unexpected entity type '%s'", existingEntitySubType), returnedEntityException);
+                String.format("Unexpected entity type '%s'", existingEntitySubType),
+                returnedEntityException);
           }
 
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
@@ -1798,10 +1804,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       RuntimeException resultException = res.getException().get();
       switch (res.getReturnStatus()) {
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
-          throw new NotFoundException(resultException, "Parent path does not exist for %s", identifier);
+          throw new NotFoundException(
+              resultException, "Parent path does not exist for %s", identifier);
         case BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS:
           throw new AlreadyExistsException(
-              resultException, "Iceberg table, view, or generic table already exists: %s", identifier);
+              resultException,
+              "Iceberg table, view, or generic table already exists: %s",
+              identifier);
         default:
           throw resultException;
       }
@@ -1832,10 +1841,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       RuntimeException resultException = res.getException().get();
       switch (res.getReturnStatus()) {
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
-          throw new NotFoundException(resultException, "Parent path does not exist for %s", identifier);
+          throw new NotFoundException(
+              resultException, "Parent path does not exist for %s", identifier);
         case BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED:
           throw new CommitFailedException(
-              resultException, "Failed to commit Table or View %s because it was concurrently modified", identifier);
+              resultException,
+              "Failed to commit Table or View %s because it was concurrently modified",
+              identifier);
         default:
           throw resultException;
       }
@@ -1903,7 +1915,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     Preconditions.checkNotNull(notificationType, "Expected a valid notification type.");
 
     if (notificationType == NotificationType.DROP) {
-      DropEntityResult dropEntityResult = dropTableLike(
+      DropEntityResult dropEntityResult =
+          dropTableLike(
               PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier, Map.of(), false /* purge */);
       dropEntityResult.maybeThrowException();
       return true;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -269,6 +269,7 @@ public class PolicyCatalog {
             Map.of(),
             false);
 
+    dropEntityResult.maybeThrowException();
     return dropEntityResult.isSuccess();
   }
 


### PR DESCRIPTION
In many `...Catalog` methods like `dropPolicy` or `dropGenericTable`, we simply return `false` if there's a `BaseResult` from persistence that doesn't have a `SUCCESS` error code. In some cases like in `IcebergCatalog` we do a little better, mapping a small subset of failures into exceptions.

This PR pushes this mapping down into `BaseResult` so that methods which rely on `BaseResult` to report the success of a persistence call can pass accurate information about the error back to the caller (via the exception mapper in the case of a REST call).