### PR TITLE
Allow BasePolarisTableOperations to skip refreshing metadata after a commit

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -65,8 +65,8 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
           .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
           .description(
               "If true, BasePolarisTableOperations should update the metadata that is passed into"
-                  + " `commit`, which means that future calls to `refresh` may be able to skip a trip to"
-                  + " object storage")
+                  + " `commit`, and re-use it to skip a trip to object storage to re-construct"
+                  + " the committed metadata again.")
           .defaultValue(true)
           .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -59,4 +59,13 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
           .description("Whether or not to use soft values in the entity cache")
           .defaultValue(false)
           .buildBehaviorChangeConfiguration();
+
+  public static final BehaviorChangeConfiguration<Boolean> TABLE_OPERATIONS_COMMIT_UPDATE_METADATA =
+      PolarisConfiguration.<Boolean>builder()
+          .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
+          .description(
+              "If true, BasePolarisTableOperations should cache metadata that has been committed"
+                  + " which can reduce File IO")
+          .defaultValue(true)
+          .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -64,9 +64,9 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
           .description(
-              "If true, BasePolarisTableOperations should update the metadata that is passed into" +
-                  " `commit`, which means that future calls to `refresh` may be able to skip a trip to" +
-                  " object storage")
+              "If true, BasePolarisTableOperations should update the metadata that is passed into"
+                  + " `commit`, which means that future calls to `refresh` may be able to skip a trip to"
+                  + " object storage")
           .defaultValue(true)
           .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -64,8 +64,9 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
           .description(
-              "If true, BasePolarisTableOperations should cache metadata that has been committed"
-                  + " which can reduce File IO")
+              "If true, BasePolarisTableOperations should update the metadata that is passed into" +
+                  " `commit`, which means that future calls to `refresh` may be able to skip a trip to" +
+                  " object storage")
           .defaultValue(true)
           .buildBehaviorChangeConfiguration();
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -133,6 +133,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.exception.RetryableException;
@@ -1793,6 +1795,50 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     Assertions.assertThatThrownBy(() -> update.commit())
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("conflict_table");
+  }
+
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testTableOperationsDoesNotRefreshAfterCommit(boolean updateMetadataOnCommit) {
+    if (this.requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    catalog.buildTable(TABLE, SCHEMA).create();
+
+    IcebergCatalog.BasePolarisTableOperations realOps =
+        (IcebergCatalog.BasePolarisTableOperations) catalog.newTableOps(TABLE, updateMetadataOnCommit);
+    IcebergCatalog.BasePolarisTableOperations ops = Mockito.spy(realOps);
+
+    try (MockedStatic<TableMetadataParser> mocked =
+             Mockito.mockStatic(TableMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
+      TableMetadata base1 = ops.current();
+      mocked.verify(() -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      TableMetadata base2 = ops.refresh();
+      mocked.verify(() -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      Assertions.assertThat(base1.metadataFileLocation()).isEqualTo(base2.metadataFileLocation());
+      Assertions.assertThat(base1).isEqualTo(base2);
+
+      Schema newSchema = new Schema(Types.NestedField.optional(100, "new_col", Types.LongType.get()));
+      TableMetadata newMetadata =
+          TableMetadata.buildFrom(base1).setCurrentSchema(newSchema, 100).build();
+      ops.commit(base2, newMetadata);
+      mocked.verify(() -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      ops.current();
+      int expectedReads = 2;
+      if (updateMetadataOnCommit) {
+        expectedReads = 1;
+      }
+      mocked.verify(() -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(expectedReads));
+      ops.refresh();
+      mocked.verify(() -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(expectedReads));
+    } finally {
+      catalog.dropTable(TABLE, true);
+    }
   }
 
   private static InMemoryFileIO getInMemoryIo(IcebergCatalog catalog) {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -1647,8 +1647,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     table.updateProperties().set("foo", "bar").commit();
     Assertions.assertThat(measured.getInputBytes())
-        .as("A table was read and written")
-        .isGreaterThan(0);
+        .as("A table was read and written, but no trip to storage was made")
+        .isEqualTo(0);
 
     Assertions.assertThat(catalog.dropTable(TABLE)).as("Table deletion should succeed").isTrue();
     TaskEntity taskEntity =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
@@ -41,7 +41,6 @@ import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.TestServices;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -133,7 +132,13 @@ public class FileIOExceptionsTest {
         services
             .restApi()
             .loadTable(
-                catalog, "ns1", "t1", null, "ALL", services.realmContext(), services.securityContext());
+                catalog,
+                "ns1",
+                "t1",
+                null,
+                "ALL",
+                services.realmContext(),
+                services.securityContext());
     res.close();
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1345,17 +1345,22 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       String oldLocation = base == null ? null : base.metadataFileLocation();
 
       // TODO: we should not need to do this hack, but there's no other way to modify
-      // metadataFileLocation / currentMetadataLocation
+      // currentMetadata / currentMetadataLocation
       if (updateMetadataOnCommit) {
         try {
           Field tableMetadataField = TableMetadata.class.getDeclaredField("metadataFileLocation");
           tableMetadataField.setAccessible(true);
           tableMetadataField.set(metadata, newLocation);
 
-          Field currentMetadataField =
+          Field currentMetadataLocationField =
               BaseMetastoreTableOperations.class.getDeclaredField("currentMetadataLocation");
+          currentMetadataLocationField.setAccessible(true);
+          currentMetadataLocationField.set(this, newLocation);
+
+          Field currentMetadataField =
+              BaseMetastoreTableOperations.class.getDeclaredField("currentMetadata");
           currentMetadataField.setAccessible(true);
-          currentMetadataField.set(this, newLocation);
+          currentMetadataField.set(this, metadata);
         } catch (IllegalAccessException | NoSuchFieldException e) {
           LOGGER.error(
               "Encountered an unexpected error while attempting to modify TableMetadata.metadataFileLocation",

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,6 +48,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -1351,6 +1353,15 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
           Field tableMetadataField = TableMetadata.class.getDeclaredField("metadataFileLocation");
           tableMetadataField.setAccessible(true);
           tableMetadataField.set(metadata, newLocation);
+
+          Field tableMetadataChanges = TableMetadata.class.getDeclaredField("changes");
+
+          Field modifiersField = Field.class.getDeclaredField("modifiers");
+          modifiersField.setAccessible(true);
+          modifiersField.setInt(tableMetadataChanges, tableMetadataChanges.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+
+          tableMetadataField.setAccessible(true);
+          tableMetadataField.set(metadata, new ArrayList<MetadataUpdate>());
 
           Field currentMetadataLocationField =
               BaseMetastoreTableOperations.class.getDeclaredField("currentMetadataLocation");

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -351,7 +351,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   @VisibleForTesting
-  public TableOperations newTableOps(TableIdentifier tableIdentifier, boolean updateMetadataOnCommit) {
+  public TableOperations newTableOps(
+      TableIdentifier tableIdentifier, boolean updateMetadataOnCommit) {
     return new BasePolarisTableOperations(catalogFileIO, tableIdentifier, updateMetadataOnCommit);
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1358,7 +1358,9 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
           Field modifiersField = Field.class.getDeclaredField("modifiers");
           modifiersField.setAccessible(true);
-          modifiersField.setInt(tableMetadataChanges, tableMetadataChanges.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+          modifiersField.setInt(
+              tableMetadataChanges,
+              tableMetadataChanges.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
 
           tableMetadataField.setAccessible(true);
           tableMetadataField.set(metadata, new ArrayList<MetadataUpdate>());

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1343,14 +1343,6 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeNewMetadataIfRequired(base == null, metadata);
       String oldLocation = base == null ? null : base.metadataFileLocation();
 
-      // TODO: we should not need to do this hack, but there's no other way to modify
-      // currentMetadata / currentMetadataLocation
-      if (updateMetadataOnCommit) {
-        TableOperationsReflectionUtil reflectionUtil = TableOperationsReflectionUtil.getInstance();
-        reflectionUtil.setMetadataFileLocation(metadata, newLocation);
-        reflectionUtil.setCurrentMetadata(this, metadata, newLocation);
-      }
-
       // TODO: Consider using the entity from doRefresh() directly to do the conflict detection
       // instead of a two-layer CAS (checking metadataLocation to detect concurrent modification
       // between doRefresh() and doCommit(), and then updateEntityPropertiesIfNotChanged to detect
@@ -1404,6 +1396,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             "Cannot commit to table %s metadata location from %s to %s "
                 + "because it has been concurrently modified to %s",
             tableIdentifier, oldLocation, newLocation, existingLocation);
+      }
+      // TODO: we should not need to do this hack, but there's no other way to modify
+      // currentMetadata / currentMetadataLocation
+      if (updateMetadataOnCommit) {
+        TableOperationsReflectionUtil reflectionUtil = TableOperationsReflectionUtil.getInstance();
+        reflectionUtil.setMetadataFileLocation(metadata, newLocation);
+        reflectionUtil.setCurrentMetadata(this, metadata, newLocation);
       }
       if (null == existingLocation) {
         createTableLike(tableIdentifier, entity);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/TableOperationsReflectionUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/TableOperationsReflectionUtil.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.misc.Unsafe;
+
+/**
+ * Used to handle reflection-related fields for TableOperations and TableMetadata TODO remove the
+ * following if the Iceberg library allows us to do this without reflection For more details see <a
+ * href="https://github.com/apache/polaris/pull/1378">#1378</a>
+ */
+public final class TableOperationsReflectionUtil {
+  private static Logger LOGGER = LoggerFactory.getLogger(TableOperationsReflectionUtil.class);
+
+  private static class Instance {
+    private static TableOperationsReflectionUtil instance = new TableOperationsReflectionUtil();
+  }
+
+  static TableOperationsReflectionUtil getInstance() {
+    return Instance.instance;
+  }
+
+  public void setMetadataFileLocation(TableMetadata tableMetadata, String metadataFileLocation) {
+    try {
+      tableMetadataField.set(tableMetadata, metadataFileLocation);
+      unsafe.putObject(tableMetadata, changesFieldOffset, new ArrayList<MetadataUpdate>());
+    } catch (IllegalAccessException e) {
+      LOGGER.error(
+          "Encountered an unexpected error while attempting to access private fields"
+              + " in TableMetadata",
+          e);
+    }
+  }
+
+  public void setCurrentMetadata(
+      BaseMetastoreTableOperations tableOperations,
+      TableMetadata tableMetadata,
+      String metadataFileLocation) {
+    try {
+      currentMetadataLocationField.set(tableOperations, metadataFileLocation);
+      currentMetadataField.set(tableOperations, tableMetadata);
+    } catch (IllegalAccessException e) {
+      LOGGER.error(
+          "Encountered an unexpected error while attempting to access private fields"
+              + " in BaseMetastoreTableOperations",
+          e);
+    }
+  }
+
+  private final Unsafe unsafe;
+  private final Field tableMetadataField;
+  private final long changesFieldOffset;
+  private final Field currentMetadataLocationField;
+  private final Field currentMetadataField;
+
+  private TableOperationsReflectionUtil() {
+    try {
+      tableMetadataField = TableMetadata.class.getDeclaredField("metadataFileLocation");
+      tableMetadataField.setAccessible(true);
+
+      Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+      unsafeField.setAccessible(true);
+      unsafe = (Unsafe) unsafeField.get(null);
+      Field changesField = TableMetadata.class.getDeclaredField("changes");
+      changesField.setAccessible(true);
+      changesFieldOffset = unsafe.objectFieldOffset(changesField);
+
+      currentMetadataLocationField =
+          BaseMetastoreTableOperations.class.getDeclaredField("currentMetadataLocation");
+      currentMetadataLocationField.setAccessible(true);
+
+      currentMetadataField = BaseMetastoreTableOperations.class.getDeclaredField("currentMetadata");
+      currentMetadataField.setAccessible(true);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      LOGGER.error(
+          "Encountered an unexpected error while attempting to access private fields in TableMetadata",
+          e);
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
For rest catalogs, `TableOperations.refresh()` can result in an expensive trip to object storage. Despite this, the method is called quite frequently and is currently called after every commit when we construct a BaseTable to return back to a client that requested a commit.

In some cases, the same TableOperations is used for one commit and then is immediately used for another. We can see this in some tests, such as Iceberg's `CatalogTests.testUpdateTableSchemaThenRevert`:

```
table.updateSchema().addColumn("col1", StringType.get()).addColumn("col2", StringType.get()).addColumn("col3", StringType.get()).commit();
table.updateSchema().deleteColumn("col1").deleteColumn("col2").deleteColumn("col3").commit();      
```

This PR proposes that the TableOperations can update its `currentMetadata` metadata on commit so that future calls to `doRefresh` might be able to skip a trip to object storage.