### PR TITLE
Avoid using deprecated `NestedField.of()`

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -372,7 +372,7 @@ public class PolarisPolicyServiceIntegrationTest {
 
     restCatalog
         .buildTable(
-            NS2_T1, new Schema(Types.NestedField.of(1, true, "string", Types.StringType.get())))
+            NS2_T1, new Schema(Types.NestedField.optional(1, "string", Types.StringType.get())))
         .create();
 
     PolicyAttachmentTarget catalogTarget =


### PR DESCRIPTION
Use `NestedField.optional()` instead.