### PR TITLE
Remove activatedPrincipalRoles property from AuthenticatedPolarisPrincipal

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthenticatedPolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthenticatedPolarisPrincipal.java
@@ -19,24 +19,18 @@
 package org.apache.polaris.core.auth;
 
 import jakarta.annotation.Nonnull;
-import java.util.List;
 import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PrincipalRoleEntity;
 
 /** Holds the results of request authentication. */
 public class AuthenticatedPolarisPrincipal implements java.security.Principal {
   private final PolarisEntity principalEntity;
   private final Set<String> activatedPrincipalRoleNames;
-  // only known and set after the above set of principal role names have been resolved. Before
-  // this, this list is null
-  private List<PrincipalRoleEntity> activatedPrincipalRoles;
 
   public AuthenticatedPolarisPrincipal(
       @Nonnull PolarisEntity principalEntity, @Nonnull Set<String> activatedPrincipalRoles) {
     this.principalEntity = principalEntity;
     this.activatedPrincipalRoleNames = activatedPrincipalRoles;
-    this.activatedPrincipalRoles = null;
   }
 
   @Override
@@ -52,21 +46,11 @@ public class AuthenticatedPolarisPrincipal implements java.security.Principal {
     return activatedPrincipalRoleNames;
   }
 
-  public List<PrincipalRoleEntity> getActivatedPrincipalRoles() {
-    return activatedPrincipalRoles;
-  }
-
-  public void setActivatedPrincipalRoles(List<PrincipalRoleEntity> activatedPrincipalRoles) {
-    this.activatedPrincipalRoles = activatedPrincipalRoles;
-  }
-
   @Override
   public String toString() {
     return "principalEntity="
         + getPrincipalEntity()
         + ";activatedPrincipalRoleNames="
-        + getActivatedPrincipalRoleNames()
-        + ";activatedPrincipalRoles="
-        + getActivatedPrincipalRoles();
+        + getActivatedPrincipalRoleNames();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
@@ -35,7 +34,6 @@ import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
@@ -56,7 +54,6 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
   private final PolarisEntityManager entityManager;
   private final CallContext callContext;
   private final SecurityContext securityContext;
-  private final AuthenticatedPolarisPrincipal authenticatedPrincipal;
   private final String catalogName;
   private final Resolver primaryResolver;
   private final PolarisDiagnostics diagnostics;
@@ -96,8 +93,6 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
         "invalid_principal_type_for_resolution_manifest",
         "principal={}",
         securityContext.getUserPrincipal());
-    this.authenticatedPrincipal =
-        (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
 
     // TODO: Make the rootContainer lookup no longer optional in the persistence store.
     // For now, we'll try to resolve the rootContainer as "optional", and only if we fail to find
@@ -149,14 +144,6 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
             != ResolverStatus.StatusEnum.CALLER_PRINCIPAL_DOES_NOT_EXIST,
         "caller_principal_does_not_exist_at_resolution_time");
 
-    // activated principal roles are known, add them to the call context
-    if (primaryResolverStatus.getStatus() == ResolverStatus.StatusEnum.SUCCESS) {
-      List<PrincipalRoleEntity> activatedPrincipalRoles =
-          primaryResolver.getResolvedCallerPrincipalRoles().stream()
-              .map(ce -> PrincipalRoleEntity.of(ce.getEntity()))
-              .collect(Collectors.toList());
-      this.authenticatedPrincipal.setActivatedPrincipalRoles(activatedPrincipalRoles);
-    }
     return primaryResolverStatus;
   }
 


### PR DESCRIPTION
This seems to be a leftover from when `ActiveRolesProvider` was introduced. The setter was still used (just in one place, by the `Resolver`), but the getter wasn't, which hints at the fact that this property can be safely removed.

As a bonus, `AuthenticatedPolarisPrincipal` now becomes immutable, which is imho a very good thing.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
