### PR TITLE
Fix the URL of the KEYS file in the release vote email template

### DIFF
--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -157,7 +157,7 @@ internal fun configureOnRootProject(project: Project) =
               * https://dist.apache.org/repos/dist/dev/incubator/$asfName/apache-$asfName-$version
 
               You can find the KEYS file here:
-              * https://dist.apache.org/repos/dist/release/incubator/$asfName/KEYS
+              * https://downloads.apache.org/incubator/$asfName/KEYS
 
               Convenience binary artifacts are staged on Nexus. The Maven repository URL is:
               * $staginRepoUrl


### PR DESCRIPTION
We should use downloads.apache.org in the release vote email template (instead of dist.apache.org).