### PR TITLE
Set version to 0.10.0-beta in prepaaration for the next release

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-1.0.0-incubating-SNAPSHOT
+0.10.0-beta-incubating-SNAPSHOT


### PR DESCRIPTION
In preparation for the next release (cut from the `main` branch), this PR sets the version to `0.10.0-beta`.