### PR TITLE
Fix SparkClient listGenericTable to use ListGenericTablesRESTResponse 

### DIFF
--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
@@ -42,7 +42,6 @@ import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.ResourcePaths;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.ConfigResponse;
-import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.polaris.core.rest.PolarisEndpoints;
@@ -50,6 +49,7 @@ import org.apache.polaris.core.rest.PolarisResourcePaths;
 import org.apache.polaris.service.types.CreateGenericTableRequest;
 import org.apache.polaris.service.types.GenericTable;
 import org.apache.polaris.spark.rest.CreateGenericTableRESTRequest;
+import org.apache.polaris.spark.rest.ListGenericTablesRESTResponse;
 import org.apache.polaris.spark.rest.LoadGenericTableRESTResponse;
 
 /**
@@ -164,17 +164,17 @@ public class PolarisRESTCatalog implements PolarisCatalog, Closeable {
 
     do {
       queryParams.put("pageToken", pageToken);
-      ListTablesResponse response =
+      ListGenericTablesRESTResponse response =
           restClient
               .withAuthSession(this.catalogAuth)
               .get(
                   pathGenerator.genericTables(ns),
                   queryParams,
-                  ListTablesResponse.class,
+                  ListGenericTablesRESTResponse.class,
                   Map.of(),
                   ErrorHandlers.namespaceErrorHandler());
-      pageToken = response.nextPageToken();
-      tables.addAll(response.identifiers());
+      pageToken = response.getNextPageToken();
+      tables.addAll(response.getIdentifiers());
     } while (pageToken != null);
 
     return tables.build();


### PR DESCRIPTION
ListTableResponse is the class used by iceberg endpoint, which is the same as ListGenericTablesRESTResponse. However, we are suppose to use ListGenericTablesRESTResponse to be correct