### PR TITLE
fix(CI): Resolve ambiguous `regtests` GH WF job name

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,6 +56,7 @@ github:
           - markdown-link-check
           - build
           - regtest
+          - spark-plugin-regtest
           - site
           - "Helm tests"
 

--- a/.github/workflows/spark_client_regtests.yml
+++ b/.github/workflows/spark_client_regtests.yml
@@ -25,7 +25,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  regtest:
+  spark-plugin-regtest:
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Job names in GH WFs should be unique and not ambiguous to be able to distinguish those.
