### PR TITLE
Remove CallContext.of()

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -49,22 +49,6 @@ public interface CallContext {
     CURRENT_CONTEXT.remove();
   }
 
-  // only tests are using this method now, we can get rid of them easily in a followup
-  static CallContext of(
-      final RealmContext realmContext, final PolarisCallContext polarisCallContext) {
-    return new CallContext() {
-      @Override
-      public RealmContext getRealmContext() {
-        return realmContext;
-      }
-
-      @Override
-      public PolarisCallContext getPolarisCallContext() {
-        return polarisCallContext;
-      }
-    };
-  }
-
   /** Copy the {@link CallContext}. */
   static CallContext copyOf(CallContext base) {
     String realmId = base.getRealmContext().getRealmIdentifier();

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -107,7 +107,7 @@ class InMemoryStorageIntegrationTest {
               }
             },
             Clock.systemUTC());
-    CallContext.setCurrentContext(CallContext.of(() -> "realm", polarisCallContext));
+    CallContext.setCurrentContext(polarisCallContext);
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =
         storage.validateAccessToLocations(
             new FileStorageConfigurationInfo(List.of("file://", "*")),

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -104,10 +104,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   @Test
   protected void testCreateEntities() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
-    CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(callCtx);
+      CallContext.setCurrentContext(polarisTestMetaStoreManager.polarisCallContext);
     }
     TaskEntity task1 = createTask("task1", 100L);
     TaskEntity task2 = createTask("task2", 101L);
@@ -155,10 +153,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   @Test
   protected void testCreateEntitiesAlreadyExisting() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
-    CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(callCtx);
+      CallContext.setCurrentContext(polarisTestMetaStoreManager.polarisCallContext);
     }
     TaskEntity task1 = createTask("task1", 100L);
     TaskEntity task2 = createTask("task2", 101L);
