### PR TITLE
Better null-safety for check against unsafe catalog configs

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -118,9 +118,14 @@ public interface PolarisConfigurationStore {
       PolarisConfiguration<T> config) {
     if (config.hasCatalogConfig() || config.hasCatalogConfigUnsafe()) {
       Map<String, String> propertiesMap = catalogEntity.getPropertiesAsMap();
-      String propertyValue = propertiesMap.get(config.catalogConfig());
+      String propertyValue = null;
+      if (config.hasCatalogConfig()) {
+        propertyValue = propertiesMap.get(config.catalogConfig());
+      }
       if (propertyValue == null) {
-        propertyValue = propertiesMap.get(config.catalogConfigUnsafe());
+        if (config.hasCatalogConfigUnsafe()) {
+          propertyValue = propertiesMap.get(config.catalogConfigUnsafe());
+        }
         if (propertyValue != null) {
           LOGGER.warn(
               String.format(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
@@ -238,46 +238,41 @@ public class DefaultConfigurationStoreTest {
   public void testRegisterAndUseFeatureConfigurations() {
     String prefix = "testRegisterAndUseFeatureConfigurations";
 
-    FeatureConfiguration<Boolean> safeConfig = FeatureConfiguration.<Boolean>builder()
-        .key(String.format("%s_safe", prefix))
-        .catalogConfig(String.format("polaris.config.%s.safe", prefix))
-        .defaultValue(true)
-        .description(prefix)
-        .buildFeatureConfiguration();
+    FeatureConfiguration<Boolean> safeConfig =
+        FeatureConfiguration.<Boolean>builder()
+            .key(String.format("%s_safe", prefix))
+            .catalogConfig(String.format("polaris.config.%s.safe", prefix))
+            .defaultValue(true)
+            .description(prefix)
+            .buildFeatureConfiguration();
 
-    FeatureConfiguration<Boolean> unsafeConfig =FeatureConfiguration.<Boolean>builder()
-        .key(String.format("%s_unsafe", prefix))
-        .catalogConfigUnsafe(String.format("%s.unsafe", prefix))
-        .defaultValue(true)
-        .description(prefix)
-        .buildFeatureConfiguration();
+    FeatureConfiguration<Boolean> unsafeConfig =
+        FeatureConfiguration.<Boolean>builder()
+            .key(String.format("%s_unsafe", prefix))
+            .catalogConfigUnsafe(String.format("%s.unsafe", prefix))
+            .defaultValue(true)
+            .description(prefix)
+            .buildFeatureConfiguration();
 
-    FeatureConfiguration<Boolean> bothConfig = FeatureConfiguration.<Boolean>builder()
-        .key(String.format("%s_both", prefix))
-        .catalogConfig(String.format("polaris.config.%s.both", prefix))
-        .catalogConfigUnsafe(String.format("%s.both", prefix))
-        .defaultValue(true)
-        .description(prefix)
-        .buildFeatureConfiguration();
+    FeatureConfiguration<Boolean> bothConfig =
+        FeatureConfiguration.<Boolean>builder()
+            .key(String.format("%s_both", prefix))
+            .catalogConfig(String.format("polaris.config.%s.both", prefix))
+            .catalogConfigUnsafe(String.format("%s.both", prefix))
+            .defaultValue(true)
+            .description(prefix)
+            .buildFeatureConfiguration();
 
     CatalogEntity catalog = new CatalogEntity.Builder().build();
 
-    Assertions.assertThat(configurationStore
-        .getConfiguration(
-            polarisContext,
-            catalog,
-            safeConfig)).isTrue();
+    Assertions.assertThat(configurationStore.getConfiguration(polarisContext, catalog, safeConfig))
+        .isTrue();
 
-    Assertions.assertThat(configurationStore
-        .getConfiguration(
-            polarisContext,
-            catalog,
-            unsafeConfig)).isTrue();
+    Assertions.assertThat(
+            configurationStore.getConfiguration(polarisContext, catalog, unsafeConfig))
+        .isTrue();
 
-    Assertions.assertThat(configurationStore
-        .getConfiguration(
-            polarisContext,
-            catalog,
-            bothConfig)).isTrue();
+    Assertions.assertThat(configurationStore.getConfiguration(polarisContext, catalog, bothConfig))
+        .isTrue();
   }
 }


### PR DESCRIPTION
After the merge of #1557, I noticed that this check may incorrectly call `config.catalogConfigUnsafe()` on a `FeatureConfiguration` that doesn't actually have a `catalogConfigUnsafe`. Unfortunately this code path never got exercised in the original PR, as we didn't have any configs that had a safe config but not an unsafe one.