### PR TITLE
[DRAFT] [DO NOT REVIEW] Introduce CachedSupplier for BasePersistence objects

### DIFF
--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -106,7 +106,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
                   realmContext.getRealmIdentifier())));
 
     // Ensure the supplier caches the first time
-    sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
+    var unused = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
 
     PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
     metaStoreManagerMap.put(realmContext.getRealmIdentifier(), metaStoreManager);

--- a/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -98,12 +98,13 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     DatasourceOperations databaseOperations = getDatasourceOperations(isBootstrap);
     sessionSupplierMap.put(
         realmContext.getRealmIdentifier(),
-        new CachedSupplier<>(() ->
-              new JdbcBasePersistenceImpl(
-                  databaseOperations,
-                  secretsGenerator(realmContext, rootCredentialsSet),
-                  storageIntegrationProvider,
-                  realmContext.getRealmIdentifier())));
+        new CachedSupplier<>(
+            () ->
+                new JdbcBasePersistenceImpl(
+                    databaseOperations,
+                    secretsGenerator(realmContext, rootCredentialsSet),
+                    storageIntegrationProvider,
+                    realmContext.getRealmIdentifier())));
 
     // Ensure the supplier caches the first time
     var unused = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
@@ -312,4 +313,3 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     }
   }
 }
-

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -41,6 +41,7 @@ import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.core.utils.CachedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +101,10 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
     final StoreType backingStore = createBackingStore(diagnostics);
     sessionSupplierMap.put(
         realmContext.getRealmIdentifier(),
-        () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics));
+        new CachedSupplier<>(
+          () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics)));
+    // Ensure the supplier caches the first time
+    sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
 
     PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
     metaStoreManagerMap.put(realmContext.getRealmIdentifier(), metaStoreManager);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -102,7 +102,9 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
     sessionSupplierMap.put(
         realmContext.getRealmIdentifier(),
         new CachedSupplier<>(
-          () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics)));
+            () ->
+                createMetaStoreSession(
+                    backingStore, realmContext, rootCredentialsSet, diagnostics)));
     // Ensure the supplier caches the first time
     var unused = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -104,7 +104,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         new CachedSupplier<>(
           () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics)));
     // Ensure the supplier caches the first time
-    sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
+    var unused = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
 
     PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
     metaStoreManagerMap.put(realmContext.getRealmIdentifier(), metaStoreManager);

