### PR TITLE
CI: Make helm-CI run for all changes

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -57,16 +57,7 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs helm)
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run 'helm template' validation
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           cd helm/polaris
           for f in values.yaml ci/*.yaml; do
@@ -76,27 +67,22 @@ jobs:
           done
 
       - name: Run Helm unit tests
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
           helm unittest helm/polaris
 
       - name: Run chart-testing (lint)
-        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --debug --charts ./helm/polaris
 
       - name: Set up Minikube
-        if: steps.list-changed.outputs.changed == 'true'
         uses: medyagh/setup-minikube@v0.0.18
 
       - name: Print Docker info
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           docker -v
           minikube docker-env
 
       - name: Image build
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           eval $(minikube -p minikube docker-env)
           ./gradlew \
@@ -108,13 +94,11 @@ jobs:
           minikube image ls
 
       - name: Install fixtures
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl create namespace polaris-ns
           kubectl apply --namespace polaris-ns -f helm/polaris/ci/fixtures 
 
       - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --target-branch ${{ github.event.repository.default_branch }} \
             --namespace polaris-ns \


### PR DESCRIPTION
Whether helm-charts work (or not) doesn't only depend on what's on the `helm/` directory, but also the production code. It's hard to figure out which changes could break the helm-charts or what the helm-charts rely on. Therefore it's likely better to run Helm-CI for all changes.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
