### PR TITLE
[Policy Store] Add policyTypeCode to Slice/Index for Future Filtering Support and Update Policy Persistence Method

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -763,7 +763,7 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     return this.store
         .loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId, policyTypeCode)
         .stream()

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -703,7 +703,7 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   @Override
   public void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
       @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
+      @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     this.store.deleteAllEntityPolicyMappingRecords(localSession.get(), entity);
@@ -760,8 +760,13 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   @Nonnull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
-    return this.store.loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId).stream()
+      @Nonnull PolarisCallContext callCtx,
+      long policyCatalogId,
+      long policyId,
+      long policyTypeCode) {
+    return this.store
+        .loadAllTargetsOnPolicy(localSession.get(), policyCatalogId, policyId, policyTypeCode)
+        .stream()
         .map(ModelPolicyMappingRecord::toPolicyMappingRecord)
         .toList();
   }

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -484,7 +484,7 @@ public class PolarisEclipseLinkStore {
       EntityManager session,
       long targetCatalogId,
       long targetId,
-      long policyTypeCode,
+      int policyTypeCode,
       long policyCatalogId,
       long policyId) {
     diagnosticServices.check(session != null, "session_is_null");
@@ -544,7 +544,7 @@ public class PolarisEclipseLinkStore {
   }
 
   List<ModelPolicyMappingRecord> loadAllTargetsOnPolicy(
-      EntityManager session, long policyCatalogId, long policyId, long policyTypeCode) {
+      EntityManager session, long policyCatalogId, long policyId, int policyTypeCode) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 

--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -37,6 +37,7 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.jpa.models.ModelEntity;
 import org.apache.polaris.jpa.models.ModelEntityActive;
 import org.apache.polaris.jpa.models.ModelEntityChangeTracking;
@@ -461,13 +462,22 @@ public class PolarisEclipseLinkStore {
     session.remove(lookupPolicyMappingRecord);
   }
 
-  void deleteAllEntityPolicyMappingRecords(EntityManager session, PolarisEntityCore entity) {
+  void deleteAllEntityPolicyMappingRecords(EntityManager session, PolarisBaseEntity entity) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
-    loadAllTargetsOnPolicy(session, entity.getCatalogId(), entity.getId()).forEach(session::remove);
-    loadAllPoliciesOnTarget(session, entity.getCatalogId(), entity.getId())
-        .forEach(session::remove);
+    if (entity.getType() == PolarisEntityType.POLICY) {
+      PolicyEntity policyEntity = PolicyEntity.of(entity);
+      loadAllTargetsOnPolicy(
+              session,
+              policyEntity.getCatalogId(),
+              policyEntity.getId(),
+              policyEntity.getPolicyTypeCode())
+          .forEach(session::remove);
+    } else {
+      loadAllPoliciesOnTarget(session, entity.getCatalogId(), entity.getId())
+          .forEach(session::remove);
+    }
   }
 
   ModelPolicyMappingRecord lookupPolicyMappingRecord(
@@ -534,16 +544,18 @@ public class PolarisEclipseLinkStore {
   }
 
   List<ModelPolicyMappingRecord> loadAllTargetsOnPolicy(
-      EntityManager session, long policyCatalogId, long policyId) {
+      EntityManager session, long policyCatalogId, long policyId, long policyTypeCode) {
     diagnosticServices.check(session != null, "session_is_null");
     checkInitialized();
 
     return session
         .createQuery(
             "SELECT m from ModelPolicyMappingRecord m "
-                + "where  m.policyCatalogId=:policyCatalogId "
+                + "where m.policyTypeCode=:policyTypeCode "
+                + "and m.policyCatalogId=:policyCatalogId "
                 + "and m.policyId=:policyId",
             ModelPolicyMappingRecord.class)
+        .setParameter("policyTypeCode", policyTypeCode)
         .setParameter("policyCatalogId", policyCatalogId)
         .setParameter("policyId", policyId)
         .getResultList();

--- a/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
+++ b/extension/persistence/jpa-model/src/main/java/org/apache/polaris/jpa/models/ModelPolicyMappingRecord.java
@@ -33,7 +33,7 @@ import org.eclipse.persistence.annotations.PrimaryKey;
     indexes = {
       @Index(
           name = "POLICY_MAPPING_RECORDS_BY_POLICY_INDEX",
-          columnList = "policyCatalogId,policyId,targetCatalogId,targetId")
+          columnList = "policyTypeCode,policyCatalogId,policyId,targetCatalogId,targetId")
     })
 @PrimaryKey(
     columns = {

--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -780,7 +780,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public void deleteAllEntityPolicyMappingRecords(
       @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
+      @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     try {
@@ -855,9 +855,20 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+      @Nonnull PolarisCallContext callCtx,
+      long policyCatalogId,
+      long policyId,
+      long policyTypeCode) {
     Map<String, Object> params =
-        Map.of("policy_catalog_id", policyCatalogId, "policy_id", policyId, "realm_id", realmId);
+        Map.of(
+            "policy_type_code",
+            policyTypeCode,
+            "policy_catalog_id",
+            policyCatalogId,
+            "policy_id",
+            policyId,
+            "realm_id",
+            realmId);
     String query = generateSelectQuery(new ModelPolicyMappingRecord(), params);
     return fetchPolicyMappingRecords(query);
   }

--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -858,7 +858,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     Map<String, Object> params =
         Map.of(
             "policy_type_code",

--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/QueryGenerator.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/QueryGenerator.java
@@ -65,19 +65,19 @@ public class QueryGenerator {
 
   public static String generateDeleteQueryForEntityPolicyMappingRecords(
       @Nonnull PolarisBaseEntity entity, @Nonnull String realmId) {
-    Map<String, Object> objMap = new HashMap<>();
+    Map<String, Object> queryParams = new HashMap<>();
     if (entity.getType() == PolarisEntityType.POLICY) {
       PolicyEntity policyEntity = PolicyEntity.of(entity);
-      objMap.put("policy_type_code", policyEntity.getPolicyTypeCode());
-      objMap.put("policy_catalog_id", policyEntity.getCatalogId());
-      objMap.put("policy_id", policyEntity.getId());
+      queryParams.put("policy_type_code", policyEntity.getPolicyTypeCode());
+      queryParams.put("policy_catalog_id", policyEntity.getCatalogId());
+      queryParams.put("policy_id", policyEntity.getId());
     } else {
-      objMap.put("target_catalog_id", entity.getCatalogId());
-      objMap.put("target_id", entity.getId());
+      queryParams.put("target_catalog_id", entity.getCatalogId());
+      queryParams.put("target_id", entity.getId());
     }
-    objMap.put("realm_id", realmId);
+    queryParams.put("realm_id", realmId);
 
-    return generateDeleteQuery(ModelPolicyMappingRecord.class, objMap);
+    return generateDeleteQuery(ModelPolicyMappingRecord.class, queryParams);
   }
 
   public static String generateSelectQueryWithEntityIds(

--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/QueryGenerator.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/QueryGenerator.java
@@ -21,10 +21,14 @@ package org.apache.polaris.extension.persistence.relational.jdbc;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.extension.persistence.relational.jdbc.models.Converter;
 import org.apache.polaris.extension.persistence.relational.jdbc.models.ModelEntity;
 import org.apache.polaris.extension.persistence.relational.jdbc.models.ModelGrantRecord;
@@ -60,23 +64,20 @@ public class QueryGenerator {
   }
 
   public static String generateDeleteQueryForEntityPolicyMappingRecords(
-      @Nonnull PolarisEntityCore entity, @Nonnull String realmId) {
-    String targetCondition =
-        String.format(
-            "target_id = %s AND target_catalog_id = %s", entity.getId(), entity.getCatalogId());
-    String sourceCondition =
-        String.format(
-            "policy_id = %s AND policy_catalog_id = %s", entity.getId(), entity.getCatalogId());
+      @Nonnull PolarisBaseEntity entity, @Nonnull String realmId) {
+    Map<String, Object> objMap = new HashMap<>();
+    if (entity.getType() == PolarisEntityType.POLICY) {
+      PolicyEntity policyEntity = PolicyEntity.of(entity);
+      objMap.put("policy_type_code", policyEntity.getPolicyTypeCode());
+      objMap.put("policy_catalog_id", policyEntity.getCatalogId());
+      objMap.put("policy_id", policyEntity.getId());
+    } else {
+      objMap.put("target_catalog_id", entity.getCatalogId());
+      objMap.put("target_id", entity.getId());
+    }
+    objMap.put("realm_id", realmId);
 
-    String whereClause =
-        " WHERE ("
-            + targetCondition
-            + " OR "
-            + sourceCondition
-            + ") AND realm_id = '"
-            + realmId
-            + "'";
-    return generateDeleteQuery(ModelPolicyMappingRecord.class, whereClause);
+    return generateDeleteQuery(ModelPolicyMappingRecord.class, objMap);
   }
 
   public static String generateSelectQueryWithEntityIds(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -203,7 +203,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       try {
         final List<PolarisPolicyMappingRecord> mappingOnPolicy =
             (entity.getType() == PolarisEntityType.POLICY)
-                ? ms.loadAllTargetsOnPolicy(callCtx, entity.getCatalogId(), entity.getId())
+                ? ms.loadAllTargetsOnPolicy(
+                    callCtx,
+                    entity.getCatalogId(),
+                    entity.getId(),
+                    PolicyEntity.of(entity).getPolicyTypeCode())
                 : List.of();
         final List<PolarisPolicyMappingRecord> mappingOnTarget =
             (entity.getType() == PolarisEntityType.POLICY)
@@ -1209,7 +1213,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         //  need to check if the policy is attached to any entity
         List<PolarisPolicyMappingRecord> records =
             ms.loadAllTargetsOnPolicy(
-                callCtx, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId());
+                callCtx,
+                refreshEntityToDrop.getCatalogId(),
+                refreshEntityToDrop.getId(),
+                PolicyEntity.of(refreshEntityToDrop).getPolicyTypeCode());
         if (!records.isEmpty()) {
           return new DropEntityResult(BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS, null);
         }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -722,7 +722,7 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   @Override
   public void deleteAllEntityPolicyMappingRecords(
       @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
+      @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     this.runActionInTransaction(
@@ -778,8 +778,14 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   @Override
   @Nonnull
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+      @Nonnull PolarisCallContext callCtx,
+      long policyCatalogId,
+      long policyId,
+      long policyTypeCode) {
     return this.runInReadTransaction(
-        callCtx, () -> this.loadAllTargetsOnPolicyInCurrentTxn(callCtx, policyCatalogId, policyId));
+        callCtx,
+        () ->
+            this.loadAllTargetsOnPolicyInCurrentTxn(
+                callCtx, policyCatalogId, policyId, policyTypeCode));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -781,7 +781,7 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     return this.runInReadTransaction(
         callCtx,
         () ->

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -205,7 +205,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         final List<PolarisPolicyMappingRecord> mappingOnPolicy =
             (entity.getType() == PolarisEntityType.POLICY)
                 ? ms.loadAllTargetsOnPolicyInCurrentTxn(
-                    callCtx, entity.getCatalogId(), entity.getId())
+                    callCtx,
+                    entity.getCatalogId(),
+                    entity.getId(),
+                    PolicyEntity.of(entity).getPolicyTypeCode())
                 : List.of();
         final List<PolarisPolicyMappingRecord> mappingOnTarget =
             (entity.getType() == PolarisEntityType.POLICY)
@@ -1397,7 +1400,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       try {
         List<PolarisPolicyMappingRecord> records =
             ms.loadAllTargetsOnPolicyInCurrentTxn(
-                callCtx, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId());
+                callCtx,
+                refreshEntityToDrop.getCatalogId(),
+                refreshEntityToDrop.getId(),
+                PolicyEntity.of(refreshEntityToDrop).getPolicyTypeCode());
         if (!records.isEmpty()) {
           return new DropEntityResult(BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS, null);
         }
@@ -2448,7 +2454,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   }
 
   /** See {@link #loadPoliciesOnEntityByType(PolarisCallContext, PolarisEntityCore, PolicyType)} */
-  public LoadPolicyMappingsResult doLoadPoliciesOnEntityByType(
+  private LoadPolicyMappingsResult doLoadPoliciesOnEntityByType(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       @Nonnull PolarisEntityCore target,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
@@ -287,7 +287,8 @@ public class TreeMapMetaStore {
         new Slice<>(
             policyMappingRecord ->
                 String.format(
-                    "%d::%d::%d::%d",
+                    "%d::%d::%d::%d::%d",
+                    policyMappingRecord.getPolicyTypeCode(),
                     policyMappingRecord.getPolicyCatalogId(),
                     policyMappingRecord.getPolicyId(),
                     policyMappingRecord.getTargetCatalogId(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -658,7 +658,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     return this.store
         .getSlicePolicyMappingRecordsByPolicy()
         .readRange(this.store.buildPrefixKeyComposite(policyTypeCode, policyCatalogId, policyId));

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 
 /**
  * Interface for interacting with the Polaris persistence backend for Policy Mapping operations.
@@ -73,7 +73,7 @@ public interface PolicyMappingPersistence {
    */
   default void deleteAllEntityPolicyMappingRecords(
       @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
+      @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     throw new UnsupportedOperationException("Not Implemented");
@@ -141,11 +141,15 @@ public interface PolicyMappingPersistence {
    * @param callCtx call context
    * @param policyCatalogId catalog id of the policy entity, NULL_ID if the entity is top-level
    * @param policyId id of the policy entity
+   * @param policyTypeCode type code of the policy entity
    * @return the list of policy mapping records for the specified policy entity
    */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+      @Nonnull PolarisCallContext callCtx,
+      long policyCatalogId,
+      long policyId,
+      long policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -149,7 +149,7 @@ public interface PolicyMappingPersistence {
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -95,7 +95,7 @@ public interface TransactionalPolicyMappingPersistence {
       @Nonnull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
-      long policyTypeCode) {
+      int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 
 public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#writeToPolicyMappingRecords} */
@@ -54,7 +54,7 @@ public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#deleteAllEntityPolicyMappingRecords} */
   default void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
       @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
+      @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     throw new UnsupportedOperationException("Not Implemented");
@@ -92,7 +92,10 @@ public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#loadAllTargetsOnPolicy} */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long policyCatalogId, long policyId) {
+      @Nonnull PolarisCallContext callCtx,
+      long policyCatalogId,
+      long policyId,
+      long policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2888,7 +2888,8 @@ public class PolarisTestMetaStoreManager {
 
     BasePersistence ms = polarisCallContext.getMetaStore();
     Assertions.assertThat(
-            ms.loadAllTargetsOnPolicy(polarisCallContext, N1_P1.getCatalogId(), N1_P1.getId()))
+            ms.loadAllTargetsOnPolicy(
+                polarisCallContext, N1_P1.getCatalogId(), N1_P1.getId(), N1_P1.getPolicyTypeCode()))
         .isEmpty();
 
     attachPolicyToTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N1), N1_P2);


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This PR adds `policyTypeCode` to both the in-memory tree map store's slice and the SQL table `policy_mapping_records` index (JDBC has already included this in #1468 ). This change lays the groundwork for future features that require efficient filtering by policy type—such as fetching all entities with a data compaction policy attached.

As part of this update, the signature of `loadAllTargetsOnPolicy` is also modified to accept `policyTypeCode`, allowing the method to take advantage of the new index for improved performance.

cc: @flyrain @singhpk234 