### PR TITLE
fix(Catalog): Add List PolarisStorageAction for all metadata read operations

### DIFF
--- a/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
+++ b/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
@@ -520,7 +520,7 @@ def test_spark_credentials_can_delete_after_purge(root_client, snowflake_catalog
     attempts = 0
 
     # watch the data directory. metadata will be deleted first, so if data directory is clear, we can expect
-    # metadatat diretory to be clear also
+    # metadata directory to be clear also
     while 'Contents' in objects and len(objects['Contents']) > 0 and attempts < 60:
       time.sleep(1)  # seconds, not milliseconds ;)
       objects = s3.list_objects(Bucket=test_bucket, Delimiter='/',
@@ -1148,6 +1148,78 @@ def test_spark_ctas(snowflake_catalog, polaris_catalog_url, snowman):
     spark.sql(f"drop table {table_name}_t1 PURGE")
     spark.sql(f"drop table {table_name}_t2 PURGE")
 
+
+@pytest.mark.skipif(os.environ.get('AWS_TEST_ENABLED', 'False').lower() != 'true',
+                    reason='AWS_TEST_ENABLED is not set or is false')
+def test_spark_credentials_s3_exceptions(root_client, snowflake_catalog, polaris_catalog_url,
+                                                snowman, snowman_catalog_client, test_bucket, aws_bucket_base_location_prefix):
+    """
+    Create a using Spark. Then call the loadTable api directly with snowman token to fetch the vended credentials
+    for the first table.
+    Delete the metadata directory and try to access the table using the vended credentials.
+    It should throw 404 exception
+    :param root_client:
+    :param snowflake_catalog:
+    :param polaris_catalog_url:
+    :param snowman_catalog_client:
+    :param reader_catalog_client:
+    :return:
+    """
+    with IcebergSparkSession(credentials=f'{snowman.principal.client_id}:{snowman.credentials.client_secret}',
+                             catalog_name=snowflake_catalog.name,
+                             polaris_url=polaris_catalog_url) as spark:
+        spark.sql(f'USE {snowflake_catalog.name}')
+        spark.sql('CREATE NAMESPACE db1')
+        spark.sql('CREATE NAMESPACE db1.schema')
+        spark.sql('USE db1.schema')
+        spark.sql('CREATE TABLE iceberg_table (col1 int, col2 string)')
+
+    response = snowman_catalog_client.load_table(snowflake_catalog.name, unquote('db1%1Fschema'),
+                                                        "iceberg_table",
+                                                        "vended-credentials")
+    assert response.config is not None
+    assert 's3.access-key-id' in response.config
+    assert 's3.secret-access-key' in response.config
+    assert 's3.session-token' in response.config
+
+    s3 = boto3.client('s3',
+                      aws_access_key_id=response.config['s3.access-key-id'],
+                      aws_secret_access_key=response.config['s3.secret-access-key'],
+                      aws_session_token=response.config['s3.session-token'])
+
+    objects = s3.list_objects(Bucket=test_bucket, Delimiter='/',
+                              Prefix=f'{aws_bucket_base_location_prefix}/snowflake_catalog/db1/schema/iceberg_table/metadata/')
+    assert objects is not None
+    assert 'Contents' in objects
+    assert len(objects['Contents']) > 0
+
+    metadata_file = next(f for f in objects['Contents'] if f['Key'].endswith('metadata.json'))
+    assert metadata_file is not None
+
+    metadata_contents = s3.get_object(Bucket=test_bucket, Key=metadata_file['Key'])
+    assert metadata_contents is not None
+    assert metadata_contents['ContentLength'] > 0
+
+    s3.delete_objects(Bucket=test_bucket,
+                      Delete={'Objects': objects})
+
+    try:
+        response = snowman_catalog_client.load_table(snowflake_catalog.name, unquote('db1%1Fschema'),
+                                                     "iceberg_table",
+                                                     "vended-credentials")
+    except Exception as e:
+        assert '404' in str(e)
+
+
+    with IcebergSparkSession(credentials=f'{snowman.principal.client_id}:{snowman.credentials.client_secret}',
+                             catalog_name=snowflake_catalog.name,
+                             polaris_url=polaris_catalog_url) as spark:
+        spark.sql(f'USE {snowflake_catalog.name}')
+        spark.sql('USE db1.schema')
+        spark.sql('DROP TABLE iceberg_table PURGE')
+        spark.sql(f'USE {snowflake_catalog.name}')
+        spark.sql('DROP NAMESPACE db1.schema')
+        spark.sql('DROP NAMESPACE db1')
 
 def create_catalog_role(api, catalog, role_name):
   catalog_role = CatalogRole(name=role_name)

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1238,7 +1238,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       Set.of(latestLocationDir),
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
-                      Set.of(PolarisStorageActions.READ));
+                      Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
               return TableMetadataParser.read(fileIO, metadataLocation);
             });
       }
