### PR TITLE
JDBC: Remove logging for DatabaseOperations

### DIFF
--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/DatasourceOperations.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/DatasourceOperations.java
@@ -77,11 +77,8 @@ public class DatasourceOperations {
             if (line.endsWith(";")) { // Execute statement when semicolon is found
               String sql = sqlBuffer.toString().trim();
               try {
-                int rowsUpdated = statement.executeUpdate(sql);
-                LOGGER.debug("Query {} executed {} rows affected", sql, rowsUpdated);
+                statement.executeUpdate(sql);
               } catch (SQLException e) {
-                LOGGER.error("Error executing query {}", sql, e);
-                // re:throw this as unhandled exception
                 throw new RuntimeException(e);
               }
               sqlBuffer.setLength(0); // Clear the buffer for the next statement
@@ -92,11 +89,7 @@ public class DatasourceOperations {
         connection.setAutoCommit(autoCommit);
       }
     } catch (IOException e) {
-      LOGGER.debug("Error reading the script file", e);
       throw new RuntimeException(e);
-    } catch (SQLException e) {
-      LOGGER.debug("Error executing the script file", e);
-      throw e;
     }
   }
 
@@ -135,7 +128,6 @@ public class DatasourceOperations {
       }
       return resultList;
     } catch (SQLException e) {
-      LOGGER.debug("Error executing query {}", query, e);
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -156,9 +148,6 @@ public class DatasourceOperations {
       connection.setAutoCommit(true);
       try {
         return statement.executeUpdate(query);
-      } catch (SQLException e) {
-        LOGGER.debug("Error executing query {}", query, e);
-        throw e;
       } finally {
         connection.setAutoCommit(autoCommit);
       }
@@ -188,9 +177,6 @@ public class DatasourceOperations {
         }
         connection.setAutoCommit(autoCommit);
       }
-    } catch (SQLException e) {
-      LOGGER.debug("Caught Error while executing transaction", e);
-      throw e;
     }
   }
 


### PR DESCRIPTION
## About the change 

The logging is a bit redundant, as in the IcebergException log's for these unhandled / unintentional exception are logged.
More details : https://github.com/apache/polaris/pull/1430#issuecomment-2825464377


cc @flyrain @dimas-b 