### PR TITLE
Fix metadata table names conflicts 

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -36,12 +36,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -67,6 +62,7 @@ import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -561,6 +557,26 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
                     .create())
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("because it conflicts with existing table or namespace");
+  }
+  
+  @Test
+  public void testCreateTableWithMetadataConflictingName() {
+    Catalog catalog = managementApi.getCatalog(currentCatalogName);
+    Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
+    catalogProps.put(
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
+    managementApi.updateCatalog(catalog, catalogProps);
+
+    restCatalog.createNamespace(Namespace.of("ns1"));
+    TableIdentifier tableIdentifier = TableIdentifier.of("ns1", "history");
+    restCatalog
+            .buildTable(tableIdentifier, SCHEMA)
+            .withProperty("stage-create", "true")
+            .create();
+    Table table = restCatalog.loadTable(tableIdentifier);
+    assertThat(table)
+            .isNotNull()
+            .isInstanceOf(BaseTable.class);
   }
 
   @Test

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -561,11 +561,6 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
   @Test
   public void testCreateTableWithMetadataConflictingName() {
     Catalog catalog = managementApi.getCatalog(currentCatalogName);
-    Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
-    catalogProps.put(
-        FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
-    managementApi.updateCatalog(catalog, catalogProps);
-
     restCatalog.createNamespace(Namespace.of("ns1"));
     TableIdentifier tableIdentifier = TableIdentifier.of("ns1", "history");
     restCatalog.buildTable(tableIdentifier, SCHEMA).withProperty("stage-create", "true").create();

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
@@ -62,7 +62,6 @@ import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -558,25 +557,20 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("because it conflicts with existing table or namespace");
   }
-  
+
   @Test
   public void testCreateTableWithMetadataConflictingName() {
     Catalog catalog = managementApi.getCatalog(currentCatalogName);
     Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
     catalogProps.put(
-            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
+        FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "false");
     managementApi.updateCatalog(catalog, catalogProps);
 
     restCatalog.createNamespace(Namespace.of("ns1"));
     TableIdentifier tableIdentifier = TableIdentifier.of("ns1", "history");
-    restCatalog
-            .buildTable(tableIdentifier, SCHEMA)
-            .withProperty("stage-create", "true")
-            .create();
+    restCatalog.buildTable(tableIdentifier, SCHEMA).withProperty("stage-create", "true").create();
     Table table = restCatalog.loadTable(tableIdentifier);
-    assertThat(table)
-            .isNotNull()
-            .isInstanceOf(BaseTable.class);
+    assertThat(table).isNotNull().isInstanceOf(BaseTable.class);
   }
 
   @Test

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -214,27 +214,10 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public boolean tableExists(TableIdentifier identifier) {
-    try {
-      loadTableIgnoreMetadata(identifier);
-      return true;
-    } catch (NoSuchTableException e) {
-      return false;
-    }
-  }
-
-  public Table loadTableIgnoreMetadata(TableIdentifier identifier) {
-    Table result;
     if (isValidIdentifier(identifier)) {
-      TableOperations ops = newTableOps(identifier);
-      if (ops.current() == null) {
-        throw new NoSuchTableException("Table does not exist: %s", identifier);
-      } else {
-        result = new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());
-      }
-    } else {
-      throw new NoSuchTableException("Invalid table identifier: %s", identifier);
+        return newTableOps(identifier).current() != null;
     }
-    return result;
+    return false;
   }
 
   @Override

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -215,7 +215,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   @Override
   public boolean tableExists(TableIdentifier identifier) {
     if (isValidIdentifier(identifier)) {
-        return newTableOps(identifier).current() != null;
+      return newTableOps(identifier).current() != null;
     }
     return false;
   }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -213,6 +213,31 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   @Override
+  public boolean tableExists(TableIdentifier identifier) {
+    try {
+      loadTableIgnoreMetadata(identifier);
+      return true;
+    } catch (NoSuchTableException e) {
+      return false;
+    }
+  }
+
+  public Table loadTableIgnoreMetadata(TableIdentifier identifier) {
+    Table result;
+    if (isValidIdentifier(identifier)) {
+      TableOperations ops = newTableOps(identifier);
+      if (ops.current() == null) {
+        throw new NoSuchTableException("Table does not exist: %s", identifier);
+      } else {
+        result = new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());
+      }
+    } else {
+      throw new NoSuchTableException("Invalid table identifier: %s", identifier);
+    }
+    return result;
+  }
+
+  @Override
   public String name() {
     return catalogName;
   }


### PR DESCRIPTION
Fixes: https://github.com/apache/polaris/issues/1771

## Fix reserved Iceberg metadata table name conflicts in Polaris (history, entries, etc.)

When we try to create or load tables named after one of the keywords defined [here](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/MetadataTableType.java), Iceberg fails since it tries to resolve them as metadata tables. 

The reason is that Polaris will call `Catalog::tableExists(...)` in [IcebergCatalogHandler.java](https://github.com/apache/polaris/blob/b7aac7212da2d2e81458d9cccecf06a38425fc85/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java#L426), which [internally calls ](https://github.com/apache/iceberg/blob/ee82cdf287a304deb58b07aa44cefdad5f9c90da/api/src/main/java/org/apache/iceberg/catalog/Catalog.java#L279)`BaseMetastoreCatalog::loadTable(...)`. If that call returns an exception then the table is considered non-existent. The problem, however, is that `loadTable()` will try to resolve the table as a metadata table if it's not found and if the table name matches one of the reserved metadata keywords. Specifically, [it will try to call](https://github.com/apache/iceberg/blob/ee82cdf287a304deb58b07aa44cefdad5f9c90da/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java#L63) `loadMetadataTable()` using the namespace as a table name, and this will fail.

Since we only care about actual tables when we call `tableExists()` and not metadata tables, we can override it and provide an implementation that does not rely on `loadTable()`. As a result, it will not conflict with metadata table names anymore.


<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
