### PR TITLE
Ship eclipselink and PostgreSQL JDBC driver by default in Polaris distribution

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -104,8 +104,7 @@ jobs:
             :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
             :polaris-quarkus-admin:assemble \
             :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
-            -Dquarkus.container-image.build=true \
-            -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+            -Dquarkus.container-image.build=true
           minikube image ls
 
       - name: Install fixtures

--- a/getting-started/assets/cloud_providers/deploy-aws.sh
+++ b/getting-started/assets/cloud_providers/deploy-aws.sh
@@ -70,7 +70,6 @@ FULL_POSTGRES_ADDR=$(printf '%s\n' "jdbc:postgresql://$POSTGRES_ADDR/{realm}" | 
 sed -i "/jakarta.persistence.jdbc.url/ s|value=\"[^\"]*\"|value=\"$FULL_POSTGRES_ADDR\"|" "getting-started/assets/eclipselink/persistence.xml"
 
 ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
-       -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
        -Dquarkus.container-image.build=true \
        --no-build-cache

--- a/getting-started/assets/cloud_providers/deploy-azure.sh
+++ b/getting-started/assets/cloud_providers/deploy-azure.sh
@@ -32,7 +32,6 @@ FULL_POSTGRES_ADDR=$(printf '%s\n' "jdbc:postgresql://$POSTGRES_ADDR:5432/{realm
 sed -i "/jakarta.persistence.jdbc.url/ s|value=\"[^\"]*\"|value=\"$FULL_POSTGRES_ADDR\"|" "getting-started/assets/eclipselink/persistence.xml"
 
 ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
-       -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
        -Dquarkus.container-image.build=true \
        --no-build-cache

--- a/getting-started/assets/cloud_providers/deploy-gcp.sh
+++ b/getting-started/assets/cloud_providers/deploy-gcp.sh
@@ -42,7 +42,6 @@ FULL_POSTGRES_ADDR=$(printf '%s\n' "jdbc:postgresql://$POSTGRES_ADDR:5432/{realm
 sed -i "/jakarta.persistence.jdbc.url/ s|value=\"[^\"]*\"|value=\"$FULL_POSTGRES_ADDR\"|" "getting-started/assets/eclipselink/persistence.xml"
 
 ./gradlew clean :polaris-quarkus-server:assemble :polaris-quarkus-admin:assemble \
-       -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
        -Dquarkus.container-image.build=true \
        --no-build-cache

--- a/getting-started/eclipselink/README.md
+++ b/getting-started/eclipselink/README.md
@@ -30,7 +30,6 @@ This example requires `jq` to be installed on your machine.
        :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
        :polaris-quarkus-admin:assemble \
        :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
-       -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
        -Dquarkus.container-image.tag=postgres-latest \
        -Dquarkus.container-image.build=true
     ```

--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -70,7 +70,7 @@ Simply run the `run.sh` script from the Polaris repo root, making sure to specif
 `--eclipse-link-deps` option:
 
 ```bash
-./run.sh --eclipse-link-deps=org.postgresql:postgresql:42.7.4
+./run.sh
 ```
 
 This script will create a Kind cluster, deploy a local Docker registry, build the Polaris Docker
@@ -86,13 +86,12 @@ If necessary, build and load the Docker images with support for Postgres into Mi
 ```bash
 eval $(minikube -p minikube docker-env)
 
-./gradlew \ 
+./gradlew \
     :polaris-quarkus-server:assemble \
     :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
     :polaris-quarkus-admin:assemble \
     :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
-    -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+    -Dquarkus.container-image.build=true
 ```
 
 ### Installing the chart locally

--- a/helm/polaris/README.md.gotmpl
+++ b/helm/polaris/README.md.gotmpl
@@ -71,7 +71,7 @@ Simply run the `run.sh` script from the Polaris repo root, making sure to specif
 `--eclipse-link-deps` option:
 
 ```bash
-./run.sh --eclipse-link-deps=org.postgresql:postgresql:42.7.4
+./run.sh
 ```
 
 This script will create a Kind cluster, deploy a local Docker registry, build the Polaris Docker
@@ -92,8 +92,7 @@ eval $(minikube -p minikube docker-env)
     :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
     :polaris-quarkus-admin:assemble \
     :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
-    -Dquarkus.container-image.build=true \
-    -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+    -Dquarkus.container-image.build=true
 ```
 
 ### Installing the chart locally

--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -1405,8 +1405,8 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 --------------------------------------------------------------------------------
 
 Group: org.eclipse.angus Name: angus-activation Version: 2.0.2
-Project URL (from POM): https://github.com/eclipse-ee4j/angus-activation
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/eclipse-ee4j/angus-activation
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
 
 --------------------------------------------------------------------------------
 
@@ -1428,10 +1428,9 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 
 --------------------------------------------------------------------------------
 
-org.eclipse.persistence.eclipselink-4.0.5.jar
-Project URL (from POM): http://www.eclipse.org/eclipselink
-License (from POM): Eclipse Public License 2.0 - http://www.eclipse.org/legal/epl-2.0
-License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Group: org.eclipse.persistence Name: eclipselink Version: 4.0.6
+Project URL: https://eclipse.dev/eclipselink/
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
 
 --------------------------------------------------------------------------------
 
@@ -1721,5 +1720,11 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
 Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
 License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.postgresql Name: postgresql Version: 42.7.5
+Project URL: https://jdbc.postgresql.org/
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
 
 --------------------------------------------------------------------------------

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -48,9 +48,8 @@ dependencies {
   implementation(project(":polaris-service-common"))
   implementation(project(":polaris-quarkus-service"))
 
-  if (project.hasProperty("eclipseLinkDeps")) {
-    runtimeOnly(project(":polaris-eclipselink"))
-  }
+  runtimeOnly(project(":polaris-eclipselink"))
+  runtimeOnly("org.postgresql:postgresql")
 
   // enforce the Quarkus _platform_ here, to get a consistent and validated set of dependencies
   implementation(enforcedPlatform(libs.quarkus.bom))

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -2086,6 +2086,12 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 
 --------------------------------------------------------------------------------
 
+Group: org.eclipse.angus Name: angus-activation Version: 2.0.2
+Project URL: https://projects.eclipse.org/projects/ee4j.angus
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
+
+--------------------------------------------------------------------------------
+
 Group: org.eclipse.jetty Name: jetty-http Version: 9.4.53.v20231009
 Project URL (from POM): https://eclipse.org/jetty
 License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -2164,6 +2170,12 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 Group: org.eclipse.microprofile.health Name: microprofile-health-api Version: 4.0.1
 Project URL (from POM): http://microprofile.io
 License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.persistence Name: eclipselink Version: 4.0.6
+Project URL: https://eclipse.dev/eclipselink/
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
 
 --------------------------------------------------------------------------------
 
@@ -2478,5 +2490,11 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
 Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
 License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.postgresql Name: postgresql Version: 42.7.5
+Project URL: https://jdbc.postgresql.org/
+License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
 
 --------------------------------------------------------------------------------

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@
 usage() {
   echo "Usage: $0 [--eclipse-link-deps=<deps>] [-h|--help]"
   echo "  --eclipse-link-deps=<deps>  EclipseLink dependencies to use, e.g."
-  echo "                              --eclipse-link-deps=org.postgresql:postgresql:42.7.4"
+  echo "                              --eclipse-link-deps=com.h2database:h2:2.3.232"
   echo "  -h, --help                  Display this help message"
   exit 1
 }

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -31,8 +31,7 @@ example, to build the tool with support for Postgres, run the following:
 ./gradlew \
   :polaris-quarkus-admin:assemble \
   :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
-  -Dquarkus.container-image.build=true \
-  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
+  -Dquarkus.container-image.build=true
 ```
 
 The above command will generate:

--- a/site/content/in-dev/unreleased/getting-started/quickstart.md
+++ b/site/content/in-dev/unreleased/getting-started/quickstart.md
@@ -34,7 +34,6 @@ cd ~/polaris
   :polaris-quarkus-server:assemble \
   :polaris-quarkus-server:quarkusAppPartsBuild \
   :polaris-quarkus-admin:assemble --rerun \
-  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4 \
   -Dquarkus.container-image.tag=postgres-latest \
   -Dquarkus.container-image.build=true
 docker compose -f getting-started/eclipselink/docker-compose.yml up

--- a/site/content/in-dev/unreleased/metastores.md
+++ b/site/content/in-dev/unreleased/metastores.md
@@ -24,12 +24,11 @@ weight: 700
 
 This page documents important configurations for connecting to a production database through [EclipseLink](https://eclipse.dev/eclipselink/).
 
-## Building Polaris with EclipseLink
+## Polaris EclipseLink
 
-Polaris doesn't ship with any JDBC driver. You must specify them when building Polaris with
-EclipseLink by using Gradle's project property:
-`-PeclipseLinkDeps=<jdbc-driver-artifact1>,<jdbc-driver-artifact2>,...`. See below examples for H2
-and Postgres.
+Polaris includes EclipseLink plugin by default with PostgreSQL driver.
+
+In order to add other JDBC drivers, you have to build Polaris using the `eclipseLinkDeps` build property.
 
 ## Polaris Server Configuration
 
@@ -104,6 +103,8 @@ java -Dpolaris.persistence.type=eclipse-link \
 
 ### Using Postgres
 
+PostgreSQL is included by default in the Polaris server distribution.
+
 The following shows a sample configuration for integrating Polaris with Postgres.
 
 ```xml
@@ -128,17 +129,4 @@ The following shows a sample configuration for integrating Polaris with Postgres
     <property name="eclipselink.transaction.join-existing" value="true"/>
   </properties>
 </persistence-unit>
-```
-
-To build Polaris with the necessary Postgres dependency and start the Polaris service, run the following:
-
-```shell
-./gradlew \
-  :polaris-quarkus-server:assemble \
-  :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
-  -PeclipseLinkDeps=org.postgresql:postgresql:42.7.4
-java -Dpolaris.persistence.type=eclipse-link \
-     -Dpolaris.persistence.eclipselink.configuration-file=/path/to/persistence.xml \
-     -Dpolaris.persistence.eclipselink.persistence-unit=polaris \
-     -jar quarkus/server/build/quarkus-app/quarkus-run.jar
 ```


### PR DESCRIPTION
As discussed on the mailing list (https://lists.apache.org/thread/7bccoyzcr77xd8qzzz4r6nn3zytc7doz), this PR:
1. ship EclipseLink and PostgreSQL JDBC driver by default in Polaris distribution
2. update LICENSE
3. update documentation
4. update helm charts/tests