### PR TITLE
Add missing postgres driver in getting-started

### DIFF
--- a/getting-started/eclipselink/README.md
+++ b/getting-started/eclipselink/README.md
@@ -30,6 +30,7 @@ This example requires `jq` to be installed on your machine.
        :polaris-quarkus-server:quarkusAppPartsBuild --rerun \
        :polaris-quarkus-admin:assemble \
        :polaris-quarkus-admin:quarkusAppPartsBuild --rerun \
+       -PeclipseLinkDeps=org.postgresql:postgresql:42.7.5 \
        -Dquarkus.container-image.tag=postgres-latest \
        -Dquarkus.container-image.build=true
     ```


### PR DESCRIPTION
When Polaris is built using the provided command, the docker-compose deployment cannot start given that the postgresql driver is not bundled in the Docker image.  The following error can be seen during the bootstrap operation.

```
polaris-bootstrap-1  | Caused by: java.sql.SQLException: No suitable driver found for jdbc:postgresql://postgres:5432/POLARIS
polaris-bootstrap-1  | 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:708)
polaris-bootstrap-1  | 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:191)
polaris-bootstrap-1  | 	at org.eclipse.persistence.sessions.DefaultConnector.connect(DefaultConnector.java:102)
polaris-bootstrap-1  | 	... 40 more
polaris-bootstrap-1  | Bootstrap encountered errors during operation.
polaris-bootstrap-1  | 2025-04-24 08:29:53,602 INFO  [io.quarkus] (main) Apache Polaris Admin Tool (incubating) stopped in 0.003s
```

The `-PeclipseLinkDeps=org.postgresql:postgresql:42.7.4` must be used at build time so that the postgres driver is included in the docker image.  This commit addresses that.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
