### PR TITLE
Push Docker Images on New Release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -76,5 +76,5 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT $TAG
-          docker push $TAG
+          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT ${{ steps.meta.outputs.tags }}
+          docker push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a #v3
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -53,14 +53,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: adnanhemani821/polaris
-          flavor: |
-            latest=false
-
       - name: Docker Image build
         run: |
           ./gradlew \
@@ -76,5 +68,4 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT ${{ steps.meta.outputs.tags }}
-          docker push ${{ steps.meta.outputs.tags }}
+          docker push apache/polaris

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -51,7 +51,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: apache/polaris
+          images: adnanhemani821/polaris
 
       - name: Docker Image build
         run: |
@@ -65,4 +65,4 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker push apache/polaris:${{ steps.meta.outputs.tags }}
+          docker push adnanhemani821/polaris:${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -59,9 +59,6 @@ jobs:
         with:
           images: adnanhemani821/polaris
 
-      - name: List all Docker images
-        run: docker images
-
       - name: Docker Image build
         run: |
           ./gradlew \
@@ -71,6 +68,9 @@ jobs:
             :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
             -Dquarkus.container-image.build=true \
             -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+
+      - name: List all Docker images
+        run: docker images
 
       - name: Push Docker image to Docker Hub
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: apache/polaris
+
+      - name: Docker Image build
+        run: |
+          ./gradlew \
+            :polaris-quarkus-server:assemble \
+            :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
+            :polaris-quarkus-admin:assemble \
+            :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
+            -Dquarkus.container-image.build=true \
+            -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+
+      - name: Push Docker image to Docker Hub
+        run: |
+          docker push apache/polaris:${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -71,4 +71,4 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker push adnanhemani821/polaris:${{ steps.meta.outputs.tags }}
+          docker push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          IFS=$'\n' read -rd '' -a TAGS <<< "$(echo -e "${{ steps.meta.outputs.tags }}")"
+          IFS=$'\n' read -rd '' TAGS <<< "$(echo -e "${{ steps.meta.outputs.tags }}")"
           for TAG in ${TAGS[@]}; do
             # Replace everything before the first "/" or ":" with "abcd"
             LOCAL_TAG=$(echo "$TAG" | sed -E 's|^[^:/]+|apache|')

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,7 +74,8 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          for TAG in ${{ steps.meta.outputs.tags }}; do
+          IFS=$'\n' read -rd '' -a TAGS <<< "$(echo -e "${{ steps.meta.outputs.tags }}")"
+          for TAG in ${TAGS[@]}; do
             # Replace everything before the first "/" or ":" with "abcd"
             LOCAL_TAG=$(echo "$TAG" | sed -E 's|^[^:/]+|apache|')
             echo "$LOCAL_TAG"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           images: adnanhemani821/polaris
 
+      - name: List all Docker images
+        run: docker images
+
       - name: Docker Image build
         run: |
           ./gradlew \

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          IFS=$'\n' read -rd '' TAGS <<< "$(echo -e "${{ steps.meta.outputs.tags }}")"
+          IFS=$'\n' read -rd '' TAGS <<< "$(echo -e '${{ steps.meta.outputs.tags }}')"
           for TAG in ${TAGS[@]}; do
             # Replace everything before the first "/" or ":" with "abcd"
             LOCAL_TAG=$(echo "$TAG" | sed -E 's|^[^:/]+|apache|')

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,10 +42,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a #v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -76,7 +76,5 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          LOCAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | sed -E 's|^[^:/]+|apache|')
-          echo "$LOCAL_TAG"
-          docker image tag $LOCAL_TAG $TAG
+          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT $TAG
           docker push $TAG

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,5 +74,5 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT adnanhemani821/polaris:${{ steps.meta.outputs.tags }}
+          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT ${{ steps.meta.outputs.tags }}
           docker push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -76,11 +76,7 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          IFS=$'\n' read -rd '' TAGS <<< "$(echo -e '${{ steps.meta.outputs.tags }}')"
-          for TAG in ${TAGS[@]}; do
-            # Replace everything before the first "/" or ":" with "abcd"
-            LOCAL_TAG=$(echo "$TAG" | sed -E 's|^[^:/]+|apache|')
-            echo "$LOCAL_TAG"
-            docker image tag $LOCAL_TAG $TAG
-            docker push $TAG
-          done
+          LOCAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | sed -E 's|^[^:/]+|apache|')
+          echo "$LOCAL_TAG"
+          docker image tag $LOCAL_TAG $TAG
+          docker push $TAG

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -58,6 +58,8 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: adnanhemani821/polaris
+          flavor: |
+            latest=false
 
       - name: Docker Image build
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,5 +74,10 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
-          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT ${{ steps.meta.outputs.tags }}
-          docker push ${{ steps.meta.outputs.tags }}
+          for TAG in ${{ steps.meta.outputs.tags }}; do
+            # Replace everything before the first "/" or ":" with "abcd"
+            LOCAL_TAG=$(echo "$TAG" | sed -E 's|^[^:/]+|apache|')
+            echo "$LOCAL_TAG"
+            docker image tag $LOCAL_TAG $TAG
+            docker push $TAG
+          done

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -74,4 +74,5 @@ jobs:
 
       - name: Push Docker image to Docker Hub
         run: |
+          docker image tag apache/polaris:0.10.0-beta-incubating-SNAPSHOT adnanhemani821/polaris:${{ steps.meta.outputs.tags }}
           docker push ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

This adds a new GitHub Action that will push the generated Docker image to the Docker Hub repository located [here](https://hub.docker.com/r/apache/polaris) whenever a new release is cut.

The only requirement left to make this work is to ensure that the Docker username and token that has the ability to authenticate to this repository is available as a GitHub Secret for the Action to use.