### PR TITLE
Add missing Postgresql dependency

### DIFF
--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   implementation(project(":polaris-api-iceberg-service"))
 
   runtimeOnly(project(":polaris-eclipselink"))
+  runtimeOnly("org.postgresql:postgresql")
 
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-picocli")


### PR DESCRIPTION
In #1411, the build was updated to always include the postgresql dependency.  But only the gradle files that package the `polaris` image were updated.  The image that packages the polaris admin tool was not.  As a result, it was not possible to bootstrap a Postgres-backed Polaris instance with the admin tool.  This commit fixes the issue.

Related: #1441

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
