### PR TITLE
Fix incorrect primary key column order in policy_mapping_records table by using EclipseLink @PrimaryKey annotation

### DIFF
--- a/extension/persistence/jpa-model/build.gradle.kts
+++ b/extension/persistence/jpa-model/build.gradle.kts
@@ -24,6 +24,8 @@ plugins {
 
 dependencies {
   implementation(project(":polaris-core"))
+  implementation(libs.eclipselink)
+
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.jakarta.persistence.api)

--- a/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
+++ b/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
@@ -18,12 +18,14 @@
  */
 package org.apache.polaris.jpa.models;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+import org.eclipse.persistence.annotations.PrimaryKey;
 
 @Entity
 @Table(
@@ -32,6 +34,14 @@ import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
       @Index(
           name = "POLICY_MAPPING_RECORDS_BY_POLICY_INDEX",
           columnList = "policyCatalogId,policyId,targetCatalogId,targetId")
+    })
+@PrimaryKey(
+    columns = {
+      @Column(name = "targetCatalogId"),
+      @Column(name = "targetId"),
+      @Column(name = "policyTypeCode"),
+      @Column(name = "policyCatalogId"),
+      @Column(name = "policyId")
     })
 public class ModelPolicyMappingRecord {
   // id of the catalog where target entity resides

--- a/getting-started/assets/eclipselink/persistence.xml
+++ b/getting-started/assets/eclipselink/persistence.xml
@@ -28,6 +28,7 @@
     <class>org.apache.polaris.jpa.models.ModelEntityChangeTracking</class>
     <class>org.apache.polaris.jpa.models.ModelEntityDropped</class>
     <class>org.apache.polaris.jpa.models.ModelGrantRecord</class>
+    <class>org.apache.polaris.jpa.models.ModelPolicyMappingRecord</class>
     <class>org.apache.polaris.jpa.models.ModelPrincipalSecrets</class>
     <class>org.apache.polaris.jpa.models.ModelSequenceId</class>
     <shared-cache-mode>NONE</shared-cache-mode>


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

This is a follow-up of https://github.com/apache/polaris/pull/1104#discussion_r2022107629. The EclipseLink seems not respect the ordering of the columns in order of their appearance in the member declarations using the `@Id` annotation. We will need to use `org.eclipse.persistence.annotations.PrimaryKey` annotation to ensure the ordering.

To verify this:

use the getting-started/eclipselink example
```
docker compose -f getting-started/eclipselink/docker-compose-postgres.yml -f getting-started/eclipselink/docker-compose-bootstrap-db.yml -f getting-started/eclipselink/docker-compose.yml up
```
Go into the Postgres container and run
```
> psql -U postgres -d POLARIS
> \d policy_mapping_records;
```
Before the fix, we will see
```
\d policy_mapping_records;
                   Table "public.policy_mapping_records"
     Column      |          Type          | Collation | Nullable | Default 
-----------------+------------------------+-----------+----------+---------
 targetcatalogid | bigint                 |           | not null | 
 policytypecode  | integer                |           | not null | 
 targetid        | bigint                 |           | not null | 
 policyid        | bigint                 |           | not null | 
 policycatalogid | bigint                 |           | not null | 
 parameters      | character varying(255) |           |          | 
 version         | bigint                 |           |          | 
Indexes:
    "policy_mapping_records_pkey" PRIMARY KEY, btree (targetcatalogid, policytypecode, targetid, policyid, policycatalogid)
    "policy_mapping_records_by_policy_index" btree (policycatalogid, policyid, targetcatalogid, targetid)

```
The ordering in `policy_mapping_records_pkey` is incorrect

After the fix, it is correct
```
\d policy_mapping_records;
                   Table "public.policy_mapping_records"
     Column      |          Type          | Collation | Nullable | Default 
-----------------+------------------------+-----------+----------+---------
 targetcatalogid | bigint                 |           | not null | 
 targetid        | bigint                 |           | not null | 
 policytypecode  | integer                |           | not null | 
 policycatalogid | bigint                 |           | not null | 
 policyid        | bigint                 |           | not null | 
 parameters      | character varying(255) |           |          | 
 version         | bigint                 |           |          | 
Indexes:
    "policy_mapping_records_pkey" PRIMARY KEY, btree (targetcatalogid, targetid, policytypecode, policycatalogid, policyid)
    "policy_mapping_records_by_policy_index" btree (policycatalogid, policyid, targetcatalogid, targetid)
```