### PR TITLE
Consolidate CallContext with PolarisCallContext

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -228,9 +228,11 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     // CallContext may not have been resolved yet.
     PolarisCallContext polarisContext =
         new PolarisCallContext(
-            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
+            realmContext,
+            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
+            diagServices);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
+      CallContext.setCurrentContext(polarisContext);
     }
 
     EntityResult preliminaryRootPrincipalLookup =
@@ -286,9 +288,11 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       RealmContext realmContext, PolarisMetaStoreManager metaStoreManager) {
     PolarisCallContext polarisContext =
         new PolarisCallContext(
-            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
+            realmContext,
+            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
+            diagServices);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
+      CallContext.setCurrentContext(polarisContext);
     }
 
     EntityResult rootPrincipalLookup =

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -90,14 +90,6 @@ public class PolarisCallContext implements CallContext {
     this.clock = Clock.system(ZoneId.systemDefault());
   }
 
-  public static PolarisCallContext copyOf(PolarisCallContext original) {
-    return new PolarisCallContext(
-        original.getMetaStore().detach(),
-        original.getDiagServices(),
-        original.getConfigurationStore(),
-        original.getClock());
-  }
-
   public BasePersistence getMetaStore() {
     return metaStore;
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -22,13 +22,15 @@ import jakarta.annotation.Nonnull;
 import java.time.Clock;
 import java.time.ZoneId;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.BasePersistence;
 
 /**
  * The Call context is allocated each time a new REST request is processed. It contains instances of
  * low-level services required to process that request
  */
-public class PolarisCallContext {
+public class PolarisCallContext implements CallContext {
 
   // meta store which is used to persist Polaris entity metadata
   private final BasePersistence metaStore;
@@ -40,6 +42,23 @@ public class PolarisCallContext {
 
   private final Clock clock;
 
+  // will make it final once we remove deprecated constructor
+  private RealmContext realmContext = null;
+
+  public PolarisCallContext(
+      @Nonnull RealmContext realmContext,
+      @Nonnull BasePersistence metaStore,
+      @Nonnull PolarisDiagnostics diagServices,
+      @Nonnull PolarisConfigurationStore configurationStore,
+      @Nonnull Clock clock) {
+    this.realmContext = realmContext;
+    this.metaStore = metaStore;
+    this.diagServices = diagServices;
+    this.configurationStore = configurationStore;
+    this.clock = clock;
+  }
+
+  @Deprecated
   public PolarisCallContext(
       @Nonnull BasePersistence metaStore,
       @Nonnull PolarisDiagnostics diagServices,
@@ -51,6 +70,18 @@ public class PolarisCallContext {
     this.clock = clock;
   }
 
+  public PolarisCallContext(
+      @Nonnull RealmContext realmContext,
+      @Nonnull BasePersistence metaStore,
+      @Nonnull PolarisDiagnostics diagServices) {
+    this.realmContext = realmContext;
+    this.metaStore = metaStore;
+    this.diagServices = diagServices;
+    this.configurationStore = new PolarisConfigurationStore() {};
+    this.clock = Clock.system(ZoneId.systemDefault());
+  }
+
+  @Deprecated
   public PolarisCallContext(
       @Nonnull BasePersistence metaStore, @Nonnull PolarisDiagnostics diagServices) {
     this.metaStore = metaStore;
@@ -81,5 +112,15 @@ public class PolarisCallContext {
 
   public Clock getClock() {
     return clock;
+  }
+
+  @Override
+  public RealmContext getRealmContext() {
+    return realmContext;
+  }
+
+  @Override
+  public PolarisCallContext getPolarisCallContext() {
+    return this;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -69,7 +69,15 @@ public interface CallContext {
   static CallContext copyOf(CallContext base) {
     String realmId = base.getRealmContext().getRealmIdentifier();
     RealmContext realmContext = () -> realmId;
-    PolarisCallContext polarisCallContext = PolarisCallContext.copyOf(base.getPolarisCallContext());
+    PolarisCallContext originalPolarisCallContext = base.getPolarisCallContext();
+    PolarisCallContext newPolarisCallContext =
+        new PolarisCallContext(
+            realmContext,
+            originalPolarisCallContext.getMetaStore(),
+            originalPolarisCallContext.getDiagServices(),
+            originalPolarisCallContext.getConfigurationStore(),
+            originalPolarisCallContext.getClock());
+
     return new CallContext() {
       @Override
       public RealmContext getRealmContext() {
@@ -78,7 +86,7 @@ public interface CallContext {
 
       @Override
       public PolarisCallContext getPolarisCallContext() {
-        return polarisCallContext;
+        return newPolarisCallContext;
       }
     };
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -49,6 +49,7 @@ public interface CallContext {
     CURRENT_CONTEXT.remove();
   }
 
+  // only tests are using this method now, we can get rid of them easily in a followup
   static CallContext of(
       final RealmContext realmContext, final PolarisCallContext polarisCallContext) {
     return new CallContext() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -202,11 +202,13 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       RealmContext realmContext, PolarisMetaStoreManager metaStoreManager) {
     // While bootstrapping we need to act as a fake privileged context since the real
     // CallContext may not have been resolved yet.
-    PolarisCallContext polarisContext =
+    var polarisContext =
         new PolarisCallContext(
-            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
+            realmContext,
+            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
+            diagServices);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
+      CallContext.setCurrentContext(polarisContext);
     }
 
     EntityResult preliminaryRootPrincipalLookup =
@@ -251,9 +253,11 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       RealmContext realmContext, PolarisMetaStoreManager metaStoreManager) {
     PolarisCallContext polarisContext =
         new PolarisCallContext(
-            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(), diagServices);
+            realmContext,
+            sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
+            diagServices);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(CallContext.of(realmContext, polarisContext));
+      CallContext.setCurrentContext(polarisContext);
     }
 
     EntityResult rootPrincipalLookup =

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -121,7 +121,7 @@ public class QuarkusProducers {
 
   @Produces
   @RequestScoped
-  public PolarisCallContext polarisCallContext(
+  public CallContext polarisCallContext(
       RealmContext realmContext,
       PolarisDiagnostics diagServices,
       PolarisConfigurationStore configurationStore,
@@ -129,13 +129,8 @@ public class QuarkusProducers {
       Clock clock) {
     BasePersistence metaStoreSession =
         metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
-    return new PolarisCallContext(metaStoreSession, diagServices, configurationStore, clock);
-  }
-
-  @Produces
-  @RequestScoped
-  public CallContext callContext(RealmContext realmContext, PolarisCallContext polarisCallContext) {
-    return CallContext.of(realmContext, polarisCallContext);
+    return new PolarisCallContext(
+        realmContext, metaStoreSession, diagServices, configurationStore, clock);
   }
 
   // Polaris service beans - selected from @Identifier-annotated beans

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
@@ -66,8 +66,7 @@ public class DefaultCallContextResolver implements CallContextResolver {
     // factories would then inject something else instead if needed.
     BasePersistence metaStoreSession =
         metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
-    PolarisCallContext polarisContext =
-        new PolarisCallContext(metaStoreSession, diagnostics, configurationStore, clock);
-    return CallContext.of(realmContext, polarisContext);
+    return new PolarisCallContext(
+        realmContext, metaStoreSession, diagnostics, configurationStore, clock);
   }
 }


### PR DESCRIPTION
This is the first step to consolidate call context. After this change, you can already use `PolarisCallContext` to get a `RealmContext`. To finish the consolidation, here are follow-ups.

- [x] Make `PolarisCallContext` extend `CallContext`
- [ ] Cleanup the tests which call `CallContext.of()`, then remove the method.
- [ ] Promote methods in `PolarisCallContext` to the interface `CallContext`, like `getMetaStore()`
- [ ] Change the method parameters to use `CallContext` instead of `PolarisCallContext` as much as possible. For example, `EntitiesResult createEntitiesIfNotExist( @Nonnull PolarisCallContext callCtx, ...)`