### PR TITLE
Generic Table/Policy Store: Move feature config check to Adapter and some small refactoring

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/common/CatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/common/CatalogAdapter.java
@@ -18,10 +18,13 @@
  */
 package org.apache.polaris.service.catalog.common;
 
+import jakarta.ws.rs.core.SecurityContext;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.rest.RESTUtil;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 
 /**
  * A common interface for adapters between the REST interface and {@link CatalogHandler}
@@ -30,5 +33,12 @@ import org.apache.iceberg.rest.RESTUtil;
 public interface CatalogAdapter {
   default Namespace decodeNamespace(String namespace) {
     return RESTUtil.decodeNamespace(URLEncoder.encode(namespace, Charset.defaultCharset()));
+  }
+
+  default void validatePrincipal(SecurityContext securityContext) {
+    var authenticatedPrincipal = (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
+    if (authenticatedPrincipal == null) {
+      throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
+    }
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -29,6 +29,7 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.api.PolarisCatalogGenericTableApiService;
 import org.apache.polaris.service.catalog.common.CatalogAdapter;
 import org.apache.polaris.service.types.CreateGenericTableRequest;
@@ -43,25 +44,31 @@ public class GenericTableCatalogAdapter
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GenericTableCatalogAdapter.class);
 
+  private final RealmContext realmContext;
   private final CallContext callContext;
   private final PolarisEntityManager entityManager;
   private final PolarisMetaStoreManager metaStoreManager;
   private final PolarisAuthorizer polarisAuthorizer;
+  private final CatalogPrefixParser prefixParser;
 
   @Inject
   public GenericTableCatalogAdapter(
+      RealmContext realmContext,
       CallContext callContext,
       PolarisEntityManager entityManager,
       PolarisMetaStoreManager metaStoreManager,
-      PolarisAuthorizer polarisAuthorizer) {
+      PolarisAuthorizer polarisAuthorizer,
+      CatalogPrefixParser prefixParser) {
+    this.realmContext = realmContext;
     this.callContext = callContext;
     this.entityManager = entityManager;
     this.metaStoreManager = metaStoreManager;
     this.polarisAuthorizer = polarisAuthorizer;
+    this.prefixParser = prefixParser;
   }
 
   private GenericTableCatalogHandler newHandlerWrapper(
-      SecurityContext securityContext, String catalogName) {
+      SecurityContext securityContext, String prefix) {
     FeatureConfiguration.enforceFeatureEnabledOrThrow(
         callContext, FeatureConfiguration.ENABLE_GENERIC_TABLES);
     validatePrincipal(securityContext);
@@ -71,7 +78,7 @@ public class GenericTableCatalogAdapter
         entityManager,
         metaStoreManager,
         securityContext,
-        catalogName,
+        prefixParser.prefixToCatalogName(realmContext, prefix),
         polarisAuthorizer);
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -23,9 +23,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NotAuthorizedException;
-import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -63,10 +62,9 @@ public class GenericTableCatalogAdapter
 
   private GenericTableCatalogHandler newHandlerWrapper(
       SecurityContext securityContext, String catalogName) {
-    var authenticatedPrincipal = (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
-    if (authenticatedPrincipal == null) {
-      throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
-    }
+    FeatureConfiguration.enforceFeatureEnabledOrThrow(
+        callContext, FeatureConfiguration.ENABLE_GENERIC_TABLES);
+    validatePrincipal(securityContext);
 
     return new GenericTableCatalogHandler(
         callContext,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.table.GenericTableEntity;
@@ -53,21 +52,8 @@ public class GenericTableCatalogHandler extends CatalogHandler {
     this.metaStoreManager = metaStoreManager;
   }
 
-  public void enforceGenericTablesEnabledOrThrow() {
-    boolean enabled =
-        callContext
-            .getPolarisCallContext()
-            .getConfigurationStore()
-            .getConfiguration(
-                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES);
-    if (!enabled) {
-      throw new UnsupportedOperationException("Generic table support is not enabled");
-    }
-  }
-
   @Override
   protected void initializeCatalog() {
-    enforceGenericTablesEnabledOrThrow();
     this.genericTableCatalog =
         new GenericTableCatalog(metaStoreManager, callContext, this.resolutionManifest);
   }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -182,11 +182,7 @@ public class IcebergCatalogAdapter
 
   private IcebergCatalogHandler newHandlerWrapper(
       SecurityContext securityContext, String catalogName) {
-    AuthenticatedPolarisPrincipal authenticatedPrincipal =
-        (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
-    if (authenticatedPrincipal == null) {
-      throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
-    }
+    validatePrincipal(securityContext);
 
     return new IcebergCatalogHandler(
         callContext,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -23,10 +23,9 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.rest.RESTUtil;
-import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -74,10 +73,9 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
   }
 
   private PolicyCatalogHandler newHandlerWrapper(SecurityContext securityContext, String prefix) {
-    var authenticatedPrincipal = (AuthenticatedPolarisPrincipal) securityContext.getUserPrincipal();
-    if (authenticatedPrincipal == null) {
-      throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
-    }
+    FeatureConfiguration.enforceFeatureEnabledOrThrow(
+        callContext, FeatureConfiguration.ENABLE_POLICY_STORE);
+    validatePrincipal(securityContext);
 
     return new PolicyCatalogHandler(
         callContext,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -73,8 +72,6 @@ public class PolicyCatalogHandler extends CatalogHandler {
 
   @Override
   protected void initializeCatalog() {
-    FeatureConfiguration.enforceFeatureEnabledOrThrow(
-        callContext, FeatureConfiguration.ENABLE_POLICY_STORE);
     this.policyCatalog = new PolicyCatalog(metaStoreManager, callContext, this.resolutionManifest);
   }
 


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This PR moves the feature config check from `CatalogHandler::initializeCatalog` to `CatalogAdapter::newHandlerWrapper` for generic-table and policy, such that if the feature is not enabled we can directly throw unsupported exception instead of doing authorization first.

cc: @flyrain @eric-maynard @gh-yzou 