### PR TITLE
In binary distributions, now we group the artifacts and we add BSD/MIT licenses inline

### DIFF
--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -206,504 +206,515 @@ This binary artifact bundles the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: io.github.crac Name: org.crac Version: 0.1.3
-Project URL (from POM): https://github.com/crac/org.crac
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+Group: io.github.crac Name: org-crac Version: 0.1.3
+Project URL: https://github.com/crac/org.crac
+License: BSD 2-Clause
+| Copyright 2017-2022 Azul Systems, Inc.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+|
+| 1. Redistributions of source code must retain the above copyright notice,
+| this list of conditions and the following disclaimer.
+|
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+| this list of conditions and the following disclaimer in the documentation
+| and/or other materials provided with the distribution.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+| POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: io.quarkus Name: quarkus-bootstrap-runner Version: 3.21.4
-Project URL: https://quarkus.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.quarkus Name: quarkus-classloader-commons Version: 3.21.4
-Project URL: https://quarkus.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.quarkus Name: quarkus-development-mode-spi Version: 3.21.4
+Group: io.quarkus.arc Name: arc Version: 3.21.4
+Group: io.quarkus Name: quarkus-agroal Version: 3.21.4
+Group: io.quarkus Name: quarkus-arc Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image-docker Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image-docker-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-core Version: 3.21.4
+Group: io.quarkus Name: quarkus-credentials Version: 3.21.4
+Group: io.quarkus Name: quarkus-datasource Version: 3.21.4
+Group: io.quarkus Name: quarkus-datasource-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
+Group: io.quarkus Name: quarkus-jdbc-postgresql Version: 3.21.4
+Group: io.quarkus Name: quarkus-mutiny Version: 3.21.4
+Group: io.quarkus Name: quarkus-narayana-jta Version: 3.21.4
+Group: io.quarkus Name: quarkus-picocli Version: 3.21.4
+Group: io.quarkus Name: quarkus-smallrye-context-propagation Version: 3.21.4
+Group: io.quarkus Name: quarkus-transaction-annotations Version: 3.21.4
 Project URL: https://quarkus.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.smallrye.common Name: smallrye-common-constraint Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-cpu Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-expression Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-function Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-io Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-net Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-os Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-ref Version: 2.12.0
+Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.12.0
+Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.12.0
+Group: io.smallrye.config Name: smallrye-config Version: 3.12.4
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.12.4
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.12.4
+Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
+Group: io.smallrye.reactive Name: mutiny-smallrye-context-propagation Version: 2.8.0
+Group: io.smallrye.reactive Name: mutiny-zero-flow-adapters Version: 1.1.1
+Group: io.smallrye.reactive Name: smallrye-reactive-converter-api Version: 3.0.3
+Group: io.smallrye.reactive Name: smallrye-reactive-converter-mutiny Version: 3.0.3
+Group: io.smallrye Name: smallrye-context-propagation Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-api Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-jta Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-storage Version: 2.2.1
 Project URL: https://smallrye.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jboss.logging Name: jboss-logging Version: 3.6.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.logmanager Name: jboss-logmanager Version: 3.1.2.Final
 Project URL: http://www.jboss.org
-License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+License: Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.azure Name: azure-core Version: 1.55.3
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-core-http-netty Version: 1.15.11
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-identity Version: 1.15.4
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-json Version: 1.5.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-blob Version: 12.30.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-common Version: 12.29.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-file-datalake Version: 12.23.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-internal-avro Version: 12.15.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-xml Version: 1.2.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+Project URL: https://github.com/Azure/azure-sdk-for-java
+License: MIT License
+| The MIT License (MIT)
+|
+| Copyright (c) 2015 Microsoft
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/FasterXML/jackson
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
-Project URL (from POM): https://github.com/ben-manes/caffeine
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/ben-manes/caffeine
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.github.stephenc.jcip Name: jcip-annotations Version: 1.0-1
-Project URL (from POM): http://stephenc.github.com/jcip-annotations
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://stephenc.github.com/jcip-annotations
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.android Name: annotations Version: 4.1.1.4
-Project URL (from POM): http://source.android.com/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://source.android.com/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.api-client Name: google-api-client Version: 2.7.2
-Project URL (from POM): https://github.com/googleapis/google-api-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-api-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: api-common Version: 2.47.1
-Project URL (from POM): https://github.com/googleapis/api-common-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+Group: com.google.api Name: api-common Version: 2.48.0
+Project URL: https://github.com/googleapis/api-common-java
+License: BSD 3-Clause
+| Copyright 2016, Google Inc.
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: gax Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+Group: com.google.api Name: gax Version: 2.65.0
+Group: com.google.api Name: gax-grpc Version: 2.65.0
+Group: com.google.api Name: gax-httpjson Version: 2.65.0
+Project URL: https://github.com/googleapis/gax-java
+License: BSD 3-Clause
+| Copyright 2016, Google Inc. All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: gax-grpc Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api Name: gax-httpjson Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
+Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.52.2
+Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.52.2
 Group: com.google.api.grpc Name: proto-google-cloud-monitoring-v3 Version: 3.52.0
-Project URL (from POM): https://github.com/googleapis/google-cloud-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.52.2
+Project URL: https://github.com/googleapis/java-storage
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.api.grpc Name: proto-google-common-protos Version: 2.53.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.51.0
+Project URL: https://github.com/googleapis/sdk-platform-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.50.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250424-2.0.0
+Project URL: http://www.google.com
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250312-2.0.0
-Project URL (from POM): http://www.google.com
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth Name: google-auth-library-credentials Version: 1.33.1
-Project URL (from POM): https://github.com/googleapis/google-auth-library-java
-License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.33.1
-Project URL (from POM): https://github.com/googleapis/google-auth-library-java
-License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+Group: com.google.auth Name: google-auth-library-credentials Version: 1.34.0
+Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.34.0
+Project URL: https://github.com/googleapis/google-auth-library-java
+License: BSD 3-Clause
+| Copyright 2014, Google Inc. All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: com.google.auto.value Name: auto-value-annotations Version: 1.11.0
-Project URL (from POM): https://github.com/google/auto
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/auto
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud Name: google-cloud-core Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-core-http Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
+Group: com.google.cloud Name: google-cloud-core Version: 2.55.0
+Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.55.0
+Group: com.google.cloud Name: google-cloud-core-http Version: 2.55.0
 Group: com.google.cloud Name: google-cloud-monitoring Version: 3.52.0
-Project URL (from POM): https://github.com/googleapis/google-cloud-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-storage Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.cloud Name: google-cloud-storage Version: 2.52.2
+Project URL: https://github.com/googleapis/google-cloud-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.cloud.opentelemetry Name: detector-resources-support Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.cloud.opentelemetry Name: exporter-metrics Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.cloud.opentelemetry Name: shared-resourcemapping Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.code.gson Name: gson Version: 2.12.1
-Project URL (from POM): https://github.com/google/gson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/gson
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.errorprone Name: error_prone_annotations Version: 2.36.0
-Project URL (from POM): https://errorprone.info
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://errorprone.info
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.guava Name: failureaccess Version: 1.0.1
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.guava Name: guava Version: 33.4.8-jre
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.guava Name: listenablefuture Version: 9999.0-empty-to-avoid-conflict-with-guava
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/guava
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.http-client Name: google-http-client Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-apache-v2 Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-appengine Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-gson Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-jackson2 Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-http-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.j2objc Name: j2objc-annotations Version: 2.8
-Project URL (from POM): https://github.com/google/j2objc/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/j2objc/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.oauth-client Name: google-oauth-client Version: 1.37.0
-Project URL (from POM): https://github.com/googleapis/google-oauth-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-oauth-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.protobuf Name: protobuf-java Version: 3.25.5
-Project URL (from POM): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
 Group: com.google.protobuf Name: protobuf-java-util Version: 3.25.5
-Project URL (from POM): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+Project URL: https://developers.google.com/protocol-buffers/
+License: BSD 3-Clause
+| Copyright 2008 Google Inc.  All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+|
+| Code generated by the Protocol Buffer compiler is owned by the owner
+| of the input file used when generating it.  This code is not
+| standalone and requires a support library to be linked with it.  This
+| support library is itself covered by the above license.
 
 --------------------------------------------------------------------------------
 
 Group: com.google.re2j Name: re2j Version: 1.7
-Project URL (from POM): http://github.com/google/re2j
-License (from POM): Go License - https://golang.org/LICENSE
+Project URL: http://github.com/google/re2j
+License: Go License
+| This is a work derived from Russ Cox's RE2 in Go, whose license
+| http://golang.org/LICENSE is as follows:
+|
+| Copyright (c) 2009 The Go Authors. All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|    * Redistributions of source code must retain the above copyright
+|      notice, this list of conditions and the following disclaimer.
+|
+|    * Redistributions in binary form must reproduce the above copyright
+|      notice, this list of conditions and the following disclaimer in
+|      the documentation and/or other materials provided with the
+|      distribution.
+|
+|    * Neither the name of Google Inc. nor the names of its contributors
+|      may be used to endorse or promote products derived from this
+|      software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: com.microsoft.azure Name: msal4j Version: 1.19.1
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
-
---------------------------------------------------------------------------------
-
 Group: com.microsoft.azure Name: msal4j-persistence-extension Version: 1.3.0
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
+Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
+License: MIT License
+|     MIT License
+|
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+|
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+|
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+|
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: content-type Version: 2.3
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-content-type
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: lang-tag Version: 1.7
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: nimbus-jose-jwt Version: 10.0.2
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: oauth2-oidc-sdk Version: 11.23
-Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.sun.xml.bind Name: jaxb-core Version: 4.0.5
-Project URL: https://eclipse-ee4j.github.io/jaxb-ri/
-License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
 Group: com.sun.xml.bind Name: jaxb-xjc Version: 4.0.5