@@ -194,10 +190,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
   @Test
   protected void testCreateEntitiesWithConflict() {
     PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
-    CallContext callCtx =
-        CallContext.of(() -> "testRealm", polarisTestMetaStoreManager.polarisCallContext);
     if (CallContext.getCurrentContext() == null) {
-      CallContext.setCurrentContext(callCtx);
+      CallContext.setCurrentContext(polarisTestMetaStoreManager.polarisCallContext);
     }
     TaskEntity task1 = createTask("task1", 100L);
     TaskEntity task2 = createTask("task2", 101L);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
@@ -76,7 +76,7 @@ public class ManagementServiceTest {
             fakeServices.polarisDiagnostics(),
             fakeServices.configurationStore(),
             Mockito.mock(Clock.class));
-    CallContext.setCurrentContext(CallContext.of(fakeServices.realmContext(), polarisCallContext));
+    CallContext.setCurrentContext(polarisCallContext);
     services =
         TestServices.builder()
             .config(Map.of("SUPPORTED_CATALOG_STORAGE_TYPES", List.of("S3", "GCS", "AZURE")))
@@ -193,10 +193,9 @@ public class ManagementServiceTest {
 
   private PolarisAdminService setupPolarisAdminService(
       PolarisMetaStoreManager metaStoreManager, PolarisCallContext callContext) {
-    RealmContext realmContext = services.realmContext();
     return new PolarisAdminService(
-        CallContext.of(realmContext, callContext),
-        services.entityManagerFactory().getOrCreateEntityManager(realmContext),
+        callContext,
+        services.entityManagerFactory().getOrCreateEntityManager(callContext.getRealmContext()),
         metaStoreManager,
         new UnsafeInMemorySecretsManager(),
         new SecurityContext() {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -244,7 +244,7 @@ public abstract class PolarisAuthzTestBase {
             clock);
     this.entityManager = realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
 
-    callContext = CallContext.of(realmContext, polarisContext);
+    callContext = polarisContext;
     CallContext.setCurrentContext(callContext);
 
     PrincipalEntity rootEntity =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -212,7 +212,6 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   @Inject PolarisEventListener polarisEventListener;
 
   private IcebergCatalog catalog;
-  private CallContext callContext;
   private String realmName;
   private PolarisMetaStoreManager metaStoreManager;
   private UserSecretsManager userSecretsManager;
@@ -260,8 +259,6 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new PolarisEntityManager(
             metaStoreManager, new StorageCredentialCache(), createEntityCache(metaStoreManager));
 
-    callContext = CallContext.of(realmContext, polarisContext);
-
     PrincipalEntity rootEntity =
         new PrincipalEntity(
             PolarisEntity.of(
@@ -285,7 +282,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     adminService =
         new PolarisAdminService(
-            callContext,
+            polarisContext,
             entityManager,
             metaStoreManager,
             userSecretsManager,
@@ -369,13 +366,13 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
       String catalogName, Map<String, String> additionalProperties) {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     IcebergCatalog icebergCatalog =
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             taskExecutor,
@@ -661,7 +658,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     final String tableMetadataLocation = tableLocation + "metadata/";
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, catalog().name());
+            polarisContext, entityManager, securityContext, catalog().name());
     FileIOFactory fileIOFactory =
         spy(
             new DefaultFileIOFactory(
@@ -672,7 +669,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(TaskExecutor.class),
@@ -997,13 +994,13 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, catalogWithoutStorage);
+            polarisContext, entityManager, securityContext, catalogWithoutStorage);
     TaskExecutor taskExecutor = Mockito.mock();
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             taskExecutor,
@@ -1030,11 +1027,10 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         metadataLocation,
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
-    PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
-    if (!polarisCallContext
+    if (!polarisContext
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+            polarisContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -1063,14 +1059,14 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, catalogName);
+            polarisContext, entityManager, securityContext, catalogName);
     TaskExecutor taskExecutor = Mockito.mock();
     InMemoryFileIO localFileIO = new InMemoryFileIO();
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             taskExecutor,
@@ -1099,11 +1095,10 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         metadataLocation,
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
-    PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
-    if (!polarisCallContext
+    if (!polarisContext
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+            polarisContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
           .isInstanceOf(ForbiddenException.class)
@@ -1122,10 +1117,10 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         httpsMetadataLocation,
         TableMetadataParser.toJson(createSampleTableMetadata(metadataLocation)).getBytes(UTF_8));
 
-    if (!polarisCallContext
+    if (!polarisContext
         .getConfigurationStore()
         .getConfiguration(
-            callContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
+            polarisContext.getRealmContext(), FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES)
         .contains("FILE")) {
       Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, newRequest))
           .isInstanceOf(ForbiddenException.class)
@@ -1566,7 +1561,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
                     new RealmEntityManagerFactory(metaStoreManagerFactory),
                     metaStoreManagerFactory,
                     configurationStore))
-            .apply(taskEntity, callContext);
+            .apply(taskEntity, polarisContext);
     Assertions.assertThat(fileIO).isNotNull().isInstanceOf(ExceptionMappingFileIO.class);
     Assertions.assertThat(((ExceptionMappingFileIO) fileIO).getInnerIo())
         .isInstanceOf(InMemoryFileIO.class);
@@ -1600,12 +1595,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
                 .asCatalog()));
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, noPurgeCatalogName);
+            polarisContext, entityManager, securityContext, noPurgeCatalogName);
     IcebergCatalog noPurgeCatalog =
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(),
@@ -1703,7 +1698,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   public void testFileIOWrapper() {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
 
     MeasuredFileIOFactory measured =
         new MeasuredFileIOFactory(
@@ -1714,7 +1709,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(),
@@ -1748,8 +1743,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     TaskEntity taskEntity =
         TaskEntity.of(
             metaStoreManager
-                .loadTasks(
-                    callContext.getPolarisCallContext(), "testExecutor", PageToken.fromLimit(1))
+                .loadTasks(polarisContext, "testExecutor", PageToken.fromLimit(1))
                 .getEntities()
                 .getFirst());
     Map<String, String> properties = taskEntity.getInternalPropertiesAsMap();
@@ -1781,7 +1775,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     TableCleanupTaskHandler handler =
         new TableCleanupTaskHandler(
             Mockito.mock(), createMockMetaStoreManagerFactory(), taskFileIOSupplier);
-    handler.handleTask(taskEntity, callContext);
+    handler.handleTask(taskEntity, polarisContext);
     Assertions.assertThat(measured.getNumDeletedFiles()).as("A table was deleted").isGreaterThan(0);
   }
 
@@ -1810,12 +1804,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisMetaStoreManager spyMetaStore = spy(metaStoreManager);
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
     final IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
             spyMetaStore,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(TaskExecutor.class),
@@ -1859,12 +1853,12 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisMetaStoreManager spyMetaStore = spy(metaStoreManager);
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
     final IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
             spyMetaStore,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(TaskExecutor.class),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -182,8 +182,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
             new StorageCredentialCache(),
             new InMemoryEntityCache(metaStoreManager));
 
-    CallContext callContext = CallContext.of(realmContext, polarisContext);
-    CallContext.setCurrentContext(callContext);
+    CallContext.setCurrentContext(polarisContext);
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(
@@ -207,7 +206,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
 
     PolarisAdminService adminService =
         new PolarisAdminService(
-            callContext,
+            polarisContext,
             entityManager,
             metaStoreManager,
             userSecretsManager,
@@ -233,7 +232,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(
             new RealmEntityManagerFactory(managerFactory), managerFactory, configurationStore);
@@ -243,7 +242,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             Mockito.mock(),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogTest.java
@@ -51,7 +51,6 @@ import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -132,7 +131,6 @@ public class PolarisGenericTableCatalogTest {
 
   private PolarisGenericTableCatalog genericTableCatalog;
   private IcebergCatalog icebergCatalog;
-  private CallContext callContext;
   private AwsStorageConfigInfo storageConfigModel;
   private String realmName;
   private PolarisMetaStoreManager metaStoreManager;
@@ -182,8 +180,6 @@ public class PolarisGenericTableCatalogTest {
             new StorageCredentialCache(),
             new InMemoryEntityCache(metaStoreManager));
 
-    callContext = CallContext.of(realmContext, polarisContext);
-
     PrincipalEntity rootEntity =
         new PrincipalEntity(
             PolarisEntity.of(
@@ -206,7 +202,7 @@ public class PolarisGenericTableCatalogTest {
 
     adminService =
         new PolarisAdminService(
-            callContext,
+            polarisContext,
             entityManager,
             metaStoreManager,
             userSecretsManager,
@@ -243,7 +239,7 @@ public class PolarisGenericTableCatalogTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, entityManager, securityContext, CATALOG_NAME);
+            polarisContext, entityManager, securityContext, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
@@ -268,13 +264,13 @@ public class PolarisGenericTableCatalogTest {
         .thenReturn((PolarisStorageIntegration) storageIntegration);
 
     this.genericTableCatalog =
-        new PolarisGenericTableCatalog(metaStoreManager, callContext, passthroughView);
+        new PolarisGenericTableCatalog(metaStoreManager, polarisContext, passthroughView);
     this.genericTableCatalog.initialize(CATALOG_NAME, Map.of());
     this.icebergCatalog =
         new IcebergCatalog(
             entityManager,
             metaStoreManager,
-            callContext,
+            polarisContext,
             passthroughView,
             securityContext,
             taskExecutor,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -206,7 +206,7 @@ public class PolicyCatalogTest {
             new StorageCredentialCache(),
             new InMemoryEntityCache(metaStoreManager));
 
-    callContext = CallContext.of(realmContext, polarisContext);
+    callContext = polarisContext;
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
@@ -50,8 +50,7 @@ public class CatalogEntityTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(() -> "realm").get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callContext = CallContext.of(() -> "realm", polarisCallContext);
-    CallContext.setCurrentContext(callContext);
+    CallContext.setCurrentContext(polarisCallContext);
   }
 
   @Test

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -95,7 +95,6 @@ public class BatchFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
     FileIO fileIO =
         new InMemoryFileIO() {
           @Override
@@ -195,7 +194,7 @@ public class BatchFileCleanupTaskHandlerTest {
 
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
 
     for (String cleanupFile : cleanupFiles) {
       assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO)).rejects(cleanupFile);
@@ -209,8 +208,7 @@ public class BatchFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
-    CallContext.setCurrentContext(callCtx);
+    CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
     BatchFileCleanupTaskHandler handler =
@@ -245,7 +243,7 @@ public class BatchFileCleanupTaskHandlerTest {
 
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
   }
 
   @Test
@@ -255,8 +253,7 @@ public class BatchFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
-    CallContext.setCurrentContext(callCtx);
+    CallContext.setCurrentContext(polarisCallContext);
     Map<String, AtomicInteger> retryCounter = new HashMap<>();
     FileIO fileIO =
         new InMemoryFileIO() {
@@ -308,10 +305,10 @@ public class BatchFileCleanupTaskHandlerTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              CallContext.setCurrentContext(callCtx);
+              CallContext.setCurrentContext(polarisCallContext);
               addTaskLocation(task);
               assertThatPredicate(handler::canHandleTask).accepts(task);
-              handler.handleTask(task, callCtx); // this will schedule the batch deletion
+              handler.handleTask(task, polarisCallContext); // this will schedule the batch deletion
             });
 
     // Wait for all async tasks to finish

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
@@ -94,7 +94,6 @@ class ManifestFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
 
@@ -115,7 +114,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
   }
 
   @Test
@@ -125,8 +124,7 @@ class ManifestFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
-    CallContext.setCurrentContext(callCtx);
+    CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
     ManifestFileCleanupTaskHandler handler =
@@ -145,7 +143,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
   }
 
   @Test
@@ -155,8 +153,7 @@ class ManifestFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
-    CallContext.setCurrentContext(callCtx);
+    CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO =
         new InMemoryFileIO() {
           @Override
@@ -190,7 +187,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile1Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile2Path);
   }
@@ -202,8 +199,7 @@ class ManifestFileCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             new PolarisDefaultDiagServiceImpl());
-    CallContext callCtx = CallContext.of(realmContext, polarisCallContext);
-    CallContext.setCurrentContext(callCtx);
+    CallContext.setCurrentContext(polarisCallContext);
     Map<String, AtomicInteger> retryCounter = new HashMap<>();
     FileIO fileIO =
         new InMemoryFileIO() {
@@ -251,7 +247,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, callCtx)).isTrue();
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile1Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile2Path);
   }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -100,15 +100,14 @@ class TableCleanupTaskHandlerTest {
   @BeforeEach
   void setup() {
     QuarkusMock.installMockForType(realmContext, RealmContext.class);
-    PolarisCallContext polarisCallContext =
+
+    callContext =
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
             Clock.systemDefaultZone());
-
-    callContext = CallContext.of(realmContext, polarisCallContext);
   }
 
   private void addTaskLocation(TaskEntity task) {

--- a/service/common/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -51,7 +51,6 @@ public class TaskExecutorImplTest {
 
     PolarisCallContext polarisCallCtx =
         new PolarisCallContext(realmContext, bp, testServices.polarisDiagnostics());
-    CallContext callContext = CallContext.of(realmContext, polarisCallCtx);
 
     // This task doesn't have a type so it won't be handle-able by a real handler. We register a
     // test TaskHandler below that can handle any task.
@@ -88,11 +87,11 @@ public class TaskExecutorImplTest {
           }
         });
 
-    executor.handleTask(taskEntity.getId(), callContext, attempt);
+    executor.handleTask(taskEntity.getId(), polarisCallCtx, attempt);
 
     var afterAttemptTaskEvent = testPolarisEventListener.getLatest(AfterTaskAttemptedEvent.class);
     Assertions.assertEquals(taskEntity.getId(), afterAttemptTaskEvent.taskEntityId());
-    Assertions.assertEquals(callContext, afterAttemptTaskEvent.callContext());
+    Assertions.assertEquals(polarisCallCtx, afterAttemptTaskEvent.callContext());
     Assertions.assertEquals(attempt, afterAttemptTaskEvent.attempt());
     Assertions.assertTrue(afterAttemptTaskEvent.success());
   }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This PR is a follow-up of https://github.com/apache/polaris/pull/1806 to remove all usage of CallContext.of() in tests and the method itself
