### PR TITLE
fix(testing): Do not let PolarisOverlappingTableTest spam `/tmp`

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingTableTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisOverlappingTableTest.java
@@ -24,6 +24,7 @@ import static org.apache.polaris.service.quarkus.admin.PolarisAuthzTestBase.SCHE
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.core.Response;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -39,6 +40,7 @@ import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.TestServices;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,7 +49,6 @@ public class PolarisOverlappingTableTest {
 
   private static final String namespace = "ns";
   private static final String catalog = "test-catalog";
-  private static final String baseLocation = "file:///tmp/PolarisOverlappingTableTest";
 
   private int createTable(TestServices services, String location) {
     CreateTableRequest createTableRequest =
@@ -120,8 +121,14 @@ public class PolarisOverlappingTableTest {
   void testTableLocationRestrictions(
       Map<String, Object> serverConfig,
       Map<String, String> catalogConfig,
-      int expectedStatusForOverlaps) {
+      int expectedStatusForOverlaps,
+      @TempDir Path tempDir) {
     TestServices services = TestServices.builder().config(serverConfig).build();
+
+    String baseLocation = tempDir.toAbsolutePath().toUri().toString();
+    if (baseLocation.endsWith("/")) {
+      baseLocation = baseLocation.substring(0, baseLocation.length() - 1);
+    }
 
     CatalogProperties.Builder propertiesBuilder =
         CatalogProperties.builder()


### PR DESCRIPTION
Changes the test to leverage JUnit's `@TempDir`.
