### PR TITLE
Remove Java URI validations for Blob Storage providers

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -44,8 +44,10 @@ public class StorageLocation {
       this.location = URI.create(location.replaceFirst("file:/+", LOCAL_PATH_PREFIX)).toString();
     } else if (location.startsWith("/")) {
       this.location = URI.create(location.replaceFirst("/+", LOCAL_PATH_PREFIX)).toString();
-    } else {
+    } else if (location.startsWith(LOCAL_PATH_PREFIX)) {
       this.location = URI.create(location).toString();
+    } else {
+      this.location = location;
     }
   }
 


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

This is a retry at #1586, which I'll close if this PR is on the right direction instead. 

Java URI does not actually apply any normalization to URIs if we do not call `URI.normalize()` (which we currently do not). Additionally, blob storage providers like S3 and GCS can provide ".." and "." as valid fragments in URLs - which Java URI would attempt to normalize incorrectly. As a result, attempting to validate and/or normalize URIs for blob storage providers is the incorrect behavior. While we may want to add location validation via regex later, removing it first should at least unblock the bug we see in #1545.
