### PR TITLE
Build: Fix `fetchAsfProjectName` and make the publishing extension more flexible

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -36,13 +36,40 @@ abstract class PublishingHelperExtension
 @Inject
 constructor(objectFactory: ObjectFactory, project: Project) {
   // the following are only relevant on the root project
-  val asfProjectName = objectFactory.property<String>().convention(project.name)
+
+  /**
+   * Lowercase ASF project ID, as present in keys in the JSON docs describing the projects (for
+   * example in `https://whimsy.apache.org/public/public_ldap_projects.json`).
+   */
+  val asfProjectId = objectFactory.property<String>().convention(project.name)
+
+  /** Used to override the full project name, for example `Apache Polaris`. */
   val overrideName = objectFactory.property<String>()
+  /** Used to override the project description as it appears in published Maven poms. */
   val overrideDescription = objectFactory.property<String>()
+  /** Used to override the project URL as it appears in published Maven poms. */
+  val overrideProjectUrl = objectFactory.property<String>()
+  /**
+   * Used to override the name of the GitHub repo in the apache organization. Defaults to the
+   * project ID.
+   */
+  val githubRepositoryName = objectFactory.property<String>()
+  /**
+   * Used to override the project's SCM as it appears in published Maven poms. Default is derived
+   * from `githubRepoName`.
+   */
+  val overrideScm = objectFactory.property<String>()
+  /** Used to override the project's issue management URL as it appears in published Maven poms. */
+  val overrideIssueManagement = objectFactory.property<String>()
+  /** Prefix for the tag published for non-SNAPSHOT versions in the Maven poms. */
+  val overrideTagPrefix = objectFactory.property<String>()
+
+  /** The published distributables, including the source tarball, base file name. */
   val baseName =
     objectFactory
       .property<String>()
-      .convention(project.provider { "apache-${asfProjectName.get()}-${project.version}" })
+      .convention(project.provider { "apache-${asfProjectId.get()}-${project.version}" })
+
   val distributionDir =
     objectFactory.directoryProperty().convention(project.layout.buildDirectory.dir("distributions"))
   val sourceTarball =
@@ -50,6 +77,7 @@ constructor(objectFactory: ObjectFactory, project: Project) {
       .fileProperty()
       .convention(project.provider { distributionDir.get().file("${baseName.get()}.tar.gz") })
 
+  /** List of mailing-lists. */
   val mailingLists = objectFactory.listProperty(String::class.java).convention(emptyList())
 
   fun distributionFile(ext: String): File =

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -96,7 +96,7 @@ internal fun configureOnRootProject(project: Project) =
 
       doFirst {
         val e = project.extensions.getByType(PublishingHelperExtension::class.java)
-        val asfName = e.asfProjectName.get()
+        val asfName = e.asfProjectId.get()
 
         val gitInfo = MemoizedGitInfo.gitInfo(rootProject)
         val gitCommitId = gitInfo["Apache-Polaris-Build-Git-Head"]
@@ -132,7 +132,8 @@ internal fun configureOnRootProject(project: Project) =
             "NO STAGING REPOSITORY (no build service) !!"
           }
 
-        val asfProjectName = "Apache Polaris"
+        val asfProjectName =
+          e.overrideName.orElse(project.provider { "Apache ${fetchAsfProjectName(asfName)}" }).get()
 
         val versionNoRc = version.toString().replace("-rc-?[0-9]+".toRegex(), "")
 


### PR DESCRIPTION
The added flexibility is intended to be ported to the multiple project in the polaris-tools repository.

(Follow up of #1384)

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
