### PR TITLE
Reinstate dependencies between Docker Compose services

### DIFF
--- a/getting-started/eclipselink/README.md
+++ b/getting-started/eclipselink/README.md
@@ -71,7 +71,7 @@ This example requires `jq` to be installed on your machine.
 
     ```shell
     curl -v http://127.0.0.1:8181/api/management/v1/principal-roles -H "Authorization: Bearer $POLARIS_TOKEN"
-    curl -v http://127.0.0.1:8181/api/management/v1/catalogs/polaris_demo -H "Authorization: Bearer $POLARIS_TOKEN"
+    curl -v http://127.0.0.1:8181/api/management/v1/catalogs/quickstart_catalog -H "Authorization: Bearer $POLARIS_TOKEN"
     ```
 
 6. Using Trino CLI: To access the Trino CLI, run this command:

--- a/getting-started/eclipselink/docker-compose-bootstrap-db.yml
+++ b/getting-started/eclipselink/docker-compose-bootstrap-db.yml
@@ -30,3 +30,7 @@ services:
       - "bootstrap"
       - "--realm=POLARIS"
       - "--credential=POLARIS,root,s3cr3t"
+  polaris:
+    depends_on:
+      polaris-bootstrap:
+        condition: service_completed_successfully

--- a/getting-started/eclipselink/docker-compose-postgres.yml
+++ b/getting-started/eclipselink/docker-compose-postgres.yml
@@ -43,3 +43,11 @@ services:
       interval: 5s
       timeout: 2s
       retries: 15
+  polaris-bootstrap:
+    depends_on:
+      postgres:
+        condition: service_healthy
+  polaris:
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/getting-started/eclipselink/docker-compose.yml
+++ b/getting-started/eclipselink/docker-compose.yml
@@ -56,6 +56,9 @@ services:
 
   spark-sql:
     image: apache/spark:3.5.5-java17-python3
+    depends_on:
+      polaris-setup:
+        condition: service_completed_successfully
     stdin_open: true
     tty: true
     ports:
@@ -81,6 +84,9 @@ services:
 
   trino:
     image: trinodb/trino:latest
+    depends_on:
+      polaris-setup:
+        condition: service_completed_successfully
     stdin_open: true
     tty: true
     ports:


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Fixes #1398. Reinstates the missing dependencies that were taken out due to the recomposition of the `docker-compose.yml` files.

This should restore previous behavior - here's my local output:

```
ahemani@F7Q5C90CJX polaris % docker compose -f getting-started/eclipselink/docker-compose-postgres.yml -f getting-started/eclipselink/docker-compose-bootstrap-db.yml -f getting-started/eclipselink/docker-compose.yml up -d
[+] Running 7/7
 ✔ Network eclipselink_default                Created                                                                                                                                                                                       0.0s 
 ✔ Container eclipselink-postgres-1           Healthy                                                                                                                                                                                       6.4s 
 ✔ Container eclipselink-polaris-bootstrap-1  Exited                                                                                                                                                                                        6.9s 
 ✔ Container eclipselink-polaris-1            Healthy                                                                                                                                                                                      12.4s 
 ✔ Container eclipselink-polaris-setup-1      Exited                                                                                                                                                                                       13.5s 
 ✔ Container eclipselink-spark-sql-1          Started                                                                                                                                                                                      13.5s 
 ✔ Container eclipselink-trino-1              Started                                                                                                                                                                                      13.5s
```