### PR TITLE
dont print provided creds in BootstrapCommand

### DIFF
--- a/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
+++ b/quarkus/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
@@ -127,14 +127,16 @@ public abstract class BootstrapCommandTestBase {
   @Test
   @Launch(
       value = {"bootstrap", "-r", "realm1", "-c", "realm1,client1d,s3cr3t", "--print-credentials"})
-  public void testPrintCredentials(LaunchResult result) {
+  public void testPrintCredentialsProvided(LaunchResult result) {
+    assertThat(result.exitCode()).isEqualTo(0);
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
-    assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: client1d:");
+    assertThat(result.getOutput()).doesNotContain("root principal credentials");
   }
 
   @Test
   @Launch(value = {"bootstrap", "-r", "realm1", "--print-credentials"})
   public void testPrintCredentialsSystemGenerated(LaunchResult result) {
+    assertThat(result.exitCode()).isEqualTo(0);
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
     assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: ");
   }


### PR DESCRIPTION
`bootstrapRealms` is called from `BootstrapCommand.call` and `QuarkusProducers.maybeBootstrap`.
The latter is already only printing credentials that were not in the provided `RootCredentialsSet`.
so we adjust `BootstrapCommand` to do the same.

the general idea is to only print credentials that were generated as part of the bootstrap.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
