### PR TITLE
Fix releaseEmailTemplate task

### DIFF
--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -132,7 +132,7 @@ internal fun configureOnRootProject(project: Project) =
             "NO STAGING REPOSITORY (no build service) !!"
           }
 
-        val asfProjectName = fetchAsfProjectName(asfName)
+        val asfProjectName = "Apache Polaris"
 
         val versionNoRc = version.toString().replace("-rc-?[0-9]+".toRegex(), "")
 

--- a/build-logic/src/main/kotlin/publishing/util.kt
+++ b/build-logic/src/main/kotlin/publishing/util.kt
@@ -79,6 +79,8 @@ internal fun <T : Any> parseJson(url: String): T {
   }
 }
 
+// TODO: this function doesn't work because name attribute doesn't exist on
+// public_ldap_projects.json
 internal fun fetchAsfProjectName(apacheId: String): String {
   val projectsAll: Map<String, Map<String, Any>> =
     parseJson("https://whimsy.apache.org/public/public_ldap_projects.json")


### PR DESCRIPTION
The `releaseEmailTemplate` task is looking for project name from https://whimsy.apache.org/public/public_ldap_projects.json. It's looking for `name` attribute in the project json, but `name` doesn't exist there, meaning the task is failing.

This PR remove the fetch project name method and just use `Apache Polaris` as project name (as it's the project name 😄 ).