--- a/polaris-core/src/main/java/org/apache/polaris/core/utils/CachedSupplier.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/utils/CachedSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.utils;
+
+import java.util.function.Supplier;
+
+public class CachedSupplier<T> implements Supplier<T> {
+  private final Supplier<T> delegate;
+  private T value;
+  private boolean initialized = false;
+
+  public CachedSupplier(Supplier<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public synchronized T get() {
+    if (!initialized) {
+      value = delegate.get();
+      initialized = true;
+    }
+    return value;
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/utils/CachedSupplierTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/utils/CachedSupplierTest.java
@@ -19,46 +19,52 @@
 
 package org.apache.polaris.core.utils;
 
+import java.util.function.Supplier;
 import org.apache.polaris.core.context.RealmContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Supplier;
-
 public class CachedSupplierTest {
-    private String realmName = "test";
-    private int timesCalled = 0;
-    private final RealmContext realmContext = new RealmContext() {
+  private String realmName = "test";
+  private int timesCalled = 0;
+  private final RealmContext realmContext =
+      new RealmContext() {
         @Override
         public String getRealmIdentifier() {
-            if (++timesCalled == 1) {
-                return realmName;
-            }
-            throw new IllegalStateException();
+          if (++timesCalled == 1) {
+            return realmName;
+          }
+          throw new IllegalStateException();
         }
-    };
+      };
 
-    private static class ContainerRealmIdentifier {
-        private String realmIdentifier;
+  private static class ContainerRealmIdentifier {
+    private String realmIdentifier;
 
-        public ContainerRealmIdentifier(RealmContext realmContext) {
-            this.realmIdentifier = realmContext.getRealmIdentifier();
-        }
-
-        public String getRealmIdentifier() {
-            return realmIdentifier;
-        }
+    public ContainerRealmIdentifier(RealmContext realmContext) {
+      this.realmIdentifier = realmContext.getRealmIdentifier();
     }
 
-    @Test
-    public void testCachedSupplier() {
-        Supplier<ContainerRealmIdentifier> realmIdentifierSupplier = () -> new ContainerRealmIdentifier(realmContext);
-        Assertions.assertThat(realmName.equals(realmIdentifierSupplier.get().getRealmIdentifier())).isTrue(); // This will work
-        Assertions.assertThatThrownBy(() -> realmIdentifierSupplier.get().getRealmIdentifier()).isInstanceOf(IllegalStateException.class);
-
-        timesCalled = 0;
-        CachedSupplier<ContainerRealmIdentifier> cachedSupplier = new CachedSupplier<>(() -> new ContainerRealmIdentifier(realmContext));
-        Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier())).isTrue(); // This will work
-        Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier())).isTrue(); // This will work
+    public String getRealmIdentifier() {
+      return realmIdentifier;
     }
+  }
+
+  @Test
+  public void testCachedSupplier() {
+    Supplier<ContainerRealmIdentifier> realmIdentifierSupplier =
+        () -> new ContainerRealmIdentifier(realmContext);
+    Assertions.assertThat(realmName.equals(realmIdentifierSupplier.get().getRealmIdentifier()))
+        .isTrue(); // This will work
+    Assertions.assertThatThrownBy(() -> realmIdentifierSupplier.get().getRealmIdentifier())
+        .isInstanceOf(IllegalStateException.class);
+
+    timesCalled = 0;
+    CachedSupplier<ContainerRealmIdentifier> cachedSupplier =
+        new CachedSupplier<>(() -> new ContainerRealmIdentifier(realmContext));
+    Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier()))
+        .isTrue(); // This will work
+    Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier()))
+        .isTrue(); // This will work
+  }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/utils/CachedSupplierTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/utils/CachedSupplierTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.utils;
+
+import org.apache.polaris.core.context.RealmContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+public class CachedSupplierTest {
+    private String realmName = "test";
+    private int timesCalled = 0;
+    private final RealmContext realmContext = new RealmContext() {
+        @Override
+        public String getRealmIdentifier() {
+            if (++timesCalled == 1) {
+                return realmName;
+            }
+            throw new IllegalStateException();
+        }
+    };
+
+    private static class ContainerRealmIdentifier {
+        private String realmIdentifier;
+
+        public ContainerRealmIdentifier(RealmContext realmContext) {
+            this.realmIdentifier = realmContext.getRealmIdentifier();
+        }
+
+        public String getRealmIdentifier() {
+            return realmIdentifier;
+        }
+    }
+
+    @Test
+    public void testCachedSupplier() {
+        Supplier<ContainerRealmIdentifier> realmIdentifierSupplier = () -> new ContainerRealmIdentifier(realmContext);
+        Assertions.assertThat(realmName.equals(realmIdentifierSupplier.get().getRealmIdentifier())).isTrue(); // This will work
+        Assertions.assertThatThrownBy(() -> realmIdentifierSupplier.get().getRealmIdentifier()).isInstanceOf(IllegalStateException.class);
+
+        timesCalled = 0;
+        CachedSupplier<ContainerRealmIdentifier> cachedSupplier = new CachedSupplier<>(() -> new ContainerRealmIdentifier(realmContext));
+        Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier())).isTrue(); // This will work
+        Assertions.assertThat(realmName.equals(cachedSupplier.get().getRealmIdentifier())).isTrue(); // This will work
+    }
+}


### PR DESCRIPTION
I came across an interesting bug yesterday that we need to fix to ensure that tasks can use the BasePersistence object, as they run outside of user call contexts.

What I was trying to do:
1. Create and run a Task which dumps some information to the persistence. In order to do this, I was using the following line of code to get a BasePersistence object: `metaStoreManagerFactory.getOrCreateSessionSupplier(CallContext.getCurrentContext().getRealmContext()).get();`
2. Get the following error message when executing the last `.get()` call: 
```
jakarta.enterprise.context.ContextNotActiveException: RequestScoped context was not active when trying to obtain a bean instance for a client proxy...
```

When digging deeper into why this is happening, I realized that due to the Supplier's lazy-loading at https://github.com/apache/polaris/blob/main/extension/persistence/relational-jdbc/src/main/java/org/apache/polaris/extension/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java#L100-L105, the `.get()` was actually using a RequestScoped realmContext bean given by the previously-ran `TokenBroker` initialization (which is a `RequestScoped` object here: https://github.com/apache/polaris/blob/main/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java#L290-L299. Given this is a relatively-new addition, this may be why we haven't seen this bug previously.

As Tasks run asynchronously, likely after the original request was already completed, this error actually makes sense - we should not be able to use a request scoped bean inside of a Task execution. But upon further looking, we do not actually need `realmContext` for anything other than resolving the `realmIdentifier` once during the BasePersistence object initialization - as a result, we can cache the BasePersistence object using a supplier that caches the original result instead of constantly making new objects. This will also solve our issue, as the original request scoped RealmContext bean will not be used again during the Task's call to get a BasePersistence object.

I've added a test case that shows the difference between the OOTB supplier and my ideal way to solve this problem using a CachedSupplier. If there is significant concern that we cannot cache the BasePersistence object, we can materialize the RealmContext object prior to the supplier so that at a minimum the RequestScoped RealmContext object is not being used - but I'm not sure if there's an easy way to test this, given that the MetastoreFactories are Quarkus `ApplicationScoped` objects.

Please note, this is an issue in both EclipseLink and JDBC, as they have almost identical code paths here.

Many thanks to @singhpk234 for being my debugging rubber ducky :)
