### PR TITLE
Use .sha512 extension instead of -sha512

### DIFF
--- a/build-logic/src/main/kotlin/publishing/digest-task.kt
+++ b/build-logic/src/main/kotlin/publishing/digest-task.kt
@@ -39,7 +39,7 @@ abstract class GenerateDigest @Inject constructor(objectFactory: ObjectFactory) 
     objectFactory.fileProperty().convention {
       val input = file.get().asFile
       val algo = algorithm.get()
-      input.parentFile.resolve("${input.name}-${algo.replace("-", "").lowercase()}")
+      input.parentFile.resolve("${input.name}.${algo.replace("-", "").lowercase()}")
     }
 
   @TaskAction


### PR DESCRIPTION
The sha512 files should use `.sha512` extension, today it's `-sha512`.