### PR TITLE
Fix test failure for IcebergCatalogTest and TableCleanupTaskHandlerTest under low concurrency

### DIFF
--- a/quarkus/service/build.gradle.kts
+++ b/quarkus/service/build.gradle.kts
@@ -147,7 +147,11 @@ tasks.withType(Test::class.java).configureEach {
   systemProperty("java.security.manager", "allow")
 }
 
-tasks.named<Test>("test").configure { maxParallelForks = 4 }
+tasks.named<Test>("test").configure {
+  maxParallelForks = 4
+  // enlarge the max heap size to avoid out of memory error
+  maxHeapSize = "4g"
+}
 
 tasks.named<Test>("intTest").configure {
   maxParallelForks = 1

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -769,9 +769,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     // The location of the metadata JSON file specified is outside of the table's base location
     // according to the
     // metadata. We assume this is fraudulent and disallowed
-    final String tableLocation = "s3://my-bucket/path/to/data/my_table/";
+    final String tableSuffix = UUID.randomUUID().toString();
+    final String tableLocation =
+        String.format("s3://my-bucket/path/to/data/my_table_%s/", tableSuffix);
     final String tableMetadataLocation = tableLocation + "metadata/v1.metadata.json";
-    final String anotherTableLocation = "s3://my-bucket/path/to/data/another_table/";
+    final String anotherTableLocation =
+        String.format("s3://my-bucket/path/to/data/another_table_%s/", tableSuffix);
 
     metaStoreManager.updateEntityPropertiesIfNotChanged(
         polarisContext,
@@ -820,15 +823,18 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     Assumptions.assumeTrue(
         supportsNotifications(), "Only applicable if notifications are supported");
 
+    final String tableSuffix = UUID.randomUUID().toString();
     // The location of the metadata JSON file specified is outside of the table's metadata directory
     // according to the
     // metadata. We assume this is fraudulent and disallowed
-    final String tableLocation = "s3://my-bucket/path/to/data/my_table/";
+    final String tableLocation =
+        String.format("s3://my-bucket/path/to/data/my_table_%s/", tableSuffix);
     final String tableMetadataLocation = tableLocation + "metadata/v3.metadata.json";
 
     // this passes the first validation, since it's within the namespace subdirectory, but
     // the location is in another table's subdirectory
-    final String anotherTableLocation = "s3://my-bucket/path/to/data/another_table";
+    final String anotherTableLocation =
+        String.format("s3://my-bucket/path/to/data/another_table_%s", tableSuffix);
 
     metaStoreManager.updateEntityPropertiesIfNotChanged(
         polarisContext,
@@ -880,9 +886,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     // The location of the metadata JSON file specified is outside of the table's base location
     // according to the
     // metadata. We assume this is fraudulent and disallowed
-    final String tableLocation = "s3://my-bucket/path/to/data/my_table/";
+    final String tableSuffix = UUID.randomUUID().toString();
+    final String tableLocation =
+        String.format("s3://my-bucket/path/to/data/my_table_%s/", tableSuffix);
     final String tableMetadataLocation = tableLocation + "metadata/v1.metadata.json";
-    final String anotherTableLocation = "s3://my-bucket/path/to/data/another_table/";
+    final String anotherTableLocation =
+        String.format("s3://my-bucket/path/to/data/another_table_%s/", tableSuffix);
 
     metaStoreManager.updateEntityPropertiesIfNotChanged(
         polarisContext,


### PR DESCRIPTION
Test IcebergCatalogTest and TableCleanupTaskHandlerTest fails when maxParallelForks is set to 1.
1) IcebergCatalogTest fails because the metadata location file already exists, this is due to the fact that couple of tests points try to write to the same location. Mitigated by using location with random suffix to avoid conflict.
2) TableCleanupTaskHandlerTest fails due to Null pointer problem for getCurrentCallContext. Fix the test by using quarkus injection to get the callContext correctly.
3) The quarkus tests sometimes fails due to OutOfMemory error, default heap size seems 512 MB. Increase it to 4g to avoid the problem
