### PR TITLE
Use builder for CreateGenericTableRequest instead of constructor for easier API spec update

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/GenericTableApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/GenericTableApi.java
@@ -89,7 +89,12 @@ public class GenericTableApi extends RestApi {
                 "polaris/v1/{cat}/namespaces/{ns}/generic-tables/",
                 Map.of("cat", catalog, "ns", ns))
             .post(
-                Entity.json(new CreateGenericTableRequest(id.name(), format, "doc", properties)))) {
+                Entity.json(
+                    CreateGenericTableRequest.builder()
+                        .setName(id.name())
+                        .setFormat(format)
+                        .setDoc("doc")
+                        .setProperties(properties)))) {
       return res.readEntity(LoadGenericTableResponse.class).getTable();
     }
   }

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.polaris.core.rest.PolarisEndpoints;
 import org.apache.polaris.core.rest.PolarisResourcePaths;
+import org.apache.polaris.service.types.CreateGenericTableRequest;
 import org.apache.polaris.service.types.GenericTable;
 import org.apache.polaris.spark.rest.CreateGenericTableRESTRequest;
 import org.apache.polaris.spark.rest.LoadGenericTableRESTResponse;
@@ -202,7 +203,13 @@ public class PolarisRESTCatalog implements PolarisCatalog, Closeable {
       TableIdentifier identifier, String format, String doc, Map<String, String> props) {
     Endpoint.check(endpoints, PolarisEndpoints.V1_CREATE_GENERIC_TABLE);
     CreateGenericTableRESTRequest request =
-        new CreateGenericTableRESTRequest(identifier.name(), format, doc, props);
+        new CreateGenericTableRESTRequest(
+            CreateGenericTableRequest.builder()
+                .setName(identifier.name())
+                .setFormat(format)
+                .setDoc(doc)
+                .setProperties(props)
+                .build());
 
     LoadGenericTableRESTResponse response =
         restClient

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRESTRequest.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRESTRequest.java
@@ -41,6 +41,10 @@ public class CreateGenericTableRESTRequest extends CreateGenericTableRequest
     super(name, format, doc, properties);
   }
 
+  public CreateGenericTableRESTRequest(CreateGenericTableRequest request) {
+    this(request.getName(), request.getFormat(), request.getDoc(), request.getProperties());
+  }
+
   @Override
   public void validate() {}
 }

--- a/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/rest/DeserializationTest.java
+++ b/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/rest/DeserializationTest.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTSerializers;
+import org.apache.polaris.service.types.CreateGenericTableRequest;
 import org.apache.polaris.service.types.GenericTable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +91,13 @@ public class DeserializationTest {
   public void testCreateGenericTableRESTRequest(String doc, Map<String, String> properties)
       throws JsonProcessingException {
     CreateGenericTableRESTRequest request =
-        new CreateGenericTableRESTRequest("test-table", "delta", doc, properties);
+        new CreateGenericTableRESTRequest(
+            CreateGenericTableRequest.builder()
+                .setName("test-table")
+                .setFormat("delta")
+                .setDoc(doc)
+                .setProperties(properties)
+                .build());
     String json = mapper.writeValueAsString(request);
     CreateGenericTableRESTRequest deserializedRequest =
         mapper.readValue(json, CreateGenericTableRESTRequest.class);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -75,11 +75,12 @@ public class GenericTableCatalogHandler extends CatalogHandler {
     GenericTableEntity createdEntity =
         this.genericTableCatalog.createGenericTable(identifier, format, doc, properties);
     GenericTable createdTable =
-        new GenericTable(
-            createdEntity.getName(),
-            createdEntity.getFormat(),
-            createdEntity.getDoc(),
-            createdEntity.getPropertiesAsMap());
+        GenericTable.builder()
+            .setName(createdEntity.getName())
+            .setFormat(createdEntity.getFormat())
+            .setDoc(createdEntity.getDoc())
+            .setProperties(createdEntity.getPropertiesAsMap())
+            .build();
 
     return LoadGenericTableResponse.builder().setTable(createdTable).build();
   }
@@ -97,11 +98,12 @@ public class GenericTableCatalogHandler extends CatalogHandler {
 
     GenericTableEntity loadedEntity = this.genericTableCatalog.loadGenericTable(identifier);
     GenericTable loadedTable =
-        new GenericTable(
-            loadedEntity.getName(),
-            loadedEntity.getFormat(),
-            loadedEntity.getDoc(),
-            loadedEntity.getPropertiesAsMap());
+        GenericTable.builder()
+            .setName(loadedEntity.getName())
+            .setFormat(loadedEntity.getFormat())
+            .setDoc(loadedEntity.getDoc())
+            .setProperties(loadedEntity.getPropertiesAsMap())
+            .build();
 
     return LoadGenericTableResponse.builder().setTable(loadedTable).build();
   }

--- a/spec/polaris-catalog-apis/generic-tables-api.yaml
+++ b/spec/polaris-catalog-apis/generic-tables-api.yaml
@@ -199,8 +199,6 @@ components:
           type: object
           additionalProperties:
             type: string
-        location:
-          type: string
 
     GenericTable:
       type: object
@@ -228,8 +226,6 @@ components:
           type: object
           additionalProperties:
             type: string
-        location:
-          type: string
 
     LoadGenericTableResponse:
       description: Result used when a table is successfully loaded.

--- a/spec/polaris-catalog-apis/generic-tables-api.yaml
+++ b/spec/polaris-catalog-apis/generic-tables-api.yaml
@@ -199,6 +199,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        location:
+          type: string
 
     GenericTable:
       type: object
@@ -226,6 +228,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        location:
+          type: string
 
     LoadGenericTableResponse:
       description: Result used when a table is successfully loaded.


### PR DESCRIPTION
Today, we directly uses the CreateGenericTableRequest constructor in the code, when new field is added or removed, we need to update the main code also.

Instead of using constructor, we switch to use builder to avoid changes in main code to allow api (api class) only change in the future