### PR TITLE
PolicyCatalog: Update GetApplicablePolicies to return List<ApplicablePolicies>

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyEntity.java
@@ -75,6 +75,15 @@ public class PolicyEntity extends PolarisEntity {
     return Integer.parseInt(getPropertiesAsMap().get(POLICY_VERSION_KEY));
   }
 
+  @JsonIgnore
+  public Namespace getParentNamespace() {
+    String parentNamespace = getInternalPropertiesAsMap().get(NamespaceEntity.PARENT_NAMESPACE_KEY);
+    if (parentNamespace != null) {
+      return RESTUtil.decodeNamespace(parentNamespace);
+    }
+    return null;
+  }
+
   public static class Builder extends PolarisEntity.BaseBuilder<PolicyEntity, Builder> {
     public Builder(Namespace namespace, String policyName, PolicyType policyType) {
       super();

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -38,6 +38,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +95,7 @@ import org.apache.polaris.service.catalog.policy.PolicyCatalog;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.storage.PolarisStorageIntegrationProviderImpl;
 import org.apache.polaris.service.task.TaskExecutor;
+import org.apache.polaris.service.types.ApplicablePolicy;
 import org.apache.polaris.service.types.Policy;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 import org.apache.polaris.service.types.PolicyIdentifier;
@@ -585,8 +587,8 @@ public class PolicyCatalogTest {
     policyCatalog.attachPolicy(POLICY2, POLICY_ATTACH_TARGET_NS, null);
     var applicablePolicies = policyCatalog.getApplicablePolicies(NS, null, null);
     assertThat(applicablePolicies.size()).isEqualTo(2);
-    assertThat(applicablePolicies.contains(p1)).isTrue();
-    assertThat(applicablePolicies.contains(p2)).isTrue();
+    assertThat(applicablePolicies.contains(policyToApplicablePolicy(p1, true, NS))).isTrue();
+    assertThat(applicablePolicies.contains(policyToApplicablePolicy(p2, false, NS))).isTrue();
 
     // attach policies to a table
     icebergCatalog.createTable(TABLE, SCHEMA);
@@ -605,8 +607,8 @@ public class PolicyCatalogTest {
     policyCatalog.attachPolicy(POLICY4, POLICY_ATTACH_TARGET_TBL, null);
     applicablePolicies = policyCatalog.getApplicablePolicies(NS, TABLE.name(), null);
     // p2 should be overwritten by p4, as they are the same type
-    assertThat(applicablePolicies.contains(p4)).isTrue();
-    assertThat(applicablePolicies.contains(p2)).isFalse();
+    assertThat(applicablePolicies.contains(policyToApplicablePolicy(p4, false, NS))).isTrue();
+    assertThat(applicablePolicies.contains(policyToApplicablePolicy(p2, true, NS))).isFalse();
   }
 
   @Test
@@ -626,6 +628,19 @@ public class PolicyCatalogTest {
     policyCatalog.attachPolicy(POLICY2, POLICY_ATTACH_TARGET_NS, null);
     var applicablePolicies = policyCatalog.getApplicablePolicies(NS, null, DATA_COMPACTION);
     // only p2 is with the type fetched
-    assertThat(applicablePolicies.contains(p2)).isTrue();
+    assertThat(applicablePolicies.contains(policyToApplicablePolicy(p2, false, NS))).isTrue();
+  }
+
+  private static ApplicablePolicy policyToApplicablePolicy(
+      Policy policy, boolean inherited, Namespace parent) {
+    return new ApplicablePolicy(
+        policy.getPolicyType(),
+        policy.getInheritable(),
+        policy.getName(),
+        policy.getDescription(),
+        policy.getContent(),
+        policy.getVersion(),
+        inherited,
+        Arrays.asList(parent.levels()));
   }
 }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
The spec has been updated (https://github.com/apache/polaris/pull/1277) that now `GetApplicablePolicies` shall return a list of `ApplicablePolicies`, which include the policy's parent namespace and whether the policy is inherited or not. This PR updates the `getApplicablePolicies` method in `PolicyCatalog` to include the additional information.

cc @flyrain 