### PR TITLE
Make entity lookups by id honor the specified entity type

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -309,7 +309,8 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
       @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore entity) {
 
     // delete it
-    this.store.deleteFromEntities(localSession.get(), entity.getCatalogId(), entity.getId());
+    this.store.deleteFromEntities(
+        localSession.get(), entity.getCatalogId(), entity.getId(), entity.getTypeCode());
   }
 
   /** {@inheritDoc} */

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -360,7 +360,8 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   @Override
   public @Nullable PolarisBaseEntity lookupEntityInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode) {
-    return ModelEntity.toEntity(this.store.lookupEntity(localSession.get(), catalogId, entityId));
+    return ModelEntity.toEntity(
+        this.store.lookupEntity(localSession.get(), catalogId, entityId, typeCode));
   }
 
   @Override

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -84,7 +84,8 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    ModelEntity model = lookupEntity(session, entity.getCatalogId(), entity.getId(), -1);
+    ModelEntity model =
+        lookupEntity(session, entity.getCatalogId(), entity.getId(), entity.getTypeCode());
     if (model != null) {
       // Update if the same entity already exists
       model.update(entity);
@@ -129,11 +130,11 @@ public class PolarisEclipseLinkStore {
     session.persist(ModelGrantRecord.fromGrantRecord(grantRec));
   }
 
-  void deleteFromEntities(EntityManager session, long catalogId, long entityId) {
+  void deleteFromEntities(EntityManager session, long catalogId, long entityId, int typeCode) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    ModelEntity model = lookupEntity(session, catalogId, entityId, -1);
+    ModelEntity model = lookupEntity(session, catalogId, entityId, typeCode);
     diagnosticServices.check(model != null, "entity_not_found");
 
     session.remove(model);
@@ -207,22 +208,11 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    TypedQuery<ModelEntity> query;
-    if (typeCode != -1) {
-      query =
-          session
-              .createQuery(
-                  "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id and m.typeCode=:typeCode",
-                  ModelEntity.class)
-              .setParameter("typeCode", typeCode);
-    } else {
-      query =
-          session.createQuery(
-              "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id",
-              ModelEntity.class);
-    }
-
-    return query
+    return session
+        .createQuery(
+            "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id and m.typeCode=:typeCode",
+            ModelEntity.class)
+        .setParameter("typeCode", typeCode)
         .setParameter("catalogId", catalogId)
         .setParameter("id", entityId)
         .getResultStream()

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -84,7 +84,7 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    ModelEntity model = lookupEntity(session, entity.getCatalogId(), entity.getId());
+    ModelEntity model = lookupEntity(session, entity.getCatalogId(), entity.getId(), -1);
     if (model != null) {
       // Update if the same entity already exists
       model.update(entity);
@@ -133,7 +133,7 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    ModelEntity model = lookupEntity(session, catalogId, entityId);
+    ModelEntity model = lookupEntity(session, catalogId, entityId, -1);
     diagnosticServices.check(model != null, "entity_not_found");
 
     session.remove(model);
@@ -203,14 +203,26 @@ public class PolarisEclipseLinkStore {
     LOGGER.debug("All entities deleted.");
   }
 
-  ModelEntity lookupEntity(EntityManager session, long catalogId, long entityId) {
+  ModelEntity lookupEntity(EntityManager session, long catalogId, long entityId, long typeCode) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    return session
-        .createQuery(
-            "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id",
-            ModelEntity.class)
+    TypedQuery<ModelEntity> query;
+    if (typeCode != -1) {
+      query =
+          session
+              .createQuery(
+                  "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id and m.typeCode=:typeCode",
+                  ModelEntity.class)
+              .setParameter("typeCode", typeCode);
+    } else {
+      query =
+          session.createQuery(
+              "SELECT m from ModelEntity m where m.catalogId=:catalogId and m.id=:id",
+              ModelEntity.class);
+    }
+
+    return query
         .setParameter("catalogId", catalogId)
         .setParameter("id", entityId)
         .getResultStream()

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -217,7 +217,12 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
   @Override
   public @Nullable PolarisBaseEntity lookupEntityInCurrentTxn(
       @Nonnull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode) {
-    return this.store.getSliceEntities().read(this.store.buildKeyComposite(catalogId, entityId));
+    PolarisBaseEntity entity =
+        this.store.getSliceEntities().read(this.store.buildKeyComposite(catalogId, entityId));
+    if (entity != null && entity.getTypeCode() != typeCode) {
+      return null;
+    }
+    return entity;
   }
 
   /** {@inheritDoc} */

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -273,6 +273,12 @@ public abstract class BasePolarisMetaStoreManagerTest {
     polarisTestMetaStoreManager.testRename();
   }
 
+  /** test entity lookup */
+  @Test
+  protected void testLookup() {
+    polarisTestMetaStoreManager.testLookup();
+  }
+
   /** Test the set of functions for the entity cache */
   @Test
   protected void testEntityCache() {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -193,6 +193,24 @@ public class PolarisTestMetaStoreManager {
   }
 
   /**
+   * Validate that the specified identity identified by the pair catalogId, entityId does not exist.
+   *
+   * @param catalogId catalog id of that entity
+   * @param entityId the entity id
+   * @param expectedType its expected type
+   */
+  private void ensureNotExistsById(long catalogId, long entityId, PolarisEntityType expectedType) {
+
+    PolarisBaseEntity entity =
+        polarisMetaStoreManager
+            .loadEntity(this.polarisCallContext, catalogId, entityId, expectedType)
+            .getEntity();
+
+    // assert entity was not found
+    Assertions.assertThat(entity).isNull();
+  }
+
+  /**
    * Check if the specified grant record exists
    *
    * @param grantRecords list of grant records
@@ -2562,6 +2580,68 @@ public class PolarisTestMetaStoreManager {
 
     // this should work, T7 does not exist
     this.renameEntity(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N5), "T7");
+  }
+
+  /** Play with looking up entities */
+  public void testLookup() {
+    // load all principals
+    List<EntityNameLookupRecord> principals =
+        polarisMetaStoreManager
+            .listEntities(
+                this.polarisCallContext,
+                null,
+                PolarisEntityType.PRINCIPAL,
+                PolarisEntitySubType.NULL_SUBTYPE)
+            .getEntities();
+
+    // ensure not null, one element only
+    Assertions.assertThat(principals).isNotNull().hasSize(1);
+
+    // get catalog list information
+    EntityNameLookupRecord principalListInfo = principals.get(0);
+
+    PolarisBaseEntity principal =
+        this.ensureExistsById(
+            null,
+            principalListInfo.getId(),
+            true,
+            PolarisEntityConstants.getRootPrincipalName(),
+            PolarisEntityType.PRINCIPAL,
+            PolarisEntitySubType.NULL_SUBTYPE);
+
+    this.ensureNotExistsById(
+        PolarisEntityConstants.getNullId(), principal.getId(), PolarisEntityType.PRINCIPAL_ROLE);
+    this.ensureNotExistsById(
+        PolarisEntityConstants.getNullId(), principal.getId(), PolarisEntityType.CATALOG);
+    this.ensureNotExistsById(
+        PolarisEntityConstants.getNullId(), principal.getId(), PolarisEntityType.CATALOG_ROLE);
+
+    // create new catalog
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            polarisMetaStoreManager.generateNewEntityId(this.polarisCallContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "test");
+    CreateCatalogResult catalogCreated =
+        polarisMetaStoreManager.createCatalog(this.polarisCallContext, catalog, List.of());
+    Assertions.assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    // now create all objects
+    PolarisBaseEntity N1 = this.createEntity(List.of(catalog), PolarisEntityType.NAMESPACE, "N1");
+    PolarisBaseEntity N1_N2 =
+        this.createEntity(List.of(catalog, N1), PolarisEntityType.NAMESPACE, "N2");
+    PolarisBaseEntity T1 =
+        this.createEntity(
+            List.of(catalog, N1, N1_N2),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            "T1");
+
+    this.ensureNotExistsById(catalog.getId(), T1.getId(), PolarisEntityType.NAMESPACE);
   }
 
   /** Test the set of functions for the entity cache */


### PR DESCRIPTION
All implementations of `TransactionalPersistence.lookupEntityInCurrentTxn()` are currently ignoring the `typeCode` parameter completely and could potentially return an entity of the wrong type.

This can become very concerning during authentication, since a principal lookup could return some entity that is not a principal, and that would be considered a successful authentication.