### PR TITLE
Add optional `format` parameter to loadGenericTable

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -125,6 +125,7 @@ public class GenericTableCatalogAdapter
       String prefix,
       String namespace,
       String genericTable,
+      String format,
       RealmContext realmContext,
       SecurityContext securityContext) {
     GenericTableCatalogHandler handler = newHandlerWrapper(securityContext, prefix);

--- a/spec/polaris-catalog-apis/generic-tables-api.yaml
+++ b/spec/polaris-catalog-apis/generic-tables-api.yaml
@@ -116,7 +116,15 @@ paths:
         Load a generic table from the catalog under the given namespace.
       
         The response contains all table information passed during create.
-
+      parameters:
+        - name: format
+          in: query
+          description:
+            When set, Polaris will try to provide the generic table in the requested format. 
+            If a format is specified that the generic table is not available in, the request may fail.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/LoadGenericTableResponse'


### PR DESCRIPTION
To support table conversion on read, a small spec change is needed to the loadGenericTable endpoint. This will allow the client to optionally request conversion to a specified format, and if specified it could allow the catalog to reject the request when conversion is not possible.