-Project URL: https://eclipse-ee4j.github.io/jaxb-ri/
-License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+Project URL: https://github.com/eclipse-ee4j/jaxb-ri
+License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: commons-codec Name: commons-codec Version: 1.18.0
-Project URL (from POM): https://commons.apache.org/proper/commons-codec/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-codec/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-io Name: commons-io Version: 2.18.0
-Project URL (from POM): https://commons.apache.org/proper/commons-io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: dev.failsafe Name: failsafe Version: 3.3.2
-Project URL (from POM): https://failsafe.dev
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://failsafe.dev
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: info.picocli Name: picocli Name: 4.7.7
-Project URL (from POM): https://picocli.info
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: info.picocli Name: picocli Version: 4.7.7
+Project URL: https://picocli.info
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------`
 
 Group: io.agroal Name: agroal-api Version: 2.6
-Project URL: https://agroal.github.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.agroal Name: agroal-narayana Version: 2.6
-Project URL: https://agroal.github.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.agroal Name: agroal-pool Version: 2.6
 Project URL: https://agroal.github.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -711,810 +722,355 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 --------------------------------------------------------------------------------
 
 Group: io.airlift Name: aircompressor Version: 2.0.2
-Project URL (from POM): https://github.com/airlift/aircompressor
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/airlift/aircompressor
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.grpc Name: grpc-alts Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-api Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-auth Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-context Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-core Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-googleapis Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-grpclb Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-inprocess Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-protobuf Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-rls Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-services Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-stub Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-util Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-xds Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/grpc/grpc-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/micrometer-metrics/micrometer
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.netty Name: netty-buffer Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-dns Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-http Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-http2 Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-socks Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-common Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-handler Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-handler-proxy Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-epoll Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://netty.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opencensus Name: opencensus-api Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opencensus Name: opencensus-contrib-http-util Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/census-instrumentation/opencensus-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-contrib
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/opentelemetry-java-contrib
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry Name: opentelemetry-api Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-api-incubator Version: 1.44.1-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-context Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-common Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-logs Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-trace Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/opentelemetry-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.28.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/semantic-conventions-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.perfmark Name: perfmark-api Version: 0.27.0
-Project URL (from POM): https://github.com/perfmark/perfmark
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/perfmark/perfmark
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.5
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.5
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/reactor/reactor-netty
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.projectreactor Name: reactor-core Version: 3.7.5
-Project URL (from POM): https://github.com/reactor/reactor-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.arc Name: arc Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-agroal Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-arc Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image-docker Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image-docker-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-core Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-credentials Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-datasource Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-datasource-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-jdbc-postgresql Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-mutiny Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-narayana-jta Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-picocli Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-smallrye-context-propagation Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-transaction-annotations Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.12.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.12.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config-common Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config-core Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny-smallrye-context-propagation Version: 2.8.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny-zero-flow-adapters Version: 2.8.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-reactive-converter-api Version: 3.0.3
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-reactive-converter-mutiny Version: 3.0.3
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-api Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-jta Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-storage Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/reactor/reactor-core
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.swagger Name: swagger-annotations Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-core Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-models Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/swagger-api/swagger-core
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.activation Name: jakarta.activation-api Version: 2.1.3
-Project URL (from POM): https://github.com/jakartaee/jaf-api
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/jakartaee/jaf-api
+License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.annotation Name: jakarta.annotation-api Version: 3.0.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.ca
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.ca
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.el Name: jakarta.el-api Version: 5.0.1
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.el
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.el
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
-Project URL (from POM): http://cdi-spec.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://cdi-spec.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.enterprise Name: jakarta.enterprise.lang-model Version: 4.1.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://projects.eclipse.org/projects/ee4j
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
-Project URL (from POM): https://github.com/eclipse-ee4j/injection-api
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/eclipse-ee4j/injection-api
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.interceptor Name: jakarta.interceptor-api Version: 2.2.0
-Project URL (from POM): https://github.com/jakartaee/interceptors
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://github.com/jakartaee/interceptors
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.json Name: jakarta.json-api Version: 2.1.3
-Project URL (from POM): https://github.com/eclipse-ee4j/jsonp
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://github.com/eclipse-ee4j/jsonp
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.persistence Name: jakarta.persistence-api Version: 3.1.0
-Project URL (from POM): https://github.com/eclipse-ee4j/jpa-api
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/eclipse-ee4j/jpa-api
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.resource Name: jakarta.resource-api Version: 2.1.0
-Project URL (from POM): https://github.com/jakartaee/connectors
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+Project URL: https://github.com/jakartaee/connectors
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.servlet Name: jakarta.servlet-api Version: 6.0.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.servlet
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.servlet
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.transaction Name: jakarta.transaction-api Version: 2.0.1
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.jta
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.jta
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
-Project URL (from POM): https://beanvalidation.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://beanvalidation.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.ws.rs Name: jakarta.ws.rs-api Version: 3.1.0
-Project URL (from POM): https://github.com/eclipse-ee4j/jaxrs-api
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://github.com/eclipse-ee4j/jaxrs-api
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.xml.bind Name: jakarta.xml.bind-api Version: 4.0.2
-Project URL (from POM): https://github.com/jakartaee/jaxb-api
-License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/jakartaee/jaxb-api
+License: Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: javax.validation Name: validation-api Version: 1.1.0.Final
-Project URL (from POM): https://beanvalidation.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://beanvalidation.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: javax.ws.rs Name: jsr311-api Version: 1.1.1
-Project URL (from POM): https://jsr311.dev.java.net
-License (from POM): CDDL License - http://www.opensource.org/licenses/cddl1.php
+Project URL: https://jsr311.dev.java.net
+License: CDDL License - http://www.opensource.org/licenses/cddl1.php
 
 --------------------------------------------------------------------------------
 
 Group: net.java.dev.jna Name: jna Version: 5.8.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
-
---------------------------------------------------------------------------------
-
 Group: net.java.dev.jna Name: jna-platform Version: 5.8.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+Project URL: https://github.com/java-native-access/jna
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: net.minidev Name: accessors-smart Version: 2.5.2
-Project URL (from POM): https://urielch.github.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: net.minidev Name: json-smart Version: 2.5.2
-Project URL (from POM): https://urielch.github.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://urielch.github.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.avro Name: avro Version: 1.12.0
-Project URL (from POM): https://avro.apache.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://avro.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-compress Version: 1.27.1
-Project URL (from POM): https://commons.apache.org/proper/commons-compress/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-compress/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-lang3 Version: 3.17.0
-Project URL (from POM): https://commons.apache.org/proper/commons-lang/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-lang/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents.client5 Name: httpclient5 Version: 5.4.3
-Project URL (from POM): https://hc.apache.org/httpcomponents-client-5.4.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-client-5.4.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents.core5 Name: httpcore5 Version: 5.3.4
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.httpcomponents.core5 Name: httpcore5-h2 Version: 5.3.4
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-core-5.3.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents Name: httpclient Version: 4.5.14
-Project URL (from POM): https://hc.apache.org/httpcomponents-client-4.5.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-client-4.5.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents Name: httpcore Version: 4.4.16
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-4.4.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-core-4.4.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.iceberg Name: iceberg-api Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-aws Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-azure Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-bundled-guava Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-common Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-core Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-gcp Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://iceberg.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.checkerframework Name: checker-qual Version: 3.49.1
-Project URL (from POM): https://checkerframework.org/
-License (from POM): MIT License - http://opensource.org/licenses/MIT
+Project URL: https://checkerframework.org/
+License: MIT License
+| The Checker Framework
+| Copyright 2004-present by the Checker Framework developers
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.codehaus.mojo Name: animal-sniffer-annotations Version: 1.24
-Project URL (from POM): https://www.mojohaus.org/animal-sniffer
-License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+Project URL: https://www.mojohaus.org/animal-sniffer
+License: MIT license
+| The MIT License
+|
+| Copyright (c) 2009 codehaus.org.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
-Project URL (from POM): https://conscrypt.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://conscrypt.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1525,14 +1081,9 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 --------------------------------------------------------------------------------
 
 Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.microprofile.context-propagation Name: microprofile-context-propagation-api Version: 1.3
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://microprofile.io
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1549,320 +1100,311 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 --------------------------------------------------------------------------------
 
 Group: org.hdrhistogram Name: HdrHistogram Version: 2.2.2
-Project URL (from POM): http://hdrhistogram.github.io/HdrHistogram/
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+Project URL: http://hdrhistogram.github.io/HdrHistogram/
+License: BSD 2-Clause
+| The code in this repository code was Written by Gil Tene, Michael Barker,
+| and Matt Warren, and released to the public domain, as explained at
+| http://creativecommons.org/publicdomain/zero/1.0/
+|
+| For users of this code who wish to consume it under the "BSD" license
+| rather than under the public domain or CC0 contribution text mentioned
+| above, the code found under this directory is *also* provided under the
+| following license (commonly referred to as the BSD 2-Clause License). This
+| license does not detract from the above stated release of the code into
+| the public domain, and simply represents an additional license granted by
+| the Author.
+|
+| -----------------------------------------------------------------------------
+| ** Beginning of "BSD 2-Clause License" text. **
+|
+|  Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+|  Copyright (c) 2014 Michael Barker
+|  Copyright (c) 2014 Matt Warren
+|  All rights reserved.
+|
+|  Redistribution and use in source and binary forms, with or without
+|  modification, are permitted provided that the following conditions are met:
+|
+|  1. Redistributions of source code must retain the above copyright notice,
+|     this list of conditions and the following disclaimer.
+|
+|  2. Redistributions in binary form must reproduce the above copyright notice,
+|     this list of conditions and the following disclaimer in the documentation
+|     and/or other materials provided with the distribution.
+|
+|  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+|  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+|  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+|  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+|  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+|  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+|  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+|  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+|  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+|  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+|  THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.javassist Name: javassist Version: 3.28.0-GA
-Project URL (from POM): http://www.javassist.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://www.javassist.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jboss.invocation Name: jboss-invocation Version: 2.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss Name: jboss-transaction-spi Version: 8.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.logging Name: jboss-logging-annotations Version: 3.0.4.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.narayana.jta Name: narayana-jta Version: 7.2.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.jboss.narayana.jta Name: narayana-jts-integration Version: 7.2.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
+Group: org.jboss.narayana.jts Name: narayana-jts-integration Version: 7.2.1.Final
 Group: org.jboss.slf4j Name: slf4j-jboss-logmanager Version: 2.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.threads Name: jboss-threads Version: 3.8.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
+Project URL: http://www.jboss.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jctools Name: jctools-core Version: 4.0.5
 Project URL: https://github.com/JCTools/JCTools
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jspecify Name: jspecify Version: 1.0.0
-Project URL (from POM): http://jspecify.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://jspecify.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.latencyutils Name: LatencyUtils Version: 2.0.3
-Project URL (from POM): http://latencyutils.github.io/LatencyUtils/
-License (from POM): Public Domain, per Creative Commons CC0 - http://creativecommons.org/publicdomain/zero/1.0/
+Project URL: http://latencyutils.github.io/LatencyUtils/
+License: BSD 2-Clause
+|   * This code was Written by Gil Tene of Azul Systems, and released to the
+|   * public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+|
+|  For users of this code who wish to consume it under the "BSD" license
+|  rather than under the public domain or CC0 contribution text mentioned
+|  above, the code found under this directory is *also* provided under the
+|  following license (commonly referred to as the BSD 2-Clause License). This
+|  license does not detract from the above stated release of the code into
+|  the public domain, and simply represents an additional license granted by
+|  the Author.
+|
+|  -----------------------------------------------------------------------------
+|  ** Beginning of "BSD 2-Clause License" text. **
+|
+|   Copyright (c) 2012, 2013, 2014 Gil Tene
+|   All rights reserved.
+|
+|   Redistribution and use in source and binary forms, with or without
+|   modification, are permitted provided that the following conditions are met:
+|
+|   1. Redistributions of source code must retain the above copyright notice,
+|      this list of conditions and the following disclaimer.
+|
+|   2. Redistributions in binary form must reproduce the above copyright notice,
+|      this list of conditions and the following disclaimer in the documentation
+|      and/or other materials provided with the distribution.
+|
+|   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+|   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+|   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+|   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+|   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+|   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+|   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+|   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+|   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+|   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+|   THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.ow2.asm Name: asm Version: 9.7.1
-Project URL (from POM): http://asm.ow2.io/
-License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+Project URL: http://asm.ow2.io/
+License: BSD 3-Clause
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.postgresql Name: postgresql Version: 42.7.5
 Project URL: https://jdbc.postgresql.org/
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+License: BSD 2-Clause
+| Copyright (c) 1997, PostgreSQL Global Development Group All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+|
+|   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+|   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+|      in the documentation and/or other materials provided with the distribution.
+|
+| This Software Is Provided By The Copyright Holders And Contributors “as Is” And Any Express Or Implied Warranties, Including, But
+| Not Limited To, The Implied Warranties Of Merchantability And Fitness For A Particular Purpose Are Disclaimed. In No Event Shall
+| The Copyright Owner Or Contributors Be Liable For Any Direct, Indirect, Incidental, Special, Exemplary, Or Consequential Damages
+| (including, But Not Limited To, Procurement Of Substitute Goods Or Services; Loss Of Use, Data, Or Profits; Or Business
+| Interruption) However Caused And On Any Theory Of Liability, Whether In Contract, Strict Liability, Or Tort (including Negligence Or
+| Otherwise) Arising In Any Way Out Of The Use Of This Software, Even If Advised Of The Possibility Of Such Damage.
 
 --------------------------------------------------------------------------------
 
 Group: org.reactivestreams Name: reactive-streams Version: 1.0.4
-Project URL (from POM): http://www.reactive-streams.org/
-License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+Project URL: http://www.reactive-streams.org/
+License: MIT License
+| MIT No Attribution
+|
+| Copyright 2014 Reactive Streams
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.reflections Name: reflections Version: 0.10.2
-Project URL (from POM): http://github.com/ronmamo/reflections
-License (from POM): WTFPL - http://www.wtfpl.net
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://github.com/ronmamo/reflections
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.roaringbitmap Name: RoaringBitmap Version: 1.3.0
-Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/RoaringBitmap/RoaringBitmap
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.slf4j Name: slf4j-api Version: 2.0.6
-Project URL (from POM): http://www.slf4j.org
-License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+Project URL: http://www.slf4j.org
+License: MIT License
+| Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+| All rights reserved.
+|
+| Permission is hereby granted, free  of charge, to any person obtaining
+| a  copy  of this  software  and  associated  documentation files  (the
+| "Software"), to  deal in  the Software without  restriction, including
+| without limitation  the rights to  use, copy, modify,  merge, publish,
+| distribute,  sublicense, and/or sell  copies of  the Software,  and to
+| permit persons to whom the Software  is furnished to do so, subject to
+| the following conditions:
+|
+| The  above  copyright  notice  and  this permission  notice  shall  be
+| included in all copies or substantial portions of the Software.
+|
+| THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+| EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+| MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+| NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+| LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+| OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+| WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.threeten Name: threetenbp Version: 1.7.0
-Project URL (from POM): https://www.threeten.org/threetenbp
-License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
-Project URL (from POM): https://www.jboss.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://www.threeten.org/threetenbp
+License: BSD 3-Clause
+| Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+|
+| All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+|
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.yaml Name: snakeyaml Version: 2.4
-Project URL (from POM): https://bitbucket.org/snakeyaml/snakeyaml
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/snakeyaml/snakeyaml
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: annotations Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: arns Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: auth Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: checksums Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: profiles Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: regions Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: retries Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: s3 Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: sts Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: utils Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: software.amazon.awssdk Name: annotations Version: 2.31.40
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.40
+Group: software.amazon.awssdk Name: arns Version: 2.31.40
+Group: software.amazon.awssdk Name: auth Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.40
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.40
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.40
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.40
+Group: software.amazon.awssdk Name: profiles Version: 2.31.40
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.40
+Group: software.amazon.awssdk Name: regions Version: 2.31.40
+Group: software.amazon.awssdk Name: retries Version: 2.31.40
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: s3 Version: 2.31.40
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.40
+Group: software.amazon.awssdk Name: sts Version: 2.31.40
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.40
+Group: software.amazon.awssdk Name: utils Version: 2.31.40
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
-Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/awslabs/aws-eventstream-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------

--- a/quarkus/admin/distribution/NOTICE
+++ b/quarkus/admin/distribution/NOTICE
@@ -13,7 +13,7 @@ This binary artifact bundles the following projects with NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: info.picocli Name: picocli Name: 4.7.7
+Group: info.picocli Name: picocli Version: 4.7.7
 
 NOTICE:
 | This project includes one or more documentation files from OpenJDK, licensed under GPL v2 with Classpath Exception.
@@ -1163,36 +1163,36 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.30
-Group: software.amazon.awssdk Name: arns Version: 2.31.30
-Group: software.amazon.awssdk Name: auth Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.30
-Group: software.amazon.awssdk Name: checksums Version: 2.31.30
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.30
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.30
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.30
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.30
-Group: software.amazon.awssdk Name: profiles Version: 2.31.30
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.30
-Group: software.amazon.awssdk Name: regions Version: 2.31.30
-Group: software.amazon.awssdk Name: retries Version: 2.31.30
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: s3 Version: 2.31.30
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.30
-Group: software.amazon.awssdk Name: sts Version: 2.31.30
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.30
-Group: software.amazon.awssdk Name: utils Version: 2.31.30
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.40
+Group: software.amazon.awssdk Name: arns Version: 2.31.40
+Group: software.amazon.awssdk Name: auth Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.40
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.40
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.40
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.40
+Group: software.amazon.awssdk Name: profiles Version: 2.31.40
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.40
+Group: software.amazon.awssdk Name: regions Version: 2.31.40
+Group: software.amazon.awssdk Name: retries Version: 2.31.40
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: s3 Version: 2.31.40
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.40
+Group: software.amazon.awssdk Name: sts Version: 2.31.40
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.40
+Group: software.amazon.awssdk Name: utils Version: 2.31.40
 
 NOTICE:
 | AWS SDK for Java

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -206,88 +206,149 @@ This binary artifact bundles the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: io.github.crac Name: org.crac Version: 0.1.3
-Project URL (from POM): https://github.com/crac/org.crac
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+Group: io.github.crac Name: org-crac Version: 0.1.3
+Project URL: https://github.com/crac/org.crac
+License: BSD 2-Clause
+| Copyright 2017-2022 Azul Systems, Inc.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| 1. Redistributions of source code must retain the above copyright notice,
+| this list of conditions and the following disclaimer.
+| 
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+| this list of conditions and the following disclaimer in the documentation
+| and/or other materials provided with the distribution.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+| POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: io.quarkus Name: quarkus-bootstrap-runner Version: 3.21.4
-Project URL: https://quarkus.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.quarkus Name: quarkus-classloader-commons Version: 3.21.4
-Project URL: https://quarkus.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.quarkus Name: quarkus-development-mode-spi Version: 3.21.4
-Project URL: https://quarkus.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.quarkus Name: quarkus-vertx-latebound-mdc-provider Version: 3.21.4
+Group: io.quarkus.arc Name: arc Version: 3.21.4
+Group: io.quarkus Name: quarkus-agroal Version: 3.21.4
+Group: io.quarkus Name: quarkus-arc Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image-docker Version: 3.21.4
+Group: io.quarkus Name: quarkus-container-image-docker-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-core Version: 3.21.4
+Group: io.quarkus Name: quarkus-credentials Version: 3.21.4
+Group: io.quarkus Name: quarkus-datasource Version: 3.21.4
+Group: io.quarkus Name: quarkus-datasource-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
+Group: io.quarkus Name: quarkus-grpc-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-hibernate-validator Version: 3.21.4
+Group: io.quarkus Name: quarkus-jackson Version: 3.21.4
+Group: io.quarkus Name: quarkus-jdbc-postgresql Version: 3.21.4
+Group: io.quarkus Name: quarkus-jsonp Version: 3.21.4
+Group: io.quarkus Name: quarkus-logging-json Version: 3.21.4
+Group: io.quarkus Name: quarkus-micrometer Version: 3.21.4
+Group: io.quarkus Name: quarkus-micrometer-registry-prometheus Version: 3.21.4
+Group: io.quarkus Name: quarkus-mutiny Version: 3.21.4
+Group: io.quarkus Name: quarkus-narayana-jta Version: 3.21.4
+Group: io.quarkus Name: quarkus-netty Version: 3.21.4
+Group: io.quarkus Name: quarkus-oidc Version: 3.21.4
+Group: io.quarkus Name: quarkus-oidc-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-opentelemetry Version: 3.21.4
+Group: io.quarkus Name: quarkus-reactive-routes Version: 3.21.4
+Group: io.quarkus Name: quarkus-rest Version: 3.21.4
+Group: io.quarkus Name: quarkus-rest-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-rest-jackson Version: 3.21.4
+Group: io.quarkus Name: quarkus-rest-jackson-common Version: 3.21.4
+Group: io.quarkus Name: quarkus-security Version: 3.21.4
+Group: io.quarkus Name: quarkus-security-runtime-spi Version: 3.21.4
+Group: io.quarkus Name: quarkus-smallrye-context-propagation Version: 3.21.4
+Group: io.quarkus Name: quarkus-smallrye-fault-tolerance Version: 3.21.4
+Group: io.quarkus Name: quarkus-smallrye-health Version: 3.21.4
+Group: io.quarkus Name: quarkus-smallrye-jwt-build Version: 3.21.4
+Group: io.quarkus Name: quarkus-tls-registry Version: 3.21.4
+Group: io.quarkus Name: quarkus-tls-registry-spi Version: 3.21.4
+Group: io.quarkus Name: quarkus-transaction-annotations Version: 3.21.4
+Group: io.quarkus Name: quarkus-vertx Version: 3.21.4
+Group: io.quarkus Name: quarkus-vertx-http Version: 3.21.4
+Group: io.quarkus Name: quarkus-virtual-threads Version: 3.21.4
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive Version: 3.21.4
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common Version: 3.21.4
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common-types Version: 3.21.4
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-jackson Version: 3.21.4
+Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-vertx Version: 3.21.4
+Group: io.quarkus.security Name: quarkus-security Version: 2.2.1
+Group: io.quarkus.vertx.utils Name: quarkus-vertx-utils Version: 3.21.4
 Project URL: https://quarkus.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.smallrye.common Name: smallrye-common-constraint Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-cpu Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-expression Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-function Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-io Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-net Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-os Version: 2.12.0
-Project URL: https://smallrye.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.smallrye.common Name: smallrye-common-ref Version: 2.12.0
+Group: io.smallrye.certs Name: smallrye-private-key-pem-parser Version: 0.9.2
+Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.12.0
+Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.12.0
+Group: io.smallrye.common Name: smallrye-common-vertx-context Version: 2.12.0
+Group: io.smallrye.config Name: smallrye-config Version: 3.12.4
+Group: io.smallrye.config Name: smallrye-config-common Version: 3.12.4
+Group: io.smallrye.config Name: smallrye-config-core Version: 3.12.4
+Group: io.smallrye.config Name: smallrye-config-validator Version: 3.12.4
+Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
+Group: io.smallrye.reactive Name: mutiny-smallrye-context-propagation Version: 2.8.0
+Group: io.smallrye.reactive Name: mutiny-zero-flow-adapters Version: 1.1.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-auth-common Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-bridge-common Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-core Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-runtime Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-uri-template Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web-client Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web-common Version: 3.18.1
+Group: io.smallrye.reactive Name: smallrye-reactive-converter-api Version: 3.0.3
+Group: io.smallrye.reactive Name: smallrye-reactive-converter-mutiny Version: 3.0.3
+Group: io.smallrye.reactive Name: vertx-mutiny-generator Version: 3.18.1
+Group: io.smallrye Name: smallrye-context-propagation Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-api Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-jta Version: 2.2.1
+Group: io.smallrye Name: smallrye-context-propagation-storage Version: 2.2.1
+Group: io.smallrye Name: smallrye-fault-tolerance Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-api Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-apiimpl Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-autoconfig-core Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-context-propagation Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-core Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-vertx Version: 6.9.1
+Group: io.smallrye Name: smallrye-fault-tolerance-mutiny Version: 6.9.1
+Group: io.smallrye Name: smallrye-health Version: 4.2.0
+Group: io.smallrye Name: smallrye-health-api Version: 4.2.0
+Group: io.smallrye Name: smallrye-health-provided-checks Version: 4.2.0
+Group: io.smallrye Name: smallrye-jwt Version: 4.6.1
+Group: io.smallrye Name: smallrye-jwt-build Version: 4.6.1
+Group: io.smallrye Name: smallrye-jwt-common Version: 4.6.1
 Project URL: https://smallrye.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.json Name: jakarta.json-api Version: 2.1.3
-Project URL (from POM): https://github.com/eclipse-ee4j/jsonp
-License (from POM): Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
-License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://projects.eclipse.org/license/secondary-gpl-2.0-cp
+Project URL: https://github.com/eclipse-ee4j/jsonp
+License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
 
 --------------------------------------------------------------------------------
 
@@ -298,23 +359,13 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 --------------------------------------------------------------------------------
 
 Group: org.jboss.logging Name: jboss-logging Version: 3.6.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.logmanager Name: jboss-logmanager Version: 3.1.2.Final
 Project URL: http://www.jboss.org
-License (from POM): Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
+License: Apache License 2.0 - https://repository.jboss.org/licenses/apache-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.aayushatharva.brotli4j Name: brotli4j Version: 1.16.0
-Project URL: https://github.com/hyperxpro/Brotli4j
-License: Apache License 2.0 - https://github.com/hyperxpro/Brotli4j/blob/v1.16.0/LICENSE
-
---------------------------------------------------------------------------------
-
 Group: com.aayushatharva.brotli4j Name: service Version: 1.16.0
 Project URL: https://github.com/hyperxpro/Brotli4j
 License: Apache License 2.0 - https://github.com/hyperxpro/Brotli4j/blob/v1.16.0/LICENSE
@@ -322,485 +373,559 @@ License: Apache License 2.0 - https://github.com/hyperxpro/Brotli4j/blob/v1.16.0
 --------------------------------------------------------------------------------
 
 Group: com.auth0 Name: java-jwt Version: 4.5.0
-Project URL (from POM): https://github.com/auth0/java-jwt
-License (from POM): The MIT License (MIT) - https://raw.githubusercontent.com/auth0/java-jwt/master/LICENSE
+Project URL: https://github.com/auth0/java-jwt
+License: MIT License
+| The MIT License (MIT)
+|  
+| Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
+|  
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|  
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|  
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: com.azure Name: azure-core Version: 1.55.3
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-core-http-netty Version: 1.15.11
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-identity Version: 1.15.4
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-json Version: 1.5.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-blob Version: 12.30.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-common Version: 12.29.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-file-datalake Version: 12.23.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-storage-internal-avro Version: 12.15.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure Name: azure-xml Version: 1.2.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+Project URL: https://github.com/Azure/azure-sdk-for-java
+License: MIT License
+| The MIT License (MIT)
+| 
+| Copyright (c) 2015 Microsoft
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml Name: classmate Version: 1.7.0
-Project URL (from POM): https://github.com/FasterXML/java-classmate
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/FasterXML/java-classmate
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.dataformat Name: jackson-dataformat-yaml Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jdk8 Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.datatype Name: jackson-datatype-jsr310 Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.fasterxml.jackson.module Name: jackson-module-parameter-names Version: 2.18.2
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/FasterXML/jackson
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml.woodstox Name: woodstox-core Version: 7.1.0
-Project URL (from POM): https://github.com/FasterXML/woodstox
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/FasterXML/woodstox
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
-Project URL (from POM): https://github.com/ben-manes/caffeine
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/ben-manes/caffeine
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.github.stephenc.jcip Name: jcip-annotations Version: 1.0-1
-Project URL (from POM): http://stephenc.github.com/jcip-annotations
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://stephenc.github.com/jcip-annotations
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.android Name: annotations Version: 4.1.1.4
-Project URL (from POM): http://source.android.com/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://source.android.com/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.api-client Name: google-api-client Version: 2.7.2
-Project URL (from POM): https://github.com/googleapis/google-api-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-api-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: api-common Version: 2.47.1
-Project URL (from POM): https://github.com/googleapis/api-common-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+Group: com.google.api Name: api-common Version: 2.48.0
+Project URL: https://github.com/googleapis/api-common-java
+License: BSD 3-Clause
+| Copyright 2016, Google Inc.
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: gax Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+Group: com.google.api Name: gax Version: 2.65.0
+Group: com.google.api Name: gax-grpc Version: 2.65.0
+Group: com.google.api Name: gax-httpjson Version: 2.65.0
+Project URL: https://github.com/googleapis/gax-java
+License: BSD 3-Clause
+| Copyright 2016, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api Name: gax-grpc Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api Name: gax-httpjson Version: 2.64.1
-Project URL (from POM): https://github.com/googleapis/gax-java
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
+Group: com.google.api.grpc Name: gapic-google-cloud-storage-v2 Version: 2.52.2
+Group: com.google.api.grpc Name: grpc-google-cloud-storage-v2 Version: 2.52.2
 Group: com.google.api.grpc Name: proto-google-cloud-monitoring-v3 Version: 3.52.0
-Project URL (from POM): https://github.com/googleapis/google-cloud-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.52.2
+Group: com.google.cloud Name: google-cloud-storage Version: 2.52.2
+Project URL: https://github.com/googleapis/java-storage
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc Name: proto-google-cloud-storage-v2 Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250424-2.0.0
+Project URL: http://www.google.com
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc Name: proto-google-common-protos Version: 2.53.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.50.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.apis Name: google-api-services-storage Version: v1-rev20250312-2.0.0
-Project URL (from POM): http://www.google.com
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth Name: google-auth-library-credentials Version: 1.33.1
-Project URL (from POM): https://github.com/googleapis/google-auth-library-java
-License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.33.1
-Project URL (from POM): https://github.com/googleapis/google-auth-library-java
-License (from POM): BSD-3-Clause - http://opensource.org/licenses/BSD-3-Clause
+Group: com.google.auth Name: google-auth-library-credentials Version: 1.34.0
+Group: com.google.auth Name: google-auth-library-oauth2-http Version: 1.34.0
+Project URL: https://github.com/googleapis/google-auth-library-java
+License: BSD 3-Clause
+| Copyright 2014, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+| 
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: com.google.auto.value Name: auto-value-annotations Version: 1.11.0
-Project URL (from POM): https://github.com/google/auto
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/auto
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud Name: google-cloud-core Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-core-http Version: 2.54.1
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.api.grpc Name: proto-google-common-protos Version: 2.53.0
+Group: com.google.api.grpc Name: proto-google-iam-v1 Version: 1.51.0
+Project URL: https://github.com/googleapis/sdk-platform-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.cloud Name: google-cloud-monitoring Version: 3.52.0
-Project URL (from POM): https://github.com/googleapis/google-cloud-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud Name: google-cloud-storage Version: 2.51.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: com.google.cloud Name: google-cloud-core Version: 2.55.0
+Group: com.google.cloud Name: google-cloud-core-grpc Version: 2.55.0
+Group: com.google.cloud Name: google-cloud-core-http Version: 2.55.0
+Project URL: https://github.com/googleapis/google-cloud-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.cloud.opentelemetry Name: detector-resources-support Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.cloud.opentelemetry Name: exporter-metrics Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.cloud.opentelemetry Name: shared-resourcemapping Version: 0.33.0
-Project URL (from POM): https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.code.gson Name: gson Version: 2.12.1
-Project URL (from POM): https://github.com/google/gson
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/gson
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.errorprone Name: error_prone_annotations Version: 2.36.0
-Project URL (from POM): https://errorprone.info
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://errorprone.info
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.guava Name: failureaccess Version: 1.0.1
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.guava Name: guava Version: 33.4.8-jre
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.guava Name: listenablefuture Version: 9999.0-empty-to-avoid-conflict-with-guava
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/guava
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.http-client Name: google-http-client Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-apache-v2 Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-appengine Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-gson Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.google.http-client Name: google-http-client-jackson2 Version: 1.46.3
-Project URL (from POM): https://github.com/googleapis/google-http-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-http-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.j2objc Name: j2objc-annotations Version: 2.8
-Project URL (from POM): https://github.com/google/j2objc/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/google/j2objc/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.oauth-client Name: google-oauth-client Version: 1.37.0
-Project URL (from POM): https://github.com/googleapis/google-oauth-java-client
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/googleapis/google-oauth-java-client
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.google.protobuf Name: protobuf-java Version: 3.25.5
-Project URL (from POM): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
 Group: com.google.protobuf Name: protobuf-java-util Version: 3.25.5
-Project URL (from POM): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+Project URL: https://developers.google.com/protocol-buffers/
+License: BSD 3-Clause
+| Copyright 2008 Google Inc.  All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| 
+| Code generated by the Protocol Buffer compiler is owned by the owner
+| of the input file used when generating it.  This code is not
+| standalone and requires a support library to be linked with it.  This
+| support library is itself covered by the above license.
 
 --------------------------------------------------------------------------------
 
 Group: com.google.re2j Name: re2j Version: 1.7
-Project URL (from POM): http://github.com/google/re2j
-License (from POM): Go License - https://golang.org/LICENSE
+Project URL: http://github.com/google/re2j
+License: Go License
+| This is a work derived from Russ Cox's RE2 in Go, whose license
+| http://golang.org/LICENSE is as follows:
+| 
+| Copyright (c) 2009 The Go Authors. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+|      notice, this list of conditions and the following disclaimer.
+| 
+|    * Redistributions in binary form must reproduce the above copyright
+|      notice, this list of conditions and the following disclaimer in
+|      the documentation and/or other materials provided with the
+|      distribution.
+| 
+|    * Neither the name of Google Inc. nor the names of its contributors
+|      may be used to endorse or promote products derived from this
+|      software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: com.jcraft Name: jsch Version: 0.1.55
-Project URL (from POM): http://www.jcraft.com/jsch/
-License (from POM): BSD License - http://www.jcraft.com/jsch/LICENSE.txt
+Project URL: http://www.jcraft.com/jsch/
+License: BSD License
+| Copyright (c) 2002-2015 Atsuhiko Yamanaka, JCraft,Inc. 
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+|   1. Redistributions of source code must retain the above copyright notice,
+|      this list of conditions and the following disclaimer.
+| 
+|   2. Redistributions in binary form must reproduce the above copyright 
+|      notice, this list of conditions and the following disclaimer in 
+|      the documentation and/or other materials provided with the distribution.
+| 
+|   3. The names of the authors may not be used to endorse or promote products
+|      derived from this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+| INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+| FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+| INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+| INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+| OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+| EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: com.microsoft.azure Name: msal4j Version: 1.19.1
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
-
---------------------------------------------------------------------------------
-
 Group: com.microsoft.azure Name: msal4j-persistence-extension Version: 1.3.0
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
+Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
+License: MIT License
+|     MIT License
+| 
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+| 
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+| 
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+| 
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: content-type Version: 2.3
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-content-type
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: lang-tag Version: 1.7
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: nimbus-jose-jwt Version: 10.0.2
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds Name: oauth2-oidc-sdk Version: 11.23
-Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.sun.xml.bind Name: jaxb-core Version: 4.0.5
-Project URL (from POM): https://github.com/eclipse-ee4j/jaxb-ri
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: com.sun.xml.bind Name: jaxb-xjc Version: 4.0.5
-Project URL (from POM): https://github.com/eclipse-ee4j/jaxb-ri
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/eclipse-ee4j/jaxb-ri
+License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: commons-beanutils Name: commons-beanutils Version: 1.9.4
-Project URL (from POM): https://commons.apache.org/proper/commons-beanutils/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-beanutils/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-cli Name: commons-cli Version: 1.5.0
-Project URL (from POM): https://commons.apache.org/proper/commons-cli/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-cli/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-codec Name: commons-codec Version: 1.18.0
-Project URL (from POM): https://commons.apache.org/proper/commons-codec/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-codec/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-collections Name: commons-collections Version: 3.2.2
-Project URL (from POM): http://commons.apache.org/collections/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://commons.apache.org/collections/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-io Name: commons-io Version: 2.18.0
-Project URL (from POM): https://commons.apache.org/proper/commons-io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: commons-logging Name: commons-logging Version: 1.3.2
-Project URL (from POM): https://commons.apache.org/proper/commons-logging/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: commons-logging Name: commons-logging Version: 1.3.5
+Project URL: https://commons.apache.org/proper/commons-logging/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-net Name: commons-net Version: 3.9.0
-Project URL (from POM): https://commons.apache.org/proper/commons-net/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-net/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: dev.failsafe Name: failsafe Version: 3.3.2
-Project URL (from POM): https://failsafe.dev
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://failsafe.dev
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: dnsjava Name: dnsjava Version: 3.6.1
-Project URL (from POM): https://github.com/dnsjava/dnsjava
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+Project URL: https://github.com/dnsjava/dnsjava
+License: BSD 3-Clause
+| Copyright (c) 1998-2019, Brian Wellington
+| Copyright (c) 2005 VeriSign. All rights reserved.
+| Copyright (c) 2019-2023, dnsjava authors
+| 
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| 1. Redistributions of source code must retain the above copyright notice, this
+|    list of conditions and the following disclaimer.
+| 
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+|    this list of conditions and the following disclaimer in the documentation
+|    and/or other materials provided with the distribution.
+| 
+| 3. Neither the name of the copyright holder nor the names of its
+|    contributors may be used to endorse or promote products derived from
+|    this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+| DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+| SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+| CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+| OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------`
 
 Group: io.agroal Name: agroal-api Version: 2.6
