### PR TITLE
Update the link to OpenAPI in the documentation

### DIFF
--- a/site/content/in-dev/0.9.0/rest-catalog-open-api.md
+++ b/site/content/in-dev/0.9.0/rest-catalog-open-api.md
@@ -24,4 +24,4 @@ params:
   show_page_toc: false
 ---
 
-{{< redoc-polaris "rest-catalog-open-api.yaml" >}}
+{{< redoc-polaris "https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-0.9.0-incubating/spec/rest-catalog-open-api.yaml" >}}


### PR DESCRIPTION
The 0.9.0 release documentation should point to the right OpenAPI spec (on the tag).