### PR TITLE
Bump version to 0.11.0-beta-incubating-SNAPSHOT

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-0.10.0-beta-incubating-SNAPSHOT
+0.11.0-beta-incubating-SNAPSHOT


### PR DESCRIPTION
As 0.10.0-beta-incubating release branch has been created, we can bump to 0.11.0-beta-incubating on `main`.