### PR TITLE
[PROPOSAL] Add Context-Aware Functions for Apache Polaris

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -164,6 +164,7 @@ public abstract class PolarisAuthzTestBase {
   // Two views under ns1a
   protected static final TableIdentifier VIEW_NS1A_1 = TableIdentifier.of(NS1A, "view1");
   protected static final TableIdentifier VIEW_NS1A_2 = TableIdentifier.of(NS1A, "view2");
+  protected static final TableIdentifier VIEW_NS1A_3_DYNAMIC = TableIdentifier.of(NS1A, "view3");
 
   // One view under ns1b with same name as one under ns1a
   protected static final TableIdentifier VIEW_NS1B_1 = TableIdentifier.of(NS1B, "view1");
@@ -172,6 +173,8 @@ public abstract class PolarisAuthzTestBase {
   protected static final TableIdentifier VIEW_NS2_1 = TableIdentifier.of(NS2, "view1");
 
   protected static final String VIEW_QUERY = "select * from ns1.layer1_table";
+
+  protected static final String VIEW_QUERY_DYNAMIC = "select * from ns1.layer1_table where is_principal_role('ANALYST')";
 
   public static final Schema SCHEMA =
       new Schema(
@@ -359,6 +362,12 @@ public abstract class PolarisAuthzTestBase {
         .withDefaultNamespace(NS1)
         .withQuery("spark", VIEW_QUERY)
         .create();
+    baseCatalog
+            .buildView(VIEW_NS1A_3_DYNAMIC)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(NS1)
+            .withQuery("spark", VIEW_QUERY_DYNAMIC)
+            .create();
     baseCatalog
         .buildView(VIEW_NS1B_1)
         .withSchema(SCHEMA)

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -175,7 +175,9 @@ public abstract class PolarisAuthzTestBase {
   protected static final String VIEW_QUERY = "select * from ns1.layer1_table";
 
   protected static final String VIEW_QUERY_DYNAMIC =
-      String.format("SELECT * from ns1.layer1_table where is_principal_role('%s') OR IS_MEMBER()", PRINCIPAL_ROLE1);
+      String.format(
+          "SELECT * from ns1.layer1_table where is_principal_role('%s') OR IS_MEMBER()",
+          PRINCIPAL_ROLE1);
 
   public static final Schema SCHEMA =
       new Schema(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -174,7 +174,8 @@ public abstract class PolarisAuthzTestBase {
 
   protected static final String VIEW_QUERY = "select * from ns1.layer1_table";
 
-  protected static final String VIEW_QUERY_DYNAMIC = "select * from ns1.layer1_table where is_principal_role('ANALYST')";
+  protected static final String VIEW_QUERY_DYNAMIC =
+      String.format("SELECT * from ns1.layer1_table where is_principal_role('%s') OR IS_MEMBER()", PRINCIPAL_ROLE1);
 
   public static final Schema SCHEMA =
       new Schema(
@@ -363,11 +364,11 @@ public abstract class PolarisAuthzTestBase {
         .withQuery("spark", VIEW_QUERY)
         .create();
     baseCatalog
-            .buildView(VIEW_NS1A_3_DYNAMIC)
-            .withSchema(SCHEMA)
-            .withDefaultNamespace(NS1)
-            .withQuery("spark", VIEW_QUERY_DYNAMIC)
-            .create();
+        .buildView(VIEW_NS1A_3_DYNAMIC)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS1)
+        .withQuery("spark", VIEW_QUERY_DYNAMIC)
+        .create();
     baseCatalog
         .buildView(VIEW_NS1B_1)
         .withSchema(SCHEMA)

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -48,8 +48,10 @@ import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
@@ -1509,6 +1511,28 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.CATALOG_MANAGE_CONTENT),
         () -> newWrapper().loadView(VIEW_NS1A_2),
         null /* cleanupAction */);
+  }
+
+  @Test
+  public void testLoadViewSufficientPrivilegesWithDynamicViewResolution() {
+//    doTestSufficientPrivileges(
+//            List.of(
+//                    PolarisPrivilege.VIEW_READ_PROPERTIES,
+//                    PolarisPrivilege.VIEW_WRITE_PROPERTIES,
+//                    PolarisPrivilege.VIEW_FULL_METADATA,
+//                    PolarisPrivilege.CATALOG_MANAGE_CONTENT),
+//            () -> {
+//              LoadViewResponse lv1 =  newWrapper(Set.of("ANALYST")).loadView(VIEW_NS1A_3_DYNAMIC);
+//              Assertions.assertThat(((SQLViewRepresentation) (lv1.metadata().currentVersion().representations().getFirst())).sql()).isEqualTo("select * from ns1.layer1_table where TRUE");
+//            },
+//            null /* cleanupAction */);
+    doTestSufficientPrivileges(
+            List.of(PolarisPrivilege.VIEW_READ_PROPERTIES),
+            () -> {
+              LoadViewResponse lv1 =  newWrapper().loadView(VIEW_NS1A_3_DYNAMIC);
+              Assertions.assertThat(((SQLViewRepresentation) (lv1.metadata().currentVersion().representations().getFirst())).sql()).isEqualTo("select * from ns1.layer1_table where TRUE");
+            },
+            null /* cleanupAction */);
   }
 
   @Test

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -1515,24 +1515,31 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
 
   @Test
   public void testLoadViewSufficientPrivilegesWithDynamicViewResolution() {
-//    doTestSufficientPrivileges(
-//            List.of(
-//                    PolarisPrivilege.VIEW_READ_PROPERTIES,
-//                    PolarisPrivilege.VIEW_WRITE_PROPERTIES,
-//                    PolarisPrivilege.VIEW_FULL_METADATA,
-//                    PolarisPrivilege.CATALOG_MANAGE_CONTENT),
-//            () -> {
-//              LoadViewResponse lv1 =  newWrapper(Set.of("ANALYST")).loadView(VIEW_NS1A_3_DYNAMIC);
-//              Assertions.assertThat(((SQLViewRepresentation) (lv1.metadata().currentVersion().representations().getFirst())).sql()).isEqualTo("select * from ns1.layer1_table where TRUE");
-//            },
-//            null /* cleanupAction */);
+    //    doTestSufficientPrivileges(
+    //            List.of(
+    //                    PolarisPrivilege.VIEW_READ_PROPERTIES,
+    //                    PolarisPrivilege.VIEW_WRITE_PROPERTIES,
+    //                    PolarisPrivilege.VIEW_FULL_METADATA,
+    //                    PolarisPrivilege.CATALOG_MANAGE_CONTENT),
+    //            () -> {
+    //              LoadViewResponse lv1 =
+    // newWrapper(Set.of("ANALYST")).loadView(VIEW_NS1A_3_DYNAMIC);
+    //              Assertions.assertThat(((SQLViewRepresentation)
+    // (lv1.metadata().currentVersion().representations().getFirst())).sql()).isEqualTo("select *
+    // from ns1.layer1_table where TRUE");
+    //            },
+    //            null /* cleanupAction */);
     doTestSufficientPrivileges(
-            List.of(PolarisPrivilege.VIEW_READ_PROPERTIES),
-            () -> {
-              LoadViewResponse lv1 =  newWrapper().loadView(VIEW_NS1A_3_DYNAMIC);
-              Assertions.assertThat(((SQLViewRepresentation) (lv1.metadata().currentVersion().representations().getFirst())).sql()).isEqualTo("select * from ns1.layer1_table where TRUE");
-            },
-            null /* cleanupAction */);
+        List.of(PolarisPrivilege.VIEW_READ_PROPERTIES),
+        () -> {
+          LoadViewResponse lv1 = newWrapper(Set.of(PRINCIPAL_ROLE1)).loadView(VIEW_NS1A_3_DYNAMIC);
+          Assertions.assertThat(
+                  ((SQLViewRepresentation)
+                          (lv1.metadata().versions().getFirst().representations().getFirst()))
+                      .sql())
+              .isEqualTo("SELECT * FROM ns1.layer1_table WHERE TRUE OR IS_MEMBER()");
+        },
+        null /* cleanupAction */);
   }
 
   @Test

--- a/service/common/build.gradle.kts
+++ b/service/common/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-api")
   implementation("org.apache.iceberg:iceberg-core")
   implementation("org.apache.iceberg:iceberg-aws")
+  implementation("com.github.jsqlparser:jsqlparser:4.6")
 
   implementation(libs.hadoop.common) {
     exclude("org.slf4j", "slf4j-reload4j")

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -27,16 +27,22 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
@@ -91,10 +97,11 @@ public class CatalogHandlerUtils {
   private static final String INITIAL_PAGE_TOKEN = "";
 
   // is_principal_role('ANALYST')
-  private static final Pattern IS_PRINCIPAL_ROLE = Pattern.compile(
+  private static final Pattern IS_PRINCIPAL_ROLE =
+      Pattern.compile(
           "is_principal_role\\(\\s*'([^']+)'\\s*\\)",
-          Pattern.CASE_INSENSITIVE                     // drop this flag if you want case-sensitive
-  );
+          Pattern.CASE_INSENSITIVE // drop this flag if you want case-sensitive
+          );
 
   private final PolarisCallContext polarisCallContext;
   private final PolarisConfigurationStore configurationStore;
@@ -521,28 +528,91 @@ public class CatalogHandlerUtils {
     return viewResponse(view, Set.of());
   }
 
+  // NOTE: This is just put together to do a quick POC
+  public static String rewriteIdentityFunctions(String sql, Set<String> authenticatedPrincipals) {
+    Statement statement = null;
+    try {
+      statement = CCJSqlParserUtil.parse(sql);
+    } catch (Exception e) {
+      return sql;
+    }
+
+    class CustomExpressionDeParser extends ExpressionDeParser {
+      private boolean isConverted = false;
+
+      @Override
+      public void visit(Function function) {
+        String name = function.getName().toLowerCase(Locale.ROOT);
+        if (Set.of("is_principal", "is_principal_role", "is_catalog_role").contains(name)) {
+          ExpressionList params = function.getParameters();
+          if (params != null && !params.getExpressions().isEmpty()) {
+            Expression argExpr = params.getExpressions().getFirst();
+            String arg =
+                argExpr instanceof StringValue
+                    ? ((StringValue) argExpr).getValue()
+                    : argExpr.toString();
+
+            boolean result = evaluateFunction(name, arg);
+            getBuffer().append(result ? "TRUE" : "FALSE");
+            isConverted = true;
+          } else {
+            super.visit(function);
+          }
+        } else {
+          super.visit(function);
+        }
+      }
+
+      private boolean evaluateFunction(String functionName, String arg) {
+        return switch (functionName) {
+          case "is_principal", "is_catalog_role", "is_principal_role" ->
+              authenticatedPrincipals.contains(arg);
+          default -> false;
+        };
+      }
+
+      public boolean isConverted() {
+        return isConverted;
+      }
+    }
+
+    StringBuilder buffer = new StringBuilder();
+    CustomExpressionDeParser exprDeParser = new CustomExpressionDeParser();
+
+    SelectDeParser selectDeParser = new SelectDeParser((ExpressionDeParser) exprDeParser, buffer);
+    exprDeParser.setSelectVisitor(selectDeParser);
+    exprDeParser.setBuffer(buffer);
+
+    if (statement instanceof Select select) {
+      select.getSelectBody().accept(selectDeParser);
+    }
+
+    if (exprDeParser.isConverted()) {
+      return buffer.toString();
+    } else {
+      return sql;
+    }
+  }
+
   private LoadViewResponse viewResponse(View view, Set<String> authenticatedPrincipals) {
     ViewMetadata metadata = asBaseView(view).operations().current();
-    // in all the representations, find and replace the is_principal_role('ANALYST')
     ViewVersion version = metadata.currentVersion();
     List<ViewRepresentation> representations = version.representations();
     List<ViewRepresentation> identityResolved = new ArrayList<>(representations.size());
     for (ViewRepresentation viewRepresentation : representations) {
       if (viewRepresentation instanceof SQLViewRepresentation sqlView) {
-          Matcher m = IS_PRINCIPAL_ROLE.matcher(sqlView.sql());
-        StringBuffer sb = new StringBuffer();         // efficient incremental builder
-        while (m.find()) {
-          String groupName = m.group(1);      // captured expected principal name
-          String replacement = authenticatedPrincipals.contains(groupName) ? "TRUE" : "FALSE";
-          m.appendReplacement(sb, replacement);
-        }
-        m.appendTail(sb);
-        identityResolved.add(ImmutableSQLViewRepresentation.builder().sql(sb.toString()).dialect(sqlView.dialect()).build());
+        String modifiedSQL = rewriteIdentityFunctions(sqlView.sql(), authenticatedPrincipals);
+        identityResolved.add(
+            ImmutableSQLViewRepresentation.builder()
+                .sql(modifiedSQL)
+                .dialect(sqlView.dialect())
+                .build());
       } else {
         identityResolved.add(viewRepresentation);
       }
     }
-    ImmutableViewVersion resolvedViewVersion = ImmutableViewVersion.builder().from(version).build().withRepresentations(identityResolved);
+    ImmutableViewVersion resolvedViewVersion =
+        ImmutableViewVersion.builder().from(version).build().withRepresentations(identityResolved);
 
     // This is a temp hack, for quick POC
     Class<?> clazz = metadata.getClass();
@@ -567,7 +637,8 @@ public class CatalogHandlerUtils {
     }
   }
 
-  public LoadViewResponse loadView(ViewCatalog catalog, TableIdentifier viewIdentifier, Set<String> principal) {
+  public LoadViewResponse loadView(
+      ViewCatalog catalog, TableIdentifier viewIdentifier, Set<String> principal) {
     View view = catalog.loadView(viewIdentifier);
     return viewResponse(view, principal);
   }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1055,7 +1055,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.ICEBERG_VIEW, viewIdentifier);
     Set<String> principal = authenticatedPrincipal.getActivatedPrincipalRoleNames();
 
-    return catalogHandlerUtils.loadView(viewCatalog, viewIdentifier, Set.of("ANALYST"));
+    return catalogHandlerUtils.loadView(viewCatalog, viewIdentifier, principal);
   }
 
   public LoadViewResponse replaceView(TableIdentifier viewIdentifier, UpdateTableRequest request) {
@@ -1086,7 +1086,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.ICEBERG_VIEW, viewIdentifier);
 
     // TODO: Just skip CatalogHandlers for this one maybe
-    catalogHandlerUtils.loadView(viewCatalog, viewIdentifier, authenticatedPrincipal.getActivatedPrincipalRoleNames());
+    catalogHandlerUtils.loadView(
+        viewCatalog, viewIdentifier, authenticatedPrincipal.getActivatedPrincipalRoleNames());
   }
 
   public void renameView(RenameTableRequest request) {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1053,8 +1053,9 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
   public LoadViewResponse loadView(TableIdentifier viewIdentifier) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LOAD_VIEW;
     authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.ICEBERG_VIEW, viewIdentifier);
+    Set<String> principal = authenticatedPrincipal.getActivatedPrincipalRoleNames();
 
-    return catalogHandlerUtils.loadView(viewCatalog, viewIdentifier);
+    return catalogHandlerUtils.loadView(viewCatalog, viewIdentifier, Set.of("ANALYST"));
   }
 
   public LoadViewResponse replaceView(TableIdentifier viewIdentifier, UpdateTableRequest request) {
@@ -1085,7 +1086,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.ICEBERG_VIEW, viewIdentifier);
 
     // TODO: Just skip CatalogHandlers for this one maybe
-    catalogHandlerUtils.loadView(viewCatalog, viewIdentifier);
+    catalogHandlerUtils.loadView(viewCatalog, viewIdentifier, authenticatedPrincipal.getActivatedPrincipalRoleNames());
   }
 
   public void renameView(RenameTableRequest request) {


### PR DESCRIPTION
### About the change 

I’d like to propose adding context-aware functions to Apache Polaris so that view definitions can resolve security context on the Polaris side (aka catalog end without depending on engines).

Proposed functions

```
is_principal('<principal_name>') – returns TRUE if the authenticated principal matches <principal_name>, otherwise FALSE.

is_principal_role('<principal_role_name>') – returns TRUE when <principal_role_name> appears in the principal’s role set.

is_catalog_role('<catalog_role_name>') – analogous check at the catalog-role level.
```

Why it matters

These predicates make views dynamic. Example:

```sql
CREATE VIEW dynamic_vw AS
SELECT *
FROM ns1.layer1_table
WHERE is_principal_role('ANALYST');
```

When a user whose one of principal roles include ANALYST calls LOAD VIEW, Polaris rewrites the view to
```
SELECT * FROM ns1.layer1_table WHERE TRUE;
```
For everyone else the view becomes
```
SELECT * FROM ns1.layer1_table WHERE FALSE;
```
The result is better and consistent control of the identity resolution without relying on the engine side changes and giving Polaris more authority in enforcing things like FGAC.
Note the same can be extrapolated to any Polaris stored entity.

Proof of concept

I’ve put together a quick POC branch:
here ^^^

Prior art

Snowflake context functions :[ https://docs.snowflake.com/en/sql-reference/functions-context](https://docs.snowflake.com/en/sql-reference/functions-context)
Databricks Unity Catalog offers a similar mechanism called dynamic views:
https://docs.databricks.com/aws/en/views/dynamic

Next steps

If the community is interested, we can discuss API surface, engine implications, and a roadmap for merging.
