### PR TITLE
Remove PolarisConfiguration.loadConfig 

### DIFF
--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.core:jackson-core")
   implementation("com.fasterxml.jackson.core:jackson-databind")
+  implementation("jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0")
   implementation(libs.caffeine)
   implementation(libs.commons.lang3)
   implementation(libs.commons.codec1)

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.config;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.polaris.core.context.CallContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,25 +113,6 @@ public abstract class PolarisConfiguration<T> {
       }
       return new BehaviorChangeConfiguration<>(key, description, defaultValue, catalogConfig);
     }
-  }
-
-  /**
-   * Returns the value of a `PolarisConfiguration`, or the default if it cannot be loaded. This
-   * method does not need to be used when a `CallContext` is already available
-   */
-  public static <T> T loadConfig(PolarisConfiguration<T> configuration) {
-    var callContext = CallContext.getCurrentContext();
-    if (callContext == null) {
-      LOGGER.warn(
-          String.format(
-              "Unable to load current call context; using %s = %s",
-              configuration.key, configuration.defaultValue));
-      return configuration.defaultValue;
-    }
-    return callContext
-        .getPolarisCallContext()
-        .getConfigurationStore()
-        .getConfiguration(callContext.getPolarisCallContext(), configuration);
   }
 
   public static <T> Builder<T> builder() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -22,6 +22,7 @@ import static org.apache.polaris.core.admin.model.StorageConfigInfo.StorageTypeE
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.enterprise.inject.spi.CDI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
+import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.storage.FileStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
@@ -279,9 +281,14 @@ public class CatalogEntity extends PolarisEntity {
 
     /** Validate the number of allowed locations not exceeding the max value. */
     private void validateMaxAllowedLocations(Collection<String> allowedLocations) {
+      CallContext callContext = CDI.current().select(CallContext.class).get();
       int maxAllowedLocations =
-          BehaviorChangeConfiguration.loadConfig(
-              BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS);
+          callContext
+              .getPolarisCallContext()
+              .getConfigurationStore()
+              .getConfiguration(
+                  callContext.getPolarisCallContext(),
+                  BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS);
       if (maxAllowedLocations != -1 && allowedLocations.size() > maxAllowedLocations) {
         throw new IllegalArgumentException(
             String.format(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1575,7 +1575,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     try {
       EnumMap<PolarisCredentialProperty, String> creds =
           storageIntegration.getSubscopedCreds(
-              callCtx.getDiagServices(),
+              callCtx,
               storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -178,10 +178,10 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
 
   @Override
   public synchronized StorageCredentialCache getOrCreateStorageCredentialCache(
-      RealmContext realmContext) {
+      RealmContext realmContext, PolarisCallContext polarisCallContext) {
     if (!storageCredentialCacheMap.containsKey(realmContext.getRealmIdentifier())) {
       storageCredentialCacheMap.put(
-          realmContext.getRealmIdentifier(), new StorageCredentialCache());
+          realmContext.getRealmIdentifier(), new StorageCredentialCache(polarisCallContext));
     }
 
     return storageCredentialCacheMap.get(realmContext.getRealmIdentifier());

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreManagerFactory.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.persistence;
 
 import java.util.Map;
 import java.util.function.Supplier;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.cache.EntityCache;
@@ -34,7 +35,8 @@ public interface MetaStoreManagerFactory {
 
   Supplier<? extends BasePersistence> getOrCreateSessionSupplier(RealmContext realmContext);
 
-  StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext);
+  StorageCredentialCache getOrCreateStorageCredentialCache(
+      RealmContext realmContext, PolarisCallContext polarisCallContext);
 
   EntityCache getOrCreateEntityCache(RealmContext realmContext);
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2004,7 +2004,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     try {
       EnumMap<PolarisCredentialProperty, String> creds =
           storageIntegration.getSubscopedCreds(
-              callCtx.getDiagServices(),
+              callCtx,
               storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -23,7 +23,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.PolarisCallContext;
 
 /**
  * Abstract of Polaris Storage Integration. It holds the reference to an object that having the
@@ -55,7 +55,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
    * @return An enum map including the scoped credentials
    */
   public abstract EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull PolarisDiagnostics diagnostics,
+      @Nonnull PolarisCallContext callContext,
       @Nonnull T storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.storage.azure;
 
+import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
+
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredential;
@@ -45,8 +47,7 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.slf4j.Logger;
@@ -71,7 +72,7 @@ public class AzureCredentialsStorageIntegration
 
   @Override
   public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull PolarisDiagnostics diagnostics,
+      @Nonnull PolarisCallContext callContext,
       @Nonnull AzureStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
@@ -126,7 +127,9 @@ public class AzureCredentialsStorageIntegration
     // clock skew between the client and server,
     OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds =
-        FeatureConfiguration.loadConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+        callContext
+            .getConfigurationStore()
+            .getConfiguration(callContext, STORAGE_CREDENTIAL_DURATION_SECONDS);
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -23,14 +23,11 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
-import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-
-import jakarta.inject.Inject;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -42,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Storage subscoped credential cache. */
-@ApplicationScoped
 public class StorageCredentialCache {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StorageCredentialCache.class);
@@ -53,7 +49,6 @@ public class StorageCredentialCache {
   private final long maxCacheDurationMs;
 
   /** Initialize the creds cache */
-  @Inject
   public StorageCredentialCache(PolarisCallContext polarisCallContext) {
     this.maxCacheDurationMs = maxCacheDurationMs(polarisCallContext);
     cache =

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -70,7 +70,7 @@ public class GcpCredentialsStorageIntegration
 
   @Override
   public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-      @Nonnull PolarisDiagnostics diagnostics,
+      @Nonnull PolarisCallContext callContext,
       @Nonnull GcpStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
-import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
@@ -208,7 +207,7 @@ class InMemoryStorageIntegrationTest {
 
     @Override
     public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-        @Nonnull PolarisDiagnostics diagnostics,
+        @Nonnull PolarisCallContext callContext,
         @Nonnull PolarisStorageConfigurationInfo storageConfig,
         boolean allowListOperation,
         @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -71,12 +71,12 @@ public class StorageCredentialCacheTest {
         new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
     callCtx = new PolarisCallContext(metaStore, diagServices);
     metaStoreManager = Mockito.mock(PolarisMetaStoreManager.class);
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
   }
 
   @Test
   public void testBadResult() {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     ScopedCredentialsResult badResult =
         new ScopedCredentialsResult(
             BaseResult.ReturnStatus.SUBSCOPE_CREDS_ERROR, "extra_error_info");
@@ -109,7 +109,7 @@ public class StorageCredentialCacheTest {
 
   @Test
   public void testCacheHit() {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     List<ScopedCredentialsResult> mockedScopedCreds =
         getFakeScopedCreds(3, /* expireSoon= */ false);
     Mockito.when(
@@ -152,7 +152,7 @@ public class StorageCredentialCacheTest {
 
   @RepeatedTest(10)
   public void testCacheEvict() throws InterruptedException {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     List<ScopedCredentialsResult> mockedScopedCreds = getFakeScopedCreds(3, /* expireSoon= */ true);
 
     Mockito.when(
@@ -210,7 +210,7 @@ public class StorageCredentialCacheTest {
 
   @Test
   public void testCacheGenerateNewEntries() {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     List<ScopedCredentialsResult> mockedScopedCreds =
         getFakeScopedCreds(3, /* expireSoon= */ false);
     Mockito.when(
@@ -297,7 +297,7 @@ public class StorageCredentialCacheTest {
 
   @Test
   public void testCacheNotAffectedBy() {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     List<ScopedCredentialsResult> mockedScopedCreds =
         getFakeScopedCreds(3, /* expireSoon= */ false);
 
@@ -442,7 +442,7 @@ public class StorageCredentialCacheTest {
 
   @Test
   public void testAzureCredentialFormatting() {
-    storageCredentialCache = new StorageCredentialCache();
+    storageCredentialCache = new StorageCredentialCache(callCtx);
     List<ScopedCredentialsResult> mockedScopedCreds =
         List.of(
             new ScopedCredentialsResult(

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -22,20 +22,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.annotation.Nonnull;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
-import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import org.threeten.extra.MutableClock;
 import software.amazon.awssdk.policybuilder.iam.IamAction;
 import software.amazon.awssdk.policybuilder.iam.IamCondition;
 import software.amazon.awssdk.policybuilder.iam.IamConditionOperator;
@@ -64,6 +69,18 @@ class AwsCredentialsStorageIntegrationTest {
           .build();
   public static final String AWS_PARTITION = "aws";
 
+  public PolarisCallContext callContext;
+
+  @BeforeEach
+  public void setup() {
+    callContext =
+        new PolarisCallContext(
+            Mockito.mock(),
+            Mockito.mock(),
+            new PolarisConfigurationStore() {},
+            MutableClock.of(Instant.now(), ZoneOffset.UTC).withZone(ZoneId.systemDefault()));
+  }
+
   @Test
   public void testGetSubscopedCreds() {
     StsClient stsClient = Mockito.mock(StsClient.class);
@@ -83,7 +100,7 @@ class AwsCredentialsStorageIntegrationTest {
     EnumMap<PolarisCredentialProperty, String> credentials =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                Mockito.mock(PolarisDiagnostics.class),
+                callContext,
                 new AwsStorageConfigurationInfo(
                     PolarisStorageConfigurationInfo.StorageType.S3,
                     List.of(warehouseDir),
@@ -231,7 +248,7 @@ class AwsCredentialsStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            Mockito.mock(PolarisDiagnostics.class),
+                            callContext,
                             new AwsStorageConfigurationInfo(
                                 storageType,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -248,7 +265,7 @@ class AwsCredentialsStorageIntegrationTest {
         EnumMap<PolarisCredentialProperty, String> credentials =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    Mockito.mock(PolarisDiagnostics.class),
+                    callContext,
                     new AwsStorageConfigurationInfo(
                         storageType,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -349,7 +366,7 @@ class AwsCredentialsStorageIntegrationTest {
     EnumMap<PolarisCredentialProperty, String> credentials =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                Mockito.mock(PolarisDiagnostics.class),
+                callContext,
                 new AwsStorageConfigurationInfo(
                     PolarisStorageConfigurationInfo.StorageType.S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -444,7 +461,7 @@ class AwsCredentialsStorageIntegrationTest {
     EnumMap<PolarisCredentialProperty, String> credentials =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                Mockito.mock(PolarisDiagnostics.class),
+                callContext,
                 new AwsStorageConfigurationInfo(
                     storageType,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -509,7 +526,7 @@ class AwsCredentialsStorageIntegrationTest {
     EnumMap<PolarisCredentialProperty, String> credentials =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                Mockito.mock(PolarisDiagnostics.class),
+                callContext,
                 new AwsStorageConfigurationInfo(
                     PolarisStorageConfigurationInfo.StorageType.S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -549,7 +566,7 @@ class AwsCredentialsStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            Mockito.mock(PolarisDiagnostics.class),
+                            callContext,
                             new AwsStorageConfigurationInfo(
                                 PolarisStorageConfigurationInfo.StorageType.S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -566,7 +583,7 @@ class AwsCredentialsStorageIntegrationTest {
         EnumMap<PolarisCredentialProperty, String> credentials =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    Mockito.mock(PolarisDiagnostics.class),
+                    callContext,
                     new AwsStorageConfigurationInfo(
                         PolarisStorageConfigurationInfo.StorageType.S3,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -604,7 +621,7 @@ class AwsCredentialsStorageIntegrationTest {
         EnumMap<PolarisCredentialProperty, String> credentials =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    Mockito.mock(PolarisDiagnostics.class),
+                    callContext,
                     new AwsStorageConfigurationInfo(
                         PolarisStorageConfigurationInfo.StorageType.S3,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -624,7 +641,7 @@ class AwsCredentialsStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            Mockito.mock(PolarisDiagnostics.class),
+                            callContext,
                             new AwsStorageConfigurationInfo(
                                 PolarisStorageConfigurationInfo.StorageType.S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -40,6 +40,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -47,7 +50,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
@@ -60,6 +64,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mockito;
+import org.threeten.extra.MutableClock;
 
 public class AzureCredentialStorageIntegrationTest {
 
@@ -349,7 +355,11 @@ public class AzureCredentialStorageIntegrationTest {
         new AzureCredentialsStorageIntegration();
     EnumMap<PolarisCredentialProperty, String> credsMap =
         azureCredsIntegration.getSubscopedCreds(
-            new PolarisDefaultDiagServiceImpl(),
+            new PolarisCallContext(
+                Mockito.mock(),
+                Mockito.mock(),
+                new PolarisConfigurationStore() {},
+                MutableClock.of(Instant.now(), ZoneOffset.UTC).withZone(ZoneId.systemDefault())),
             azureConfig,
             allowListAction,
             new HashSet<>(allowedReadLoc),

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -39,6 +39,8 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,7 +50,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
@@ -58,6 +61,8 @@ import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguratio
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.threeten.extra.MutableClock;
 
 class GcpCredentialsStorageIntegrationTest {
 
@@ -172,7 +177,11 @@ class GcpCredentialsStorageIntegrationTest {
             ServiceOptions.getFromServiceLoader(HttpTransportFactory.class, NetHttpTransport::new));
     EnumMap<PolarisCredentialProperty, String> credsMap =
         gcpCredsIntegration.getSubscopedCreds(
-            new PolarisDefaultDiagServiceImpl(),
+            new PolarisCallContext(
+                Mockito.mock(),
+                Mockito.mock(),
+                new PolarisConfigurationStore() {},
+                MutableClock.of(Instant.now(), ZoneOffset.UTC).withZone(ZoneId.systemDefault())),
             gcpConfig,
             allowListAction,
             new HashSet<>(allowedReadLoc),

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -81,8 +81,8 @@ public class QuarkusProducers {
 
   @Produces
   @ApplicationScoped
-  public StorageCredentialCache storageCredentialCache() {
-    return new StorageCredentialCache();
+  public StorageCredentialCache storageCredentialCache(PolarisCallContext polarisCallContext) {
+    return new StorageCredentialCache(polarisCallContext);
   }
 
   @Produces
@@ -230,8 +230,10 @@ public class QuarkusProducers {
   @Produces
   @RequestScoped
   public PolarisEntityManager polarisEntityManager(
-      RealmContext realmContext, RealmEntityManagerFactory factory) {
-    return factory.getOrCreateEntityManager(realmContext);
+      RealmContext realmContext,
+      RealmEntityManagerFactory factory,
+      PolarisCallContext polarisCallContext) {
+    return factory.getOrCreateEntityManager(realmContext, polarisCallContext);
   }
 
   @Produces

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -223,7 +223,8 @@ public abstract class PolarisAuthzTestBase {
               }
             },
             clock);
-    this.entityManager = realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
+    this.entityManager =
+        realmEntityManagerFactory.getOrCreateEntityManager(realmContext, polarisContext);
 
     callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);
@@ -262,7 +263,7 @@ public abstract class PolarisAuthzTestBase {
                 .setName(CATALOG_NAME)
                 .setCatalogType("INTERNAL")
                 .setDefaultBaseLocation(storageLocation)
-                .setStorageConfigurationInfo(storageConfigModel, storageLocation)
+                .setStorageConfigurationInfo(storageConfigModel, storageLocation, polarisContext)
                 .build());
 
     initBaseCatalog();

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -165,7 +165,7 @@ public class GenericTableCatalogTest {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(), new EntityCache(metaStoreManager));
+            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 
@@ -213,7 +213,7 @@ public class GenericTableCatalogTest {
                     FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                 .addProperty(
                     FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-                .setStorageConfigurationInfo(storageConfigModel, storageLocation)
+                .setStorageConfigurationInfo(storageConfigModel, storageLocation, polarisContext)
                 .build());
 
     PolarisPassthroughResolutionView passthroughView =
@@ -278,8 +278,9 @@ public class GenericTableCatalogTest {
       }
 
       @Override
-      public StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext) {
-        return new StorageCredentialCache();
+      public StorageCredentialCache getOrCreateStorageCredentialCache(
+          RealmContext realmContext, PolarisCallContext polarisCallContext) {
+        return new StorageCredentialCache(polarisCallContext);
       }
 
       @Override

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -165,7 +165,9 @@ public class GenericTableCatalogTest {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
+            metaStoreManager,
+            new StorageCredentialCache(polarisContext),
+            new EntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -1727,7 +1728,8 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         new CatalogEntity.Builder()
             .setName(externalCatalog)
             .setDefaultBaseLocation(storageLocation)
-            .setStorageConfigurationInfo(storageConfigModel, storageLocation)
+            .setStorageConfigurationInfo(
+                storageConfigModel, storageLocation, callContext.getPolarisCallContext())
             .setCatalogType("EXTERNAL")
             .build());
     adminService.createCatalogRole(
@@ -1794,7 +1796,8 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         new PolarisCallContextCatalogFactory(
             new RealmEntityManagerFactory(null) {
               @Override
-              public PolarisEntityManager getOrCreateEntityManager(RealmContext realmContext) {
+              public PolarisEntityManager getOrCreateEntityManager(
+                  RealmContext realmContext, PolarisCallContext polarisCallContext) {
                 return entityManager;
               }
             },

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -212,7 +212,9 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(polarisContext), createEntityCache(metaStoreManager));
+            metaStoreManager,
+            new StorageCredentialCache(polarisContext),
+            createEntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 
@@ -261,7 +263,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
                     FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                 .addProperty(
                     FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-                .setStorageConfigurationInfo(storageConfigModel, storageLocation)
+                .setStorageConfigurationInfo(storageConfigModel, storageLocation, polarisContext)
                 .build());
 
     RealmEntityManagerFactory realmEntityManagerFactory =
@@ -1505,7 +1507,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
             .addProperty(
                 FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
             .addProperty(FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "false")
-            .setStorageConfigurationInfo(noPurgeStorageConfigModel, storageLocation)
+            .setStorageConfigurationInfo(noPurgeStorageConfigModel, storageLocation, polarisContext)
             .build());
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -212,7 +212,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(), createEntityCache(metaStoreManager));
+            metaStoreManager, new StorageCredentialCache(polarisContext), createEntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 
@@ -364,8 +364,9 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
       }
 
       @Override
-      public StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext) {
-        return new StorageCredentialCache();
+      public StorageCredentialCache getOrCreateStorageCredentialCache(
+          RealmContext realmContext, PolarisCallContext polarisCallContext) {
+        return new StorageCredentialCache(polarisCallContext);
       }
 
       @Override

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -139,7 +139,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
 
     PolarisEntityManager entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(), new EntityCache(metaStoreManager));
+            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
 
     CallContext callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);
@@ -178,7 +178,8 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
             .setStorageConfigurationInfo(
                 new FileStorageConfigInfo(
                     StorageConfigInfo.StorageTypeEnum.FILE, List.of("file://", "/", "*")),
-                "file://tmp")
+                "file://tmp",
+                polarisContext)
             .build());
 
     PolarisPassthroughResolutionView passthroughView =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -139,7 +139,9 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
 
     PolarisEntityManager entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
+            metaStoreManager,
+            new StorageCredentialCache(polarisContext),
+            new EntityCache(metaStoreManager));
 
     CallContext callContext = CallContext.of(realmContext, polarisContext);
     CallContext.setCurrentContext(callContext);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -186,7 +186,9 @@ public class PolicyCatalogTest {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
+            metaStoreManager,
+            new StorageCredentialCache(polarisContext),
+            new EntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -186,7 +186,7 @@ public class PolicyCatalogTest {
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(
-            metaStoreManager, new StorageCredentialCache(), new EntityCache(metaStoreManager));
+            metaStoreManager, new StorageCredentialCache(polarisContext), new EntityCache(metaStoreManager));
 
     callContext = CallContext.of(realmContext, polarisContext);
 
@@ -234,7 +234,7 @@ public class PolicyCatalogTest {
                     FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                 .addProperty(
                     FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-                .setStorageConfigurationInfo(storageConfigModel, storageLocation)
+                .setStorageConfigurationInfo(storageConfigModel, storageLocation, polarisContext)
                 .build());
 
     PolarisPassthroughResolutionView passthroughView =
@@ -298,8 +298,9 @@ public class PolicyCatalogTest {
       }
 
       @Override
-      public StorageCredentialCache getOrCreateStorageCredentialCache(RealmContext realmContext) {
-        return new StorageCredentialCache();
+      public StorageCredentialCache getOrCreateStorageCredentialCache(
+          RealmContext realmContext, PolarisCallContext polarisCallContext) {
+        return new StorageCredentialCache(polarisCallContext);
       }
 
       @Override

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
@@ -33,17 +33,19 @@ import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class CatalogEntityTest {
 
-  @BeforeAll
-  public static void setup() {
+  private PolarisCallContext polarisCallContext;
+
+  @BeforeEach
+  public void setup() {
     MetaStoreManagerFactory metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
-    PolarisCallContext polarisCallContext =
+    this.polarisCallContext =
         new PolarisCallContext(
             metaStoreManagerFactory.getOrCreateSessionSupplier(() -> "realm").get(),
             new PolarisDefaultDiagServiceImpl());
@@ -70,7 +72,7 @@ public class CatalogEntityTest {
             .setProperties(prop)
             .setStorageConfigInfo(awsStorageConfigModel)
             .build();
-    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog))
+    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog, polarisCallContext))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Location prefix not allowed: 'unsupportPrefix://mybucket/path', expected prefixes");
@@ -91,7 +93,7 @@ public class CatalogEntityTest {
                 new CatalogProperties("abfs://container@storageaccount.blob.windows.net/path"))
             .setStorageConfigInfo(azureStorageConfigModel)
             .build();
-    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(azureCatalog))
+    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(azureCatalog, polarisCallContext))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid azure location uri unsupportPrefix://mybucket/path");
 
@@ -108,7 +110,7 @@ public class CatalogEntityTest {
             .setProperties(new CatalogProperties("gs://externally-owned-bucket"))
             .setStorageConfigInfo(gcpStorageConfigModel)
             .build();
-    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(gcpCatalog))
+    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(gcpCatalog, polarisCallContext))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Location prefix not allowed: 'unsupportPrefix://mybucket/path', expected prefixes");
@@ -140,7 +142,7 @@ public class CatalogEntityTest {
             .setProperties(prop)
             .setStorageConfigInfo(awsStorageConfigModel)
             .build();
-    Assertions.assertThatCode(() -> CatalogEntity.fromCatalog(awsCatalog))
+    Assertions.assertThatCode(() -> CatalogEntity.fromCatalog(awsCatalog, polarisCallContext))
         .doesNotThrowAnyException();
   }
 
@@ -164,7 +166,8 @@ public class CatalogEntityTest {
             .setProperties(prop)
             .setStorageConfigInfo(awsStorageConfigModel)
             .build();
-    Assertions.assertThatNoException().isThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog, polarisCallContext));
 
     basedLocation = "abfs://container@storageaccount.blob.windows.net/path";
     prop.put(CatalogEntity.DEFAULT_BASE_LOCATION_KEY, basedLocation);
@@ -181,7 +184,8 @@ public class CatalogEntityTest {
             .setProperties(new CatalogProperties(basedLocation))
             .setStorageConfigInfo(azureStorageConfigModel)
             .build();
-    Assertions.assertThatNoException().isThrownBy(() -> CatalogEntity.fromCatalog(azureCatalog));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> CatalogEntity.fromCatalog(azureCatalog, polarisCallContext));
 
     basedLocation = "gs://externally-owned-bucket";
     prop.put(CatalogEntity.DEFAULT_BASE_LOCATION_KEY, basedLocation);
@@ -197,7 +201,8 @@ public class CatalogEntityTest {
             .setProperties(new CatalogProperties(basedLocation))
             .setStorageConfigInfo(gcpStorageConfigModel)
             .build();
-    Assertions.assertThatNoException().isThrownBy(() -> CatalogEntity.fromCatalog(gcpCatalog));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> CatalogEntity.fromCatalog(gcpCatalog, polarisCallContext));
   }
 
   @ParameterizedTest
@@ -232,7 +237,7 @@ public class CatalogEntityTest {
         expectedMessage = "Invalid role ARN format";
     }
     ;
-    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog))
+    Assertions.assertThatThrownBy(() -> CatalogEntity.fromCatalog(awsCatalog, polarisCallContext))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);
   }

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -714,7 +714,9 @@ public class PolarisAdminService {
     }
     if (updateRequest.getStorageConfigInfo() != null) {
       updateBuilder.setStorageConfigurationInfo(
-          updateRequest.getStorageConfigInfo(), defaultBaseLocation);
+          updateRequest.getStorageConfigInfo(),
+          defaultBaseLocation,
+          callContext.getPolarisCallContext());
     }
     CatalogEntity updatedEntity = updateBuilder.build();
 

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -110,7 +110,8 @@ public class PolarisServiceImpl
     }
 
     PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(realmContext);
+        entityManagerFactory.getOrCreateEntityManager(
+            realmContext, callContext.getPolarisCallContext());
     PolarisMetaStoreManager metaStoreManager =
         metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     return new PolarisAdminService(
@@ -125,7 +126,9 @@ public class PolarisServiceImpl
     Catalog catalog = request.getCatalog();
     validateStorageConfig(catalog.getStorageConfigInfo());
     Catalog newCatalog =
-        new CatalogEntity(adminService.createCatalog(CatalogEntity.fromCatalog(catalog)))
+        new CatalogEntity(
+                adminService.createCatalog(
+                    CatalogEntity.fromCatalog(catalog, callContext.getPolarisCallContext())))
             .asCatalog();
     LOGGER.info("Created new catalog {}", newCatalog);
     return Response.status(Response.Status.CREATED).build();

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -79,7 +79,8 @@ public class DefaultFileIOFactory implements FileIOFactory {
       @Nonnull PolarisResolvedPathWrapper resolvedEntityPath) {
     RealmContext realmContext = callContext.getRealmContext();
     PolarisEntityManager entityManager =
-        realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
+        realmEntityManagerFactory.getOrCreateEntityManager(
+            realmContext, callContext.getPolarisCallContext());
     PolarisCredentialVendor credentialVendor =
         metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
 

--- a/service/common/src/main/java/org/apache/polaris/service/config/RealmEntityManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/RealmEntityManagerFactory.java
@@ -22,6 +22,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -44,7 +45,8 @@ public class RealmEntityManagerFactory {
     this.metaStoreManagerFactory = metaStoreManagerFactory;
   }
 
-  public PolarisEntityManager getOrCreateEntityManager(RealmContext context) {
+  public PolarisEntityManager getOrCreateEntityManager(
+      RealmContext context, PolarisCallContext polarisCallContext) {
     String realm = context.getRealmIdentifier();
 
     LOGGER.debug("Looking up PolarisEntityManager for realm {}", realm);
@@ -55,7 +57,8 @@ public class RealmEntityManagerFactory {
           LOGGER.info("Initializing new PolarisEntityManager for realm {}", r);
           return new PolarisEntityManager(
               metaStoreManagerFactory.getOrCreateMetaStoreManager(context),
-              metaStoreManagerFactory.getOrCreateStorageCredentialCache(context),
+              metaStoreManagerFactory.getOrCreateStorageCredentialCache(
+                  context, polarisCallContext),
               metaStoreManagerFactory.getOrCreateEntityCache(context));
         });
   }

--- a/service/common/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/PolarisCallContextCatalogFactory.java
@@ -81,7 +81,8 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
     LOGGER.debug("Initializing new BasePolarisCatalog for key: {}", catalogKey);
 
     PolarisEntityManager entityManager =
-        entityManagerFactory.getOrCreateEntityManager(context.getRealmContext());
+        entityManagerFactory.getOrCreateEntityManager(
+            context.getRealmContext(), context.getPolarisCallContext());
 
     IcebergCatalog catalogInstance =
         new IcebergCatalog(

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -30,7 +30,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.storage.PolarisCredentialProperty;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -90,7 +90,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
             new PolarisStorageIntegration<>("file") {
               @Override
               public EnumMap<PolarisCredentialProperty, String> getSubscopedCreds(
-                  @Nonnull PolarisDiagnostics diagnostics,
+                  @Nonnull PolarisCallContext callContext,
                   @Nonnull T storageConfig,
                   boolean allowListOperation,
                   @Nonnull Set<String> allowedReadLocations,

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -233,12 +233,16 @@ public class FileIOFactoryTest {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext,
-            services.entityManagerFactory().getOrCreateEntityManager(realmContext),
+            services
+                .entityManagerFactory()
+                .getOrCreateEntityManager(realmContext, callContext.getPolarisCallContext()),
             services.securityContext(),
             CATALOG_NAME);
     IcebergCatalog polarisCatalog =
         new IcebergCatalog(
-            services.entityManagerFactory().getOrCreateEntityManager(realmContext),
+            services
+                .entityManagerFactory()
+                .getOrCreateEntityManager(realmContext, callContext.getPolarisCallContext()),
             services.metaStoreManagerFactory().getOrCreateMetaStoreManager(realmContext),
             callContext,
             passthroughView,

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -133,12 +133,18 @@ public record TestServices(
       RealmEntityManagerFactory realmEntityManagerFactory =
           new RealmEntityManagerFactory(metaStoreManagerFactory) {};
 
-      PolarisEntityManager entityManager =
-          realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
-      PolarisMetaStoreManager metaStoreManager =
-          metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
       TransactionalPersistence metaStoreSession =
           metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
+
+      PolarisCallContext polarisCallContext =
+          new PolarisCallContext(
+              metaStoreSession, polarisDiagnostics, configurationStore, Mockito.mock(Clock.class));
+
+      PolarisEntityManager entityManager =
+          realmEntityManagerFactory.getOrCreateEntityManager(realmContext, polarisCallContext);
+      PolarisMetaStoreManager metaStoreManager =
+          metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+
       CallContext callContext =
           new CallContext() {
             @Override
@@ -148,11 +154,7 @@ public record TestServices(
 
             @Override
             public PolarisCallContext getPolarisCallContext() {
-              return new PolarisCallContext(
-                  metaStoreSession,
-                  polarisDiagnostics,
-                  configurationStore,
-                  Mockito.mock(Clock.class));
+              return polarisCallContext;
             }
 
             @Override


### PR DESCRIPTION
`PolarisConfiguration.loadConfig` relies on `CallContext.getCurrentContext` which may not be apparent to callers and often will not work. If the CallContext ThreadLocal hasn't been appropriately set in the calling thread, this method will return invalid results. This PR proposed to remove the problematic method as part of a series of changes to reduce or remove the usage of ThreadLocal throughout Polaris.