### PR TITLE
Keep generated RSA-key-pair for JWT token broker on heap

### DIFF
--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
@@ -26,7 +26,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import java.nio.file.Path;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import org.apache.polaris.core.PolarisCallContext;
@@ -39,6 +38,7 @@ import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.service.auth.JWTRSAKeyPair;
+import org.apache.polaris.service.auth.KeyProvider;
 import org.apache.polaris.service.auth.LocalRSAKeyProvider;
 import org.apache.polaris.service.auth.PemUtils;
 import org.apache.polaris.service.auth.TokenBroker;
@@ -46,7 +46,6 @@ import org.apache.polaris.service.auth.TokenRequestValidator;
 import org.apache.polaris.service.auth.TokenResponse;
 import org.apache.polaris.service.types.TokenType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 @QuarkusTest
@@ -55,10 +54,8 @@ public class JWTRSAKeyPairTest {
   @Inject protected PolarisConfigurationStore configurationStore;
 
   @Test
-  public void testSuccessfulTokenGeneration(@TempDir Path tempDir) throws Exception {
-    Path privateFileLocation = tempDir.resolve("test-private.pem");
-    Path publicFileLocation = tempDir.resolve("test-public.pem");
-    PemUtils.generateKeyPair(privateFileLocation, publicFileLocation);
+  public void testSuccessfulTokenGeneration() throws Exception {
+    var keyPair = PemUtils.generateKeyPair();
 
     final String clientId = "test-client-id";
     final String scope = "PRINCIPAL_ROLE:TEST";
@@ -82,8 +79,8 @@ public class JWTRSAKeyPairTest {
     Mockito.when(
             metastoreManager.loadEntity(polarisCallContext, 0L, 1L, PolarisEntityType.PRINCIPAL))
         .thenReturn(new EntityResult(principal));
-    TokenBroker tokenBroker =
-        new JWTRSAKeyPair(metastoreManager, 420, publicFileLocation, privateFileLocation);
+    KeyProvider provider = new LocalRSAKeyProvider(keyPair);
+    TokenBroker tokenBroker = new JWTRSAKeyPair(metastoreManager, 420, provider);
     TokenResponse token =
         tokenBroker.generateFromClientSecrets(
             clientId,
@@ -95,7 +92,6 @@ public class JWTRSAKeyPairTest {
     assertThat(token).isNotNull();
     assertThat(token.getExpiresIn()).isEqualTo(420);
 
-    LocalRSAKeyProvider provider = new LocalRSAKeyProvider(publicFileLocation, privateFileLocation);
     assertThat(provider.getPrivateKey()).isNotNull();
     assertThat(provider.getPublicKey()).isNotNull();
     JWTVerifier verifier =

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPair.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTRSAKeyPair.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.service.auth;
 
 import com.auth0.jwt.algorithms.Algorithm;
-import java.nio.file.Path;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -32,10 +31,9 @@ public class JWTRSAKeyPair extends JWTBroker {
   public JWTRSAKeyPair(
       PolarisMetaStoreManager metaStoreManager,
       int maxTokenGenerationInSeconds,
-      Path publicKeyFile,
-      Path privateKeyFile) {
+      KeyProvider keyProvider) {
     super(metaStoreManager, maxTokenGenerationInSeconds);
-    keyProvider = new LocalRSAKeyProvider(publicKeyFile, privateKeyFile);
+    this.keyProvider = keyProvider;
   }
 
   @Override

--- a/service/common/src/main/java/org/apache/polaris/service/auth/PemUtils.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/PemUtils.java
@@ -120,15 +120,23 @@ public class PemUtils {
     return PemUtils.getPrivateKey(bytes, algorithm);
   }
 
-  public static void generateKeyPair(Path privateFileLocation, Path publicFileLocation)
-      throws NoSuchAlgorithmException, IOException {
+  public static KeyPair generateKeyPair() throws NoSuchAlgorithmException {
     KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
     kpg.initialize(2048);
-    KeyPair kp = kpg.generateKeyPair();
+    return kpg.generateKeyPair();
+  }
+
+  public static void generateKeyPairFiles(Path privateFileLocation, Path publicFileLocation)
+      throws NoSuchAlgorithmException, IOException {
+    writeKeyPairFiles(generateKeyPair(), privateFileLocation, publicFileLocation);
+  }
+
+  public static void writeKeyPairFiles(
+      KeyPair keyPair, Path privateFileLocation, Path publicFileLocation) throws IOException {
     try (BufferedWriter writer = Files.newBufferedWriter(privateFileLocation, UTF_8)) {
       writer.write("-----BEGIN PRIVATE KEY-----");
       writer.newLine();
-      writer.write(Base64.getMimeEncoder().encodeToString(kp.getPrivate().getEncoded()));
+      writer.write(Base64.getMimeEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
       writer.newLine();
       writer.write("-----END PRIVATE KEY-----");
       writer.newLine();
@@ -136,7 +144,7 @@ public class PemUtils {
     try (BufferedWriter writer = Files.newBufferedWriter(publicFileLocation, UTF_8)) {
       writer.write("-----BEGIN PUBLIC KEY-----");
       writer.newLine();
-      writer.write(Base64.getMimeEncoder().encodeToString(kp.getPublic().getEncoded()));
+      writer.write(Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
       writer.newLine();
       writer.write("-----END PUBLIC KEY-----");
       writer.newLine();

--- a/service/common/src/test/java/org/apache/polaris/service/auth/LocalRSAKeyProviderTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/auth/LocalRSAKeyProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.auth;
+
+import static org.assertj.core.api.InstanceOfAssertFactories.BYTE_ARRAY;
+
+import java.nio.file.Path;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class LocalRSAKeyProviderTest {
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @Test
+  public void fromFiles(@TempDir Path tempDir) throws Exception {
+    var publicKeyFile = tempDir.resolve("public.key");
+    var privateKeyFile = tempDir.resolve("private.key");
+    PemUtils.generateKeyPairFiles(privateKeyFile, publicKeyFile);
+
+    var generatedPublicKey = PemUtils.readPublicKeyFromFile(publicKeyFile, "RSA");
+    var generatedPrivateKey = PemUtils.readPrivateKeyFromFile(privateKeyFile, "RSA");
+
+    var keyProvider = LocalRSAKeyProvider.fromFiles(publicKeyFile, privateKeyFile);
+    soft.assertThat(keyProvider)
+        .extracting(KeyProvider::getPublicKey)
+        .extracting(PublicKey::getEncoded, BYTE_ARRAY)
+        .containsExactly(generatedPublicKey.getEncoded());
+    soft.assertThat(keyProvider)
+        .extracting(KeyProvider::getPrivateKey)
+        .extracting(PrivateKey::getEncoded, BYTE_ARRAY)
+        .containsExactly(generatedPrivateKey.getEncoded());
+  }
+
+  @Test
+  public void onHeap() throws Exception {
+    var keyPair = PemUtils.generateKeyPair();
+
+    var generatedPublicKey = keyPair.getPublic();
+    var generatedPrivateKey = keyPair.getPrivate();
+
+    var keyProvider = new LocalRSAKeyProvider(keyPair);
+    soft.assertThat(keyProvider)
+        .extracting(KeyProvider::getPublicKey)
+        .extracting(PublicKey::getEncoded, BYTE_ARRAY)
+        .containsExactly(generatedPublicKey.getEncoded());
+    soft.assertThat(keyProvider)
+        .extracting(KeyProvider::getPrivateKey)
+        .extracting(PrivateKey::getEncoded, BYTE_ARRAY)
+        .containsExactly(generatedPrivateKey.getEncoded());
+  }
+}


### PR DESCRIPTION
Polaris allows using RSA key-paris for the JWT token broker. The recommended way is to [generate the RSA key pair](https://github.com/apache/polaris/blob/d8b862b13914d526ee147dc0e359bfc9c1e319ad/site/content/in-dev/unreleased/configuring-polaris-for-production.md?plain=1#L61-L66) and configure the location of the key files.

However, if only `polaris.authentication.token-broker.type=rsa-key-pair` but not the `public/private-key-pair` options are configured, Polaris generates those and stores them in `/tmp` using random file names (using `Files.createTempFile()`) - this happens for each (matching) realm. Each Polaris startup generates new key-pairs for each of those realms. It's practically not possible to associate the files to a realm. There is already a [production readiness check](https://github.com/apache/polaris/blob/d8b862b13914d526ee147dc0e359bfc9c1e319ad/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/ProductionReadinessChecks.java#L118-L166) to warn users about this behavior.

Due to the issue that the files cannot be associated, those seem to be somewhat useless and bring no advantage over keeping these "ephemeral RSA key pairs" on heap. This PR changes the code to not write the key-pair to the file system and keeps these "ephemeral key pairs" on heap. Since the same code path is used for key-paris _provided_ by the user (via the `public/private-key-pair` config options), that code path now only reads those files once and not every time the private/public key is needed.
