### PR TITLE
fix credentials getting printed  twice

### DIFF
--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -135,17 +135,12 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
     for (String realm : realms) {
       RealmContext realmContext = () -> realm;
-      if (!metaStoreManagerMap.containsKey(realmContext.getRealmIdentifier())) {
+      if (!metaStoreManagerMap.containsKey(realm)) {
         initializeForRealm(realmContext, rootCredentialsSet, true);
         PrincipalSecretsResult secretsResult =
             bootstrapServiceAndCreatePolarisPrincipalForRealm(
-                realmContext, metaStoreManagerMap.get(realmContext.getRealmIdentifier()));
-
-        if (rootCredentialsSet.credentials().containsKey(realm)) {
-          LOGGER.info("Bootstrapped realm {} using preset credentials.", realm);
-        }
-
-        results.put(realmContext.getRealmIdentifier(), secretsResult);
+                realmContext, metaStoreManagerMap.get(realm));
+        results.put(realm, secretsResult);
       }
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -113,12 +113,12 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
 
     for (String realm : realms) {
       RealmContext realmContext = () -> realm;
-      if (!metaStoreManagerMap.containsKey(realmContext.getRealmIdentifier())) {
+      if (!metaStoreManagerMap.containsKey(realm)) {
         initializeForRealm(realmContext, rootCredentialsSet);
         PrincipalSecretsResult secretsResult =
             bootstrapServiceAndCreatePolarisPrincipalForRealm(
-                realmContext, metaStoreManagerMap.get(realmContext.getRealmIdentifier()));
-        results.put(realmContext.getRealmIdentifier(), secretsResult);
+                realmContext, metaStoreManagerMap.get(realm));
+        results.put(realm, secretsResult);
       }
     }
 

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -32,7 +32,6 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.bootstrap.RootCredentials;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
@@ -104,28 +103,6 @@ public class InMemoryPolarisMetaStoreManagerFactory
       Iterable<String> realms, RootCredentialsSet rootCredentialsSet) {
     Map<String, PrincipalSecretsResult> results = super.bootstrapRealms(realms, rootCredentialsSet);
     bootstrappedRealms.addAll(results.keySet());
-
-    Map<String, RootCredentials> presetCredentials = rootCredentialsSet.credentials();
-    for (String realmId : realms) {
-      if (presetCredentials.containsKey(realmId)) {
-        // Credentials provided in the runtime env... no need to print
-        continue;
-      }
-
-      PrincipalSecretsResult principalSecrets = results.get(realmId);
-      if (principalSecrets == null) {
-        continue; // already bootstrapped (possible benign race)
-      }
-
-      String msg =
-          String.format(
-              "realm: %1s root principal credentials: %2s:%3s",
-              realmId,
-              principalSecrets.getPrincipalSecrets().getPrincipalClientId(),
-              principalSecrets.getPrincipalSecrets().getMainSecret());
-      System.out.println(msg);
-    }
-
     return results;
   }
 }


### PR DESCRIPTION
after https://github.com/apache/polaris/pull/1376 a comment shows that non-root credentials could get printed twice:
```
2025-05-07 23:40:06,767 INFO  [org.apa.pol.ser.qua.con.QuarkusProducers] [,] [,,,] (Quarkus Main Thread) Bootstrapping realm(s) 'POLARIS', if necessary, from root credentials set provided via the environment variable POLARIS_BOOTSTRAP_CREDENTIALS or Java system property polaris.bootstrap.credentials ...
realm: POLARIS root principal credentials: c15135cbf0977e3d:a38976b705f0959e0017e0cef831122e
2025-05-07 23:40:06,819 INFO  [org.apa.pol.ser.qua.con.QuarkusProducers] [,] [,,,] (Quarkus Main Thread) Realm 'POLARIS' automatically bootstrapped, credentials were not present in root credentials set provided via the environment variable POLARIS_BOOTSTRAP_CREDENTIALS or Java system property polaris.bootstrap.credentials, see separate message printed to stdout.
realm: POLARIS root principal credentials: c15135cbf0977e3d:a38976b705f0959e0017e0cef831122e
```

so we remove all logging/printing from the `bootstrapRealms` implementations as the outer callers `QuarkusProducers.maybeBootstrap` and `BootstrapCommand.call` are already taking care of that.