### PR TITLE
fix(quickstart): fixed quickstart jdbc to include client id and secrets (#1613)

### DIFF
--- a/getting-started/jdbc/README.md
+++ b/getting-started/jdbc/README.md
@@ -40,6 +40,8 @@ This example requires `jq` to be installed on your machine.
     export QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/POLARIS
     export QUARKUS_DATASOURCE_USERNAME=postgres
     export QUARKUS_DATASOURCE_PASSWORD=postgres
+    export CLIENT_ID=root
+    export CLIENT_SECRET=s3cr3t
     docker compose -f getting-started/jdbc/docker-compose-bootstrap-db.yml -f getting-started/assets/postgres/docker-compose-postgres.yml -f getting-started/jdbc/docker-compose.yml up
     ```
 

--- a/getting-started/jdbc/docker-compose.yml
+++ b/getting-started/jdbc/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       - STORAGE_LOCATION=${STORAGE_LOCATION}
       - AWS_ROLE_ARN=${AWS_ROLE_ARN}
       - AZURE_TENANT_ID=${AZURE_TENANT_ID}
+      - CLIENT_ID=${CLIENT_ID}
+      - CLIENT_SECRET=${CLIENT_SECRET}
     volumes:
       - ../assets/polaris/:/polaris
     entrypoint: '/bin/sh -c "chmod +x /polaris/create-catalog.sh && /polaris/create-catalog.sh"'


### PR DESCRIPTION
While following the quickstart for jdbc the instructions are incomplete, this change adds missing env variables so that your can follow the instructions to launch a jdbc connected instance.