### PR TITLE
Initial SigV4 Auth Support for Catalog Federation

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
@@ -21,10 +21,12 @@ package org.apache.polaris.core.connection;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.annotation.Nonnull;
 import java.util.Map;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.BearerAuthenticationParameters;
 import org.apache.polaris.core.admin.model.OAuthClientCredentialsParameters;
+import org.apache.polaris.core.admin.model.SigV4AuthenticationParameters;
 import org.apache.polaris.core.secrets.UserSecretReference;
 
 /**
@@ -38,6 +40,7 @@ import org.apache.polaris.core.secrets.UserSecretReference;
 @JsonSubTypes({
   @JsonSubTypes.Type(value = OAuthClientCredentialsParametersDpo.class, name = "1"),
   @JsonSubTypes.Type(value = BearerAuthenticationParametersDpo.class, name = "2"),
+  @JsonSubTypes.Type(value = SigV4AuthenticationParametersDpo.class, name = "3"),
 })
 public abstract class AuthenticationParametersDpo implements IcebergCatalogPropertiesProvider {
 
@@ -56,7 +59,7 @@ public abstract class AuthenticationParametersDpo implements IcebergCatalogPrope
     return authenticationTypeCode;
   }
 
-  public abstract AuthenticationParameters asAuthenticationParametersModel();
+  public abstract @Nonnull AuthenticationParameters asAuthenticationParametersModel();
 
   public static AuthenticationParametersDpo fromAuthenticationParametersModelWithSecrets(
       AuthenticationParameters authenticationParameters,
@@ -79,6 +82,18 @@ public abstract class AuthenticationParametersDpo implements IcebergCatalogPrope
         config =
             new BearerAuthenticationParametersDpo(
                 secretReferences.get(INLINE_BEARER_TOKEN_REFERENCE_KEY));
+        break;
+      case SIGV4:
+        // SigV4 authentication is not secret-based
+        SigV4AuthenticationParameters sigV4AuthenticationParametersModel =
+            (SigV4AuthenticationParameters) authenticationParameters;
+        config =
+            new SigV4AuthenticationParametersDpo(
+                sigV4AuthenticationParametersModel.getRoleArn(),
+                sigV4AuthenticationParametersModel.getExternalId(),
+                sigV4AuthenticationParametersModel.getSigningRegion(),
+                sigV4AuthenticationParametersModel.getSigningName(),
+                sigV4AuthenticationParametersModel.getUserArn());
         break;
       default:
         throw new IllegalStateException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationType.java
@@ -33,6 +33,7 @@ public enum AuthenticationType {
   NULL_TYPE(0),
   OAUTH(1),
   BEARER(2),
+  SIGV4(3),
   ;
 
   private static final AuthenticationType[] REVERSE_MAPPING_ARRAY;

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/BearerAuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/BearerAuthenticationParametersDpo.java
@@ -56,7 +56,7 @@ public class BearerAuthenticationParametersDpo extends AuthenticationParametersD
   }
 
   @Override
-  public AuthenticationParameters asAuthenticationParametersModel() {
+  public @Nonnull AuthenticationParameters asAuthenticationParametersModel() {
     return BearerAuthenticationParameters.builder()
         .setAuthenticationType(AuthenticationParameters.AuthenticationTypeEnum.BEARER)
         .build();

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/OAuthClientCredentialsParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/OAuthClientCredentialsParametersDpo.java
@@ -86,7 +86,7 @@ public class OAuthClientCredentialsParametersDpo extends AuthenticationParameter
     return clientSecretReference;
   }
 
-  public @Nonnull List<String> getScopes() {
+  public @Nullable List<String> getScopes() {
     return scopes;
   }
 
@@ -115,7 +115,7 @@ public class OAuthClientCredentialsParametersDpo extends AuthenticationParameter
   }
 
   @Override
-  public AuthenticationParameters asAuthenticationParametersModel() {
+  public @Nonnull AuthenticationParameters asAuthenticationParametersModel() {
     return OAuthClientCredentialsParameters.builder()
         .setAuthenticationType(AuthenticationParameters.AuthenticationTypeEnum.OAUTH)
         .setTokenUri(getTokenUri())

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/SigV4AuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/SigV4AuthenticationParametersDpo.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.connection;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Map;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.rest.auth.AuthProperties;
+import org.apache.polaris.core.admin.model.AuthenticationParameters;
+import org.apache.polaris.core.admin.model.SigV4AuthenticationParameters;
+import org.apache.polaris.core.secrets.UserSecretsManager;
+
+/**
+ * The internal persistence-object counterpart to SigV4AuthenticationParameters defined in the API
+ * model.
+ */
+public class SigV4AuthenticationParametersDpo extends AuthenticationParametersDpo {
+
+  @JsonProperty(value = "roleArn")
+  private final String roleArn;
+
+  @JsonProperty(value = "externalId")
+  private final String externalId;
+
+  @JsonProperty(value = "signingRegion")
+  private final String signingRegion;
+
+  @JsonProperty(value = "signingName")
+  private final String signingName;
+
+  @JsonProperty(value = "userArn")
+  private final String userArn;
+
+  public SigV4AuthenticationParametersDpo(
+      @JsonProperty(value = "roleArn", required = true) String roleArn,
+      @JsonProperty(value = "externalId", required = false) String externalId,
+      @JsonProperty(value = "signingRegion", required = false) String signingRegion,
+      @JsonProperty(value = "signingName", required = false) String signingName,
+      @JsonProperty(value = "userArn", required = false) String userArn) {
+    super(AuthenticationType.SIGV4.getCode());
+    this.roleArn = roleArn;
+    this.externalId = externalId;
+    this.signingRegion = signingRegion;
+    this.signingName = signingName;
+    this.userArn = userArn;
+  }
+
+  public @Nonnull String getRoleArn() {
+    return roleArn;
+  }
+
+  public @Nullable String getExternalId() {
+    return externalId;
+  }
+
+  public @Nullable String getSigningRegion() {
+    return signingRegion;
+  }
+
+  public @Nullable String getSigningName() {
+    return signingName;
+  }
+
+  public @Nullable String getUserArn() {
+    return userArn;
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, String> asIcebergCatalogProperties(UserSecretsManager secretsManager) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.put(AuthProperties.AUTH_TYPE, AuthProperties.AUTH_TYPE_SIGV4);
+    if (getSigningRegion() != null) {
+      builder.put(AwsProperties.REST_SIGNER_REGION, getSigningRegion());
+    }
+    if (getSigningName() != null) {
+      builder.put(AwsProperties.REST_SIGNING_NAME, getSigningName());
+    }
+    // TODO: Add a connection credential provider to get the tmp aws credentials for SigV4 auth
+    builder.put(AwsProperties.REST_ACCESS_KEY_ID, "access_key_id");
+    builder.put(AwsProperties.REST_SECRET_ACCESS_KEY, "secret_access_key");
+    builder.put(AwsProperties.REST_SESSION_TOKEN, "session_token");
+    return builder.build();
+  }
+
+  @Override
+  public @Nonnull AuthenticationParameters asAuthenticationParametersModel() {
+    return SigV4AuthenticationParameters.builder()
+        .setAuthenticationType(AuthenticationParameters.AuthenticationTypeEnum.SIGV4)
+        .setRoleArn(this.roleArn)
+        .setExternalId(this.externalId)
+        .setSigningRegion(this.signingRegion)
+        .setSigningName(this.signingName)
+        .setUserArn(this.userArn)
+        .build();
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -627,6 +627,11 @@ public class PolarisAdminService {
                   AuthenticationParametersDpo.INLINE_BEARER_TOKEN_REFERENCE_KEY, secretReference);
               break;
             }
+          case SIGV4:
+            {
+              // SigV4 authentication is not secret-based
+              break;
+            }
           default:
             throw new IllegalStateException(
                 "Unsupported authentication type: "

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -889,13 +889,14 @@ components:
 
     AuthenticationParameters:
       type: object
-      description: Authentication-specific information for a REST connection
+      description: Authentication-specific information for a connection
       properties:
         authenticationType:
           type: string
           enum:
             - OAUTH
             - BEARER
+            - SIGV4
           description: The type of authentication to use when connecting to the remote rest service
       required:
         - authenticationType
@@ -904,6 +905,7 @@ components:
         mapping:
           OAUTH: "#/components/schemas/OAuthClientCredentialsParameters"
           BEARER: "#/components/schemas/BearerAuthenticationParameters"
+          SIGV4: "#/components/schemas/SigV4AuthenticationParameters"
 
     OAuthClientCredentialsParameters:
       type: object
@@ -937,6 +939,34 @@ components:
           type: string
           format: password
           description: Bearer token (input-only)
+
+    SigV4AuthenticationParameters:
+      type: object
+      description: AWS Signature Version 4 authentication
+      allOf:
+        - $ref: '#/components/schemas/AuthenticationParameters'
+      properties:
+        roleArn:
+          type: string
+          description: The aws IAM role arn assume when signing requests
+          example: "arn:aws:iam::123456789001:role/role-that-has-remote-catalog-access"
+        externalId:
+          type: string
+          description: An optional external id used to establish a trust relationship with AWS in the trust policy
+        signingRegion:
+          type: string
+          description: Region to be used by the SigV4 protocol for signing requests
+          example: "us-west-2"
+        signingName:
+          type: string
+          description: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
+          example: "glue"
+        userArn:
+          type: string
+          description: The aws user arn used to assume the aws role, this represents the polaris service itself
+          example: "arn:aws:iam::123456789001:user/polaris-service-user"
+      required:
+        - roleArn
 
     StorageConfigInfo:
       type: object


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
## Context

### Prior Catalog Federation work:
* https://github.com/apache/polaris/pull/1026
* https://github.com/apache/polaris/pull/1305

### SigV4 Auth

Details about AWS SigV4 protocol can be found here: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html

## Description
This PR adds the SigV4 Auth Support so that Polaris can federate to Glue IRC / S3Tables / catalog server hosted behind the AWS API Gateway.

## Details
User-provided properties:
* `roleArn`: the AWS IAM role urn, polaris will assume the role to get a tmp aws session credential
* `externalId`: An optional external id used to establish a trust relationship with AWS in the trust policy
* `signingRegion`: Region to be used by the SigV4 protocol for signing requests
* `signingName`: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
    * AWS Glue: `glue`
    * AWS S3Tables: `s3tables`
    * AWS API Gateway: `execute-api`

Service-provided properties:
* `userArn`: The aws user arn used to assume the aws role, this represents the polaris service itself, overall steps:
    * Step 1: Polaris will use an user aws credential to assume the IAM role, this aws credential is configured for polaris, usually polaris will read it from environment variable
    * Step 2: After assuming the role, polaris will get the tmp aws credential, polaris will put these credentials into the prop map, this prop map will be used to initialize the REST Catalog Client, properties can be found in [AwsProperties](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java#L174-L181): 
        * `rest.signing-region`
        * `rest.signing-name`
    * Step 3: [RESTSigV4Signer](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4Signer.java) will sign the requests based on SigV4 protocol

