### PR TITLE
Fix overlapping navigation menu component on mobile view

### DIFF
--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -1,18 +1,18 @@
 {{/*
 Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
+or more contributor license agreements. See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
+regarding copyright ownership. The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
+KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 */}}
@@ -39,81 +39,82 @@ under the License.
       {{ $p := . -}}
       {{ $s := .Site -}}
       {{ range .Site.Menus.main -}}
-      {{ if .HasChildren }}
-      <!-- Menu items with children -->
-      <div class="dropdown">
-        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{- .Pre -}}
-          <span>{{ .Name }}</span>
-        </a>
-        <ul class="dropdown-menu">
-          {{ $children := .Children.ByWeight -}}
-          {{ if eq .Identifier "releases" -}}
-            {{ with (partial "releasePages.html" (dict "site" $s)).active -}}
-              {{ range . -}}
-                <a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
-              {{- end -}}
-            {{ else -}}
-              {{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
-            {{ end -}}
-          {{ end -}}
-          {{ range $children -}}
-          <a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a>
-          {{- end -}}
-        </ul>
-      </div>
-      {{ else -}}
-      <!-- Menu items without children -->
-      {{ $topHidden := false }}
-      {{ if .Page }}
-      {{ $topHidden = .Page.Params.top_hidden | default false }}
-      {{ else }}
-      {{ $topHidden = .Params.top_hidden | default false }}
-      {{ end }}
-      {{ if not $topHidden }}
-      <li class="nav-item">
-        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
-        {{ $href := "" -}}
-        {{ with .Page -}}
-          {{ $active = or $active ( $.IsDescendant .) -}}
-          {{ $href = .RelPermalink -}}
-        {{ else -}}
-          {{ $href = .URL | relLangURL -}}
-        {{ end -}}
-        {{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
-        <a {{/**/ -}}
-          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
-          href="{{ $href }}"
-          {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
-        >
-            {{- .Pre -}}
-            <span>{{ .Name }}</span>
-            {{- .Post -}}
-        </a>
-      </li>
-      {{ end -}}
-      {{ end -}}
-      {{ end -}}
-      <!-- Other navbar items -->
-      {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown d-none d-lg-block">
-        {{ partial "navbar-version-selector.html" . -}}
-      </li>
-      {{ end -}}
-      {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown d-none d-lg-block">
-        {{ partial "navbar-lang-selector.html" . -}}
-      </li>
-      {{ end -}}
-      {{ if .Site.Params.ui.showLightDarkModeMenu -}}
-      <li class="td-light-dark-menu nav-item dropdown">
-        {{ partial "theme-toggler" . }}
-      </li>
-      {{ end -}}
-    </ul>
-  </div>
-  <div class="d-none d-lg-block">
-    {{ partial "search-input.html" . }}
-  </div>
+	<li class="nav-item">
+	  {{ if .HasChildren }}
+	  <!-- Menu items with children -->
+	  <div class="dropdown">
+		<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+		  {{- .Pre -}}
+		  <span>{{ .Name }}</span>
+		</a>
+		<ul class="dropdown-menu">
+		  {{ $children := .Children.ByWeight -}}
+		  {{ if eq .Identifier "releases" -}}
+			{{ with (partial "releasePages.html" (dict "site" $s)).active -}}
+			  {{ range . -}}
+				<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
+			  {{- end -}}
+			{{ else -}}
+			  {{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
+			{{ end -}}
+		  {{ end -}}
+		  {{ range $children -}}
+		  <a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a>
+		  {{- end -}}
+		</ul>
+	  </div>
+	  {{ else -}}
+	  <!-- Menu items without children -->
+	  {{ $topHidden := false }}
+	  {{ if .Page }}
+	  {{ $topHidden = .Page.Params.top_hidden | default false }}
+	  {{ else }}
+	  {{ $topHidden = .Params.top_hidden | default false }}
+	  {{ end }}
+	  {{ if not $topHidden }}
+	  {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+	  {{ $href := "" -}}
+	  {{ with .Page -}}
+		{{ $active = or $active ( $.IsDescendant .) -}}
+		{{ $href = .RelPermalink -}}
+	  {{ else -}}
+		{{ $href = .URL | relLangURL -}}
+	  {{ end -}}
+	  {{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
+	  <a {{/**/ -}}
+		class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+		href="{{ $href }}"
+		{{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
+	  >
+		  {{- .Pre -}}
+		  <span>{{ .Name }}</span>
+		  {{- .Post -}}
+	  </a>
+	  
+	  {{ end -}}
+	  {{ end -}}
+	</li>
+	{{ end -}}
+	<!-- Other navbar items -->
+	{{ if .Site.Params.versions -}}
+	<li class="nav-item dropdown d-none d-lg-block">
+	  {{ partial "navbar-version-selector.html" . -}}
+	</li>
+	{{ end -}}
+	{{ if (gt (len .Site.Home.Translations) 0) -}}
+	<li class="nav-item dropdown d-none d-lg-block">
+	  {{ partial "navbar-lang-selector.html" . -}}
+	</li>
+	{{ end -}}
+	{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+	<li class="td-light-dark-menu nav-item dropdown">
+	  {{ partial "theme-toggler" . }}
+	</li>
+	{{ end -}}
+  </ul>
+</div>
+<div class="d-none d-lg-block">
+  {{ partial "search-input.html" . }}
+</div>
 </div>
 </nav>

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -1,35 +1,35 @@
 {{/*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
-*/}}
-{{ $cover := and
-    (.HasShortcode "blocks/cover")
-    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
--}}
-{{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
-
-<nav class="td-navbar js-navbar-scroll
-            {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
-<div class="container-fluid flex-column flex-md-row">
-  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-    <span class="navbar-brand__logo navbar-logo">
-      {{- if ne .Site.Params.ui.navbar_logo false -}}
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  */}}
+  {{ $cover := and
+      (.HasShortcode "blocks/cover")
+      (not .Site.Params.ui.navbar_translucent_over_cover_disable)
+  -}}
+  {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
+  
+  <nav class="td-navbar js-navbar-scroll
+              {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
+  <div class="container-fluid flex-column flex-md-row">
+    <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+      <span class="navbar-brand__logo navbar-logo">
+        {{- if ne .Site.Params.ui.navbar_logo false -}}
         {{ with resources.Get "icons/logo.svg" -}}
-          {{ ( . | minify).Content | safeHTML -}}
+        {{ ( . | minify).Content | safeHTML -}}
         {{ end -}}
       {{ end -}}
     </span>


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
When viewed on our mobile phone, the navigation menu component will overlap and making it impossible to navigate the website. 

current
![image](https://github.com/user-attachments/assets/0a8f67db-0742-4bae-b97a-c269c589c652)

proposed fix:
![image](https://github.com/user-attachments/assets/453d61f8-ab97-466b-8af2-3d1cf552f13d)

with the new one, it will be scrollable and each link will not obstruct the other.

cc: @flyrain @snazy 



 
