### PR TITLE
Fix regression test docker setup for purge

### DIFF
--- a/regtests/docker-compose.yml
+++ b/regtests/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,secret
       quarkus.log.file.enable: "false"
       quarkus.otel.sdk.disabled: "true"
+      polaris.features."DROP_WITH_PURGE_ENABLED": "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"
       polaris.readiness.ignore-severe-issues: "true"

--- a/regtests/t_pyspark/src/conftest.py
+++ b/regtests/t_pyspark/src/conftest.py
@@ -28,7 +28,7 @@ from polaris.catalog.api.iceberg_catalog_api import IcebergCatalogAPI
 from polaris.catalog.api_client import ApiClient as CatalogApiClient
 from polaris.management import Catalog, AwsStorageConfigInfo, ApiClient, PolarisDefaultApi, Configuration, \
   CreateCatalogRequest, GrantCatalogRoleRequest, CatalogRole, ApiException, AddGrantRequest, CatalogGrant, \
-  CatalogPrivilege, CreateCatalogRoleRequest
+  CatalogPrivilege, CreateCatalogRoleRequest, CatalogProperties
 
 
 @pytest.fixture
@@ -107,10 +107,11 @@ def snowflake_catalog(root_client, catalog_client, test_bucket, aws_role_arn, aw
                                       allowed_locations=[f"s3://{test_bucket}/{aws_bucket_base_location_prefix}/"],
                                       role_arn=aws_role_arn)
   catalog_name = f'snowflake_{str(uuid.uuid4())[-10:]}'
-  catalog = Catalog(name=catalog_name, type='INTERNAL', properties={
+  catalog = Catalog(name=catalog_name, type='INTERNAL', properties=CatalogProperties.from_dict({
     "default-base-location": f"s3://{test_bucket}/{aws_bucket_base_location_prefix}/snowflake_catalog",
-    "client.credentials-provider": "software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider"
-  },
+    "client.credentials-provider": "software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider",
+    "polaris.config.drop-with-purge.enabled": "true"
+  }),
                     storage_config_info=storage_conf)
   catalog.storage_config_info = storage_conf
   try:


### PR DESCRIPTION
In change https://github.com/apache/polaris/commit/f2d1caf94c1f077c70b53f94e4ece1c0afc47144
DROP_WITH_PURGE is now set to false by default, however, our regression tests test with purge enabled.
Set the DROP_WITH_PURGE to true for our python regression tests
