### PR TITLE
Allow for quotes in path for blob storage

### DIFF
--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-gcp")
   implementation(platform(libs.google.cloud.storage.bom))
   implementation("com.google.cloud:google-cloud-storage")
+  implementation(libs.hadoop.client.api)
 
   testFixturesApi("com.fasterxml.jackson.core:jackson-core")
   testFixturesApi("com.fasterxml.jackson.core:jackson-databind")


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Fixes #1545. Further context on that ticket.

Java URIs do not allow special characters, such as quotes, as part of [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986). As a result, it is not possible to use paths that contain such characters with Java URIs, which we use to compare storage locations when creating a new catalog.

This change refactors that code to only use URI if the location provided is a local filesystem path - else, it will use Hadoop's `Path` class in order to normalize the location. 
