### PR TITLE
Run renovatebot only on the main branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
 
   // Added for posterity how to let Renovate manage version-branches, assuming that release branches
   // have the `release/` prefix.
-  baseBranches: ["main", "/^release\\/.*/"],
+  baseBranches: ["main"],
   additionalBranchPrefix: "{{baseBranch}}/",
   commitMessagePrefix: "{{baseBranch}}: ",
 


### PR DESCRIPTION
As discussed on the mailing list (https://lists.apache.org/thread/jnlf0yqkjy3rfzovpk1bm0p3jr6sq93k), I propose to run renovatebot only on the `main` branch.