### PR TITLE
Fix header in the gradle-wrapper.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("spec/docs.yaml")
   excludes.add("spec/index.yml")
 
-  excludes.add("gradle/wrapper/gradle-wrapper*.jar*")
+  excludes.add("gradle/wrapper/gradle-wrapper*")
 
   excludes.add("logs/**")
   excludes.add("service/common/src/**/banner.txt")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # See https://gradle.org/release-checksums/ for valid checksums


### PR DESCRIPTION
`gradle-wrapper.properties` should not contain ASF header (as it's not created by "us").