### PR TITLE
fix: Remove info log about deprecated internal method from PolarisConfiguration

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -165,6 +165,8 @@ public abstract class PolarisConfiguration<T> {
     /**
      * Used to support backwards compatability before there were reserved properties. Usage of this
      * method should be removed over time.
+     *
+     * @deprecated Use {@link #catalogConfig()} instead.
      */
     @Deprecated
     public Builder<T> catalogConfigUnsafe(String catalogConfig) {


### PR DESCRIPTION
Remove the INFO log about calls to this method in Polaris, because users cannot do anything about these messages.

Phasing out old property names requires coordination with users (e.g. release notes), so it is not a matter of merely avoiding calls to that method in Polaris code.

Fixes #1666

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
