### PR TITLE
Spec: Add SigV4 Auth Support for Catalog Federation

### DIFF
--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -966,10 +966,8 @@ components:
           type: string
           description: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
           example: "glue"
-        userArn:
-          type: string
-          description: The aws user arn used to assume the aws role, this represents the polaris service itself
-          example: "arn:aws:iam::123456789001:user/polaris-service-user"
+        serviceIdentity:
+          $ref: '#/components/schemas/ServiceIdentityInfo'
       required:
         - roleArn
         - signingRegion
@@ -1058,6 +1056,49 @@ components:
       description: file storage configuration info
       allOf:
         - $ref: '#/components/schemas/StorageConfigInfo'
+
+    ServiceIdentityInfo:
+      type: object
+      description: Identity metadata for the Polaris service used to access external resources.
+      readOnly: true
+      properties:
+        identityType:
+          type: string
+          enum:
+            - AWS_IAM_USER
+            - AWS_IAM_ROLE
+          description: The type of identity used to access external resources
+      required:
+        - identityType
+      discriminator:
+        propertyName: identityType
+        mapping:
+          AWS_IAM_USER: "#/components/schemas/AwsIamUserServiceIdentityInfo"
+          AWS_IAM_ROLE: "#/components/schemas/AwsIamRoleServiceIdentityInfo"
+
+    AwsIamUserServiceIdentityInfo:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ServiceIdentityInfo'
+      properties:
+        userArn:
+          type: string
+          description: The ARN of the IAM user Polaris uses to assume roles and then access external resources.
+          example: "arn:aws:iam::111122223333:user/polaris-service-user"
+      required:
+        - userArn
+
+    AwsIamRoleServiceIdentityInfo:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ServiceIdentityInfo'
+      properties:
+        roleArn:
+          type: string
+          description: The ARN of the IAM role Polaris uses to access external resources.
+          example: "arn:aws:iam::111122223333:role/polaris-service-role"
+      required:
+        - roleArn
 
     UpdateCatalogRequest:
       description: Updates to apply to a Catalog. Any fields which are required in the Catalog

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1065,40 +1065,26 @@ components:
         identityType:
           type: string
           enum:
-            - AWS_IAM_USER
-            - AWS_IAM_ROLE
+            - AWS_IAM
           description: The type of identity used to access external resources
       required:
         - identityType
       discriminator:
         propertyName: identityType
         mapping:
-          AWS_IAM_USER: "#/components/schemas/AwsIamUserServiceIdentityInfo"
-          AWS_IAM_ROLE: "#/components/schemas/AwsIamRoleServiceIdentityInfo"
+          AWS_IAM: "#/components/schemas/AwsIamServiceIdentityInfo"
 
-    AwsIamUserServiceIdentityInfo:
+    AwsIamServiceIdentityInfo:
       type: object
       allOf:
         - $ref: '#/components/schemas/ServiceIdentityInfo'
       properties:
-        userArn:
+        iamArn:
           type: string
-          description: The ARN of the IAM user Polaris uses to assume roles and then access external resources.
+          description: The ARN of the IAM user or IAM role Polaris uses to assume roles and then access external resources.
           example: "arn:aws:iam::111122223333:user/polaris-service-user"
       required:
-        - userArn
-
-    AwsIamRoleServiceIdentityInfo:
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/ServiceIdentityInfo'
-      properties:
-        roleArn:
-          type: string
-          description: The ARN of the IAM role Polaris uses to access external resources.
-          example: "arn:aws:iam::111122223333:role/polaris-service-role"
-      required:
-        - roleArn
+        - iamArn
 
     UpdateCatalogRequest:
       description: Updates to apply to a Catalog. Any fields which are required in the Catalog

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -868,6 +868,8 @@ components:
           description: URI to the remote catalog service
         authenticationParameters:
           $ref: "#/components/schemas/AuthenticationParameters"
+        serviceIdentity:
+          $ref: '#/components/schemas/ServiceIdentityInfo'
       required:
         - connectionType
       discriminator:
@@ -966,8 +968,6 @@ components:
           type: string
           description: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
           example: "glue"
-        serviceIdentity:
-          $ref: '#/components/schemas/ServiceIdentityInfo'
       required:
         - roleArn
         - signingRegion

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -948,11 +948,16 @@ components:
       properties:
         roleArn:
           type: string
-          description: The aws IAM role arn assume when signing requests
+          description: The aws IAM role arn assumed by polaris userArn when signing requests
           example: "arn:aws:iam::123456789001:role/role-that-has-remote-catalog-access"
+        roleSessionName:
+          type: string
+          description: The role session name to be used by the SigV4 protocol for signing requests
+          example: "polaris-remote-catalog-access"
         externalId:
           type: string
           description: An optional external id used to establish a trust relationship with AWS in the trust policy
+          example: "external-id-1234"
         signingRegion:
           type: string
           description: Region to be used by the SigV4 protocol for signing requests
@@ -967,6 +972,7 @@ components:
           example: "arn:aws:iam::123456789001:user/polaris-service-user"
       required:
         - roleArn
+        - signingRegion
 
     StorageConfigInfo:
       type: object

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -889,13 +889,14 @@ components:
 
     AuthenticationParameters:
       type: object
