### PR TITLE
Fix Connection Config DPOs

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
@@ -31,7 +31,10 @@ import org.apache.polaris.core.secrets.UserSecretReference;
  * The internal persistence-object counterpart to AuthenticationParameters defined in the API model.
  * Important: JsonSubTypes must be kept in sync with {@link AuthenticationType}.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "authenticationTypeCode", visible = true)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "authenticationTypeCode")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = OAuthClientCredentialsParametersDpo.class, name = "1"),
   @JsonSubTypes.Type(value = BearerAuthenticationParametersDpo.class, name = "2"),
@@ -65,7 +68,6 @@ public abstract class AuthenticationParametersDpo implements IcebergCatalogPrope
             (OAuthClientCredentialsParameters) authenticationParameters;
         config =
             new OAuthClientCredentialsParametersDpo(
-                AuthenticationType.OAUTH.getCode(),
                 oauthClientCredentialsModel.getTokenUri(),
                 oauthClientCredentialsModel.getClientId(),
                 secretReferences.get(INLINE_CLIENT_SECRET_REFERENCE_KEY),
@@ -76,7 +78,6 @@ public abstract class AuthenticationParametersDpo implements IcebergCatalogPrope
             (BearerAuthenticationParameters) authenticationParameters;
         config =
             new BearerAuthenticationParametersDpo(
-                AuthenticationType.BEARER.getCode(),
                 secretReferences.get(INLINE_BEARER_TOKEN_REFERENCE_KEY));
         break;
       default:

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
@@ -61,7 +61,8 @@ public enum AuthenticationType {
   }
 
   /**
-   * Given the code associated to the type, return the associated AuthenticationType. Return NULL_TYPE if not found
+   * Given the code associated to the type, return the associated AuthenticationType. Return
+   * NULL_TYPE if not found
    *
    * @param authTypeCode code associated to the authentication type
    * @return ConnectionType corresponding to that code or null if mapping not found

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
@@ -18,6 +18,9 @@
  */
 package org.apache.polaris.core.connection;
 
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+
 /**
  * The internal persistence-object counterpart to AuthenticationParameters.AuthenticationTypeEnum
  * defined in the API model. We define integer type codes in this enum for better compatibility
@@ -27,13 +30,50 @@ package org.apache.polaris.core.connection;
  * AuthenticationParametersDpo}.
  */
 public enum AuthenticationType {
+  NULL_TYPE(0),
   OAUTH(1),
-  BEARER(2);
+  BEARER(2),
+  ;
+
+  private static final AuthenticationType[] REVERSE_MAPPING_ARRAY;
+
+  static {
+    // find max array size
+    int maxCode =
+        Arrays.stream(AuthenticationType.values())
+            .mapToInt(AuthenticationType::getCode)
+            .max()
+            .orElse(0);
+
+    // allocate mapping array
+    REVERSE_MAPPING_ARRAY = new AuthenticationType[maxCode + 1];
+
+    // populate mapping array
+    for (AuthenticationType authType : AuthenticationType.values()) {
+      REVERSE_MAPPING_ARRAY[authType.code] = authType;
+    }
+  }
 
   private final int code;
 
   AuthenticationType(int code) {
     this.code = code;
+  }
+
+  /**
+   * Given the code associated to the type, return the associated AuthenticationType. Return NULL_TYPE if not found
+   *
+   * @param authTypeCode code associated to the authentication type
+   * @return ConnectionType corresponding to that code or null if mapping not found
+   */
+  public static @Nonnull AuthenticationType fromCode(int authTypeCode) {
+    // ensure it is within bounds
+    if (authTypeCode < 0 || authTypeCode >= REVERSE_MAPPING_ARRAY.length) {
+      return NULL_TYPE;
+    }
+
+    // get value
+    return REVERSE_MAPPING_ARRAY[authTypeCode];
   }
 
   public int getCode() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/BearerAuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/BearerAuthenticationParametersDpo.java
@@ -38,10 +38,9 @@ public class BearerAuthenticationParametersDpo extends AuthenticationParametersD
   private final UserSecretReference bearerTokenReference;
 
   public BearerAuthenticationParametersDpo(
-      @JsonProperty(value = "authenticationTypeCode", required = true) int authenticationTypeCode,
       @JsonProperty(value = "bearerTokenReference", required = true) @Nonnull
           UserSecretReference bearerTokenReference) {
-    super(authenticationTypeCode);
+    super(AuthenticationType.BEARER.getCode());
     this.bearerTokenReference = bearerTokenReference;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
@@ -42,7 +42,10 @@ import org.slf4j.LoggerFactory;
  * The internal persistence-object counterpart to ConnectionConfigInfo defined in the API model.
  * Important: JsonSubTypes must be kept in sync with {@link ConnectionType}.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "connectionTypeCode", visible = true)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "connectionTypeCode")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = IcebergRestConnectionConfigInfoDpo.class, name = "1"),
 })
