### PR TITLE
Ensure writeToPolicyMappingRecord update existing record if primary key equals in EclipseLink Persistence Impl

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -420,7 +420,21 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    session.persist(ModelPolicyMappingRecord.fromPolicyMappingRecord(mappingRecord));
+    ModelPolicyMappingRecord model =
+        lookupPolicyMappingRecord(
+            session,
+            mappingRecord.getTargetCatalogId(),
+            mappingRecord.getTargetId(),
+            mappingRecord.getPolicyTypeCode(),
+            mappingRecord.getPolicyCatalogId(),
+            mappingRecord.getPolicyId());
+    if (model != null) {
+      model.update(mappingRecord);
+    } else {
+      model = ModelPolicyMappingRecord.fromPolicyMappingRecord(mappingRecord);
+    }
+
+    session.persist(model);
   }
 
   void deleteFromPolicyMappingRecords(

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -420,6 +420,7 @@ public class PolarisEclipseLinkStore {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
+    // TODO: combine existence check and write into one statement
     ModelPolicyMappingRecord model =
         lookupPolicyMappingRecord(
             session,

--- a/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
+++ b/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
@@ -135,6 +135,15 @@ public class ModelPolicyMappingRecord {
     }
   }
 
+  public void update(PolarisPolicyMappingRecord record) {
+    this.targetCatalogId = record.getTargetCatalogId();
+    this.targetId = record.getTargetId();
+    this.policyTypeCode = record.getPolicyTypeCode();
+    this.policyCatalogId = record.getPolicyCatalogId();
+    this.policyId = record.getPolicyId();
+    this.parameters = record.getParameters();
+  }
+
   public static ModelPolicyMappingRecord fromPolicyMappingRecord(
       PolarisPolicyMappingRecord record) {
     if (record == null) return null;

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2775,6 +2775,16 @@ public class PolarisTestMetaStoreManager {
     Assertions.assertThat(policyAttachmentResult.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS);
 
+    policyAttachmentResult =
+        polarisMetaStoreManager.attachPolicyToEntity(
+            polarisCallContext,
+            List.of(catalog, N1, N1_N2),
+            N1_N2_T1,
+            List.of(catalog, N1),
+            N1_P1,
+            Map.of("test1", "test1"));
+    Assertions.assertThat(policyAttachmentResult.isSuccess()).isTrue();
+
     LoadPolicyMappingsResult loadPolicyMappingsResult =
         polarisMetaStoreManager.loadPoliciesOnEntityByType(
             polarisCallContext, N1_N2_T1, PredefinedPolicyTypes.DATA_COMPACTION);


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
`writeToPolicyMappingRecords` should update the existing record if there is one with the same primary key. This PR fix the implementation in EclipseLink Persistence to align with the expectation