### PR TITLE
Migrate catalog configs to the new reserved prefix

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -104,8 +104,8 @@ public class PolarisPolicyServiceIntegrationTest {
       s3BucketBase + "/" + System.getenv("USER") + "/path/to/data";
 
   private static final String[] DEFAULT_CATALOG_PROPERTIES = {
-    "allow.unstructured.table.location", "true",
-    "allow.external.table.location", "true"
+    "polaris.config.allow.unstructured.table.location", "true",
+    "polaris.config.allow.external.table.location", "true"
   };
 
   @Retention(RetentionPolicy.RUNTIME)
@@ -113,8 +113,8 @@ public class PolarisPolicyServiceIntegrationTest {
     Catalog.TypeEnum value() default Catalog.TypeEnum.INTERNAL;
 
     String[] properties() default {
-      "allow.unstructured.table.location", "true",
-      "allow.external.table.location", "true"
+      "polaris.config.allow.unstructured.table.location", "true",
+      "polaris.config.allow.external.table.location", "true"
     };
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -104,8 +104,8 @@ public class PolarisPolicyServiceIntegrationTest {
       s3BucketBase + "/" + System.getenv("USER") + "/path/to/data";
 
   private static final String[] DEFAULT_CATALOG_PROPERTIES = {
-    "polaris.config.allow.unstructured.table.location", "true",
-    "polaris.config.allow.external.table.location", "true"
+    "allow.unstructured.table.location", "true",
+    "allow.external.table.location", "true"
   };
 
   @Retention(RetentionPolicy.RUNTIME)
@@ -113,8 +113,8 @@ public class PolarisPolicyServiceIntegrationTest {
     Catalog.TypeEnum value() default Catalog.TypeEnum.INTERNAL;
 
     String[] properties() default {
-      "polaris.config.allow.unstructured.table.location", "true",
-      "polaris.config.allow.external.table.location", "true"
+      "allow.unstructured.table.location", "true",
+      "allow.external.table.location", "true"
     };
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -33,8 +33,12 @@ import java.util.Optional;
 public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
 
   protected BehaviorChangeConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
-    super(key, description, defaultValue, catalogConfig);
+      String key,
+      String description,
+      T defaultValue,
+      Optional<String> catalogConfig,
+      Optional<String> catalogConfigUnsafe) {
+    super(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
   }
 
   public static final BehaviorChangeConfiguration<Boolean> VALIDATE_VIEW_LOCATION_OVERLAP =

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -33,8 +33,12 @@ import org.apache.polaris.core.persistence.cache.EntityWeigher;
  */
 public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   protected FeatureConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
-    super(key, description, defaultValue, catalogConfig);
+      String key,
+      String description,
+      T defaultValue,
+      Optional<String> catalogConfig,
+      Optional<String> catalogConfigUnsafe) {
+    super(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
   }
 
   /**
@@ -81,7 +85,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ALLOW_TABLE_LOCATION_OVERLAP =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_TABLE_LOCATION_OVERLAP")
-          .catalogConfig("allow.overlapping.table.location")
+          .catalogConfig("polaris.config.allow.overlapping.table.location")
+          .catalogConfigUnsafe("allow.overlapping.table.location")
           .description(
               "If set to true, allow one table's location to reside within another table's location. "
                   + "This is only enforced within a given namespace.")
@@ -115,7 +120,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ALLOW_UNSTRUCTURED_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_UNSTRUCTURED_TABLE_LOCATION")
-          .catalogConfig("allow.unstructured.table.location")
+          .catalogConfig("polaris.config.allow.unstructured.table.location")
+          .catalogConfigUnsafe("allow.unstructured.table.location")
           .description("If set to true, allows unstructured table locations.")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -123,7 +129,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_TABLE_LOCATION")
-          .catalogConfig("allow.external.table.location")
+          .catalogConfig("polaris.config.allow.external.table.location")
+          .catalogConfigUnsafe("allow.external.table.location")
           .description(
               "If set to true, allows tables to have external locations outside the default structure.")
           .defaultValue(false)
@@ -132,7 +139,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING")
-          .catalogConfig("enable.credential.vending")
+          .catalogConfig("polaris.config.enable.credential.vending")
+          .catalogConfigUnsafe("enable.credential.vending")
           .description("If set to true, allow credential vending for external catalogs.")
           .defaultValue(true)
           .buildFeatureConfiguration();
@@ -140,7 +148,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<List<String>> SUPPORTED_CATALOG_STORAGE_TYPES =
       PolarisConfiguration.<List<String>>builder()
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
-          .catalogConfig("supported.storage.types")
+          .catalogConfig("polaris.config.supported.storage.types")
+          .catalogConfigUnsafe("supported.storage.types")
           .description("The list of supported storage types for a catalog")
           .defaultValue(
               List.of(
@@ -153,7 +162,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> CLEANUP_ON_NAMESPACE_DROP =
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_NAMESPACE_DROP")
-          .catalogConfig("cleanup.on.namespace.drop")
+          .catalogConfig("polaris.config.cleanup.on.namespace.drop")
+          .catalogConfigUnsafe("cleanup.on.namespace.drop")
           .description("If set to true, clean up data when a namespace is dropped")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -161,7 +171,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> CLEANUP_ON_CATALOG_DROP =
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_CATALOG_DROP")
-          .catalogConfig("cleanup.on.catalog.drop")
+          .catalogConfig("polaris.config.cleanup.on.catalog.drop")
+          .catalogConfigUnsafe("cleanup.on.catalog.drop")
           .description("If set to true, clean up data when a catalog is dropped")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -169,7 +180,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> DROP_WITH_PURGE_ENABLED =
       PolarisConfiguration.<Boolean>builder()
           .key("DROP_WITH_PURGE_ENABLED")
-          .catalogConfig("drop-with-purge.enabled")
+          .catalogConfig("polaris.config.drop-with-purge.enabled")
+          .catalogConfigUnsafe("drop-with-purge.enabled")
           .description(
               "If set to true, allows tables to be dropped with the purge parameter set to true.")
           .defaultValue(true)

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -20,13 +20,20 @@ package org.apache.polaris.core.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.polaris.core.context.CallContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * An ABC for Polaris configurations that alter the service's behavior
+ * TODO: deprecate unsafe catalog configs and remove related code
  *
  * @param <T> The type of the configuration
  */
@@ -34,19 +41,60 @@ public abstract class PolarisConfiguration<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisConfiguration.class);
 
+  public static final List<PolarisConfiguration<?>> allConfigurations = new ArrayList<>();
+
   public final String key;
   public final String description;
   public final T defaultValue;
   private final Optional<String> catalogConfigImpl;
+  private final Optional<String> catalogConfigUnsafeImpl;
   private final Class<T> typ;
+
+  /** catalog configs are expected to start with this prefix */
+  private static final String SAFE_CATALOG_CONFIG_PREFIX = "polaris.config.";
+
+  /**
+   * Helper method for building `allConfigurations` and checking for duplicate use of keys across
+   * configs.
+   */
+  private static void registerConfiguration(PolarisConfiguration<?> configuration) {
+    for (PolarisConfiguration<?> existingConfiguration : allConfigurations) {
+      if (existingConfiguration.key.equals(configuration.key)) {
+        throw new IllegalArgumentException(
+            String.format("Config '%s' is already in use", configuration.key));
+      } else {
+        var configs = Stream.of(
+            configuration.catalogConfigImpl,
+            configuration.catalogConfigUnsafeImpl,
+            existingConfiguration.catalogConfigImpl,
+            existingConfiguration.catalogConfigUnsafeImpl
+        )
+            .flatMap(Optional::stream)
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        for (var entry: configs.entrySet()) {
+          if (entry.getValue() > 1) {
+            throw new IllegalArgumentException(
+                String.format("Catalog config %s is already in use", entry.getKey()));
+          }
+        }
+
+      }
+    }
+    allConfigurations.add(configuration);
+  }
 
   @SuppressWarnings("unchecked")
   protected PolarisConfiguration(
-      String key, String description, T defaultValue, Optional<String> catalogConfig) {
+      String key,
+      String description,
+      T defaultValue,
+      Optional<String> catalogConfig,
+      Optional<String> catalogConfigUnsafe) {
     this.key = key;
     this.description = description;
     this.defaultValue = defaultValue;
     this.catalogConfigImpl = catalogConfig;
+    this.catalogConfigUnsafeImpl = catalogConfigUnsafe;
     this.typ = (Class<T>) defaultValue.getClass();
   }
 
@@ -61,6 +109,17 @@ public abstract class PolarisConfiguration<T> {
                 "Attempted to read a catalog config key from a configuration that doesn't have one."));
   }
 
+  public boolean hasCatalogConfigUnsafe() {
+    return catalogConfigUnsafeImpl.isPresent();
+  }
+
+  public String catalogConfigUnsafe() {
+    return catalogConfigUnsafeImpl.orElseThrow(
+        () ->
+            new IllegalStateException(
+                "Attempted to read an unsafe catalog config key from a configuration that doesn't have one."));
+  }
+
   T cast(Object value) {
     return this.typ.cast(value);
   }
@@ -70,6 +129,7 @@ public abstract class PolarisConfiguration<T> {
     private String description;
     private T defaultValue;
     private Optional<String> catalogConfig = Optional.empty();
+    private Optional<String> catalogConfigUnsafe = Optional.empty();
 
     public Builder<T> key(String key) {
       this.key = key;
@@ -93,7 +153,22 @@ public abstract class PolarisConfiguration<T> {
     }
 
     public Builder<T> catalogConfig(String catalogConfig) {
+      if (!catalogConfig.startsWith(SAFE_CATALOG_CONFIG_PREFIX)) {
+        throw new IllegalArgumentException(
+            "Catalog configs are expected to start with " + SAFE_CATALOG_CONFIG_PREFIX);
+      }
       this.catalogConfig = Optional.of(catalogConfig);
+      return this;
+    }
+
+    /**
+     * Used to support backwards compatability before there were reserved properties. Usage of this
+     * method should be removed over time.
+     */
+    @Deprecated
+    public Builder<T> catalogConfigUnsafe(String catalogConfig) {
+      LOGGER.info("catalogConfigUnsafe is deprecated! Use catalogConfig() instead.");
+      this.catalogConfigUnsafe = Optional.of(catalogConfig);
       return this;
     }
 
@@ -101,18 +176,24 @@ public abstract class PolarisConfiguration<T> {
       if (key == null || description == null || defaultValue == null) {
         throw new IllegalArgumentException("key, description, and defaultValue are required");
       }
-      return new FeatureConfiguration<>(key, description, defaultValue, catalogConfig);
+      FeatureConfiguration<T> config =
+          new FeatureConfiguration<>(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
+      PolarisConfiguration.registerConfiguration(config);
+      return config;
     }
 
     public BehaviorChangeConfiguration<T> buildBehaviorChangeConfiguration() {
       if (key == null || description == null || defaultValue == null) {
         throw new IllegalArgumentException("key, description, and defaultValue are required");
       }
-      if (catalogConfig.isPresent()) {
+      if (catalogConfig.isPresent() || catalogConfigUnsafe.isPresent()) {
         throw new IllegalArgumentException(
-            "catalogConfig is not valid for behavior change configs");
+            "catalog configs are not valid for behavior change configs");
       }
-      return new BehaviorChangeConfiguration<>(key, description, defaultValue, catalogConfig);
+      BehaviorChangeConfiguration<T> config =
+          new BehaviorChangeConfiguration<>(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
+      PolarisConfiguration.registerConfiguration(config);
+      return config;
     }
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -38,7 +38,7 @@ public abstract class PolarisConfiguration<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisConfiguration.class);
 
-  public static final List<PolarisConfiguration<?>> allConfigurations = new ArrayList<>();
+  private static final List<PolarisConfiguration<?>> allConfigurations = new ArrayList<>();
 
   public final String key;
   public final String description;
@@ -77,6 +77,11 @@ public abstract class PolarisConfiguration<T> {
       }
     }
     allConfigurations.add(configuration);
+  }
+
+  /** Returns a list of all PolarisConfigurations that have been registered */
+  public static List<PolarisConfiguration<?>> getAllConfigurations() {
+    return List.copyOf(allConfigurations);
   }
 
   @SuppressWarnings("unchecked")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -20,20 +20,17 @@ package org.apache.polaris.core.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.polaris.core.context.CallContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An ABC for Polaris configurations that alter the service's behavior
- * TODO: deprecate unsafe catalog configs and remove related code
+ * An ABC for Polaris configurations that alter the service's behavior TODO: deprecate unsafe
+ * catalog configs and remove related code
  *
  * @param <T> The type of the configuration
  */
@@ -63,21 +60,20 @@ public abstract class PolarisConfiguration<T> {
         throw new IllegalArgumentException(
             String.format("Config '%s' is already in use", configuration.key));
       } else {
-        var configs = Stream.of(
-            configuration.catalogConfigImpl,
-            configuration.catalogConfigUnsafeImpl,
-            existingConfiguration.catalogConfigImpl,
-            existingConfiguration.catalogConfigUnsafeImpl
-        )
-            .flatMap(Optional::stream)
-            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        for (var entry: configs.entrySet()) {
+        var configs =
+            Stream.of(
+                    configuration.catalogConfigImpl,
+                    configuration.catalogConfigUnsafeImpl,
+                    existingConfiguration.catalogConfigImpl,
+                    existingConfiguration.catalogConfigUnsafeImpl)
+                .flatMap(Optional::stream)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        for (var entry : configs.entrySet()) {
           if (entry.getValue() > 1) {
             throw new IllegalArgumentException(
                 String.format("Catalog config %s is already in use", entry.getKey()));
           }
         }
-
       }
     }
     allConfigurations.add(configuration);
@@ -168,6 +164,10 @@ public abstract class PolarisConfiguration<T> {
     @Deprecated
     public Builder<T> catalogConfigUnsafe(String catalogConfig) {
       LOGGER.info("catalogConfigUnsafe is deprecated! Use catalogConfig() instead.");
+      if (catalogConfig.startsWith(SAFE_CATALOG_CONFIG_PREFIX)) {
+        throw new IllegalArgumentException(
+            "Unsafe catalog configs are not expected to start with " + SAFE_CATALOG_CONFIG_PREFIX);
+      }
       this.catalogConfigUnsafe = Optional.of(catalogConfig);
       return this;
     }
@@ -177,7 +177,8 @@ public abstract class PolarisConfiguration<T> {
         throw new IllegalArgumentException("key, description, and defaultValue are required");
       }
       FeatureConfiguration<T> config =
-          new FeatureConfiguration<>(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
+          new FeatureConfiguration<>(
+              key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
       PolarisConfiguration.registerConfiguration(config);
       return config;
     }
@@ -191,7 +192,8 @@ public abstract class PolarisConfiguration<T> {
             "catalog configs are not valid for behavior change configs");
       }
       BehaviorChangeConfiguration<T> config =
-          new BehaviorChangeConfiguration<>(key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
+          new BehaviorChangeConfiguration<>(
+              key, description, defaultValue, catalogConfig, catalogConfigUnsafe);
       PolarisConfiguration.registerConfiguration(config);
       return config;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -23,8 +23,6 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.slf4j.Logger;
@@ -129,5 +127,4 @@ public interface PolarisConfigurationStore {
       return getConfiguration(ctx, config);
     }
   }
-
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -23,14 +23,20 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Dynamic configuration store used to retrieve runtime parameters, which may vary by realm or by
  * request.
  */
 public interface PolarisConfigurationStore {
+  Logger LOGGER = LoggerFactory.getLogger(PolarisConfigurationStore.class);
+
   /**
    * Retrieve the current value for a configuration key. May be null if not set.
    *
@@ -111,11 +117,17 @@ public interface PolarisConfigurationStore {
       PolarisCallContext ctx,
       @Nonnull CatalogEntity catalogEntity,
       PolarisConfiguration<T> config) {
-    if (config.hasCatalogConfig()
-        && catalogEntity.getPropertiesAsMap().containsKey(config.catalogConfig())) {
+    if (config.hasCatalogConfig()) {
       return tryCast(config, catalogEntity.getPropertiesAsMap().get(config.catalogConfig()));
+    } else if (config.hasCatalogConfigUnsafe()) {
+      LOGGER.warn(
+          String.format(
+              "Deprecated config %s is in use and will be removed in a future version",
+              config.catalogConfigUnsafe()));
+      return tryCast(config, catalogEntity.getPropertiesAsMap().get(config.catalogConfigUnsafe()));
     } else {
       return getConfiguration(ctx, config);
     }
   }
+
 }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -75,7 +75,7 @@ public class PolarisConfigurationStoreTest {
   public void testInvalidCastThrowsException() {
     // Bool not included because Boolean.valueOf turns non-boolean strings to false
     List<PolarisConfiguration<?>> configs =
-        List.of(buildConfig("int", 12), buildConfig("long", 34L), buildConfig("double", 5.6D));
+        List.of(buildConfig("int2", 12), buildConfig("long2", 34L), buildConfig("double2", 5.6D));
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
@@ -135,7 +135,7 @@ public class PolarisConfigurationStoreTest {
 
     BehaviorChangeConfiguration<Boolean> behaviorChangeConfig =
         PolarisConfiguration.<Boolean>builder()
-            .key("example")
+            .key("example2")
             .description("example")
             .defaultValue(true)
             .buildBehaviorChangeConfiguration();

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusReservedProperties.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusReservedProperties.java
@@ -42,15 +42,16 @@ public interface QuarkusReservedProperties extends ReservedProperties {
 
     private static Set<String> computeAllowlist() {
       Set<String> allowlist = new HashSet<>();
-      PolarisConfiguration.allConfigurations.forEach(
-          c -> {
-            if (c.hasCatalogConfig()) {
-              allowlist.add(c.catalogConfig());
-            }
-            if (c.hasCatalogConfigUnsafe()) {
-              allowlist.add(c.catalogConfigUnsafe());
-            }
-          });
+      PolarisConfiguration.getAllConfigurations()
+          .forEach(
+              c -> {
+                if (c.hasCatalogConfig()) {
+                  allowlist.add(c.catalogConfig());
+                }
+                if (c.hasCatalogConfigUnsafe()) {
+                  allowlist.add(c.catalogConfigUnsafe());
+                }
+              });
       return allowlist;
     }
   }

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusReservedProperties.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusReservedProperties.java
@@ -19,7 +19,10 @@
 package org.apache.polaris.service.quarkus.config;
 
 import io.smallrye.config.ConfigMapping;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.apache.polaris.core.config.PolarisConfiguration;
 import org.apache.polaris.service.config.ReservedProperties;
 
 @ConfigMapping(prefix = "polaris.reserved-properties")
@@ -27,5 +30,28 @@ public interface QuarkusReservedProperties extends ReservedProperties {
   @Override
   default List<String> prefixes() {
     return List.of("polaris.");
+  }
+
+  @Override
+  default Set<String> allowlist() {
+    return AllowlistHolder.INSTANCE;
+  }
+
+  class AllowlistHolder {
+    static final Set<String> INSTANCE = computeAllowlist();
+
+    private static Set<String> computeAllowlist() {
+      Set<String> allowlist = new HashSet<>();
+      PolarisConfiguration.allConfigurations.forEach(
+          c -> {
+            if (c.hasCatalogConfig()) {
+              allowlist.add(c.catalogConfig());
+            }
+            if (c.hasCatalogConfigUnsafe()) {
+              allowlist.add(c.catalogConfigUnsafe());
+            }
+          });
+      return allowlist;
+    }
   }
 }


### PR DESCRIPTION
Previously, some `FeatureConfiguration`s could have a `catalogConfig` which allowed admins to enable or disable the feature on a per-catalog basis. Unfortunately, config itself was a freeform string.

This means that new configs could potentially collide with existing configs. For example, imagine a user has had a catalog with some property `delete.everything.yes` since they started using Polaris with release 0.9.0. At some point in time, we add a new `FeatureConfiguration` with `catalogConfig` `delete.everything.yes`. When the user upgrades their Polaris, whatever new behavior is gated behind that catalog config will be silently enabled.

To prevent this, catalog configs should start with the reserved `polaris.` prefix, so that they cannot collide with existing properties. We can allowlist the configs on an individual basis so that once a catalog config is defined its property can be used, but not before that time.