@@ -146,7 +149,6 @@ public abstract class ConnectionConfigInfoDpo implements IcebergCatalogPropertie
                 icebergRestConfigModel.getAuthenticationParameters(), secretReferences);
         config =
             new IcebergRestConnectionConfigInfoDpo(
-                ConnectionType.ICEBERG_REST.getCode(),
                 icebergRestConfigModel.getUri(),
                 authenticationParameters,
                 icebergRestConfigModel.getRemoteCatalogName());

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
@@ -18,7 +18,8 @@
  */
 package org.apache.polaris.core.connection;
 
-import jakarta.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
 
 /**
  * The internal persistence-object counterpart to ConnectionConfigInfo.ConnectionTypeEnum defined in
@@ -29,21 +30,22 @@ import jakarta.annotation.Nullable;
  * ConnectionConfigInfoDpo}.
  */
 public enum ConnectionType {
-  ICEBERG_REST(1);
+  NULL_TYPE(0),
+  ICEBERG_REST(1),
+  ;
 
   private static final ConnectionType[] REVERSE_MAPPING_ARRAY;
 
   static {
     // find max array size
-    int maxId = 0;
-    for (ConnectionType connectionType : ConnectionType.values()) {
-      if (maxId < connectionType.code) {
-        maxId = connectionType.code;
-      }
-    }
+    int maxCode =
+        Arrays.stream(AuthenticationType.values())
+            .mapToInt(AuthenticationType::getCode)
+            .max()
+            .orElse(0);
 
     // allocate mapping array
-    REVERSE_MAPPING_ARRAY = new ConnectionType[maxId + 1];
+    REVERSE_MAPPING_ARRAY = new ConnectionType[maxCode + 1];
 
     // populate mapping array
     for (ConnectionType connectionType : ConnectionType.values()) {
@@ -61,13 +63,13 @@ public enum ConnectionType {
    * Given the code associated to the type, return the associated ConnectionType. Return null if not
    * found
    *
-   * @param connectionTypeCode code associated to the entity type
+   * @param connectionTypeCode code associated to the connection type
    * @return ConnectionType corresponding to that code or null if mapping not found
    */
-  public static @Nullable ConnectionType fromCode(int connectionTypeCode) {
+  public static @Nonnull ConnectionType fromCode(int connectionTypeCode) {
     // ensure it is within bounds
-    if (connectionTypeCode >= REVERSE_MAPPING_ARRAY.length) {
-      return null;
+    if (connectionTypeCode < 0 || connectionTypeCode >= REVERSE_MAPPING_ARRAY.length) {
+      return ConnectionType.NULL_TYPE;
     }
 
     // get value

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/IcebergRestConnectionConfigInfoDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/IcebergRestConnectionConfigInfoDpo.java
@@ -39,13 +39,12 @@ public class IcebergRestConnectionConfigInfoDpo extends ConnectionConfigInfoDpo
   private final String remoteCatalogName;
 
   public IcebergRestConnectionConfigInfoDpo(
-      @JsonProperty(value = "connectionTypeCode", required = true) int connectionTypeCode,
       @JsonProperty(value = "uri", required = true) @Nonnull String uri,
       @JsonProperty(value = "authenticationParameters", required = true) @Nonnull
           AuthenticationParametersDpo authenticationParameters,
       @JsonProperty(value = "remoteCatalogName", required = false) @Nullable
           String remoteCatalogName) {
-    super(connectionTypeCode, uri, authenticationParameters);
+    super(ConnectionType.ICEBERG_REST.getCode(), uri, authenticationParameters);
     this.remoteCatalogName = remoteCatalogName;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/OAuthClientCredentialsParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/OAuthClientCredentialsParametersDpo.java
@@ -59,13 +59,12 @@ public class OAuthClientCredentialsParametersDpo extends AuthenticationParameter
   private final List<String> scopes;
 
   public OAuthClientCredentialsParametersDpo(
-      @JsonProperty(value = "authenticationTypeCode", required = true) int authenticationTypeCode,
       @JsonProperty(value = "tokenUri", required = false) @Nullable String tokenUri,
       @JsonProperty(value = "clientId", required = true) @Nonnull String clientId,
       @JsonProperty(value = "clientSecretReference", required = true) @Nonnull
           UserSecretReference clientSecretReference,
       @JsonProperty(value = "scopes", required = false) @Nullable List<String> scopes) {
-    super(authenticationTypeCode);
+    super(AuthenticationType.OAUTH.getCode());
 
     this.tokenUri = tokenUri;
     this.clientId = clientId;

--- a/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.connection;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,8 +29,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ConnectionConfigInfoDpoTest {
-  PolarisDiagnostics polarisDiagnostics = new PolarisDefaultDiagServiceImpl();
-  ObjectMapper objectMapper = new ObjectMapper();
+  private static final PolarisDiagnostics polarisDiagnostics = new PolarisDefaultDiagServiceImpl();
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+  }
 
   @Test
   void testOAuthClientCredentialsParameters() throws JsonProcessingException {


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Change the annotations from

```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "authenticationTypeCode", visible = true)
@JsonSubTypes({
  @JsonSubTypes.Type(value = OAuthClientCredentialsParametersDpo.class, name = "1"),
  @JsonSubTypes.Type(value = BearerAuthenticationParametersDpo.class, name = "2"),
})
```

to

```java
@JsonTypeInfo(
    use = JsonTypeInfo.Id.NAME,
    include = JsonTypeInfo.As.EXISTING_PROPERTY,
    property = "authenticationTypeCode")
@JsonSubTypes({
  @JsonSubTypes.Type(value = OAuthClientCredentialsParametersDpo.class, name = "1"),
  @JsonSubTypes.Type(value = BearerAuthenticationParametersDpo.class, name = "2"),
})
```

The reason for this change is that when `visible = true` and `authenticationTypeCode` is already a field in the class, the serialized json ends up including two `authenticationTypeCode` entries. For example:
```json
{
  "connectionTypeCode": 1,
  "connectionTypeCode": "1",
  "uri": "https://myorg-my_account.snowflakecomputing.com/polaris/api/catalog",
  "remoteCatalogName": "my-catalog",
  "authenticationParameters": {
    "authenticationTypeCode": 1,
    "authenticationTypeCode": "1",
    "tokenUri": "https://myorg-my_account.snowflakecomputing.com/polaris/api/catalog/v1/oauth/tokens",
    "clientId": "client-id",
    "clientSecretReference": {
      "urn": "urn:polaris-secret:secretmanager-impl:keystore-id-12345",
      "referencePayload": {
        "hash": "a1b2c3",
        "encryption-key": "z0y9x8"
      }
    },
    "scopes": [
      "PRINCIPAL_ROLE:ALL"
    ]
  }
}
```

Setting `include = JsonTypeInfo.As.EXISTING_PROPERTY` ensures that it uses the existing field without duplicating it in the json.

Also some minor changes to the dpo classes:
1. Add `NULL_TYPE` to type enum
2. Remove `authenticationTypeCode` and `connectionTypeCode` from subtypes' constructor.