### PR TITLE
Add the thread local callContext setting for GenericTableCatalogAdapter and PolicyCatalogAdapter

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -65,6 +65,9 @@ public class GenericTableCatalogAdapter
     this.metaStoreManager = metaStoreManager;
     this.polarisAuthorizer = polarisAuthorizer;
     this.prefixParser = prefixParser;
+
+    // FIXME: This is a hack to set the current context for downstream calls.
+    CallContext.setCurrentContext(callContext);
   }
 
   private GenericTableCatalogHandler newHandlerWrapper(

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -70,6 +70,9 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
     this.metaStoreManager = metaStoreManager;
     this.polarisAuthorizer = polarisAuthorizer;
     this.prefixParser = prefixParser;
+
+    // FIXME: This is a hack to set the current context for downstream calls.
+    CallContext.setCurrentContext(callContext);
   }
 
   private PolicyCatalogHandler newHandlerWrapper(SecurityContext securityContext, String prefix) {


### PR DESCRIPTION
Polaris have many downstream call that relies on the thread local CallContext. There are work currently working on removing the thread local CallContext, before that continue apply the thread local context setting as IcebergCatalogAdapter  https://github.com/apache/polaris/blob/main/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java#L160