-      description: Authentication-specific information for a REST connection
+      description: Authentication-specific information for a connection
       properties:
         authenticationType:
           type: string
           enum:
             - OAUTH
             - BEARER
+            - SIGV4
           description: The type of authentication to use when connecting to the remote rest service
       required:
         - authenticationType
@@ -904,6 +905,7 @@ components:
         mapping:
           OAUTH: "#/components/schemas/OAuthClientCredentialsParameters"
           BEARER: "#/components/schemas/BearerAuthenticationParameters"
+          SIGV4: "#/components/schemas/SigV4AuthenticationParameters"
 
     OAuthClientCredentialsParameters:
       type: object
@@ -937,6 +939,34 @@ components:
           type: string
           format: password
           description: Bearer token (input-only)
+
+    SigV4AuthenticationParameters:
+      type: object
+      description: AWS Signature Version 4 authentication
+      allOf:
+        - $ref: '#/components/schemas/AuthenticationParameters'
+      properties:
+        roleArn:
+          type: string
+          description: The aws IAM role arn assume when signing requests
+          example: "arn:aws:iam::123456789001:role/role-that-has-remote-catalog-access"
+        externalId:
+          type: string
+          description: An optional external id used to establish a trust relationship with AWS in the trust policy
+        signingRegion:
+          type: string
+          description: Region to be used by the SigV4 protocol for signing requests
+          example: "us-west-2"
+        signingName:
+          type: string
+          description: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
+          example: "glue"
+        userArn:
+          type: string
+          description: The aws user arn used to assume the aws role, this represents the polaris service itself
+          example: "arn:aws:iam::123456789001:user/polaris-service-user"
+      required:
+        - roleArn
 
     StorageConfigInfo:
       type: object


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

## Context

### Prior Catalog Federation work:
* https://github.com/apache/polaris/pull/1026
* https://github.com/apache/polaris/pull/1305


### Reference

Below are all the reference mentioned in this PR:

* AWS Docs:
  * AWS SigV4 protocol: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
  * Configure IAM for Glue: https://docs.aws.amazon.com/glue/latest/dg/configure-iam-for-glue.html
  * [AWS STS Regions and endpoints](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_region-endpoints.html)
* Iceberg SDK 
  * [AuthProperties.java#30](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/auth/AuthProperties.java#L30)
  * [RESTSigV4Signer.java#L91](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4Signer.java#L91)
  * [AwsProperties.java#L417-L435](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java#L417-L435)
  * [RESTSigV4AuthSession.java#L71](https://github.com/apache/iceberg/blob/07ad9a635c6e24959280f53b76ef3036e33d13ee/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java#L71)
* Polaris Code
  * param to skip assuming IAM role: [SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION](https://github.com/apache/polaris/blob/4db7998381a61e9cab82cdc4fded6867b0bca464/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java#L92)
  * roleSessionName of the StorageConfig: https://github.com/apache/polaris/blob/ca35bbaf10aff807053bfc032f8e71a3f007cc79/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java#L68

## Description
This PR adds the SigV4 Auth Support so that Polaris can federate to Glue IRC / S3Tables / catalog server hosted behind the AWS API Gateway.

This PR is based on this new proposal for creds management in Polaris:

[Apache Polaris Creds Management Proposal](https://docs.google.com/document/d/1MAW87DtyHWPPNIEkUCRVUKBGjhh5bPn0GbtV7fifm30/edit?usp=sharing)

## Details
User-provided properties:
* `roleArn`: the AWS IAM role urn, polaris will assume the role to get a tmp aws session credential
* `roleSessionName`: The role session name to be used by the SigV4 protocol for signing requests
* `externalId`: An optional external id used to establish a trust relationship with AWS in the trust policy
* `signingRegion`: Region to be used by the SigV4 protocol for signing requests
* `signingName`: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
    * AWS Glue: `glue`
    * AWS S3Tables: `s3tables`
    * AWS API Gateway: `execute-api`

Service-provided properties:
* `serviceIdentity`: it's a nested object. In this PR, I only added two identity types:
    * **AWS_IAM_USER**: Polaris is configured with long-lived AWS credentials from an IAM user. It uses these credentials to assume the IAM role provided by Polaris users, then accesses the remote catalog using the subscoped temp credentials.
      * `userArn`: The aws user arn used to assume the aws role, this represents the polaris service itself, overall steps:
          * **Step 1**: Polaris will use an user aws credential to assume the IAM role, this aws credential is configured for polaris, usually polaris will read it from environment variable
          * **Step 2**: After assuming the role, polaris will get the tmp aws credential, polaris will put these credentials into the prop map, this prop map will be used to initialize the REST Catalog Client, properties can be found in [AwsProperties](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java#L174-L181): 
              * `rest.signing-region`
              * `rest.signing-name`
          * **Step 3**: [RESTSigV4Signer](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4Signer.java) will sign the requests based on SigV4 protocol
    * **AWS_IAM_ROLE**: Polaris retrieves temporary credentials via [Amazon ECS container credentials](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) or [Amazon EC2 instance IAM role credentials](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), then assumes the polaris user-provided IAM role to get new temporary credentials to access the remote catalog.
