### PR TITLE
fix(test): Do not let some more tests spam `/tmp`

### DIFF
--- a/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/extension/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -25,14 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
@@ -44,10 +42,10 @@ import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
 import org.apache.polaris.jpa.models.ModelPrincipalSecrets;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -60,18 +58,15 @@ import org.mockito.Mockito;
  */
 public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStoreManagerTest {
 
-  private static Path rootDir;
   private static Path persistenceXml;
   private static Path confJar;
 
   @BeforeAll
-  static void prepareConfFiles() throws IOException {
+  static void prepareConfFiles(@TempDir Path archiveDir) throws IOException {
     URL persistenceXmlSource =
         Objects.requireNonNull(
             PolarisEclipseLinkMetaStoreManagerTest.class.getResource("/META-INF/persistence.xml"));
-    rootDir = Files.createTempDirectory("root");
-    Path archiveDir = rootDir.resolve("archive");
-    Files.createDirectory(archiveDir);
+    Files.createDirectories(archiveDir);
     persistenceXml = archiveDir.resolve("persistence.xml");
     try (InputStream is = persistenceXmlSource.openStream()) {
       Files.copy(is, persistenceXml);
@@ -82,17 +77,6 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     confJar = archiveDir.resolve("test-conf.jar");
     try (InputStream is = confJarSource.openStream()) {
       Files.copy(is, confJar);
-    }
-  }
-
-  @AfterAll
-  static void deleteConfFiles() throws IOException {
-    if (rootDir != null) {
-      try (Stream<Path> paths = Files.walk(rootDir)) {
-        boolean allDeleted =
-            paths.sorted(Comparator.reverseOrder()).map(Path::toFile).allMatch(File::delete);
-        assertTrue(allDeleted);
-      }
     }
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTest.java
@@ -18,20 +18,32 @@
  */
 package org.apache.polaris.service.it.test;
 
+import java.nio.file.Path;
 import java.util.List;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on the local filesystem. */
-public class PolarisRestCatalogViewFileIntegrationTest
+public abstract class PolarisRestCatalogViewFileIntegrationTest
     extends PolarisRestCatalogViewIntegrationBase {
-  public static final String BASE_LOCATION = "file:///tmp/buckets/my-bucket";
+  static String baseLocation;
+
+  @BeforeAll
+  public static void setUp(@TempDir Path tempDir) {
+    String baseUri = tempDir.toAbsolutePath().toUri().toString();
+    if (baseUri.endsWith("/")) {
+      baseUri = baseUri.substring(0, baseUri.length() - 1);
+    }
+    baseLocation = baseUri;
+  }
 
   @Override
   protected StorageConfigInfo getStorageConfigInfo() {
     return FileStorageConfigInfo.builder()
         .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
-        .setAllowedLocations(List.of(BASE_LOCATION))
+        .setAllowedLocations(List.of(baseLocation))
         .build();
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on the local filesystem. */
-public abstract class PolarisRestCatalogViewFileIntegrationTest
+public abstract class PolarisRestCatalogViewFileIntegrationTestBase
     extends PolarisRestCatalogViewIntegrationBase {
   static String baseLocation;
 

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIT.java
@@ -22,12 +22,12 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import org.apache.iceberg.view.ViewCatalogTests;
-import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTest;
+import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class QuarkusRestCatalogViewFileIT extends PolarisRestCatalogViewFileIntegrationTest {
+public class QuarkusRestCatalogViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {
 
   @BeforeEach
   public void setUpTempDir(@TempDir Path tempDir) throws Exception {

--- a/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/relational/jdbc/JdbcQuarkusViewFileIT.java
+++ b/quarkus/service/src/intTest/java/org/apache/polaris/service/quarkus/it/relational/jdbc/JdbcQuarkusViewFileIT.java
@@ -20,9 +20,9 @@ package org.apache.polaris.service.quarkus.it.relational.jdbc;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTest;
+import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
 import org.apache.polaris.test.commons.RelationalJdbcProfile;
 
 @TestProfile(RelationalJdbcProfile.class)
 @QuarkusIntegrationTest
-public class JdbcQuarkusViewFileIT extends PolarisRestCatalogViewFileIntegrationTest {}
+public class JdbcQuarkusViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
@@ -26,7 +26,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -47,6 +46,7 @@ import org.apache.polaris.service.auth.TokenRequestValidator;
 import org.apache.polaris.service.auth.TokenResponse;
 import org.apache.polaris.service.types.TokenType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 @QuarkusTest
@@ -55,9 +55,9 @@ public class JWTRSAKeyPairTest {
   @Inject protected PolarisConfigurationStore configurationStore;
 
   @Test
-  public void testSuccessfulTokenGeneration() throws Exception {
-    Path privateFileLocation = Files.createTempFile("test-private", ".pem");
-    Path publicFileLocation = Files.createTempFile("test-public", ".pem");
+  public void testSuccessfulTokenGeneration(@TempDir Path tempDir) throws Exception {
+    Path privateFileLocation = tempDir.resolve("test-private.pem");
+    Path publicFileLocation = tempDir.resolve("test-public.pem");
     PemUtils.generateKeyPair(privateFileLocation, publicFileLocation);
 
     final String clientId = "test-client-id";

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/io/FileIOExceptionsTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.azure.core.exception.AzureException;
 import com.google.cloud.storage.StorageException;
 import jakarta.ws.rs.core.Response;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +45,7 @@ import org.apache.polaris.service.TestServices;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -54,13 +56,12 @@ public class FileIOExceptionsTest {
       new Schema(required(3, "id", Types.IntegerType.get(), "unique ID"));
 
   private static final String catalog = "test-catalog";
-  private static final String catalogBaseLocation = "file:/tmp/buckets/my-bucket/path/to/data";
 
   private static TestServices services;
   private static MeasuredFileIOFactory ioFactory;
 
   @BeforeAll
-  public static void beforeAll() {
+  public static void beforeAll(@TempDir Path tempDir) {
     services =
         TestServices.builder()
             .config(
@@ -71,6 +72,11 @@ public class FileIOExceptionsTest {
                     List.of("FILE", "S3")))
             .build();
     ioFactory = (MeasuredFileIOFactory) services.fileIOFactory();
+
+    String catalogBaseLocation = tempDir.toAbsolutePath().toUri().toString();
+    if (catalogBaseLocation.endsWith("/")) {
+      catalogBaseLocation = catalogBaseLocation.substring(0, catalogBaseLocation.length() - 1);
+    }
 
     FileStorageConfigInfo storageConfigInfo =
         FileStorageConfigInfo.builder()

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIntegrationTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/it/QuarkusRestCatalogViewFileIntegrationTest.java
@@ -25,14 +25,14 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import org.apache.iceberg.view.ViewCatalogTests;
-import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTest;
+import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusTest
 @TestProfile(QuarkusRestCatalogViewFileIntegrationTest.Profile.class)
 public class QuarkusRestCatalogViewFileIntegrationTest
-    extends PolarisRestCatalogViewFileIntegrationTest {
+    extends PolarisRestCatalogViewFileIntegrationTestBase {
 
   public static class Profile implements QuarkusTestProfile {
 


### PR DESCRIPTION
* `PolarisRestCatalogViewFileIntegrationTest`
* `FileIOExceptionsTest`
* `JWTRSAKeyPairTest`

Changes the tests to leverage JUnit's `@TempDir`.

Simplifies `PolarisEclipseLinkMetaStoreManagerTest`
