### PR TITLE
Added set credentials env instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew test` - To run unit tests and integration tests.
 - `./gradlew run` - To run the Polaris server locally; the server is reachable at 
-  localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
+    localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
+  - If you start Polaris as a direct java process via `./gradlew run`, you can set your own credentials using the environment variable `export POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,secret` where:
+    - `POLARIS` is the realm
+    - `root` is the CLIENT_ID
+    - `secret` is the CLIENT_SECRET
+  - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
-- Set your own credentials using the environment variable `export POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,s3cr3t` where:
-  - `POLARIS` is the realm
-  - `root` is the CLIENT_ID
-  - `s3cr3t` is the CLIENT_SECRET
 ```sql
 create database db1;
 show databases;

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew test` - To run unit tests and integration tests.
 - `./gradlew run` - To run the Polaris server locally; the server is reachable at 
     localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
-  - If you start Polaris as a direct java process via `./gradlew run`, you can set your own credentials using the environment variable `export POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,secret` where:
+  - If you start Polaris via `./gradlew run`, you can set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
     - `POLARIS` is the realm
     - `root` is the CLIENT_ID
     - `secret` is the CLIENT_SECRET
-  - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
+    - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
 ```sql
 create database db1;

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew run` - To run the Polaris server locally; the server is reachable at 
   localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
-- Set your own credentials using the environment variable `POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,s3cr3t` where:
+- Set your own credentials using the environment variable `export POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,s3cr3t` where:
   - `POLARIS` is the realm
   - `root` is the CLIENT_ID
   - `s3cr3t` is the CLIENT_SECRET

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew run` - To run the Polaris server locally; the server is reachable at 
   localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
+- Set your own credentials using the environment variable `POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,s3cr3t` where:
+  - `POLARIS` is the realm
+  - `root` is the CLIENT_ID
+  - `s3cr3t` is the CLIENT_SECRET
 ```sql
 create database db1;
 show databases;

--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew build` - To build and run tests. Make sure Docker is running, as the integration tests depend on it.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew test` - To run unit tests and integration tests.
-- `./gradlew run` - To run the Polaris server locally; the server is reachable at 
-    localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. 
-  - If you start Polaris via `./gradlew run`, you can set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
-    - `POLARIS` is the realm
-    - `root` is the CLIENT_ID
-    - `secret` is the CLIENT_SECRET
-    - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
+- `./gradlew run` - To run the Polaris server locally; the server is reachable at
+  localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
+  - `POLARIS` is the realm
+  - `root` is the CLIENT_ID
+  - `secret` is the CLIENT_SECRET
+  - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
 ```sql
 create database db1;

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew build` - To build and run tests. Make sure Docker is running, as the integration tests depend on it.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew test` - To run unit tests and integration tests.
-- `./gradlew run` - To run the Polaris server locally; the server is reachable at
-  localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
+- `./gradlew run` - To run the Polaris server locally; the server is reachable at localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
   - `POLARIS` is the realm
   - `root` is the CLIENT_ID
   - `secret` is the CLIENT_SECRET


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->


The instruction of how to set your own credentials is no where to be found in the polaris documents and repo markdowns, so according to the comment: https://github.com/apache/polaris/pull/1452#issuecomment-2829080942

Added the instruction of how to set credentials in README.
