### PR TITLE
Add cleanup support for partition-level statistics files when `DROP TABLE PURGE`

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -128,8 +128,7 @@ public class BatchFileCleanupTaskHandlerTest {
       PartitionStatisticsFile partitionStatisticsFile1 =
           TaskTestUtils.writePartitionStatsFile(
               snapshot.snapshotId(),
-              snapshot.sequenceNumber(),
-              "/metadata/" + UUID.randomUUID() + ".stats",
+              "/metadata/" + "partition-stats-" + UUID.randomUUID() + ".parquet",
               fileIO);
       String firstMetadataFile = "v1-295495059.metadata.json";
       TableMetadata firstMetadata =
@@ -162,8 +161,7 @@ public class BatchFileCleanupTaskHandlerTest {
       PartitionStatisticsFile partitionStatisticsFile2 =
           TaskTestUtils.writePartitionStatsFile(
               snapshot2.snapshotId(),
-              snapshot2.sequenceNumber(),
-              "/metadata/" + UUID.randomUUID() + ".stats",
+              "/metadata/" + "partition-stats-" + UUID.randomUUID() + ".parquet",
               fileIO);
       String secondMetadataFile = "v1-295495060.metadata.json";
       TableMetadata secondMetadata =
@@ -182,8 +180,6 @@ public class BatchFileCleanupTaskHandlerTest {
           Stream.of(
                   secondMetadata.previousFiles().stream().map(TableMetadata.MetadataLogEntry::file),
                   secondMetadata.statisticsFiles().stream().map(StatisticsFile::path),
-                  firstMetadata.partitionStatisticsFiles().stream()
-                      .map(PartitionStatisticsFile::path),
                   secondMetadata.partitionStatisticsFiles().stream()
                       .map(PartitionStatisticsFile::path))
               .flatMap(s -> s)

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.TableMetadata;
@@ -124,10 +125,20 @@ public class BatchFileCleanupTaskHandlerTest {
               snapshot.sequenceNumber(),
               "/metadata/" + UUID.randomUUID() + ".stats",
               fileIO);
+      PartitionStatisticsFile partitionStatisticsFile1 =
+          TaskTestUtils.writePartitionStatsFile(
+              snapshot.snapshotId(),
+              snapshot.sequenceNumber(),
+              "/metadata/" + UUID.randomUUID() + ".partition_stats",
+              fileIO);
       String firstMetadataFile = "v1-295495059.metadata.json";
       TableMetadata firstMetadata =
           TaskTestUtils.writeTableMetadata(
-              fileIO, firstMetadataFile, List.of(statisticsFile1), snapshot);
+              fileIO,
+              firstMetadataFile,
+              List.of(statisticsFile1),
+              List.of(partitionStatisticsFile1),
+              snapshot);
       assertThat(TaskUtils.exists(firstMetadataFile, fileIO)).isTrue();
 
       ManifestFile manifestFile3 =
@@ -148,6 +159,12 @@ public class BatchFileCleanupTaskHandlerTest {
               snapshot2.sequenceNumber(),
               "/metadata/" + UUID.randomUUID() + ".stats",
               fileIO);
+      PartitionStatisticsFile partitionStatisticsFile2 =
+          TaskTestUtils.writePartitionStatsFile(
+              snapshot2.snapshotId(),
+              snapshot2.sequenceNumber(),
+              "/metadata/" + UUID.randomUUID() + ".partition_stats",
+              fileIO);
       String secondMetadataFile = "v1-295495060.metadata.json";
       TableMetadata secondMetadata =
           TaskTestUtils.writeTableMetadata(
@@ -156,18 +173,21 @@ public class BatchFileCleanupTaskHandlerTest {
               firstMetadata,
               firstMetadataFile,
               List.of(statisticsFile2),
+              List.of(partitionStatisticsFile2),
               snapshot2);
       assertThat(TaskUtils.exists(firstMetadataFile, fileIO)).isTrue();
       assertThat(TaskUtils.exists(secondMetadataFile, fileIO)).isTrue();
 
       List<String> cleanupFiles =
-          Stream.concat(
-                  secondMetadata.previousFiles().stream()
-                      .map(TableMetadata.MetadataLogEntry::file)
-                      .filter(file -> TaskUtils.exists(file, fileIO)),
-                  secondMetadata.statisticsFiles().stream()
-                      .map(StatisticsFile::path)
-                      .filter(file -> TaskUtils.exists(file, fileIO)))
+          Stream.of(
+                  secondMetadata.previousFiles().stream().map(TableMetadata.MetadataLogEntry::file),
+                  secondMetadata.statisticsFiles().stream().map(StatisticsFile::path),
+                  firstMetadata.partitionStatisticsFiles().stream()
+                      .map(PartitionStatisticsFile::path),
+                  secondMetadata.partitionStatisticsFiles().stream()
+                      .map(PartitionStatisticsFile::path))
+              .flatMap(s -> s)
+              .filter(file -> TaskUtils.exists(file, fileIO))
               .toList();
 
       TaskEntity task =
@@ -183,12 +203,9 @@ public class BatchFileCleanupTaskHandlerTest {
       assertThatPredicate(handler::canHandleTask).accepts(task);
       assertThat(handler.handleTask(task, callCtx)).isTrue();
 
-      assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO))
-          .rejects(firstMetadataFile);
-      assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO))
-          .rejects(statisticsFile1.path());
-      assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO))
-          .rejects(statisticsFile2.path());
+      for (String cleanupFile : cleanupFiles) {
+        assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO)).rejects(cleanupFile);
+      }
     }
   }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -129,7 +129,7 @@ public class BatchFileCleanupTaskHandlerTest {
           TaskTestUtils.writePartitionStatsFile(
               snapshot.snapshotId(),
               snapshot.sequenceNumber(),
-              "/metadata/" + UUID.randomUUID() + ".partition_stats",
+              "/metadata/" + UUID.randomUUID() + ".stats",
               fileIO);
       String firstMetadataFile = "v1-295495059.metadata.json";
       TableMetadata firstMetadata =
@@ -163,7 +163,7 @@ public class BatchFileCleanupTaskHandlerTest {
           TaskTestUtils.writePartitionStatsFile(
               snapshot2.snapshotId(),
               snapshot2.sequenceNumber(),
-              "/metadata/" + UUID.randomUUID() + ".partition_stats",
+              "/metadata/" + UUID.randomUUID() + ".stats",
               fileIO);
       String secondMetadataFile = "v1-295495060.metadata.json";
       TableMetadata secondMetadata =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -510,8 +510,7 @@ class TableCleanupTaskHandlerTest {
     PartitionStatisticsFile partitionStatisticsFile1 =
         TaskTestUtils.writePartitionStatsFile(
             snapshot.snapshotId(),
-            snapshot.sequenceNumber(),
-            "/metadata/" + UUID.randomUUID() + ".stats",
+            "/metadata/" + "partition-stats-" + UUID.randomUUID() + ".parquet",
             fileIO);
     String firstMetadataFile = "v1-295495059.metadata.json";
     TableMetadata firstMetadata =
@@ -544,8 +543,7 @@ class TableCleanupTaskHandlerTest {
     PartitionStatisticsFile partitionStatisticsFile2 =
         TaskTestUtils.writePartitionStatsFile(
             snapshot2.snapshotId(),
-            snapshot2.sequenceNumber(),
-            "/metadata/" + UUID.randomUUID() + ".stats",
+            "/metadata/" + "partition-stats-" + UUID.randomUUID() + ".parquet",
             fileIO);
     String secondMetadataFile = "v1-295495060.metadata.json";
     TaskTestUtils.writeTableMetadata(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -511,7 +511,7 @@ class TableCleanupTaskHandlerTest {
         TaskTestUtils.writePartitionStatsFile(
             snapshot.snapshotId(),
             snapshot.sequenceNumber(),
-            "/metadata/" + UUID.randomUUID() + ".partition_stats",
+            "/metadata/" + UUID.randomUUID() + ".stats",
             fileIO);
     String firstMetadataFile = "v1-295495059.metadata.json";
     TableMetadata firstMetadata =
@@ -545,7 +545,7 @@ class TableCleanupTaskHandlerTest {
         TaskTestUtils.writePartitionStatsFile(
             snapshot2.snapshotId(),
             snapshot2.sequenceNumber(),
-            "/metadata/" + UUID.randomUUID() + ".partition_stats",
+            "/metadata/" + UUID.randomUUID() + ".stats",
             fileIO);
     String secondMetadataFile = "v1-295495060.metadata.json";
     TaskTestUtils.writeTableMetadata(


### PR DESCRIPTION
### Motivation

As a follow-up PR for #312 

Previously, when DROP TABLE PURGE was issued, Polaris cleaned up data files, manifest files, and metadata files, but did not clean up partition-level statistics files.

### Current Behavior
Partition statistics files (partition_stats) remain in storage after the table is dropped. These files are listed in the TableMetadata but were not included in the batch deletion task, resulting in orphaned files.

### Changes Introduced
- Added support for including partitionStatisticsFiles from TableMetadata in the batch cleanup task (BatchFileCleanupTaskHandler).
- Updated `getMetadataFileBatches()` to collect and batch partition statistics files for deletion.
- Added test coverage in `TableCleanupTaskHandlerTest` and `BatchFileCleanupTaskHandlerTest` to verify:
  - partitionStats files are scheduled for deletion
  - they are correctly deleted by the task handler

### Desired Outcome
After a DROP TABLE PURGE, all Iceberg table metadata including partition-level statistics are cleaned up as expected.
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
