### PR TITLE
fix overlapping menu item on the nav bar

### DIFF
--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -42,27 +42,25 @@ under the License.
 			<li class="nav-item">
 				{{ if .HasChildren }}
 				<!-- Menu items with children -->
-				<div class="dropdown">
-					<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{{- .Pre -}}
-						<span>{{ .Name }}</span>
-					</a>
-					<ul class="dropdown-menu">
-						{{ $children := .Children.ByWeight -}}
-						{{ if eq .Identifier "releases" -}}
-							{{ with (partial "releasePages.html" (dict "site" $s)).active -}}
-								{{ range . -}}
-									<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
-								{{- end -}}
-							{{ else -}}
-								{{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
-							{{ end -}}
+				<button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+					{{- .Pre -}}
+					<span>{{ .Name }}</span>
+				</button>
+				<ul class="dropdown-menu">
+					{{ $children := .Children.ByWeight -}}
+					{{ if eq .Identifier "releases" -}}
+						{{ with (partial "releasePages.html" (dict "site" $s)).active -}}
+							{{ range . -}}
+								<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
+							{{- end -}}
+						{{ else -}}
+							{{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
 						{{ end -}}
-						{{ range $children -}}
-						<a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a>
-						{{- end -}}
-					</ul>
-				</div>
+					{{ end -}}
+					{{ range $children -}}
+					<li><a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a></li>
+					{{- end -}}
+				</ul>
 				{{ else -}}
 				<!-- Menu items without children -->
 				{{ $topHidden := false }}

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -39,60 +39,60 @@ under the License.
       {{ $p := . -}}
       {{ $s := .Site -}}
       {{ range .Site.Menus.main -}}
-      {{ if .HasChildren }}
-      <!-- Menu items with children -->
-      <div class="dropdown">
-        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{- .Pre -}}
-          <span>{{ .Name }}</span>
-        </a>
-        <ul class="dropdown-menu">
-          {{ $children := .Children.ByWeight -}}
-          {{ if eq .Identifier "releases" -}}
-            {{ with (partial "releasePages.html" (dict "site" $s)).active -}}
-              {{ range . -}}
-                <a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
-              {{- end -}}
-            {{ else -}}
-              {{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
-            {{ end -}}
-          {{ end -}}
-          {{ range $children -}}
-          <a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a>
-          {{- end -}}
-        </ul>
-      </div>
-      {{ else -}}
-      <!-- Menu items without children -->
-      {{ $topHidden := false }}
-      {{ if .Page }}
-      {{ $topHidden = .Page.Params.top_hidden | default false }}
-      {{ else }}
-      {{ $topHidden = .Params.top_hidden | default false }}
-      {{ end }}
-      {{ if not $topHidden }}
-      <li class="nav-item">
-        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
-        {{ $href := "" -}}
-        {{ with .Page -}}
-          {{ $active = or $active ( $.IsDescendant .) -}}
-          {{ $href = .RelPermalink -}}
-        {{ else -}}
-          {{ $href = .URL | relLangURL -}}
-        {{ end -}}
-        {{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
-        <a {{/**/ -}}
-          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
-          href="{{ $href }}"
-          {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
-        >
-            {{- .Pre -}}
-            <span>{{ .Name }}</span>
-            {{- .Post -}}
-        </a>
-      </li>
-      {{ end -}}
-      {{ end -}}
+			<li class="nav-item">
+				{{ if .HasChildren }}
+				<!-- Menu items with children -->
+				<div class="dropdown">
+					<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						{{- .Pre -}}
+						<span>{{ .Name }}</span>
+					</a>
+					<ul class="dropdown-menu">
+						{{ $children := .Children.ByWeight -}}
+						{{ if eq .Identifier "releases" -}}
+							{{ with (partial "releasePages.html" (dict "site" $s)).active -}}
+								{{ range . -}}
+									<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Params.LinkTitle | default .Params.Title }}</a>
+								{{- end -}}
+							{{ else -}}
+								{{ $children = where .Children.ByWeight "Identifier" "ne" "all-releases-page" -}}
+							{{ end -}}
+						{{ end -}}
+						{{ range $children -}}
+						<a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a>
+						{{- end -}}
+					</ul>
+				</div>
+				{{ else -}}
+				<!-- Menu items without children -->
+				{{ $topHidden := false }}
+				{{ if .Page }}
+				{{ $topHidden = .Page.Params.top_hidden | default false }}
+				{{ else }}
+				{{ $topHidden = .Params.top_hidden | default false }}
+				{{ end }}
+				{{ if not $topHidden }}
+					{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+					{{ $href := "" -}}
+					{{ with .Page -}}
+						{{ $active = or $active ( $.IsDescendant .) -}}
+						{{ $href = .RelPermalink -}}
+					{{ else -}}
+						{{ $href = .URL | relLangURL -}}
+					{{ end -}}
+					{{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
+					<a {{/**/ -}}
+						class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+						href="{{ $href }}"
+						{{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
+					>
+							{{- .Pre -}}
+							<span>{{ .Name }}</span>
+							{{- .Post -}}
+					</a>
+				{{ end -}}
+				{{ end -}}
+			</li>
       {{ end -}}
       <!-- Other navbar items -->
       {{ if .Site.Params.versions -}}


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

When viewed on our mobile phone, the navigation menu component will overlap and making it impossible to navigate the website.

current: 
![image](https://github.com/user-attachments/assets/4193c130-20a4-481c-872b-bd67ec1ab031)

proposed fix: 
![image](https://github.com/user-attachments/assets/4cd96053-fa3d-471b-a100-2664c5061d4e)

With the new one, the nav bar will be scrollable and each link will not obstruct the other.

This change is based on [docsy's navigation bar on their web doc](https://github.com/google/docsy/blob/62273b980ed40831d3bcbc96b13f5e81915eebab/layouts/partials/navbar.html#L51) where they ensure each navigation options are enclosed with `li` tag and have `nav-item` css class.

cc: @snazy @flyrain 

