### PR TITLE
fix(nightly-CI): Do not publish snapshots from forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   nightly_build:
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/polaris'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Adopt the `Nightly Build` workflow to not (try to) publish every night from forks.
