### PR TITLE
Policy Store: Check whether Policy is in use before dropping and support `detach-all` flag

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -193,7 +193,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         ms.loadAllGrantRecordsOnSecurable(callCtx, entity.getCatalogId(), entity.getId());
     ms.deleteAllEntityGrantRecords(callCtx, entity, grantsOnGrantee, grantsOnSecurable);
 
-    // TODO: Best-effort cleanup - drop policy mapping records
+    // Best-effort cleanup - drop policy mapping records
+    // TODO: Support some more formal garbage-collection mechanism similar to above
     try {
       final List<PolarisPolicyMappingRecord> mappingOnPolicy =
           (entity.getType() == PolarisEntityType.POLICY)
@@ -205,8 +206,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
               : ms.loadAllPoliciesOnTarget(callCtx, entity.getCatalogId(), entity.getId());
       ms.deleteAllEntityPolicyMappingRecords(callCtx, entity, mappingOnTarget, mappingOnPolicy);
     } catch (UnsupportedOperationException e) {
-      // Policy mapping persistence not implemented, so there cannot be any mappings, safe to
-      // proceed
+      // Policy mapping persistence not implemented, but we should not block dropping entities
     }
 
     // Now determine the set of entities on the other side of the grants we just removed. Grants
@@ -1205,8 +1205,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
           return new DropEntityResult(BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS, null);
         }
       } catch (UnsupportedOperationException e) {
-        // Policy mapping persistence not implemented, so there cannot be any mappings, safe to
-        // proceed
+        // Policy mapping persistence not implemented, but we should not block dropping entities
       }
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1205,7 +1205,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       try {
         //  need to check if the policy is attached to any entity
         List<PolarisPolicyMappingRecord> records =
-            ms.loadAllPoliciesOnTarget(
+            ms.loadAllTargetsOnPolicy(
                 callCtx, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId());
         if (!records.isEmpty()) {
           return new DropEntityResult(BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS, null);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -198,7 +198,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         || PolicyMappingUtil.isValidTargetEntityType(entity.getType(), entity.getSubType())) {
       // Best-effort cleanup - for policy and potential target entities, drop all policy mapping
       // records related
-      // TODO: Support some more formal garbage-collection mechanism similar to above
+      // TODO: Support some more formal garbage-collection mechanism similar to grant records case
+      // above
       try {
         final List<PolarisPolicyMappingRecord> mappingOnPolicy =
             (entity.getType() == PolarisEntityType.POLICY)

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/dao/entity/BaseResult.java
@@ -117,6 +117,9 @@ public class BaseResult {
 
     // policy mapping of same type already exists
     POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS(15),
+
+    // policy has mappings and cannot be dropped
+    POLICY_HAS_MAPPINGS(16),
     ;
 
     // code for the enum

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -210,8 +210,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       ms.deleteAllEntityPolicyMappingRecordsInCurrentTxn(
           callCtx, entity, mappingOnTarget, mappingOnPolicy);
     } catch (UnsupportedOperationException e) {
-      // Policy mapping persistence not implemented, so there cannot be any mappings, safe to
-      // proceed
+      // Policy mapping persistence not implemented, but we should not block dropping entities
     }
 
     // remove the entity being dropped now
@@ -1390,8 +1389,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
           return new DropEntityResult(BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS, null);
         }
       } catch (UnsupportedOperationException e) {
-        // Policy mapping persistence not implemented, so there cannot be any mappings, safe to
-        // proceed
+        // Policy mapping persistence not implemented, but we should not block dropping entities
       }
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -589,9 +589,9 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
 
     // also delete the other side. We need to delete these mapping one at a time versus doing a
     // range delete
-    mappingOnTarget.forEach(record -> this.store.getSlicePolicyMappingRecords().delete(record));
-    mappingOnPolicy.forEach(
+    mappingOnTarget.forEach(
         record -> this.store.getSlicePolicyMappingRecordsByPolicy().delete(record));
+    mappingOnPolicy.forEach(record -> this.store.getSlicePolicyMappingRecords().delete(record));
   }
 
   /** {@inheritDoc} */

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import static org.apache.polaris.core.entity.PolarisEntityType.CATALOG;
+import static org.apache.polaris.core.entity.PolarisEntityType.NAMESPACE;
+import static org.apache.polaris.core.entity.PolarisEntityType.TABLE_LIKE;
+
+import java.util.Set;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+
+public class PolicyMappingUtil {
+
+  private static final Set<PolarisEntityType> ATTACHABLE_ENTITY_TYPES =
+      Set.of(CATALOG, NAMESPACE, TABLE_LIKE);
+
+  /**
+   * Checks if the given entity type and subtype are valid targets for policy attachment.
+   *
+   * <p>This method excludes non-attachable entities such as catalog-role and task. Each policy type
+   * may impose additional specific rules * to determine whether it can target a particular entity
+   * type or subtype.
+   */
+  public static boolean isValidTargetEntityType(
+      PolarisEntityType entityType, PolarisEntitySubType entitySubType) {
+    if (entityType == null) {
+      return false;
+    }
+
+    if (!ATTACHABLE_ENTITY_TYPES.contains(entityType)) {
+      return false;
+    }
+
+    if (entityType == TABLE_LIKE && entitySubType != PolarisEntitySubType.ICEBERG_TABLE) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+public class PolicyInUseException extends RuntimeException {
+  @FormatMethod
+  public PolicyInUseException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  @FormatMethod
+  public PolicyInUseException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
@@ -19,8 +19,9 @@
 package org.apache.polaris.core.policy.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
+import org.apache.polaris.core.exceptions.PolarisException;
 
-public class PolicyInUseException extends RuntimeException {
+public class PolicyInUseException extends PolarisException {
   @FormatMethod
   public PolicyInUseException(String message, Object... args) {
     super(String.format(message, args));

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/maintenance/BaseMaintenancePolicyValidator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/maintenance/BaseMaintenancePolicyValidator.java
@@ -18,13 +18,9 @@
  */
 package org.apache.polaris.core.policy.validator.maintenance;
 
-import static org.apache.polaris.core.entity.PolarisEntityType.CATALOG;
-import static org.apache.polaris.core.entity.PolarisEntityType.NAMESPACE;
-import static org.apache.polaris.core.entity.PolarisEntityType.TABLE_LIKE;
-
-import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.policy.PolicyMappingUtil;
 import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 import org.apache.polaris.core.policy.validator.PolicyValidator;
 
@@ -32,26 +28,11 @@ public class BaseMaintenancePolicyValidator implements PolicyValidator {
   public static final BaseMaintenancePolicyValidator INSTANCE =
       new BaseMaintenancePolicyValidator();
 
-  private static final Set<PolarisEntityType> ATTACHABLE_ENTITY_TYPES =
-      Set.of(CATALOG, NAMESPACE, TABLE_LIKE);
-
   @Override
   public void validate(String content) throws InvalidPolicyException {}
 
   @Override
   public boolean canAttach(PolarisEntityType entityType, PolarisEntitySubType entitySubType) {
-    if (entityType == null) {
-      return false;
-    }
-
-    if (!ATTACHABLE_ENTITY_TYPES.contains(entityType)) {
-      return false;
-    }
-
-    if (entityType == TABLE_LIKE && entitySubType != PolarisEntitySubType.ICEBERG_TABLE) {
-      return false;
-    }
-
-    return true;
+    return PolicyMappingUtil.isValidTargetEntityType(entityType, entitySubType);
   }
 }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -293,6 +293,11 @@ public abstract class BasePolarisMetaStoreManagerTest {
   }
 
   @Test
+  protected void testPolicyMappingCleanup() {
+    polarisTestMetaStoreManager.testPolicyMappingCleanup();
+  }
+
+  @Test
   protected void testLoadTasks() {
     for (int i = 0; i < 20; i++) {
       polarisTestMetaStoreManager.createEntity(

--- a/service/common/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/service/common/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -28,6 +28,7 @@ import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
 import org.apache.polaris.core.policy.exceptions.NoSuchPolicyException;
 import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
+import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
 import org.apache.polaris.core.policy.exceptions.PolicyVersionMismatchException;
 import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 import org.apache.polaris.service.context.UnresolvableRealmContextException;
@@ -59,6 +60,8 @@ public class PolarisExceptionMapper implements ExceptionMapper<PolarisException>
       return Response.Status.CONFLICT;
     } else if (exception instanceof PolicyMappingAlreadyExistsException) {
       return Response.Status.CONFLICT;
+    } else if (exception instanceof PolicyInUseException) {
+      return Response.Status.BAD_REQUEST;
     } else {
       return Response.Status.INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This PR updates `dropPolicy` to check if the policy is in use before dropping. It also supports a `detach-all` flag which drops policy and all corresponding mappings. 