### PR TITLE
Replace getConfiguration usage with PolarisCallContext to use RealmContext (PART 1)

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -584,7 +584,7 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
     boolean enforceCredentialRotationRequiredState =
         featureConfig.getConfiguration(
-            callContext.getPolarisCallContext(),
+            callContext.getRealmContext(),
             FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
     if (enforceCredentialRotationRequiredState
         && authenticatedPrincipal

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -52,7 +52,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
         callContext
             .getPolarisCallContext()
             .getConfigurationStore()
-            .getConfiguration(callContext.getPolarisCallContext(), featureConfig);
+            .getConfiguration(callContext.getRealmContext(), featureConfig);
     if (!enabled) {
       throw new UnsupportedOperationException("Feature not enabled: " + featureConfig.key);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -226,7 +226,7 @@ public abstract class PolarisConfiguration<T> {
     return callContext
         .getPolarisCallContext()
         .getConfigurationStore()
-        .getConfiguration(callContext.getPolarisCallContext(), configuration);
+        .getConfiguration(callContext.getRealmContext(), configuration);
   }
 
   public static <T> Builder<T> builder() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfigurationStore.java
@@ -133,23 +133,21 @@ public interface PolarisConfigurationStore {
   }
 
   /**
-   * Retrieve the current value for a configuration. TODO: update the function to take RealmContext
-   * instead of PolarisCallContext. Github issue https://github.com/apache/polaris/issues/1775
+   * Retrieve the current value for a configuration.
    *
    * @param ctx the current call context
    * @param config the configuration to load
    * @return the current value set for the configuration key or null if not set
    * @param <T> the type of the configuration value
    */
-  default <T> @Nonnull T getConfiguration(PolarisCallContext ctx, PolarisConfiguration<T> config) {
+  default <T> @Nonnull T getConfiguration(RealmContext ctx, PolarisConfiguration<T> config) {
     T result = getConfiguration(ctx, config.key, config.defaultValue);
     return tryCast(config, result);
   }
 
   /**
    * Retrieve the current value for a configuration, overriding with a catalog config if it is
-   * present. TODO: update the function to take RealmContext instead of PolarisCallContext Github
-   * issue https://github.com/apache/polaris/issues/1775
+   * present.
    *
    * @param ctx the current call context
    * @param catalogEntity the catalog to check for an override
@@ -158,9 +156,7 @@ public interface PolarisConfigurationStore {
    * @param <T> the type of the configuration value
    */
   default <T> @Nonnull T getConfiguration(
-      PolarisCallContext ctx,
-      @Nonnull CatalogEntity catalogEntity,
-      PolarisConfiguration<T> config) {
+      RealmContext ctx, @Nonnull CatalogEntity catalogEntity, PolarisConfiguration<T> config) {
     if (config.hasCatalogConfig() || config.hasCatalogConfigUnsafe()) {
       Map<String, String> propertiesMap = catalogEntity.getPropertiesAsMap();
       String propertyValue = null;

--- a/polaris-core/src/main/java/org/apache/polaris/core/rest/PolarisEndpoints.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/rest/PolarisEndpoints.java
@@ -84,7 +84,7 @@ public class PolarisEndpoints {
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES);
+                callContext.getRealmContext(), FeatureConfiguration.ENABLE_GENERIC_TABLES);
 
     return genericTableEnabled ? GENERIC_TABLE_ENDPOINTS : ImmutableSet.of();
   }
@@ -99,7 +99,7 @@ public class PolarisEndpoints {
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(), FeatureConfiguration.ENABLE_POLICY_STORE);
+                callContext.getRealmContext(), FeatureConfiguration.ENABLE_POLICY_STORE);
     return policyStoreEnabled ? POLICY_STORE_ENDPOINTS : ImmutableSet.of();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
@@ -78,11 +78,11 @@ public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigu
 
     boolean allowWildcardLocation =
         Optional.ofNullable(CallContext.getCurrentContext())
-            .flatMap(c -> Optional.ofNullable(c.getPolarisCallContext()))
             .map(
-                pc ->
-                    pc.getConfigurationStore()
-                        .getConfiguration(pc, "ALLOW_WILDCARD_LOCATION", false))
+                ctx ->
+                    ctx.getPolarisCallContext()
+                        .getConfigurationStore()
+                        .getConfiguration(ctx.getRealmContext(), "ALLOW_WILDCARD_LOCATION", false))
             .orElse(false);
 
     if (allowWildcardLocation && allowedLocationStrings.contains("*")) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -166,7 +166,7 @@ public abstract class PolarisStorageConfigurationInfo {
                       .getPolarisCallContext()
                       .getConfigurationStore()
                       .getConfiguration(
-                          CallContext.getCurrentContext().getPolarisCallContext(),
+                          CallContext.getCurrentContext().getRealmContext(),
                           catalog,
                           FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION);
               if (!allowEscape

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -100,7 +101,7 @@ class InMemoryStorageIntegrationTest {
             new PolarisConfigurationStore() {
               @SuppressWarnings("unchecked")
               @Override
-              public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
+              public <T> @Nullable T getConfiguration(RealmContext ctx, String configName) {
                 return (T) config.get(configName);
               }
             },

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -23,18 +23,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfiguration;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /** Unit test for the default behaviors of the PolarisConfigurationStore interface. */
 public class PolarisConfigurationStoreTest {
+  private final RealmContext testRealmContext = () -> "testRealm";
+
   @Test
   public void testConfigsCanBeCastedFromString() {
     List<PolarisConfiguration<?>> configs =
@@ -52,7 +53,7 @@ public class PolarisConfigurationStoreTest {
            */
           @SuppressWarnings("unchecked")
           @Override
-          public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
+          public <T> @Nullable T getConfiguration(RealmContext ctx, String configName) {
             for (PolarisConfiguration<?> c : configs) {
               if (c.key.equals(configName)) {
                 return (T) String.valueOf(c.defaultValue);
@@ -68,9 +69,8 @@ public class PolarisConfigurationStoreTest {
 
     // Ensure that we can fetch all the configs and that the value is what we expect, which
     // is the config's default value based on how we've implemented PolarisConfigurationStore above.
-    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
     for (PolarisConfiguration<?> c : configs) {
-      Assertions.assertEquals(c.defaultValue, store.getConfiguration(polarisCallContext, c));
+      Assertions.assertEquals(c.defaultValue, store.getConfiguration(testRealmContext, c));
     }
   }
 
@@ -84,15 +84,14 @@ public class PolarisConfigurationStoreTest {
         new PolarisConfigurationStore() {
           @SuppressWarnings("unchecked")
           @Override
-          public <T> T getConfiguration(PolarisCallContext ctx, String configName) {
+          public <T> T getConfiguration(RealmContext ctx, String configName) {
             return (T) "abc123";
           }
         };
 
-    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
     for (PolarisConfiguration<?> c : configs) {
       Assertions.assertThrows(
-          NumberFormatException.class, () -> store.getConfiguration(polarisCallContext, c));
+          NumberFormatException.class, () -> store.getConfiguration(testRealmContext, c));
     }
   }
 
@@ -106,18 +105,18 @@ public class PolarisConfigurationStoreTest {
 
   private static class PolarisConfigurationConsumer {
 
-    private final PolarisCallContext polarisCallContext;
+    private final RealmContext realmContext;
     private final PolarisConfigurationStore configurationStore;
 
     public PolarisConfigurationConsumer(
-        PolarisCallContext polarisCallContext, PolarisConfigurationStore configurationStore) {
-      this.polarisCallContext = polarisCallContext;
+        RealmContext realmContext, PolarisConfigurationStore configurationStore) {
+      this.realmContext = realmContext;
       this.configurationStore = configurationStore;
     }
 
     public <T> T consumeConfiguration(
         PolarisConfiguration<Boolean> config, Supplier<T> code, T defaultVal) {
-      if (configurationStore.getConfiguration(polarisCallContext, config)) {
+      if (configurationStore.getConfiguration(realmContext, config)) {
         return code.get();
       }
       return defaultVal;
@@ -127,7 +126,7 @@ public class PolarisConfigurationStoreTest {
   @Test
   public void testBehaviorAndFeatureConfigs() {
     PolarisConfigurationConsumer consumer =
-        new PolarisConfigurationConsumer(null, new PolarisConfigurationStore() {});
+        new PolarisConfigurationConsumer(testRealmContext, new PolarisConfigurationStore() {});
 
     FeatureConfiguration<Boolean> featureConfig =
         PolarisConfiguration.<Boolean>builder()
@@ -164,22 +163,25 @@ public class PolarisConfigurationStoreTest {
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
           @Override
-          public <T> @Nullable T getConfiguration(PolarisCallContext ctx, String configName) {
+          public <T> @Nullable T getConfiguration(RealmContext realmContext, String configName) {
             //noinspection unchecked
             return (T) Map.of("key2", "config-value2").get(configName);
           }
         };
 
-    PolarisCallContext ctx = null;
     CatalogEntity entity =
         new CatalogEntity.Builder()
             .addProperty("polaris.config.catalog-key3", "entity-new3")
             .addProperty("legacy-key4", "entity-legacy4")
             .build();
 
-    Assertions.assertEquals("test-default1", store.getConfiguration(ctx, entity, cfg.apply(1)));
-    Assertions.assertEquals("config-value2", store.getConfiguration(ctx, entity, cfg.apply(2)));
-    Assertions.assertEquals("entity-new3", store.getConfiguration(ctx, entity, cfg.apply(3)));
-    Assertions.assertEquals("entity-legacy4", store.getConfiguration(ctx, entity, cfg.apply(4)));
+    Assertions.assertEquals(
+        "test-default1", store.getConfiguration(() -> "testRealm", entity, cfg.apply(1)));
+    Assertions.assertEquals(
+        "config-value2", store.getConfiguration(() -> "testRealm", entity, cfg.apply(2)));
+    Assertions.assertEquals(
+        "entity-new3", store.getConfiguration(() -> "testRealm", entity, cfg.apply(3)));
+    Assertions.assertEquals(
+        "entity-legacy4", store.getConfiguration(() -> "testRealm", entity, cfg.apply(4)));
   }
 }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -1032,7 +1032,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
     if (!polarisCallContext
         .getConfigurationStore()
-        .getConfiguration(polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(
+            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -1100,7 +1101,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
     if (!polarisCallContext
         .getConfigurationStore()
-        .getConfiguration(polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(
+            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -1121,7 +1123,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     if (!polarisCallContext
         .getConfigurationStore()
-        .getConfiguration(polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+        .getConfiguration(
+            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, newRequest))
           .isInstanceOf(ForbiddenException.class)

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
@@ -238,14 +238,13 @@ public class DefaultConfigurationStoreTest {
 
     CatalogEntity catalog = new CatalogEntity.Builder().build();
 
-    Assertions.assertThat(configurationStore.getConfiguration(polarisContext, catalog, safeConfig))
+    Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, safeConfig))
         .isTrue();
 
-    Assertions.assertThat(
-            configurationStore.getConfiguration(polarisContext, catalog, unsafeConfig))
+    Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, unsafeConfig))
         .isTrue();
 
-    Assertions.assertThat(configurationStore.getConfiguration(polarisContext, catalog, bothConfig))
+    Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, bothConfig))
         .isTrue();
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -606,7 +606,7 @@ public class PolarisAdminService {
         getCurrentPolarisContext()
             .getConfigurationStore()
             .getConfiguration(
-                getCurrentPolarisContext(), FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
+                callContext.getRealmContext(), FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
 
     if (allowOverlappingCatalogUrls) {
       return false;
@@ -778,7 +778,8 @@ public class PolarisAdminService {
     boolean cleanup =
         polarisCallContext
             .getConfigurationStore()
-            .getConfiguration(polarisCallContext, FeatureConfiguration.CLEANUP_ON_CATALOG_DROP);
+            .getConfiguration(
+                callContext.getRealmContext(), FeatureConfiguration.CLEANUP_ON_CATALOG_DROP);
     DropEntityResult dropEntityResult =
         metaStoreManager.dropEntityIfExists(
             getCurrentPolarisContext(), null, entity, Map.of(), cleanup);

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -157,7 +157,8 @@ public class PolarisServiceImpl
         polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
+                callContext.getRealmContext(),
+                FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
     if (!allowedStorageTypes.contains(storageConfigInfo.getStorageType().name())) {
       LOGGER
           .atWarn()
@@ -179,7 +180,7 @@ public class PolarisServiceImpl
                   .getPolarisCallContext()
                   .getConfigurationStore()
                   .getConfiguration(
-                      callContext.getPolarisCallContext(),
+                      callContext.getRealmContext(),
                       FeatureConfiguration.SUPPORTED_CATALOG_CONNECTION_TYPES)
                   .stream()
                   .map(s -> s.toUpperCase(Locale.ROOT))

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -82,9 +82,9 @@ import org.apache.iceberg.view.ViewBuilder;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewOperations;
 import org.apache.iceberg.view.ViewRepresentation;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.context.RealmContext;
 
 /**
  * CODE_COPIED_TO_POLARIS Copied from CatalogHandler in Iceberg 1.8.0 Contains a collection of
@@ -95,13 +95,13 @@ public class CatalogHandlerUtils {
   private static final Schema EMPTY_SCHEMA = new Schema();
   private static final String INITIAL_PAGE_TOKEN = "";
 
-  private final PolarisCallContext polarisCallContext;
+  private final RealmContext realmContext;
   private final PolarisConfigurationStore configurationStore;
 
   @Inject
   public CatalogHandlerUtils(
-      PolarisCallContext polarisCallContext, PolarisConfigurationStore configurationStore) {
-    this.polarisCallContext = polarisCallContext;
+      RealmContext realmContext, PolarisConfigurationStore configurationStore) {
+    this.realmContext = realmContext;
     this.configurationStore = configurationStore;
   }
 
@@ -609,6 +609,6 @@ public class CatalogHandlerUtils {
 
   private int maxCommitRetries() {
     return configurationStore.getConfiguration(
-        polarisCallContext, FeatureConfiguration.ICEBERG_COMMIT_MAX_RETRIES);
+        realmContext, FeatureConfiguration.ICEBERG_COMMIT_MAX_RETRIES);
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -341,7 +341,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         getCurrentPolarisContext()
             .getConfigurationStore()
             .getConfiguration(
-                getCurrentPolarisContext(),
+                callContext.getRealmContext(),
                 BehaviorChangeConfiguration.TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT);
     return newTableOps(tableIdentifier, makeMetadataCurrentOnCommit);
   }
@@ -521,8 +521,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getPolarisCallContext()
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getPolarisCallContext(),
-            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+            callContext.getRealmContext(), FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap for {} with sibling tables or namespaces", namespace);
       validateNoLocationOverlap(
           entity.getBaseLocation(), resolvedParent.getRawFullPath(), entity.getName());
@@ -664,7 +663,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                 polarisCallContext
                     .getConfigurationStore()
                     .getConfiguration(
-                        polarisCallContext, FeatureConfiguration.CLEANUP_ON_NAMESPACE_DROP));
+                        callContext.getRealmContext(),
+                        FeatureConfiguration.CLEANUP_ON_NAMESPACE_DROP));
 
     if (!dropEntityResult.isSuccess() && dropEntityResult.failedBecauseNotEmpty()) {
       throw new NamespaceNotEmptyException("Namespace %s is not empty", namespace);
@@ -693,8 +693,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         .getPolarisCallContext()
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getPolarisCallContext(),
-            FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+            callContext.getRealmContext(), FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap with sibling tables or namespaces");
       validateNoLocationOverlap(
           NamespaceEntity.of(updatedEntity).getBaseLocation(),
@@ -995,7 +994,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                   .getPolarisCallContext()
                   .getConfigurationStore()
                   .getConfiguration(
-                      callContext.getPolarisCallContext(),
+                      callContext.getRealmContext(),
                       FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
           if (!allowedStorageTypes.contains(StorageConfigInfo.StorageTypeEnum.FILE.name())) {
             List<String> invalidLocations =
@@ -1026,14 +1025,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(),
+                callContext.getRealmContext(),
                 BehaviorChangeConfiguration.VALIDATE_VIEW_LOCATION_OVERLAP);
 
     if (callContext
         .getPolarisCallContext()
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getPolarisCallContext(),
+            callContext.getRealmContext(),
             catalog,
             FeatureConfiguration.ALLOW_TABLE_LOCATION_OVERLAP)) {
       LOGGER.debug("Skipping location overlap validation for identifier '{}'", identifier);
@@ -1966,12 +1965,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
+                callContext.getRealmContext(), FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
     if (!allowEscape
         && !polarisCallContext
             .getConfigurationStore()
             .getConfiguration(
-                polarisCallContext, FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
+                callContext.getRealmContext(),
+                FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
       LOGGER.debug(
           "Validating base location {} for table {} in metadata file {}",
           metadata.location(),
@@ -2268,7 +2268,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               .getPolarisCallContext()
               .getConfigurationStore()
               .getConfiguration(
-                  callContext.getPolarisCallContext(),
+                  callContext.getRealmContext(),
                   catalogEntity,
                   FeatureConfiguration.DROP_WITH_PURGE_ENABLED);
       if (!dropWithPurgeEnabled) {
@@ -2515,13 +2515,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     return callContext
         .getPolarisCallContext()
         .getConfigurationStore()
-        .getConfiguration(callContext.getPolarisCallContext(), configKey, defaultValue);
+        .getConfiguration(callContext.getRealmContext(), configKey, defaultValue);
   }
 
   private int getMaxMetadataRefreshRetries() {
     var ctx = callContext.getPolarisCallContext();
     return ctx.getConfigurationStore()
-        .getConfiguration(ctx, FeatureConfiguration.MAX_METADATA_REFRESH_RETRIES);
+        .getConfiguration(
+            callContext.getRealmContext(), FeatureConfiguration.MAX_METADATA_REFRESH_RETRIES);
   }
 
   /** Build a {@link PageToken} from a string and page size. */
@@ -2532,7 +2533,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             .getPolarisCallContext()
             .getConfigurationStore()
             .getConfiguration(
-                callContext.getPolarisCallContext(),
+                callContext.getRealmContext(),
                 catalogEntity,
                 FeatureConfiguration.LIST_PAGINATION_ENABLED);
     if (!paginationEnabled) {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -705,14 +705,14 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     LOGGER.info(
         "allow external catalog credential vending: {}",
         configurationStore.getConfiguration(
-            callContext.getPolarisCallContext(),
+            callContext.getRealmContext(),
             catalogEntity,
             FeatureConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING));
     if (catalogEntity
             .getCatalogType()
             .equals(org.apache.polaris.core.admin.model.Catalog.TypeEnum.EXTERNAL)
         && !configurationStore.getConfiguration(
-            callContext.getPolarisCallContext(),
+            callContext.getRealmContext(),
             catalogEntity,
             FeatureConfiguration.ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING)) {
       throw new ForbiddenException(
@@ -972,7 +972,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
                                   .getPolarisCallContext()
                                   .getConfigurationStore()
                                   .getConfiguration(
-                                      callContext.getPolarisCallContext(),
+                                      callContext.getRealmContext(),
                                       FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
                             throw new BadRequestException(
                                 "Unsupported operation: commitTransaction containing SetLocation"

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
@@ -46,10 +46,11 @@ public class IcebergPropertiesValidation {
       @Nullable PolarisStorageConfigurationInfo storageConfigurationInfo) {
     var ctx = callContext.getPolarisCallContext();
     var configStore = ctx.getConfigurationStore();
+    var realmContext = callContext.getRealmContext();
 
     var ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
     if (ioImpl != null) {
-      if (!configStore.getConfiguration(ctx, ALLOW_SPECIFYING_FILE_IO_IMPL)) {
+      if (!configStore.getConfiguration(realmContext, ALLOW_SPECIFYING_FILE_IO_IMPL)) {
         throw new ValidationException(
             "Cannot set property '%s' to '%s' for this catalog.",
             CatalogProperties.FILE_IO_IMPL, ioImpl);
@@ -70,14 +71,15 @@ public class IcebergPropertiesValidation {
       var storageType = StorageTypeFileIO.fromFileIoImplementation(ioImpl);
       if (storageType.validateAllowedStorageType()
           && !configStore
-              .getConfiguration(ctx, SUPPORTED_CATALOG_STORAGE_TYPES)
+              .getConfiguration(realmContext, SUPPORTED_CATALOG_STORAGE_TYPES)
               .contains(storageType.name())) {
         throw new ValidationException(
             "File IO implementation '%s', as storage type '%s' is not supported",
             ioImpl, storageType);
       }
 
-      if (!storageType.safe() && !configStore.getConfiguration(ctx, ALLOW_INSECURE_STORAGE_TYPES)) {
+      if (!storageType.safe()
+          && !configStore.getConfiguration(realmContext, ALLOW_INSECURE_STORAGE_TYPES)) {
         throw new ValidationException(
             "File IO implementation '%s' (storage type '%s') is considered insecure and must not be used",
             ioImpl, storageType);

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -103,7 +103,7 @@ public record TestServices(
     }
 
     @Override
-    public <T> @Nullable T getConfiguration(@Nonnull PolarisCallContext ctx, String configName) {
+    public <T> @Nullable T getConfiguration(@Nonnull RealmContext realmContext, String configName) {
       @SuppressWarnings("unchecked")
       T confgValue = (T) defaults.get(configName);
       return confgValue;
@@ -211,7 +211,7 @@ public record TestServices(
       ReservedProperties reservedProperties = ReservedProperties.NONE;
 
       CatalogHandlerUtils catalogHandlerUtils =
-          new CatalogHandlerUtils(callContext.getPolarisCallContext(), configurationStore);
+          new CatalogHandlerUtils(callContext.getRealmContext(), configurationStore);
 
       IcebergCatalogAdapter service =
           new IcebergCatalogAdapter(


### PR DESCRIPTION
getConfiguration should be called per RealmContext instead of per PolarisCallContext. In this PR #1758 we introduced new API to that passes RealmContext, instead. of PolarisCallContext.
This PR refactors all calls except the loadTasks  to use the new API with RealmContext, instead of calling with PolarisCallContext.


