### PR TITLE
fix(metrics): Do not emit metrics for failed realm resolutions

### DIFF
--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/RealmIdTagContributor.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/metrics/RealmIdTagContributor.java
@@ -30,10 +30,8 @@ import org.apache.polaris.service.context.RealmContextResolver;
 public class RealmIdTagContributor implements HttpServerMetricsTagsContributor {
 
   public static final String TAG_REALM = "realm_id";
-  public static final String TAG_REALM_RESOLUTION_FAILURE = "realm_resolution_failure";
 
   private static final Tags UNFINISHED_RESOLUTION_TAGS = Tags.of(TAG_REALM, "???");
-  private static final Tags FAILED_RESOLUTION_TAGS = Tags.of(TAG_REALM, "!!!");
 
   @Inject RealmContextResolver realmContextResolver;
 
@@ -50,24 +48,17 @@ public class RealmIdTagContributor implements HttpServerMetricsTagsContributor {
               request.path(),
               request.headers()::get)
           .thenApply(this::successfulResolutionTags)
-          .exceptionally(this::failedResolutionTags)
           .toCompletableFuture()
           // get the result of the CompletableFuture if it's already completed,
           // otherwise return UNFINISHED_RESOLUTION_TAGS as this code is executed on
           // an event loop thread, and we don't want to block it.
           .getNow(UNFINISHED_RESOLUTION_TAGS);
     } catch (Exception e) {
-      return failedResolutionTags(e);
+      return Tags.empty();
     }
   }
 
   private Tags successfulResolutionTags(RealmContext realmContext) {
     return Tags.of(TAG_REALM, realmContext.getRealmIdentifier());
-  }
-
-  private Tags failedResolutionTags(Throwable error) {
-    return FAILED_RESOLUTION_TAGS.and(
-        TAG_REALM_RESOLUTION_FAILURE,
-        error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage());
   }
 }


### PR DESCRIPTION
It's not a good practice to create metrics from error messages. This change removes that.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