-Project URL: https://agroal.github.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.agroal Name: agroal-narayana Version: 2.6
-Project URL: https://agroal.github.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.agroal Name: agroal-pool Version: 2.6
 Project URL: https://agroal.github.io/
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -808,1443 +933,388 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 --------------------------------------------------------------------------------
 
 Group: io.airlift Name: aircompressor Version: 2.0.2
-Project URL (from POM): https://github.com/airlift/aircompressor
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/airlift/aircompressor
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.grpc Name: grpc-alts Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-api Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-auth Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-context Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-core Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-googleapis Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-grpclb Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-inprocess Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-netty Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-netty-shaded Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-opentelemetry Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-protobuf Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-protobuf-lite Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-rls Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-services Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-stub Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-util Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.grpc Name: grpc-xds Version: 1.69.1
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/grpc/grpc-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.6
-Project URL (from POM): https://github.com/micrometer-metrics/micrometer
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/micrometer-metrics/micrometer
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.netty Name: netty-buffer Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-dns Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-haproxy Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-http Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-http2 Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-codec-socks Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-common Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-handler Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-handler-proxy Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns-classes-macos Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-resolver-dns-native-macos Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-tcnative-boringssl-static Version: 2.0.70.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-tcnative-classes Version: 2.0.70.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-classes-epoll Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-classes-kqueue Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-epoll Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-kqueue Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.netty Name: netty-transport-native-unix-common Version: 4.1.119.Final
-Project URL (from POM): https://netty.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://netty.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opencensus Name: opencensus-api Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opencensus Name: opencensus-contrib-http-util Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/census-instrumentation/opencensus-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-contrib
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/opentelemetry-java-contrib
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-annotations Version: 2.10.0
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-annotations-support Version: 2.10.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-api Version: 2.10.0
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.instrumentation Name: opentelemetry-instrumentation-api-incubator Version: 2.10.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.instrumentation Name: opentelemetry-runtime-telemetry-java17 Version: 2.10.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.instrumentation Name: opentelemetry-runtime-telemetry-java8 Version: 2.10.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java-instrumentation
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/opentelemetry-java-instrumentation
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry Name: opentelemetry-api Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-api-incubator Version: 1.44.1-alpha
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-context Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-exporter-common Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-exporter-otlp Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-exporter-otlp-common Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-exporter-sender-okhttp Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-common Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-logs Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry Name: opentelemetry-sdk-trace Version: 1.44.1
-Project URL (from POM): https://github.com/open-telemetry/opentelemetry-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/opentelemetry-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.28.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.opentelemetry.semconv Name: opentelemetry-semconv-incubating Version: 1.29.0-alpha
-Project URL (from POM): https://github.com/open-telemetry/semantic-conventions-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/open-telemetry/semantic-conventions-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.perfmark Name: perfmark-api Version: 0.27.0
-Project URL (from POM): https://github.com/perfmark/perfmark
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/perfmark/perfmark
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.5
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.5
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/reactor/reactor-netty
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.projectreactor Name: reactor-core Version: 3.7.5
-Project URL (from POM): https://github.com/reactor/reactor-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/reactor/reactor-core
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.prometheus Name: simpleclient Version: 0.16.0
-Project URL (from POM): http://github.com/prometheus/client_java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.prometheus Name: simpleclient_common Version: 0.16.0
-Project URL (from POM): http://github.com/prometheus/client_java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.prometheus Name: simpleclient_tracer_common Version: 0.16.0
-Project URL (from POM): http://github.com/prometheus/client_java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.prometheus Name: simpleclient_tracer_otel Version: 0.16.0
-Project URL (from POM): http://github.com/prometheus/client_java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.prometheus Name: simpleclient_tracer_otel_agent Version: 0.16.0
-Project URL (from POM): http://github.com/prometheus/client_java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.arc Name: arc Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-agroal Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-arc Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image-docker Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-container-image-docker-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-core Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-credentials Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-datasource Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-datasource-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-fs-util Version: 0.0.10
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-grpc-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-hibernate-validator Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-jackson Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-jdbc-postgresql Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-jsonp Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-logging-json Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-micrometer Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-micrometer-registry-prometheus Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-mutiny Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-narayana Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-netty Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-oidc Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-oidc-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-opentelemetry Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-reactive-routes Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-rest Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-rest-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-rest-jackson Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-rest-jackson-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-security Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-security-runtime-spi Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-smallrye-context-propagation Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-smallrye-fault-tolerance Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-smallrye-health Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-smallrye-jwt-build Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-tls-registry Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-tls-registry-spi Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-transaction-annotations Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-vertx Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-vertx-http Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus Name: quarkus-virtual-threads Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.resteasy Name: reactive.resteasy-reactive Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-common-types Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-jackson Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.resteasy.reactive Name: resteasy-reactive-vertx Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.security Name: quarkus-security Version: 2.2.1
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.quarkus.vertx.utils Name: quarkus-vertx-utils Version: 3.21.4
-Project URL (from POM): https://quarkus.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.certs Name: smallrye-private-key-pem-parser Version: 0.9.2
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.common Name: smallrye-common-annotation Version: 2.12.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.common Name: smallrye-common-classloader Version: 2.12.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.common Name: smallrye-common-vertx-context Version: 2.12.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config-common Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config-core Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.config Name: smallrye-config-validator Version: 3.12.4
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny Version: 2.8.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny-smallrye-context-propagation Version: 2.8.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: mutiny-zero-flow-adapters Version: 1.1.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-auth-common Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-bridge-common Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-core Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-runtime Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-uri-template Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web-client Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: smallrye-mutiny-vertx-web-common Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye.reactive Name: vertx-mutiny-generator Version: 3.18.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-api Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-jta Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-context-propagation-storage Version: 2.2.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-api Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-apiimpl Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-autoconfig-core Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-context-propagation Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-core Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-vertx Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-fault-tolerance-mutiny Version: 6.9.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-health Version: 4.2.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-health-api Version: 4.2.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-health-provided-checks Version: 4.2.0
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-jwt Version: 4.6.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-jwt-build Version: 4.6.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.smallrye Name: smallrye-jwt-common Version: 4.6.1
-Project URL (from POM): https://smallrye.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://github.com/prometheus/client_java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.swagger Name: swagger-annotations Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-core Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-jaxrs Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: io.swagger Name: swagger-models Version: 1.6.15
-Project URL (from POM): https://github.com/swagger-api/swagger-core
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/swagger-api/swagger-core
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: io.vertx Name: vertx-auth-common Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-bridge-common Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-codegen Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-core Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-grpc Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-grpc-client Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-grpc-common Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-grpc-server Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-uri-template Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
 Group: io.vertx Name: vertx-web Version: 4.5.14
-Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
-
---------------------------------------------------------------------------------
-
+Group: io.vertx Name: vertx-web-client Version: 4.5.14
 Group: io.vertx Name: vertx-web-common Version: 4.5.14
 Project URL: https://vertx.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - http://www.eclipse.org/legal/epl-v10.html
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.activation Name: jakarta.activation-api Version: 2.1.3
-Project URL (from POM): https://github.com/jakartaee/jaf-api
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/jakartaee/jaf-api
+License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.annotation Name: jakarta.annotation-api Version: 3.0.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.ca
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.ca
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.el Name: jakarta.el-api Version: 5.0.1
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.el
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.el
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.enterprise Name: jakarta.enterprise.cdi-api Version: 4.1.0
-Project URL (from POM): http://cdi-spec.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://cdi-spec.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.enterprise Name: jakarta.enterprise.lang-model Version: 4.1.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://projects.eclipse.org/projects/ee4j
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.inject Name: jakarta.inject-api Version: 2.0.1
-Project URL (from POM): https://github.com/eclipse-ee4j/injection-api
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/eclipse-ee4j/injection-api
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.interceptor Name: jakarta.interceptor-api Version: 2.2.0
-Project URL (from POM): https://github.com/jakartaee/interceptors
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://github.com/jakartaee/interceptors
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.persistence Name: jakarta.persistence-api Version: 3.1.0
-Project URL (from POM): https://github.com/jakartaee/persistence
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+Project URL: https://github.com/jakartaee/persistence
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.servlet Name: jakarta.servlet-api Version: 6.0.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.servlet
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.servlet
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.transaction Name: jakarta.transaction-api Version: 2.0.1
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j.jta
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j.jta
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.validation Name: jakarta.validation-api Version: 3.0.2
-Project URL (from POM): https://beanvalidation.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://beanvalidation.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.ws.rs Name: jakarta.ws.rs-api Version: 3.1.0
-Project URL (from POM): https://github.com/eclipse-ee4j/jaxrs-api
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://github.com/eclipse-ee4j/jaxrs-api
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: jakarta.xml.bind Name: jakarta.xml.bind-api Version: 4.0.2
-Project URL (from POM): https://github.com/jakartaee/jaxb-api
-License (from POM): Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Project URL: https://github.com/jakartaee/jaxb-api
+License: Eclipse Distribution License 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
 
 --------------------------------------------------------------------------------
 
 Group: javax.servlet Name: javax.servlet-api Version: 3.1.0
