### PR TITLE
Allow BasePolarisTableOperations to skip refreshing metadata after a commit

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -59,4 +59,14 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
           .description("Whether or not to use soft values in the entity cache")
           .defaultValue(false)
           .buildBehaviorChangeConfiguration();
+
+  public static final BehaviorChangeConfiguration<Boolean> TABLE_OPERATIONS_COMMIT_UPDATE_METADATA =
+      PolarisConfiguration.<Boolean>builder()
+          .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
+          .description(
+              "If true, BasePolarisTableOperations should update the metadata that is passed into"
+                  + " `commit`, and re-use it to skip a trip to object storage to re-construct"
+                  + " the committed metadata again.")
+          .defaultValue(true)
+          .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -60,12 +60,12 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildBehaviorChangeConfiguration();
 
-  public static final BehaviorChangeConfiguration<Boolean> TABLE_OPERATIONS_COMMIT_UPDATE_METADATA =
+  public static final BehaviorChangeConfiguration<Boolean> TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT =
       PolarisConfiguration.<Boolean>builder()
-          .key("TABLE_OPERATIONS_COMMIT_UPDATE_METADATA")
+          .key("TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT")
           .description(
-              "If true, BasePolarisTableOperations should update the metadata that is passed into"
-                  + " `commit`, and re-use it to skip a trip to object storage to re-construct"
+              "If true, BasePolarisTableOperations should mark the metadata that is passed into"
+                  + " `commit` as current, and re-use it to skip a trip to object storage to re-construct"
                   + " the committed metadata again.")
           .defaultValue(true)
           .buildBehaviorChangeConfiguration();

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -60,13 +60,14 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildBehaviorChangeConfiguration();
 
-  public static final BehaviorChangeConfiguration<Boolean> TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT =
-      PolarisConfiguration.<Boolean>builder()
-          .key("TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT")
-          .description(
-              "If true, BasePolarisTableOperations should mark the metadata that is passed into"
-                  + " `commit` as current, and re-use it to skip a trip to object storage to re-construct"
-                  + " the committed metadata again.")
-          .defaultValue(true)
-          .buildBehaviorChangeConfiguration();
+  public static final BehaviorChangeConfiguration<Boolean>
+      TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT =
+          PolarisConfiguration.<Boolean>builder()
+              .key("TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT")
+              .description(
+                  "If true, BasePolarisTableOperations should mark the metadata that is passed into"
+                      + " `commit` as current, and re-use it to skip a trip to object storage to re-construct"
+                      + " the committed metadata again.")
+              .defaultValue(true)
+              .buildBehaviorChangeConfiguration();
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -1881,10 +1881,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
           () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
 
       ops.current();
-      int expectedReads = 2;
-      if (updateMetadataOnCommit) {
-        expectedReads = 1;
-      }
+      int expectedReads = updateMetadataOnCommit ? 1 : 2;
       mocked.verify(
           () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()),
           Mockito.times(expectedReads));

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -1695,7 +1695,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     table.updateProperties().set("foo", "bar").commit();
     Assertions.assertThat(measured.getInputBytes())
-        .as("A table was read and written, but no trip to storage was made")
+        .as("A table was read and written, but a trip to storage was made")
         .isEqualTo(0);
 
     Assertions.assertThat(catalog.dropTable(TABLE)).as("Table deletion should succeed").isTrue();
