### PR TITLE
Remove CallContext.getAuthenticatedPrincipal()

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +44,6 @@ public interface CallContext extends AutoCloseable {
   // created, scoped to the current call context.
   String REQUEST_PATH_CATALOG_INSTANCE_KEY = "REQUEST_PATH_CATALOG_INSTANCE";
 
-  // Authenticator filters should populate this field alongside resolving a SecurityContext.
-  // Value type: AuthenticatedPolarisPrincipal
-  String AUTHENTICATED_PRINCIPAL = "AUTHENTICATED_PRINCIPAL";
   String CLOSEABLES = "closeables";
 
   static CallContext setCurrentContext(CallContext context) {
@@ -61,11 +57,6 @@ public interface CallContext extends AutoCloseable {
 
   static PolarisDiagnostics getDiagnostics() {
     return CURRENT_CONTEXT.get().getPolarisCallContext().getDiagServices();
-  }
-
-  static AuthenticatedPolarisPrincipal getAuthenticatedPrincipal() {
-    return (AuthenticatedPolarisPrincipal)
-        CallContext.getCurrentContext().contextVariables().get(CallContext.AUTHENTICATED_PRINCIPAL);
   }
 
   static void unsetCurrentContext() {

--- a/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/BasePolarisAuthenticator.java
@@ -111,8 +111,6 @@ public abstract class BasePolarisAuthenticator
 
     AuthenticatedPolarisPrincipal authenticatedPrincipal =
         new AuthenticatedPolarisPrincipal(new PrincipalEntity(principal), activatedPrincipalRoles);
-    LOGGER.debug("Populating authenticatedPrincipal into CallContext: {}", authenticatedPrincipal);
-    callContext.contextVariables().put(CallContext.AUTHENTICATED_PRINCIPAL, authenticatedPrincipal);
     return Optional.of(authenticatedPrincipal);
   }
 }


### PR DESCRIPTION
With the switch to Quarkus Security this method is not used anymore.

The right way to access the principal is to `@Inject SecurityIdentity identity` or `@Inject SecurityContext context`.