-Project URL (from POM): http://servlet-spec.java.net
-License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
-
---------------------------------------------------------------------------------
-
 Group: javax.servlet.jsp Name: jsp-api Version: 2.1
-Project URL (from POM): http://servlet-spec.java.net
-License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+Project URL: http://servlet-spec.java.net
+License: CDDL License - http://www.opensource.org/licenses/cddl1.php
 
 --------------------------------------------------------------------------------
 
 Group: javax.validation Name: validation-api Version: 1.1.0.Final
-Project URL (from POM): https://beanvalidation.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://beanvalidation.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: javax.ws.rs Name: jsr311-api Version: 1.1.1
-Project URL (from POM): https://jsr311.dev.java.net
-License (from POM): CDDL License - http://www.opensource.org/licenses/cddl1.php
+Project URL: https://jsr311.dev.java.net
+License: CDDL License - http://www.opensource.org/licenses/cddl1.php
 
 --------------------------------------------------------------------------------
 
 Group: net.java.dev.jna Name: jna Version: 5.8.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
-
---------------------------------------------------------------------------------
-
 Group: net.java.dev.jna Name: jna-platform Version: 5.8.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL, version 2.1 - http://www.gnu.org/licenses/licenses.html
+Project URL: https://github.com/java-native-access/jna
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: net.minidev Name: accessors-smart Version: 2.5.2
-Project URL (from POM): https://urielch.github.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: net.minidev Name: json-smart Version: 2.5.2
-Project URL (from POM): https://urielch.github.io/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://urielch.github.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.avro Name: avro Version: 1.12.0
-Project URL (from POM): https://avro.apache.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://avro.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-compress Version: 1.27.1
-Project URL (from POM): https://commons.apache.org/proper/commons-compress/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-compress/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons Name: commons-configuration2 Version: 2.11.0
-Project URL (from POM): https://commons.apache.org/proper/commons-configuration/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: org.apache.commons Name: commons-configuration2 Version: 2.12.0
+Project URL: https://commons.apache.org/proper/commons-configuration/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-lang3 Version: 3.17.0
-Project URL (from POM): https://commons.apache.org/proper/commons-lang/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-lang/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-math3 Version: 3.6.1
-Project URL (from POM): http://commons.apache.org/proper/commons-math/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://commons.apache.org/proper/commons-math/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.commons Name: commons-text Version: 1.13.1
-Project URL (from POM): https://commons.apache.org/proper/commons-text
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://commons.apache.org/proper/commons-text
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.curator Name: curator-client Version: 5.2.0
-Project URL (from POM): http://curator.apache.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.curator Name: curator-framework Version: 5.2.0
-Project URL (from POM): http://curator.apache.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.curator Name: curator-recipes Version: 5.2.0
-Project URL (from POM): http://curator.apache.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://curator.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.hadoop Name: hadoop-annotations Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop Name: hadoop-auth Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop Name: hadoop-client-api Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop Name: hadoop-client-runtime Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop Name: hadoop-common Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop Name: hadoop-hdfs-client Version: 3.4.1
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hadoop.thirdparty Name: hadoop-shaded-guava Version: 1.3.0
-Project URL (from POM): https://hadoop.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hadoop.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents.client5 Name: httpclient5 Version: 5.4.3
-Project URL (from POM): https://hc.apache.org/httpcomponents-client-5.4.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-client-5.4.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents.core5 Name: httpcore5 Version: 5.3.4
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.httpcomponents.core5 Name: httpcore5-h2 Version: 5.3.4
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-5.3.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-core-5.3.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents Name: httpclient Version: 4.5.14
-Project URL (from POM): https://hc.apache.org/httpcomponents-client-4.5.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-client-4.5.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents Name: httpcore Version: 4.4.16
-Project URL (from POM): https://hc.apache.org/httpcomponents-core-4.4.x/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://hc.apache.org/httpcomponents-core-4.4.x/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.iceberg Name: iceberg-api Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-aws Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-azure Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-bundled-guava Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-common Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-core Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.iceberg Name: iceberg-gcp Version: 1.9.0
-Project URL (from POM): https://iceberg.apache.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://iceberg.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.kerby Name: kerb-core Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerb-crypto Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerb-util Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerby-asn1 Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerby-config Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerby-pkix Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.kerby Name: kerby-util Version: 2.0.3
-Project URL (from POM): https://directory.apache.org/kerby/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://directory.apache.org/kerby/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -2255,38 +1325,131 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 --------------------------------------------------------------------------------
 
 Group: org.bouncycastle Name: bcprov-jdk18on Version: 1.80
