### PR TITLE
Handle RequestScoped instance injection gracefully for DefaultConfigurationStore

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -43,7 +43,14 @@ public interface PolarisConfigurationStore {
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key or null if not set
    * @param <T> the type of the configuration value
+   *
+   * @deprecated this function is going to be deprecated, please use the following
+   *             function to get the configuration value in a more robust way:
+   *             getConfiguration(String realm, String configName)
+   *             This function can not be called outside of active request scope, such as
+   *             background tasks (TaskExecutor).
    */
+  @Deprecated
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
     return null;
   }
@@ -57,11 +64,47 @@ public interface PolarisConfigurationStore {
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
    * @param <T> the type of the configuration value
+   *
+   * @deprecated this function is going to be deprecated, please use the following
+   *             function to get the configuration value in a more robust way:
+   *             getConfiguration(String realm, String configName, @Nonnull T defaultValue)
+   *             This function can not be called outside of active request scope, such as
+   *             background tasks (TaskExecutor).
    */
+  @Deprecated
   default <T> @Nonnull T getConfiguration(
       PolarisCallContext ctx, String configName, @Nonnull T defaultValue) {
     Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");
     T configValue = getConfiguration(ctx, configName);
+    return configValue != null ? configValue : defaultValue;
+  }
+
+  /**
+   * Retrieve the current value for a configuration key for a given realm. May be null if not set.
+   *
+   * @param realm the realm identifier
+   * @param configName the name of the configuration key to check
+   * @return the current value set for the configuration key for the given realm, or null if not set
+   * @param <T> the type of the configuration value
+   */
+  default <T>  @Nullable T getConfiguration(String realm, String configName) {
+    return null;
+  }
+
+  /**
+   * Retrieve the current value for a configuration key for the given realm. If not set,
+   * return the non-null default value.
+   *
+   * @param realm the realm identifier
+   * @param configName the name of the configuration key to check
+   * @param defaultValue the default value if the configuration key has no value
+   * @return the current value or the supplied default value
+   * @param <T> the type of the configuration value
+   */
+  default <T> @Nonnull T getConfiguration(
+      String realm, String configName, @Nonnull T defaultValue) {
+    Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");
+    T configValue = getConfiguration(realm, configName);
     return configValue != null ? configValue : defaultValue;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -43,12 +43,11 @@ public interface PolarisConfigurationStore {
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key or null if not set
    * @param <T> the type of the configuration value
-   * @deprecated this function is going to be deprecated, please use the following function to get
-   *     the configuration value in a more robust way: getConfiguration(String realm, String
-   *     configName) This function can not be called outside of active request scope, such as
-   *     background tasks (TaskExecutor).
+   *     <p>This function needs to be used with caution, it can not be called outside of active
+   *     request scope, such as background tasks (TaskExecutor). Please use the function
+   *     getConfiguration(String realm, String configName) to get the configuration value in a more
+   *     robust way.
    */
-  @Deprecated
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
     return null;
   }
@@ -62,12 +61,11 @@ public interface PolarisConfigurationStore {
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
    * @param <T> the type of the configuration value
-   * @deprecated this function is going to be deprecated, please use the following function to get
-   *     the configuration value in a more robust way: getConfiguration(String realm, String
-   *     configName, @Nonnull T defaultValue) This function can not be called outside of active
-   *     request scope, such as background tasks (TaskExecutor).
+   *     <p>This function needs to be used with caution, it can not be called outside of active
+   *     request scope, such as background tasks (TaskExecutor). Please use the function
+   *     getConfiguration(String realm, String configName, @Nonnull T defaultValue) to get the
+   *     configuration value in a more robust way.
    */
-  @Deprecated
   default <T> @Nonnull T getConfiguration(
       PolarisCallContext ctx, String configName, @Nonnull T defaultValue) {
     Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -43,12 +43,10 @@ public interface PolarisConfigurationStore {
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key or null if not set
    * @param <T> the type of the configuration value
-   *
-   * @deprecated this function is going to be deprecated, please use the following
-   *             function to get the configuration value in a more robust way:
-   *             getConfiguration(String realm, String configName)
-   *             This function can not be called outside of active request scope, such as
-   *             background tasks (TaskExecutor).
+   * @deprecated this function is going to be deprecated, please use the following function to get
+   *     the configuration value in a more robust way: getConfiguration(String realm, String
+   *     configName) This function can not be called outside of active request scope, such as
+   *     background tasks (TaskExecutor).
    */
   @Deprecated
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
@@ -64,12 +62,10 @@ public interface PolarisConfigurationStore {
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
    * @param <T> the type of the configuration value
-   *
-   * @deprecated this function is going to be deprecated, please use the following
-   *             function to get the configuration value in a more robust way:
-   *             getConfiguration(String realm, String configName, @Nonnull T defaultValue)
-   *             This function can not be called outside of active request scope, such as
-   *             background tasks (TaskExecutor).
+   * @deprecated this function is going to be deprecated, please use the following function to get
+   *     the configuration value in a more robust way: getConfiguration(String realm, String
+   *     configName, @Nonnull T defaultValue) This function can not be called outside of active
+   *     request scope, such as background tasks (TaskExecutor).
    */
   @Deprecated
   default <T> @Nonnull T getConfiguration(
@@ -87,13 +83,13 @@ public interface PolarisConfigurationStore {
    * @return the current value set for the configuration key for the given realm, or null if not set
    * @param <T> the type of the configuration value
    */
-  default <T>  @Nullable T getConfiguration(String realm, String configName) {
+  default <T> @Nullable T getConfiguration(String realm, String configName) {
     return null;
   }
 
   /**
-   * Retrieve the current value for a configuration key for the given realm. If not set,
-   * return the non-null default value.
+   * Retrieve the current value for a configuration key for the given realm. If not set, return the
+   * non-null default value.
    *
    * @param realm the realm identifier
    * @param configName the name of the configuration key to check

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -40,16 +40,17 @@ public interface PolarisConfigurationStore {
   /**
    * Retrieve the current value for a configuration key. May be null if not set.
    *
+   * <p>This function will be deprecated, it can not be called outside of active request scope, such
+   * as background tasks (TaskExecutor). Please use the function getConfiguration(RealmContext
+   * realmContext, String configName) to get the configuration value in a more robust way. TODO:
+   * Remove this function and replace the usage with the function takes realm.
+   *
    * @param ctx the current call context
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key or null if not set
    * @param <T> the type of the configuration value
-   *     <p>This function needs to be used with caution, it can not be called outside of active
-   *     request scope, such as background tasks (TaskExecutor). Please use the function
-   *     getConfiguration(RealmContext realmContext, String configName) to get the configuration
-   *     value in a more robust way. TODO: Remove this function and replace the usage with the
-   *     function takes realm.
    */
+  @Deprecated
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
     return null;
   }
@@ -58,17 +59,17 @@ public interface PolarisConfigurationStore {
    * Retrieve the current value for a configuration key. If not set, return the non-null default
    * value.
    *
+   * <p>This function will be deprecated, it can not be called outside of active request scope, such
+   * as background tasks (TaskExecutor). Please use the function getConfiguration(RealmContext
+   * realmContext, String configName, T defaultValue) to get the configuration value in a more
+   * robust way. TODO: Remove this function and replace the usage with the function takes realm.
+   *
    * @param ctx the current call context
    * @param configName the name of the configuration key to check
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
-   * @param <T> the type of the configuration value
-   *     <p>This function needs to be used with caution, it can not be called outside of active
-   *     request scope, such as background tasks (TaskExecutor). Please use the function
-   *     getConfiguration(RealmContext realmContext, String configName, T defaultValue) to get the
-   *     configuration value in a more robust way. TODO: Remove this function and replace the usage
-   *     with the function takes realm.
    */
+  @Deprecated
   default <T> @Nonnull T getConfiguration(
       PolarisCallContext ctx, String configName, @Nonnull T defaultValue) {
     Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");
@@ -130,7 +131,8 @@ public interface PolarisConfigurationStore {
   }
 
   /**
-   * Retrieve the current value for a configuration.
+   * Retrieve the current value for a configuration. TODO: update the function to take RealmContext
+   * instead of PolarisCallContext
    *
    * @param ctx the current call context
    * @param config the configuration to load
@@ -144,7 +146,7 @@ public interface PolarisConfigurationStore {
 
   /**
    * Retrieve the current value for a configuration, overriding with a catalog config if it is
-   * present.
+   * present. TODO: update the function to take RealmContext instead of PolarisCallContext
    *
    * @param ctx the current call context
    * @param catalogEntity the catalog to check for an override

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,9 @@ public interface PolarisConfigurationStore {
    * @param <T> the type of the configuration value
    *     <p>This function needs to be used with caution, it can not be called outside of active
    *     request scope, such as background tasks (TaskExecutor). Please use the function
-   *     getConfiguration(String realm, String configName) to get the configuration value in a more
-   *     robust way. TODO: Remove this function and replace the usage with the function takes realm
+   *     getConfiguration(RealmContext realmContext, String configName) to get the configuration
+   *     value in a more robust way. TODO: Remove this function and replace the usage with the
+   *     function takes realm.
    */
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
     return null;
@@ -63,9 +65,9 @@ public interface PolarisConfigurationStore {
    * @param <T> the type of the configuration value
    *     <p>This function needs to be used with caution, it can not be called outside of active
    *     request scope, such as background tasks (TaskExecutor). Please use the function
-   *     getConfiguration(String realm, String configName, @Nonnull T defaultValue) to get the
+   *     getConfiguration(RealmContext realmContext, String configName, T defaultValue) to get the
    *     configuration value in a more robust way. TODO: Remove this function and replace the usage
-   *     with the function takes realm
+   *     with the function takes realm.
    */
   default <T> @Nonnull T getConfiguration(
       PolarisCallContext ctx, String configName, @Nonnull T defaultValue) {
@@ -77,12 +79,12 @@ public interface PolarisConfigurationStore {
   /**
    * Retrieve the current value for a configuration key for a given realm. May be null if not set.
    *
-   * @param realm the realm identifier
+   * @param realmContext the realm context
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key for the given realm, or null if not set
    * @param <T> the type of the configuration value
    */
-  default <T> @Nullable T getConfiguration(String realm, String configName) {
+  default <T> @Nullable T getConfiguration(@Nonnull RealmContext realmContext, String configName) {
     return null;
   }
 
@@ -90,16 +92,16 @@ public interface PolarisConfigurationStore {
    * Retrieve the current value for a configuration key for the given realm. If not set, return the
    * non-null default value.
    *
-   * @param realm the realm identifier
+   * @param realmContext the realm context
    * @param configName the name of the configuration key to check
    * @param defaultValue the default value if the configuration key has no value
    * @return the current value or the supplied default value
    * @param <T> the type of the configuration value
    */
   default <T> @Nonnull T getConfiguration(
-      String realm, String configName, @Nonnull T defaultValue) {
+      RealmContext realmContext, String configName, @Nonnull T defaultValue) {
     Preconditions.checkNotNull(defaultValue, "Cannot pass null as a default value");
-    T configValue = getConfiguration(realm, configName);
+    T configValue = getConfiguration(realmContext, configName);
     return configValue != null ? configValue : defaultValue;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -46,7 +46,7 @@ public interface PolarisConfigurationStore {
    *     <p>This function needs to be used with caution, it can not be called outside of active
    *     request scope, such as background tasks (TaskExecutor). Please use the function
    *     getConfiguration(String realm, String configName) to get the configuration value in a more
-   *     robust way.
+   *     robust way. TODO: Remove this function and replace the usage with the function takes realm
    */
   default <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
     return null;
@@ -64,7 +64,8 @@ public interface PolarisConfigurationStore {
    *     <p>This function needs to be used with caution, it can not be called outside of active
    *     request scope, such as background tasks (TaskExecutor). Please use the function
    *     getConfiguration(String realm, String configName, @Nonnull T defaultValue) to get the
-   *     configuration value in a more robust way.
+   *     configuration value in a more robust way. TODO: Remove this function and replace the usage
+   *     with the function takes realm
    */
   default <T> @Nonnull T getConfiguration(
       PolarisCallContext ctx, String configName, @Nonnull T defaultValue) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -43,7 +43,8 @@ public interface PolarisConfigurationStore {
    * <p>This function will be deprecated, it can not be called outside of active request scope, such
    * as background tasks (TaskExecutor). Please use the function getConfiguration(RealmContext
    * realmContext, String configName) to get the configuration value in a more robust way. TODO:
-   * Remove this function and replace the usage with the function takes realm.
+   * Remove this function and replace the usage with the function takes realm. Github issue
+   * https://github.com/apache/polaris/issues/1775
    *
    * @param ctx the current call context
    * @param configName the name of the configuration key to check
@@ -63,6 +64,7 @@ public interface PolarisConfigurationStore {
    * as background tasks (TaskExecutor). Please use the function getConfiguration(RealmContext
    * realmContext, String configName, T defaultValue) to get the configuration value in a more
    * robust way. TODO: Remove this function and replace the usage with the function takes realm.
+   * Github issue https://github.com/apache/polaris/issues/1775
    *
    * @param ctx the current call context
    * @param configName the name of the configuration key to check
@@ -132,7 +134,7 @@ public interface PolarisConfigurationStore {
 
   /**
    * Retrieve the current value for a configuration. TODO: update the function to take RealmContext
-   * instead of PolarisCallContext
+   * instead of PolarisCallContext. Github issue https://github.com/apache/polaris/issues/1775
    *
    * @param ctx the current call context
    * @param config the configuration to load
@@ -146,7 +148,8 @@ public interface PolarisConfigurationStore {
 
   /**
    * Retrieve the current value for a configuration, overriding with a catalog config if it is
-   * present. TODO: update the function to take RealmContext instead of PolarisCallContext
+   * present. TODO: update the function to take RealmContext instead of PolarisCallContext Github
+   * issue https://github.com/apache/polaris/issues/1775
    *
    * @param ctx the current call context
    * @param catalogEntity the catalog to check for an override

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
@@ -149,16 +149,19 @@ public class DefaultConfigurationStoreTest {
   void testGetConfigurationWithRealm() {
     // the falseByDefaultKey is set to `false` for all realms, but overwrite with value `true` for
     // realmOne.
-    assertThat((Boolean) configurationStore.getConfiguration(realmOne, falseByDefaultKey)).isTrue();
+    assertThat((Boolean) configurationStore.getConfiguration(realmOneContext, falseByDefaultKey))
+        .isTrue();
     // the trueByDefaultKey is set to `false` for all realms, no overwrite for realmOne
-    assertThat((Boolean) configurationStore.getConfiguration(realmOne, trueByDefaultKey)).isTrue();
+    assertThat((Boolean) configurationStore.getConfiguration(realmOneContext, trueByDefaultKey))
+        .isTrue();
 
     // the falseByDefaultKey is set to `false` for all realms, no overwrite for realmTwo
-    assertThat((Boolean) configurationStore.getConfiguration(realmTwo, falseByDefaultKey))
+    assertThat((Boolean) configurationStore.getConfiguration(realmTwoContext, falseByDefaultKey))
         .isFalse();
     // the trueByDefaultKey is set to `false` for all realms, and overwrite with value `false` for
     // realmTwo
-    assertThat((Boolean) configurationStore.getConfiguration(realmTwo, trueByDefaultKey)).isFalse();
+    assertThat((Boolean) configurationStore.getConfiguration(realmTwoContext, trueByDefaultKey))
+        .isFalse();
   }
 
   @Test

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
@@ -87,7 +87,7 @@ public class FileIOUtil {
 
     boolean skipCredentialSubscopingIndirection =
         configurationStore.getConfiguration(
-            callContext.getPolarisCallContext(),
+            callContext.getRealmContext().getRealmIdentifier(),
             FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.key,
             FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.defaultValue);
     if (skipCredentialSubscopingIndirection) {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
@@ -87,7 +87,7 @@ public class FileIOUtil {
 
     boolean skipCredentialSubscopingIndirection =
         configurationStore.getConfiguration(
-            callContext.getRealmContext().getRealmIdentifier(),
+            callContext.getRealmContext(),
             FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.key,
             FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION.defaultValue);
     if (skipCredentialSubscopingIndirection) {

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -68,10 +68,7 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
         return getDefaultConfiguration(configName);
       }
     } catch (Exception e) {
-      LOGGER.debug(
-          "Exception encountered when lookup value for configuration {} with exception {}",
-          configName,
-          e);
+      LOGGER.debug("Exception encountered when lookup value for configuration {}", configName, e);
       // fall back to the default behavior
       return getDefaultConfiguration(configName);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -50,26 +50,25 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   }
 
   @Override
+  public <T>  @Nullable T getConfiguration(String realm, String configName) {
+    LOGGER.debug("Get configuration value for {} with realm {}", configName, realm);
+    @SuppressWarnings("unchecked")
+    T confgValue =
+        (T)
+            Optional.ofNullable(realmOverrides.getOrDefault(realm, Map.of()).get(configName))
+                .orElseGet(() -> getDefaultConfiguration(configName));
+    return confgValue;
+  }
+
+  @Override
   public <T> @Nullable T getConfiguration(@Nonnull PolarisCallContext ctx, String configName) {
-    try {
-      if (realmContextInstance.isResolvable()) {
-        RealmContext realmContext = realmContextInstance.get();
-        String realm = realmContext.getRealmIdentifier();
-        LOGGER.debug("Get configuration value for {} with realm {}", configName, realm);
-        @SuppressWarnings("unchecked")
-        T confgValue =
-            (T)
-                Optional.ofNullable(realmOverrides.getOrDefault(realm, Map.of()).get(configName))
-                    .orElseGet(() -> getDefaultConfiguration(configName));
-        return confgValue;
-      } else {
-        LOGGER.debug(
-            "No RealmContext is injected when lookup value for configuration {} ", configName);
-        return getDefaultConfiguration(configName);
-      }
-    } catch (Exception e) {
-      LOGGER.debug("Exception encountered when lookup value for configuration {}", configName, e);
-      // fall back to the default behavior
+    if (realmContextInstance.isResolvable()) {
+      RealmContext realmContext = realmContextInstance.get();
+      String realm = realmContext.getRealmIdentifier();
+      return getConfiguration(realm, configName);
+    } else {
+      LOGGER.debug(
+          "No RealmContext is injected when lookup value for configuration {} ", configName);
       return getDefaultConfiguration(configName);
     }
   }

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -50,7 +50,8 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   }
 
   @Override
-  public <T> @Nullable T getConfiguration(String realm, String configName) {
+  public <T> @Nullable T getConfiguration(@Nonnull RealmContext realmContext, String configName) {
+    String realm = realmContext.getRealmIdentifier();
     LOGGER.debug("Get configuration value for {} with realm {}", configName, realm);
     @SuppressWarnings("unchecked")
     T confgValue =
@@ -64,8 +65,7 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   public <T> @Nullable T getConfiguration(@Nonnull PolarisCallContext ctx, String configName) {
     if (realmContextInstance.isResolvable()) {
       RealmContext realmContext = realmContextInstance.get();
-      String realm = realmContext.getRealmIdentifier();
-      return getConfiguration(realm, configName);
+      return getConfiguration(realmContext, configName);
     } else {
       LOGGER.debug(
           "No RealmContext is injected when lookup value for configuration {} ", configName);

--- a/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -50,7 +50,7 @@ public class DefaultConfigurationStore implements PolarisConfigurationStore {
   }
 
   @Override
-  public <T>  @Nullable T getConfiguration(String realm, String configName) {
+  public <T> @Nullable T getConfiguration(String realm, String configName) {
     LOGGER.debug("Get configuration value for {} with realm {}", configName, realm);
     @SuppressWarnings("unchecked")
     T confgValue =

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -115,13 +115,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
 
       Stream<TaskEntity> metadataFileCleanupTasks =
           getMetadataTaskStream(
-              cleanupTask,
-              tableMetadata,
-              fileIO,
-              tableEntity,
-              metaStoreManager,
-              polarisCallContext,
-              callContext.getRealmContext().getRealmIdentifier());
+              cleanupTask, tableMetadata, fileIO, tableEntity, metaStoreManager, callContext);
 
       List<TaskEntity> taskEntities =
           Stream.concat(manifestCleanupTasks, metadataFileCleanupTasks).toList();
@@ -207,12 +201,12 @@ public class TableCleanupTaskHandler implements TaskHandler {
       FileIO fileIO,
       IcebergTableLikeEntity tableEntity,
       PolarisMetaStoreManager metaStoreManager,
-      PolarisCallContext polarisCallContext,
-      String realm) {
+      CallContext callContext) {
+    PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
     int batchSize =
         polarisCallContext
             .getConfigurationStore()
-            .getConfiguration(realm, BATCH_SIZE_CONFIG_KEY, 10);
+            .getConfiguration(callContext.getRealmContext(), BATCH_SIZE_CONFIG_KEY, 10);
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {

--- a/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -120,7 +120,8 @@ public class TableCleanupTaskHandler implements TaskHandler {
               fileIO,
               tableEntity,
               metaStoreManager,
-              polarisCallContext);
+              polarisCallContext,
+              callContext.getRealmContext().getRealmIdentifier());
 
       List<TaskEntity> taskEntities =
           Stream.concat(manifestCleanupTasks, metadataFileCleanupTasks).toList();
@@ -206,11 +207,12 @@ public class TableCleanupTaskHandler implements TaskHandler {
       FileIO fileIO,
       IcebergTableLikeEntity tableEntity,
       PolarisMetaStoreManager metaStoreManager,
-      PolarisCallContext polarisCallContext) {
+      PolarisCallContext polarisCallContext,
+      String realm) {
     int batchSize =
         polarisCallContext
             .getConfigurationStore()
-            .getConfiguration(polarisCallContext, BATCH_SIZE_CONFIG_KEY, 10);
+            .getConfiguration(realm, BATCH_SIZE_CONFIG_KEY, 10);
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {


### PR DESCRIPTION
Although we do a check of !realmContextInstance.isUnsatisfied() it only checks if there is matching bean, however, it doesn't check if the context is active or not. Similarly isResolvable also don't check if the scope is active. Therefore if getConfiguration is called when there is no active scope, it will get Exception like ContextNotActiveException. 
This actually fails the TaskExecutor because it runs in a separate thread.

In order to fix the problem, we introduces a new getConfiguration function to handle the background tasks, and also use isResolvable instead of isUnsatisfied to handle ambiguities.

Tests:
1) Manually verified the test with S3 setup
2) Tried to add a SparkIntegration tests for the purge, however, either runs into dependency problem like following
```
 javax.annotation.Nonnull
java.lang.ClassNotFoundException: javax.annotation.Nonnull
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.apache.spark.sql.catalyst.JavaTypeInference$.$anonfun$encoderFor$1(JavaTypeInference.scala:141)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
```
or runs into prelivege issue when directly using rest call
follow up this in a separate branch here  https://github.com/gh-yzou/polaris/pull/new/yzou-purge-spark-integration

Follow up tasks:
1) PR to switch non loadTasks API to use the new API
2) PR to update the loadTasks to use the new API