### PR TITLE
Fix: Remove Dev Containers pulling diff postgres version

### DIFF
--- a/quarkus/admin/src/main/resources/application.properties
+++ b/quarkus/admin/src/main/resources/application.properties
@@ -49,3 +49,4 @@ quarkus.index-dependency.guava.group-id=com.google.guava
 quarkus.index-dependency.guava.artifact-id=guava
 quarkus.index-dependency.protobuf.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf.artifact-id=protobuf-java
+quarkus.datasource.devservices.image-name=postgres:17-alpine

--- a/quarkus/defaults/src/main/resources/application-test.properties
+++ b/quarkus/defaults/src/main/resources/application-test.properties
@@ -21,3 +21,4 @@
 # Per-test specific configuration should use QuarkusTestProfile
 
 quarkus.log.file.enable=false
+quarkus.datasource.devservices.image-name=postgres:17-alpine

--- a/quarkus/test-commons/src/main/java/org/apache/polaris/test/commons/PostgresRelationalJdbcLifeCycleManagement.java
+++ b/quarkus/test-commons/src/main/java/org/apache/polaris/test/commons/PostgresRelationalJdbcLifeCycleManagement.java
@@ -42,7 +42,7 @@ public class PostgresRelationalJdbcLifeCycleManagement
   @SuppressWarnings("resource")
   public Map<String, String> start() {
     postgres =
-        new PostgreSQLContainer<>(DockerImageName.parse("postgres:17"))
+        new PostgreSQLContainer<>(DockerImageName.parse("postgres:17-alpine"))
             .withDatabaseName("polaris_db")
             .withUsername("polaris")
             .withPassword("polaris");


### PR DESCRIPTION
### About the change

Some of the user experience at 409 for docker pull of postgres-17 image during (./gradlew build), which gets fixed by docker pull of postgres:17 i.e making the image of postgres locally available. I never experience this as this image was always on my docker locally. turns out the dev-services pull the postgres-17 default and we just need them to use postgres-17-alpine

To fix this looked into logs : 

#### Success scenario 

```
 Task :polaris-quarkus-admin:compileTestJava FROM-CACHE
> Task :polaris-quarkus-admin:testClasses
SLF4J: Class path contains multiple SLF4J providers.
SLF4J: Found provider [org.slf4j.impl.JBossSlf4jServiceProvider@39722b04]
SLF4J: Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@1c916ca1]
SLF4J: See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual provider is of type [org.slf4j.impl.JBossSlf4jServiceProvider@39722b04]
2025-04-29 09:02:08,292 INFO  [org.tes.ima.PullPolicy] (pool-2-thread-1) Image pull policy will be performed by: DefaultPullPolicy()
2025-04-29 09:02:08,294 INFO  [org.tes.uti.ImageNameSubstitutor] (pool-2-thread-1) Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
2025-04-29 09:02:08,301 INFO  [org.tes.DockerClientFactory] (pool-2-thread-1) Testcontainers version: 1.20.6
2025-04-29 09:02:08,473 INFO  [org.tes.doc.DockerClientProviderStrategy] (pool-2-thread-1) Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
2025-04-29 09:02:08,671 INFO  [org.tes.doc.DockerClientProviderStrategy] (pool-2-thread-1) Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
2025-04-29 09:02:08,672 INFO  [org.tes.DockerClientFactory] (pool-2-thread-1) Docker host IP address is localhost
2025-04-29 09:02:08,683 INFO  [org.tes.DockerClientFactory] (pool-2-thread-1) Connected to docker: 
  Server Version: 28.0.4
  API Version: 1.48
  Operating System: Docker Desktop
  Total Memory: 7837 MB
  Labels: 
    com.docker.desktop.address=unix:///Users/prsingh/Library/Containers/com.docker.docker/Data/docker-cli.sock
2025-04-29 09:02:08,689 INFO  [org.tes.DockerClientFactory] (pool-2-thread-1) Checking the system...
2025-04-29 09:02:08,690 INFO  [org.tes.DockerClientFactory] (pool-2-thread-1) ✔︎ Docker server version should be at least 1.6.0
2025-04-29 09:02:09,110 INFO  [tc.postgres:17-alpine] (pool-2-thread-1) Creating container for image: postgres:17-alpine
2025-04-29 09:02:09,259 INFO  [tc.tes.11.0] (pool-2-thread-1) Creating container for image: testcontainers/ryuk:0.11.0
2025-04-29 09:02:09,358 INFO  [tc.tes.11.0] (pool-2-thread-1) Container testcontainers/ryuk:0.11.0 is starting: 12532e8151c0599e10504cbb78b346b32f414b67e42b59bfd6317949b36d5879
2025-04-29 09:02:09,635 INFO  [tc.tes.11.0] (pool-2-thread-1) Container testcontainers/ryuk:0.11.0 started in PT0.375731S
2025-04-29 09:02:09,698 INFO  [tc.postgres:17-alpine] (pool-2-thread-1) Container postgres:17-alpine is starting: 20be6053659e93e3b0ef9784b323efd9087dc26df38867109cf9d759502539b3
2025-04-29 09:02:10,778 INFO  [tc.postgres:17-alpine] (pool-2-thread-1) Container postgres:17-alpine started in PT1.667712S
2025-04-29 09:02:10,779 INFO  [tc.postgres:17-alpine] (pool-2-thread-1) Container is started (JDBC URL: jdbc:postgresql://localhost:54464/polaris_realm1?loggerLevel=OFF)
2025-04-29 09:02:10,790 INFO  [org.tes.ext.ScriptUtils] (pool-2-thread-1) Executing database script from org/apache/polaris/admintool/init.sql
2025-04-29 09:02:10,976 INFO  [org.tes.ext.ScriptUtils] (pool-2-thread-1) Executed database script from org/apache/polaris/admintool/init.sql in 185 ms.
```

409 Scenario 

```
2025-04-29 09:05:04,070 INFO  [org.tes.DockerClientFactory] (build-9) Testcontainers version: 1.20.6
2025-04-29 09:05:04,312 INFO  [org.tes.doc.DockerClientProviderStrategy] (build-9) Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
2025-04-29 09:05:04,533 INFO  [org.tes.doc.DockerClientProviderStrategy] (build-9) Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
2025-04-29 09:05:04,534 INFO  [org.tes.DockerClientFactory] (build-9) Docker host IP address is localhost
2025-04-29 09:05:04,565 INFO  [org.tes.DockerClientFactory] (build-9) Connected to docker: 
  Server Version: 28.0.4
  API Version: 1.48
  Operating System: Docker Desktop
  Total Memory: 7837 MB
  Labels: 
    com.docker.desktop.address=unix:///Users/prsingh/Library/Containers/com.docker.docker/Data/docker-cli.sock
2025-04-29 09:05:04,573 INFO  [org.tes.ima.PullPolicy] (build-9) Image pull policy will be performed by: DefaultPullPolicy()
2025-04-29 09:05:04,575 INFO  [org.tes.uti.ImageNameSubstitutor] (build-9) Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
2025-04-29 09:05:04,579 INFO  [org.tes.DockerClientFactory] (build-9) Checking the system...
2025-04-29 09:05:04,580 INFO  [org.tes.DockerClientFactory] (build-9) ✔︎ Docker server version should be at least 1.6.0
2025-04-29 09:05:05,012 INFO  [tc.doc.io/postgres:17] (build-9) Pulling docker image: docker.io/postgres:17. Please be patient; this may take some time but only needs to be done once.
2025-04-29 09:05:05,143 INFO  [org.tes.uti.RegistryAuthLocator] (build-9) Credential helper/store (docker-credential-desktop) does not have credentials for docker.io
```

The one pulling the image `build-9` thread in gradle which doesn't have access to the creds, so we just mark the eclipse-link 