### PR TITLE
Quickstart documentation contained an error around starting Polaris using docker compose

### DIFF
--- a/getting-started/assets/postgres/docker-compose-postgres.yml
+++ b/getting-started/assets/postgres/docker-compose-postgres.yml
@@ -32,8 +32,11 @@ services:
     volumes:
       # Bind local conf file to a convenient location in the container
       - type: bind
-        source: ../assets/postgres/postgresql.conf
+        source: postgresql.conf
         target: /etc/postgresql/postgresql.conf
+      - type: bind
+        source: pg_hba.conf
+        target: /etc/postgresql/pg_hba.conf
     command:
       - "postgres"
       - "-c"

--- a/getting-started/assets/postgres/pg_hba.conf
+++ b/getting-started/assets/postgres/pg_hba.conf
@@ -1,0 +1,2 @@
+host        all        all         all                   md5
+hostnossl   all        all         all                   md5

--- a/getting-started/eclipselink/docker-compose-bootstrap-db.yml
+++ b/getting-started/eclipselink/docker-compose-bootstrap-db.yml
@@ -25,7 +25,7 @@ services:
       polaris.persistence.type: eclipse-link
       polaris.persistence.eclipselink.configuration-file: /deployments/config/eclipselink/persistence.xml
     volumes:
-      - ../assets/eclipselink/:/deployments/config/eclipselink
+      - ../eclipselink/:/deployments/config/eclipselink
     command:
       - "bootstrap"
       - "--realm=POLARIS"

--- a/site/content/in-dev/unreleased/getting-started/quickstart.md
+++ b/site/content/in-dev/unreleased/getting-started/quickstart.md
@@ -36,7 +36,7 @@ cd ~/polaris
   :polaris-quarkus-admin:assemble --rerun \
   -Dquarkus.container-image.tag=postgres-latest \
   -Dquarkus.container-image.build=true
-docker compose -f getting-started/eclipselink/docker-compose-postgres.yml -f getting-started/eclipselink/docker-compose-bootstrap-db.yml -f getting-started/eclipselink/docker-compose.yml up
+docker compose -f getting-started/assets/postgres/docker-compose-postgres.yml -f getting-started/eclipselink/docker-compose-bootstrap-db.yml -f getting-started/eclipselink/docker-compose.yml up
 ```
 
 You should see output for some time as Polaris, Spark, and Trino build and start up. Eventually, you won’t see any more logs and see some logs relating to Spark, resembling the following:


### PR DESCRIPTION
Hello.  I was interested in learning more about Polaris, and when to run an instance up using the instructions in the documentation.  I reached the docker-compose example for starting polaris and the command failed.

Specifically, the docker compose command was attempting to use the file "getting-started/eclipselink/docker-compose-postgres.yml" to start postgres and that file did not exist.

![image](https://github.com/user-attachments/assets/085c5292-b752-49d0-8d4e-3f96aeaa7f1c)

I noticed there was a file at "getting-started/assets/postgres/docker-compose-postgres.yaml", and when I updated the command it was able to progress.

This PR has an update to the documentation to reflect the new location.