### PR TITLE
Initial POC - streaming table metadata rather than de/serializing in memory

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -201,4 +201,11 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
                   + " requires experimentation in the specific deployment environment")
           .defaultValue(100 * EntityWeigher.WEIGHT_PER_MB)
           .buildFeatureConfiguration();
+
+  public static final FeatureConfiguration<Boolean> ENABLE_STREAMING_TABLE_METADATA =
+      PolarisConfiguration.<Boolean>builder()
+          .key("ENABLE_STREAMING_TABLE_METADATA")
+          .description("If true, enable streaming table metadata without deserializing into memory")
+          .defaultValue(true)
+          .buildFeatureConfiguration();
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.rest.RESTResponse;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -48,6 +49,7 @@ import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
@@ -772,7 +774,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
 
     // To get a handy metadata file we can use one from another table.
     // to avoid overlapping directories, drop the original table and recreate it via registerTable
-    final String metadataLocation = newWrapper().loadTable(TABLE_NS1_1, "all").metadataLocation();
+    final String metadataLocation = getMetadataLocation(newWrapper().loadTable(TABLE_NS1_1, "all"));
     newWrapper(Set.of(PRINCIPAL_ROLE2)).dropTableWithoutPurge(TABLE_NS1_1);
 
     final RegisterTableRequest registerRequest =
@@ -802,6 +804,14 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         });
   }
 
+  private static String getMetadataLocation(RESTResponse resp) {
+    final String metadataLocation =
+        resp instanceof IcebergCatalogHandler.StreamingLoadTableResponse
+            ? ((IcebergCatalogHandler.StreamingLoadTableResponse) resp).metadataLocation()
+            : ((LoadTableResponse) resp).metadataLocation();
+    return metadataLocation;
+  }
+
   @Test
   public void testRegisterTableInsufficientPermissions() {
     Assertions.assertThat(
@@ -810,7 +820,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         .isTrue();
 
     // To get a handy metadata file we can use one from another table.
-    final String metadataLocation = newWrapper().loadTable(TABLE_NS1_1, "all").metadataLocation();
+    final String metadataLocation = getMetadataLocation(newWrapper().loadTable(TABLE_NS1_1, "all"));
 
     final RegisterTableRequest registerRequest =
         new RegisterTableRequest() {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/SupportsCredentialDelegation.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/SupportsCredentialDelegation.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 
 /**
@@ -36,4 +38,12 @@ public interface SupportsCredentialDelegation {
       TableIdentifier tableIdentifier,
       TableMetadata tableMetadata,
       Set<PolarisStorageActions> storageActions);
+
+  Map<String, String> getCredentialConfig(
+      TableIdentifier tableIdentifier,
+      IcebergTableLikeEntity tableMetadata,
+      Set<PolarisStorageActions> storageActions);
+
+  Credential getCredentialConfig(
+      TableIdentifier tableIdentifier, Set<PolarisStorageActions> storageActions);
 }

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/StreamingLoadTableResponseTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/StreamingLoadTableResponseTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.rest.RESTSerializers;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
+import org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandler;
+import org.junit.jupiter.api.Test;
+
+public class StreamingLoadTableResponseTest {
+  @Test
+  public void testSerialization() throws IOException {
+    TableMetadata metadata =
+        TableMetadata.buildFromEmpty()
+            .setLocation("s3://foo")
+            .setCurrentSchema(
+                new Schema(
+                    0, List.of(Types.NestedField.required(1, "col1", Types.StringType.get()))),
+                1)
+            .addPartitionSpec(PartitionSpec.unpartitioned())
+            .setDefaultSortOrder(SortOrder.unsorted())
+            .build();
+    IcebergCatalogHandler.StreamingLoadTableResponse resp =
+        new IcebergCatalogHandler.StreamingLoadTableResponse(
+            "s3://foo",
+            new ByteArrayInputStream(
+                TableMetadataParser.toJson(metadata).getBytes(Charset.defaultCharset())),
+            Map.of(),
+            List.of());
+    ObjectMapper objectMapper = new ObjectMapper();
+    RESTSerializers.registerAll(objectMapper);
+    LoadTableResponse deserializedResponse =
+        objectMapper.readValue(objectMapper.writeValueAsBytes(resp), LoadTableResponse.class);
+    assertThat(deserializedResponse.metadataLocation()).isEqualTo("s3://foo");
+    assertThat(deserializedResponse.tableMetadata())
+        .returns("s3://foo", TableMetadata::location)
+        .returns(0, TableMetadata::currentSchemaId)
+        .extracting(TableMetadata::schema)
+        .returns(
+            List.of(Types.NestedField.required(1, "col1", Types.StringType.get())),
+            Schema::columns);
+  }
+}


### PR DESCRIPTION
Initial POC for streaming table metadata directly from storage rather than deserializing in memory, then serializing back out. The goal is to avoid parsing very large metadata files and holding them in memory. We can avoid the need to throttle based on large file sizes and use fixed memory for handling any size TableMetadata.

Some aspects need consideration, such as reading table properties, which we currently do by parsing the TableMetadata. These properties could be written to the table entity properties in addition to the TableMetadata file so that we can look up some things from the entity directly.

Not all tests are passing yet (the catalog integration tests do). Just gauging interest.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