@@ -1848,10 +1848,11 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testTableOperationsDoesNotRefreshAfterCommit(boolean updateMetadataOnCommit) {
-    if (this.requiresNamespaceCreate()) {
-      catalog.createNamespace(NS);
-    }
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
 
+    catalog.createNamespace(NS);
     catalog.buildTable(TABLE, SCHEMA).create();
 
     IcebergCatalog.BasePolarisTableOperations realOps =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -1695,8 +1695,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     table.updateProperties().set("foo", "bar").commit();
     Assertions.assertThat(measured.getInputBytes())
-        .as("A table was read and written")
-        .isGreaterThan(0);
+        .as("A table was read and written, but no trip to storage was made")
+        .isEqualTo(0);
 
     Assertions.assertThat(catalog.dropTable(TABLE)).as("Table deletion should succeed").isTrue();
     TaskEntity taskEntity =
@@ -1860,7 +1860,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     IcebergCatalog.BasePolarisTableOperations ops = Mockito.spy(realOps);
 
     try (MockedStatic<TableMetadataParser> mocked =
-             Mockito.mockStatic(TableMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
+        Mockito.mockStatic(TableMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
       TableMetadata base1 = ops.current();
       mocked.verify(
           () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -136,6 +136,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.exception.RetryableException;
@@ -1841,6 +1843,58 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     Assertions.assertThatThrownBy(() -> update.commit())
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("conflict_table");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testTableOperationsDoesNotRefreshAfterCommit(boolean updateMetadataOnCommit) {
+    if (this.requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    catalog.buildTable(TABLE, SCHEMA).create();
+
+    IcebergCatalog.BasePolarisTableOperations realOps =
+        (IcebergCatalog.BasePolarisTableOperations)
+            catalog.newTableOps(TABLE, updateMetadataOnCommit);
+    IcebergCatalog.BasePolarisTableOperations ops = Mockito.spy(realOps);
+
+    try (MockedStatic<TableMetadataParser> mocked =
+             Mockito.mockStatic(TableMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
+      TableMetadata base1 = ops.current();
+      mocked.verify(
+          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      TableMetadata base2 = ops.refresh();
+      mocked.verify(
+          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      Assertions.assertThat(base1.metadataFileLocation()).isEqualTo(base2.metadataFileLocation());
+      Assertions.assertThat(base1).isEqualTo(base2);
+
+      Schema newSchema =
+          new Schema(Types.NestedField.optional(100, "new_col", Types.LongType.get()));
+      TableMetadata newMetadata =
+          TableMetadata.buildFrom(base1).setCurrentSchema(newSchema, 100).build();
+      ops.commit(base2, newMetadata);
+      mocked.verify(
+          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+
+      ops.current();
+      int expectedReads = 2;
+      if (updateMetadataOnCommit) {
+        expectedReads = 1;
+      }
+      mocked.verify(
+          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()),
+          Mockito.times(expectedReads));
+      ops.refresh();
+      mocked.verify(
+          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()),
+          Mockito.times(expectedReads));
+    } finally {
+      catalog.dropTable(TABLE, true);
+    }
   }
 
   private static InMemoryFileIO getInMemoryIo(IcebergCatalog catalog) {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.quarkus.catalog.io;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.azure.core.exception.AzureException;
@@ -117,6 +118,30 @@ public class FileIOExceptionsTest {
     res.close();
   }
 
+  private static void requestDropTable() {
+    Response res =
+        services
+            .restApi()
+            .dropTable(
+                catalog, "ns1", "t1", false, services.realmContext(), services.securityContext());
+    res.close();
+  }
+
+  private static void requestLoadTable() {
+    Response res =
+        services
+            .restApi()
+            .loadTable(
+                catalog,
+                "ns1",
+                "t1",
+                null,
+                "ALL",
+                services.realmContext(),
+                services.securityContext());
+    res.close();
+  }
+
   static Stream<RuntimeException> exceptions() {
     return Stream.of(
         new AzureException("Forbidden"),
@@ -135,7 +160,9 @@ public class FileIOExceptionsTest {
   @MethodSource("exceptions")
   void testNewInputFileExceptionPropagation(RuntimeException ex) {
     ioFactory.newInputFileExceptionSupplier = Optional.of(() -> ex);
-    assertThatThrownBy(FileIOExceptionsTest::requestCreateTable).isSameAs(ex);
+    assertThatCode(FileIOExceptionsTest::requestCreateTable).doesNotThrowAnyException();
+    assertThatThrownBy(FileIOExceptionsTest::requestLoadTable).isSameAs(ex);
+    assertThatCode(FileIOExceptionsTest::requestDropTable).doesNotThrowAnyException();
   }
 
   @ParameterizedTest

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1495,11 +1495,11 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
       // We diverge from `BaseMetastoreTableOperations` in the below code block
       if (updateMetadataOnCommit) {
-        currentMetadata = TableMetadata
-            .buildFrom(metadata)
-            .withMetadataLocation(newLocation)
-            .discardChanges()
-            .build();
+        currentMetadata =
+            TableMetadata.buildFrom(metadata)
+                .withMetadataLocation(newLocation)
+                .discardChanges()
+                .build();
         currentMetadataLocation = newLocation;
       }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1219,6 +1219,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
    * org.apache.iceberg.BaseMetastoreTableOperations}. CODE_COPIED_TO_POLARIS From Apache Iceberg
    * Version: 1.8
    */
+  @VisibleForTesting
   public class BasePolarisTableOperations extends PolarisOperationsBase<TableMetadata>
       implements TableOperations {
     private final TableIdentifier tableIdentifier;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -363,7 +363,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   @VisibleForTesting
   public TableOperations newTableOps(
       TableIdentifier tableIdentifier, boolean makeMetadataCurrentOnCommit) {
-    return new BasePolarisTableOperations(catalogFileIO, tableIdentifier, makeMetadataCurrentOnCommit);
+    return new BasePolarisTableOperations(
+        catalogFileIO, tableIdentifier, makeMetadataCurrentOnCommit);
   }
 
   @Override
@@ -1229,7 +1230,9 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     private FileIO tableFileIO;
 
     BasePolarisTableOperations(
-        FileIO defaultFileIO, TableIdentifier tableIdentifier, boolean makeMetadataCurrentOnCommit) {
+        FileIO defaultFileIO,
+        TableIdentifier tableIdentifier,
+        boolean makeMetadataCurrentOnCommit) {
       LOGGER.debug("new BasePolarisTableOperations for {}", tableIdentifier);
       this.tableIdentifier = tableIdentifier;
       this.fullTableName = fullTableName(catalogName, tableIdentifier);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1605,7 +1605,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
    * of this code was originally copied from {@link org.apache.iceberg.view.BaseViewOperations}.
    * CODE_COPIED_TO_POLARIS From Apache Iceberg Version: 1.8
    */
-  public class BasePolarisViewOperations extends PolarisOperationsBase<ViewMetadata>
+  private class BasePolarisViewOperations extends PolarisOperationsBase<ViewMetadata>
       implements ViewOperations {
     private final TableIdentifier identifier;
     private final String fullViewName;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -374,7 +374,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             .getConfigurationStore()
             .getConfiguration(
                 getCurrentPolarisContext(),
-                BehaviorChangeConfiguration.TABLE_OPERATIONS_COMMIT_UPDATE_METADATA);
+                BehaviorChangeConfiguration.TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT);
     return newTableOps(tableIdentifier, makeMetadataCurrentOnCommit);
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -362,19 +362,19 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @VisibleForTesting
   public TableOperations newTableOps(
-      TableIdentifier tableIdentifier, boolean updateMetadataOnCommit) {
-    return new BasePolarisTableOperations(catalogFileIO, tableIdentifier, updateMetadataOnCommit);
+      TableIdentifier tableIdentifier, boolean makeMetadataCurrentOnCommit) {
+    return new BasePolarisTableOperations(catalogFileIO, tableIdentifier, makeMetadataCurrentOnCommit);
   }
 
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
-    boolean updateMetadataOnCommit =
+    boolean makeMetadataCurrentOnCommit =
         getCurrentPolarisContext()
             .getConfigurationStore()
             .getConfiguration(
                 getCurrentPolarisContext(),
                 BehaviorChangeConfiguration.TABLE_OPERATIONS_COMMIT_UPDATE_METADATA);
-    return newTableOps(tableIdentifier, updateMetadataOnCommit);
+    return newTableOps(tableIdentifier, makeMetadataCurrentOnCommit);
   }
 
   @Override
@@ -1224,17 +1224,17 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       implements TableOperations {
     private final TableIdentifier tableIdentifier;
     private final String fullTableName;
-    private final boolean updateMetadataOnCommit;
+    private final boolean makeMetadataCurrentOnCommit;
 
     private FileIO tableFileIO;
 
     BasePolarisTableOperations(
-        FileIO defaultFileIO, TableIdentifier tableIdentifier, boolean updateMetadataOnCommit) {
+        FileIO defaultFileIO, TableIdentifier tableIdentifier, boolean makeMetadataCurrentOnCommit) {
       LOGGER.debug("new BasePolarisTableOperations for {}", tableIdentifier);
       this.tableIdentifier = tableIdentifier;
       this.fullTableName = fullTableName(catalogName, tableIdentifier);
       this.tableFileIO = defaultFileIO;
-      this.updateMetadataOnCommit = updateMetadataOnCommit;
+      this.makeMetadataCurrentOnCommit = makeMetadataCurrentOnCommit;
     }
 
     @Override
@@ -1495,7 +1495,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       }
 
       // We diverge from `BaseMetastoreTableOperations` in the below code block
-      if (updateMetadataOnCommit) {
+      if (makeMetadataCurrentOnCommit) {
         currentMetadata =
             TableMetadata.buildFrom(metadata)
                 .withMetadataLocation(newLocation)


### PR DESCRIPTION
For rest catalogs, `TableOperations.refresh()` can result in an expensive trip to object storage. Despite this, the method is called quite frequently and is currently called after every commit when we construct a BaseTable to return back to a client that requested a commit.

In some cases, the same TableOperations is used for one commit and then is immediately used for another. We can see this in some tests, such as Iceberg's `CatalogTests.testUpdateTableSchemaThenRevert`:

```
table.updateSchema().addColumn("col1", StringType.get()).addColumn("col2", StringType.get()).addColumn("col3", StringType.get()).commit();
table.updateSchema().deleteColumn("col1").deleteColumn("col2").deleteColumn("col3").commit();      
```

This PR proposes that the TableOperations can update its `currentMetadata` metadata on commit so that future calls to `doRefresh` might be able to skip a trip to object storage.

<hr>

This is an alternate implementation to #1378 that does not rely on reflection