@@ -1274,7 +1274,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               getLocationsAllowedToBeAccessed(metadata),
               resolvedStorageEntity,
               new HashMap<>(metadata.properties()),
-              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE));
+              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE, PolarisStorageActions.LIST));
 
       List<PolarisEntity> resolvedNamespace =
           resolvedTableEntities == null
@@ -1479,7 +1479,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       Set.of(latestLocationDir),
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
-                      Set.of(PolarisStorageActions.READ));
+                      Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
 
               return ViewMetadataParser.read(fileIO.newInputFile(metadataLocation));
             });
@@ -2010,7 +2010,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               Set.of(locationDir),
               resolvedParent,
               new HashMap<>(tableDefaultProperties),
-              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE));
+              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE, PolarisStorageActions.LIST));
       TableMetadata tableMetadata = TableMetadataParser.read(fileIO, newLocation);
 
       // then validate that it points to a valid location for this table

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -330,7 +330,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             Set.of(locationDir),
             resolvedParent,
             new HashMap<>(tableDefaultProperties),
-            Set.of(PolarisStorageActions.READ));
+            Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
 
     InputFile metadataFile = fileIO.newInputFile(metadataFileLocation);
     TableMetadata metadata = TableMetadataParser.read(fileIO, metadataFile);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -330,7 +330,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             Set.of(locationDir),
             resolvedParent,
             new HashMap<>(tableDefaultProperties),
-            Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
+            Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
 
     InputFile metadataFile = fileIO.newInputFile(metadataFileLocation);
     TableMetadata metadata = TableMetadataParser.read(fileIO, metadataFile);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1238,7 +1238,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       Set.of(latestLocationDir),
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
-                      Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
+                      Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
               return TableMetadataParser.read(fileIO, metadataLocation);
             });
       }
@@ -1274,7 +1274,10 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               getLocationsAllowedToBeAccessed(metadata),
               resolvedStorageEntity,
               new HashMap<>(metadata.properties()),
-              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE, PolarisStorageActions.LIST));
+              Set.of(
+                  PolarisStorageActions.READ,
+                  PolarisStorageActions.WRITE,
+                  PolarisStorageActions.LIST));
 
       List<PolarisEntity> resolvedNamespace =
           resolvedTableEntities == null
@@ -1479,7 +1482,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       Set.of(latestLocationDir),
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
-                      Set.of(PolarisStorageActions.READ,PolarisStorageActions.LIST));
+                      Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
 
               return ViewMetadataParser.read(fileIO.newInputFile(metadataLocation));
             });
@@ -2010,7 +2013,10 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               Set.of(locationDir),
               resolvedParent,
               new HashMap<>(tableDefaultProperties),
-              Set.of(PolarisStorageActions.READ, PolarisStorageActions.WRITE, PolarisStorageActions.LIST));
+              Set.of(
+                  PolarisStorageActions.READ,
+                  PolarisStorageActions.WRITE,
+                  PolarisStorageActions.LIST));
       TableMetadata tableMetadata = TableMetadataParser.read(fileIO, newLocation);
 
       // then validate that it points to a valid location for this table


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Fixes #1380 

**Issue:**
 
Currently, loadTable returns a 403 error when the metadata file is not found, which can be misleading. Since users are expected to have configured the appropriate ListBucket permissions in their IAM policy, a 404 error would be more accurate in this scenario.

`Access Denied or Forbidden error: User: arn:aws:sts::{account}:assumed-role/{role}/PolarisAwsCredentialsStorageIntegration is not authorized to perform: s3:ListBucket on resource: \"arn:aws:s3:::ashok-test-local\" because no session policy allows the s3:ListBucket action (Service: S3, Status Code: 403, Request ID: W6Q2D563ETEKR6XZ, Extended Request ID: Izq3QS7eZmGjhjfyoxJWMHeCgrFvUlpZjj73JYMO8i/qnKw6CjOaPVgOWVLFr/JsToTeTxO0YaM=)`


As per S3 GetObject [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html), the error message returned depens on ListBucket permission

```
If the object that you request doesn’t exist, the error that Amazon S3 returns depends on whether you also have the s3:ListBucket permission.

If you have the s3:ListBucket permission on the bucket, Amazon S3 returns an HTTP status code 404 Not Found error.

If you don’t have the s3:ListBucket permission, Amazon S3 returns an HTTP status code 403 Access Denied error.
```

We are adding [ListBucket statement](https://github.com/apache/polaris/blob/main/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java#L137) to the session policy only when PolarisStorageAction.List is passed
