### PR TITLE
Include LICENSE, NOTICE, DISCLAIMER files in the docker images

### DIFF
--- a/quarkus/admin/build.gradle.kts
+++ b/quarkus/admin/build.gradle.kts
@@ -98,7 +98,7 @@ distributions {
       from("distribution/NOTICE")
       from("distribution/LICENSE")
       from("distribution/README.md")
-      from("../../DISCLAIMER")
+      from("distribution/DISCLAIMER")
     }
   }
 }

--- a/quarkus/admin/distribution/DISCLAIMER
+++ b/quarkus/admin/distribution/DISCLAIMER
@@ -1,0 +1,10 @@
+Apache Polaris (incubating) is an effort undergoing incubation at The Apache
+Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review
+indicates that the infrastructure, communications, and decision making process
+have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness
+or stability of the code, it does indicate that the project has yet to be
+fully endorsed by the ASF.

--- a/quarkus/admin/src/main/docker/Dockerfile.jvm
+++ b/quarkus/admin/src/main/docker/Dockerfile.jvm
@@ -41,5 +41,8 @@ COPY --chown=polaris:polaris build/quarkus-app/lib/ /deployments/lib/
 COPY --chown=polaris:polaris build/quarkus-app/quarkus-run.jar /deployments/polaris-admin-tool.jar
 COPY --chown=polaris:polaris build/quarkus-app/app/ /deployments/app/
 COPY --chown=polaris:polaris build/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=polaris:polaris distribution/LICENSE /deployments/
+COPY --chown=polaris:polaris distribution/NOTICE /deployments/
+COPY --chown=polaris:polaris distribution/DISCLAIMER /deployments/
 
 ENTRYPOINT [ "java", "-jar", "/deployments/polaris-admin-tool.jar" ]

--- a/quarkus/server/build.gradle.kts
+++ b/quarkus/server/build.gradle.kts
@@ -92,7 +92,7 @@ distributions {
       from("distribution/NOTICE")
       from("distribution/LICENSE")
       from("distribution/README.md")
-      from("../../DISCLAIMER")
+      from("distribution/DISCLAIMER")
     }
   }
 }

--- a/quarkus/server/distribution/DISCLAIMER
+++ b/quarkus/server/distribution/DISCLAIMER
@@ -1,0 +1,10 @@
+Apache Polaris (incubating) is an effort undergoing incubation at The Apache
+Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review
+indicates that the infrastructure, communications, and decision making process
+have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness
+or stability of the code, it does indicate that the project has yet to be
+fully endorsed by the ASF.

--- a/quarkus/server/src/main/docker/Dockerfile.jvm
+++ b/quarkus/server/src/main/docker/Dockerfile.jvm
@@ -41,6 +41,9 @@ COPY --chown=polaris:polaris build/quarkus-app/lib/ /deployments/lib/
 COPY --chown=polaris:polaris build/quarkus-app/*.jar /deployments/
 COPY --chown=polaris:polaris build/quarkus-app/app/ /deployments/app/
 COPY --chown=polaris:polaris build/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=polaris:polaris distribution/LICENSE /deployments/
+COPY --chown=polaris:polaris distribution/NOTICE /deployments/
+COPY --chown=polaris:polaris distribution/DISCLAIMER /deployments/
 
 EXPOSE 8181
 EXPOSE 8182


### PR DESCRIPTION
As we are going to publish Docker images (SNAPSHOT and release), like for any binary distribution, the Docker images have to contain `LICENSE`, `NOTICE`, and `DISCLAIMER` files.