### PR TITLE
Policy: Rename Snapshot Retention to Snapshot Expiry

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PredefinedPolicyTypes.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PredefinedPolicyTypes.java
@@ -28,7 +28,7 @@ public enum PredefinedPolicyTypes implements PolicyType {
   DATA_COMPACTION(0, "system.data-compaction", true),
   METADATA_COMPACTION(1, "system.metadata-compaction", true),
   ORPHAN_FILE_REMOVAL(2, "system.orphan-file-removal", true),
-  SNAPSHOT_RETENTION(3, "system.snapshot-retention", true);
+  SNAPSHOT_EXPIRY(3, "system.snapshot-expiry", true);
 
   private final int code;
   private final String name;

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/content/maintenance/SnapshotExpiryPolicyContent.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/content/maintenance/SnapshotExpiryPolicyContent.java
@@ -25,24 +25,24 @@ import java.util.Set;
 import org.apache.polaris.core.policy.content.PolicyContentUtil;
 import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 
-public class SnapshotRetentionPolicyContent extends BaseMaintenancePolicyContent {
+public class SnapshotExpiryPolicyContent extends BaseMaintenancePolicyContent {
   private static final String DEFAULT_POLICY_SCHEMA_VERSION = "2025-02-03";
   private static final Set<String> POLICY_SCHEMA_VERSIONS = Set.of(DEFAULT_POLICY_SCHEMA_VERSION);
 
   @JsonCreator
-  public SnapshotRetentionPolicyContent(
+  public SnapshotExpiryPolicyContent(
       @JsonProperty(value = "enable", required = true) boolean enable) {
     super(enable);
   }
 
-  public static SnapshotRetentionPolicyContent fromString(String content) {
+  public static SnapshotExpiryPolicyContent fromString(String content) {
     if (Strings.isNullOrEmpty(content)) {
       throw new InvalidPolicyException("Policy is empty");
     }
 
-    SnapshotRetentionPolicyContent policy;
+    SnapshotExpiryPolicyContent policy;
     try {
-      policy = PolicyContentUtil.MAPPER.readValue(content, SnapshotRetentionPolicyContent.class);
+      policy = PolicyContentUtil.MAPPER.readValue(content, SnapshotExpiryPolicyContent.class);
     } catch (Exception e) {
       throw new InvalidPolicyException(e);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/PolicyValidators.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/PolicyValidators.java
@@ -25,7 +25,7 @@ import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.core.policy.content.maintenance.DataCompactionPolicyContent;
 import org.apache.polaris.core.policy.content.maintenance.MetadataCompactionPolicyContent;
 import org.apache.polaris.core.policy.content.maintenance.OrphanFileRemovalPolicyContent;
-import org.apache.polaris.core.policy.content.maintenance.SnapshotRetentionPolicyContent;
+import org.apache.polaris.core.policy.content.maintenance.SnapshotExpiryPolicyContent;
 import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
 import org.apache.polaris.core.policy.validator.maintenance.BaseMaintenancePolicyValidator;
 import org.slf4j.Logger;
@@ -60,8 +60,8 @@ public class PolicyValidators {
       case METADATA_COMPACTION:
         MetadataCompactionPolicyContent.fromString(policy.getContent());
         break;
-      case SNAPSHOT_RETENTION:
-        SnapshotRetentionPolicyContent.fromString(policy.getContent());
+      case SNAPSHOT_EXPIRY:
+        SnapshotExpiryPolicyContent.fromString(policy.getContent());
         break;
       case ORPHAN_FILE_REMOVAL:
         OrphanFileRemovalPolicyContent.fromString(policy.getContent());
@@ -94,7 +94,7 @@ public class PolicyValidators {
     switch (policyType) {
       case DATA_COMPACTION:
       case METADATA_COMPACTION:
-      case SNAPSHOT_RETENTION:
+      case SNAPSHOT_EXPIRY:
       case ORPHAN_FILE_REMOVAL:
         return BaseMaintenancePolicyValidator.INSTANCE.canAttach(entityType, entitySubType);
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/policy/MaintenancePolicyContentTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/policy/MaintenancePolicyContentTest.java
@@ -28,7 +28,7 @@ import org.apache.polaris.core.policy.content.maintenance.BaseMaintenancePolicyC
 import org.apache.polaris.core.policy.content.maintenance.DataCompactionPolicyContent;
 import org.apache.polaris.core.policy.content.maintenance.MetadataCompactionPolicyContent;
 import org.apache.polaris.core.policy.content.maintenance.OrphanFileRemovalPolicyContent;
-import org.apache.polaris.core.policy.content.maintenance.SnapshotRetentionPolicyContent;
+import org.apache.polaris.core.policy.content.maintenance.SnapshotExpiryPolicyContent;
 import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,8 +52,8 @@ public class MaintenancePolicyContentTest {
         return MetadataCompactionPolicyContent::fromString;
       case ORPHAN_FILE_REMOVAL:
         return OrphanFileRemovalPolicyContent::fromString;
-      case SNAPSHOT_RETENTION:
-        return SnapshotRetentionPolicyContent::fromString;
+      case SNAPSHOT_EXPIRY:
+        return SnapshotExpiryPolicyContent::fromString;
       default:
         throw new IllegalArgumentException("Unknown policy type: " + policyType);
     }

--- a/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyTypeTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyTypeTest.java
@@ -31,7 +31,7 @@ public class PolicyTypeTest {
         Arguments.of(0, "system.data-compaction", true),
         Arguments.of(1, "system.metadata-compaction", true),
         Arguments.of(2, "system.orphan-file-removal", true),
-        Arguments.of(3, "system.snapshot-retention", true));
+        Arguments.of(3, "system.snapshot-expiry", true));
   }
 
   @ParameterizedTest

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -1259,7 +1259,7 @@ public class PolarisTestMetaStoreManager {
     this.createPolicy(List.of(catalog, N7, N7_N8), "POL1", PredefinedPolicyTypes.DATA_COMPACTION);
     this.createPolicy(
         List.of(catalog, N7, N7_N8), "POL2", PredefinedPolicyTypes.METADATA_COMPACTION);
-    this.createPolicy(List.of(catalog, N7), "POL3", PredefinedPolicyTypes.SNAPSHOT_RETENTION);
+    this.createPolicy(List.of(catalog, N7), "POL3", PredefinedPolicyTypes.SNAPSHOT_EXPIRY);
 
     // the two catalog roles
     PolarisBaseEntity R1 =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -361,7 +361,7 @@ public class PolicyCatalogTest {
             () ->
                 policyCatalog.createPolicy(
                     POLICY1,
-                    PredefinedPolicyTypes.SNAPSHOT_RETENTION.getName(),
+                    PredefinedPolicyTypes.SNAPSHOT_EXPIRY.getName(),
                     "test",
                     "{\"enable\": false}"))
         .isInstanceOf(AlreadyExistsException.class);
@@ -380,7 +380,7 @@ public class PolicyCatalogTest {
         "{\"enable\": false}");
 
     policyCatalog.createPolicy(
-        POLICY3, PredefinedPolicyTypes.SNAPSHOT_RETENTION.getName(), "test", "{\"enable\": false}");
+        POLICY3, PredefinedPolicyTypes.SNAPSHOT_EXPIRY.getName(), "test", "{\"enable\": false}");
 
     policyCatalog.createPolicy(
         POLICY4, ORPHAN_FILE_REMOVAL.getName(), "test", "{\"enable\": false}");
@@ -403,7 +403,7 @@ public class PolicyCatalogTest {
         "{\"enable\": false}");
 
     policyCatalog.createPolicy(
-        POLICY3, PredefinedPolicyTypes.SNAPSHOT_RETENTION.getName(), "test", "{\"enable\": false}");
+        POLICY3, PredefinedPolicyTypes.SNAPSHOT_EXPIRY.getName(), "test", "{\"enable\": false}");
 
     policyCatalog.createPolicy(
         POLICY4, ORPHAN_FILE_REMOVAL.getName(), "test", "{\"enable\": false}");


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
In https://github.com/apache/polaris/pull/1284 we've made the decision to rename `snapshot-retention` to `snapshot-expiry`. This PR updates the corresponding names in `polaris-core`

cc @flyrain 