### PR TITLE
Include DISCLAIMER in binary distributions

### DIFF
--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -97,6 +97,7 @@ distributions {
       from("distribution/NOTICE")
       from("distribution/LICENSE")
       from("distribution/README.md")
+      from("../../DISCLAIMER")
     }
   }
 }

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -92,6 +92,7 @@ distributions {
       from("distribution/NOTICE")
       from("distribution/LICENSE")
       from("distribution/README.md")
+      from("../../DISCLAIMER")
     }
   }
 }


### PR DESCRIPTION
We forgot to include `DISCLAIMER` file in the binary distributions (`admin` and `server`).