-Project URL (from POM): https://www.bouncycastle.org/download/bouncy-castle-java/
-License (from POM): Bouncy Castle Licence - https://www.bouncycastle.org/licence.html
+Project URL: https://www.bouncycastle.org/download/bouncy-castle-java/
+License: MIT License
+| Copyright (c) 2000 - 2024 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.checkerframework Name: checker-qual Version: 3.49.1
-Project URL (from POM): https://checkerframework.org/
-License (from POM): MIT License - http://opensource.org/licenses/MIT
+Project URL: https://checkerframework.org/
+License: MIT License
+| The Checker Framework
+| Copyright 2004-present by the Checker Framework developers
+| 
+| 
+| Most of the Checker Framework is licensed under the GNU General Public
+| License, version 2 (GPL2), with the classpath exception.  The text of this
+| license appears below.  This is the same license used for OpenJDK.
+| 
+| A few parts of the Checker Framework have more permissive licenses, notably
+| the parts that you might want to include with your own program.
+| 
+|  * The annotations and utility files are licensed under the MIT License.
+|    (The text of this license also appears below.)  This applies to
+|    checker-qual*.jar and checker-util.jar and all the files that appear in
+|    them, which is all files in checker-qual and checker-util directories.
+|    It also applies to the cleanroom implementations of
+|    third-party annotations (in checker/src/testannotations/,
+|    framework/src/main/java/org/jmlspecs/, and
+|    framework/src/main/java/com/google/).
+| 
+| The Checker Framework includes annotations for some libraries.  Those in
+| .astub files use the MIT License.  Those in https://github.com/typetools/jdk
+| (which appears in the annotated-jdk directory of file checker.jar) use the
+| GPL2 license.
+| 
+| Some external libraries that are included with the Checker Framework
+| distribution have different licenses.  Here are some examples.
+| 
+|  * JavaParser is dual licensed under the LGPL or the Apache license -- you
+|    may use it under whichever one you want.  (The JavaParser source code
+|    contains a file with the text of the GPL, but it is not clear why, since
+|    JavaParser does not use the GPL.)  See
+|    https://github.com/typetools/stubparser .
+| 
+|  * Annotation Tools (https://github.com/typetools/annotation-tools) uses
+|    the MIT license.
+| 
+|  * Libraries in plume-lib (https://github.com/plume-lib/) are licensed
+|    under the MIT License.
 
 --------------------------------------------------------------------------------
 
 Group: org.codehaus.jettison Name: jettison Version: 1.5.4
-Project URL (from POM): https://github.com/jettison-json/jettison
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/jettison-json/jettison
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.codehaus.mojo Name: animal-sniffer-annotations Version: 1.24
-Project URL (from POM): https://www.mojohaus.org/animal-sniffer
-License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+Project URL: https://www.mojohaus.org/animal-sniffer
+License: MIT license
+| The MIT License
+| 
+| Copyright (c) 2009 codehaus.org.
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
+
 
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.woodstox Name: stax2-api Version: 4.2.1
-Project URL (from POM): http://github.com/FasterXML/stax2-api
-License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
+Group: org.codehaus.woodstox Name: stax2-api Version: 4.2.2
+Project URL: http://github.com/FasterXML/stax2-api
+License: BSD 2-Clause
+| BSD 2-Clause License
+| 
+| Copyright (c) 2008+, FasterXML, LLC
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+| DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+| SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+| CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+| OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.conscrypt Name: conscrypt-openjdk-uber Version: 2.5.2
-Project URL (from POM): https://conscrypt.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://conscrypt.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -2297,89 +1460,27 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 --------------------------------------------------------------------------------
 
 Group: org.eclipse.jetty Name: jetty-http Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-io Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-security Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-server Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-servlet Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-util Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-util-ajax Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-webapp Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.jetty Name: jetty-xml Version: 9.4.53.v20231009
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): Eclipse Public License 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+Project URL: https://eclipse.org/jetty
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.eclipse.microprofile.config Name: microprofile-config-api Version: 3.1
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.microprofile.context-propagation Name: microprofile-context-propagation-api Version: 1.3
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.microprofile.fault-tolerance Name: microprofile-fault-tolerance-api Version: 4.1.1
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.eclipse.microprofile.health Name: microprofile-health-api Version: 4.0.1
-Project URL (from POM): http://microprofile.io
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: org.eclipse.microprofile.jwt Name: microprofile-jwt-auth-api Version: 2.1
+Group: org.eclipse.microprofile.reactive-streams-operators Name: microprofile-reactive-streams-operators-api Version: 3.0.1
+Project URL: http://microprofile.io
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -2390,345 +1491,330 @@ License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2
 --------------------------------------------------------------------------------
 
 Group: org.glassfish.expressly Name: expressly Version: 5.0.0
-Project URL (from POM): https://projects.eclipse.org/projects/ee4j
-License (from POM): EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-License (from POM): GPL2 w/ CPE - https://www.gnu.org/software/classpath/license.html
+Project URL: https://projects.eclipse.org/projects/ee4j
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
 
 --------------------------------------------------------------------------------
 
 Group: org.hdrhistogram Name: HdrHistogram Version: 2.2.2
-Project URL (from POM): http://hdrhistogram.github.io/HdrHistogram/
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+Project URL: http://hdrhistogram.github.io/HdrHistogram/
+License: BSD 2-Clause
+| The code in this repository code was Written by Gil Tene, Michael Barker,
+| and Matt Warren, and released to the public domain, as explained at
+| http://creativecommons.org/publicdomain/zero/1.0/
+| 
+| For users of this code who wish to consume it under the "BSD" license
+| rather than under the public domain or CC0 contribution text mentioned
+| above, the code found under this directory is *also* provided under the
+| following license (commonly referred to as the BSD 2-Clause License). This
+| license does not detract from the above stated release of the code into
+| the public domain, and simply represents an additional license granted by
+| the Author.
+| 
+| -----------------------------------------------------------------------------
+| ** Beginning of "BSD 2-Clause License" text. **
+| 
+|  Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+|  Copyright (c) 2014 Michael Barker
+|  Copyright (c) 2014 Matt Warren
+|  All rights reserved.
+| 
+|  Redistribution and use in source and binary forms, with or without
+|  modification, are permitted provided that the following conditions are met:
+| 
+|  1. Redistributions of source code must retain the above copyright notice,
+|     this list of conditions and the following disclaimer.
+| 
+|  2. Redistributions in binary form must reproduce the above copyright notice,
+|     this list of conditions and the following disclaimer in the documentation
+|     and/or other materials provided with the distribution.
+| 
+|  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+|  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+|  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+|  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+|  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+|  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+|  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+|  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+|  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+|  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+|  THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.hibernate.validator Name: hibernate-validator Version: 8.0.2.Final
-Project URL (from POM): http://hibernate.org/validator
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://hibernate.org/validator
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.javassist Name: javassist Version: 3.28.0-GA
-Project URL (from POM): http://www.javassist.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://www.javassist.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jboss.invocation Name: jboss-invocation Version: 2.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss Name: jboss-transaction-spi Version: 8.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.logging Name: commons-logging-jboss-logging Version: 1.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.logging Name: jboss-logging-annotations Version: 3.0.4.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.narayana.jta Name: narayana-jta Version: 7.2.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.jboss.narayana.jta Name: narayana-jts-integration Version: 7.2.1.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
+Group: org.jboss.narayana.jts Name: narayana-jts-integration Version: 7.2.1.Final
 Group: org.jboss.slf4j Name: slf4j-jboss-logmanager Version: 2.0.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.jboss.threads Name: jboss-threads Version: 3.8.0.Final
-Project URL (from POM): http://www.jboss.org
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
+Project URL: http://www.jboss.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jctools Name: jctools-core Version: 4.0.5
 Project URL: https://github.com/JCTools/JCTools
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.jspecify Name: jspecify Version: 1.0.0
-Project URL (from POM): http://jspecify.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://jspecify.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.latencyutils Name: LatencyUtils Version: 2.0.3
-Project URL (from POM): http://latencyutils.github.io/LatencyUtils/
-License (from POM): Public Domain, per Creative Commons CC0 - http://creativecommons.org/publicdomain/zero/1.0/
+Project URL: http://latencyutils.github.io/LatencyUtils/
+License: BSD 2-Clause
+|   * This code was Written by Gil Tene of Azul Systems, and released to the
+|   * public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+| 
+|  For users of this code who wish to consume it under the "BSD" license
+|  rather than under the public domain or CC0 contribution text mentioned
+|  above, the code found under this directory is *also* provided under the
+|  following license (commonly referred to as the BSD 2-Clause License). This
+|  license does not detract from the above stated release of the code into
+|  the public domain, and simply represents an additional license granted by
+|  the Author.
+| 
+|  -----------------------------------------------------------------------------
+|  ** Beginning of "BSD 2-Clause License" text. **
+| 
+|   Copyright (c) 2012, 2013, 2014 Gil Tene
+|   All rights reserved.
+| 
+|   Redistribution and use in source and binary forms, with or without
+|   modification, are permitted provided that the following conditions are met:
+| 
+|   1. Redistributions of source code must retain the above copyright notice,
+|      this list of conditions and the following disclaimer.
+| 
+|   2. Redistributions in binary form must reproduce the above copyright notice,
+|      this list of conditions and the following disclaimer in the documentation
+|      and/or other materials provided with the distribution.
+| 
+|   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+|   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+|   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+|   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+|   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+|   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+|   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+|   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+|   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+|   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+|   THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.ow2.asm Name: asm Version: 9.7.1
-Project URL (from POM): http://asm.ow2.io/
-License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+Project URL: http://asm.ow2.io/
+License: BSD 3-Clause
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.postgresql Name: postgresql Version: 42.7.5
 Project URL: https://jdbc.postgresql.org/
-License (from POM): BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+License: BSD 2-Clause
+| Copyright (c) 1997, PostgreSQL Global Development Group All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+| 
+|   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+|   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+|      in the documentation and/or other materials provided with the distribution.
+| 
+| This Software Is Provided By The Copyright Holders And Contributors “as Is” And Any Express Or Implied Warranties, Including, But
+| Not Limited To, The Implied Warranties Of Merchantability And Fitness For A Particular Purpose Are Disclaimed. In No Event Shall
+| The Copyright Owner Or Contributors Be Liable For Any Direct, Indirect, Incidental, Special, Exemplary, Or Consequential Damages
+| (including, But Not Limited To, Procurement Of Substitute Goods Or Services; Loss Of Use, Data, Or Profits; Or Business
+| Interruption) However Caused And On Any Theory Of Liability, Whether In Contract, Strict Liability, Or Tort (including Negligence Or 
+| Otherwise) Arising In Any Way Out Of The Use Of This Software, Even If Advised Of The Possibility Of Such Damage.
 
 --------------------------------------------------------------------------------
 
 Group: org.reactivestreams Name: reactive-streams Version: 1.0.4
-Project URL (from POM): http://www.reactive-streams.org/
-License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+Project URL: http://www.reactive-streams.org/
+License: MIT License
+| MIT No Attribution
+| 
+| Copyright 2014 Reactive Streams
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.reflections Name: reflections Version: 0.10.2
-Project URL (from POM): http://github.com/ronmamo/reflections
-License (from POM): WTFPL - http://www.wtfpl.net
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: http://github.com/ronmamo/reflections
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.roaringbitmap Name: RoaringBitmap Version: 1.3.0
-Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/RoaringBitmap/RoaringBitmap
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.slf4j Name: slf4j-api Version: 2.0.6
-Project URL (from POM): http://www.slf4j.org
-License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+Project URL: http://www.slf4j.org
+License: MIT License
+| Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+| All rights reserved.
+| 
+| Permission is hereby granted, free  of charge, to any person obtaining
+| a  copy  of this  software  and  associated  documentation files  (the
+| "Software"), to  deal in  the Software without  restriction, including
+| without limitation  the rights to  use, copy, modify,  merge, publish,
+| distribute,  sublicense, and/or sell  copies of  the Software,  and to
+| permit persons to whom the Software  is furnished to do so, subject to
+| the following conditions:
+| 
+| The  above  copyright  notice  and  this permission  notice  shall  be
+| included in all copies or substantial portions of the Software.
+| 
+| THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+| EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+| MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+| NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+| LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+| OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+| WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
 Group: org.threeten Name: threetenbp Version: 1.7.0
-Project URL (from POM): https://www.threeten.org/threetenbp
-License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: org.wildfly.common Name: wildfly-common Version: 2.0.1
-Project URL (from POM): https://www.jboss.org/
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://www.threeten.org/threetenbp
+License: BSD 3-Clause
+| Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+| 
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+| 
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
 Group: org.xerial.snappy Name: snappy-java Version: 1.1.10.5
-Project URL (from POM): https://github.com/xerial/snappy-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/xerial/snappy-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.yaml Name: snakeyaml Version: 2.4
-Project URL (from POM): https://bitbucket.org/snakeyaml/snakeyaml
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://bitbucket.org/snakeyaml/snakeyaml
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: annotations Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: arns Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: auth Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: checksums Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: profiles Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: regions Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: retries Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: s3 Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: sts Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk Name: utils Version: 2.31.30
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Group: software.amazon.awssdk Name: annotations Version: 2.31.40
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.40
+Group: software.amazon.awssdk Name: arns Version: 2.31.40
+Group: software.amazon.awssdk Name: auth Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.40
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.40
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.40
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.40
+Group: software.amazon.awssdk Name: profiles Version: 2.31.40
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.40
+Group: software.amazon.awssdk Name: regions Version: 2.31.40
+Group: software.amazon.awssdk Name: retries Version: 2.31.40
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: s3 Version: 2.31.40
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.40
+Group: software.amazon.awssdk Name: sts Version: 2.31.40
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.40
+Group: software.amazon.awssdk Name: utils Version: 2.31.40
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: software.amazon.eventstream Name: eventstream Version: 1.0.1
-Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Project URL: https://github.com/awslabs/aws-eventstream-java
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------

--- a/quarkus/server/distribution/NOTICE
+++ b/quarkus/server/distribution/NOTICE
@@ -1032,36 +1032,36 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.30
-Group: software.amazon.awssdk Name: arns Version: 2.31.30
-Group: software.amazon.awssdk Name: auth Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.30
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.30
-Group: software.amazon.awssdk Name: checksums Version: 2.31.30
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.30
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.30
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.30
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.30
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.30
-Group: software.amazon.awssdk Name: profiles Version: 2.31.30
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.30
-Group: software.amazon.awssdk Name: regions Version: 2.31.30
-Group: software.amazon.awssdk Name: retries Version: 2.31.30
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.30
-Group: software.amazon.awssdk Name: s3 Version: 2.31.30
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.30
-Group: software.amazon.awssdk Name: sts Version: 2.31.30
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.30
-Group: software.amazon.awssdk Name: utils Version: 2.31.30
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.40
+Group: software.amazon.awssdk Name: arns Version: 2.31.40
+Group: software.amazon.awssdk Name: auth Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums Version: 2.31.40
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.40
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.40
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.40
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.40
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.40
+Group: software.amazon.awssdk Name: profiles Version: 2.31.40
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.40
+Group: software.amazon.awssdk Name: regions Version: 2.31.40
+Group: software.amazon.awssdk Name: retries Version: 2.31.40
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.40
+Group: software.amazon.awssdk Name: s3 Version: 2.31.40
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.40
+Group: software.amazon.awssdk Name: sts Version: 2.31.40
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.40
+Group: software.amazon.awssdk Name: utils Version: 2.31.40
 
 NOTICE:
 | AWS SDK for Java


### PR DESCRIPTION
My script to help on `LICENSE` didn't include the required license content inline (for BSD or MIT licenses).

I updated my script:
1. To group the artifacts (to reduce the duplicate content)
2. Add BSD and MIT licenses inline