### PR TITLE
Fix FileIOExceptionsTest to conform to new Iceberg 1.8 API

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
@@ -136,6 +136,7 @@ public class FileIOExceptionsTest {
                 "ns1",
                 "t1",
                 null,
+                null,
                 "ALL",
                 services.realmContext(),
                 services.securityContext());


### PR DESCRIPTION
It looks like after #1283, this test no longer compiles as the Iceberg API has changed. I'm not sure how this wasn't caught by CI on that PR itself.