### PR TITLE
Turn CallContext.copyOf into an interface instead of static function

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -101,10 +101,6 @@ public class PolarisCallContext implements CallContext {
     String realmId = this.realmContext.getRealmIdentifier();
     RealmContext realmContext = () -> realmId;
     return new PolarisCallContext(
-            realmContext,
-            this.metaStore,
-            this.diagServices,
-            this.configurationStore,
-            this.clock);
+        realmContext, this.metaStore, this.diagServices, this.configurationStore, this.clock);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -94,4 +94,17 @@ public class PolarisCallContext implements CallContext {
   public PolarisCallContext getPolarisCallContext() {
     return this;
   }
+
+  @Override
+  public PolarisCallContext copy() {
+    // make a copy of the realm context
+    String realmId = this.realmContext.getRealmIdentifier();
+    RealmContext realmContext = () -> realmId;
+    return new PolarisCallContext(
+            realmContext,
+            this.metaStore,
+            this.diagServices,
+            this.configurationStore,
+            this.clock);
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.context;
 
+import org.apache.commons.compress.harmony.pack200.NewAttributeBands;
 import org.apache.polaris.core.PolarisCallContext;
 
 /**
@@ -45,30 +46,7 @@ public interface CallContext {
   }
 
   /** Copy the {@link CallContext}. */
-  static CallContext copyOf(CallContext base) {
-    String realmId = base.getRealmContext().getRealmIdentifier();
-    RealmContext realmContext = () -> realmId;
-    PolarisCallContext originalPolarisCallContext = base.getPolarisCallContext();
-    PolarisCallContext newPolarisCallContext =
-        new PolarisCallContext(
-            realmContext,
-            originalPolarisCallContext.getMetaStore(),
-            originalPolarisCallContext.getDiagServices(),
-            originalPolarisCallContext.getConfigurationStore(),
-            originalPolarisCallContext.getClock());
-
-    return new CallContext() {
-      @Override
-      public RealmContext getRealmContext() {
-        return realmContext;
-      }
-
-      @Override
-      public PolarisCallContext getPolarisCallContext() {
-        return newPolarisCallContext;
-      }
-    };
-  }
+  CallContext copy();
 
   RealmContext getRealmContext();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.context;
 
-import org.apache.commons.compress.harmony.pack200.NewAttributeBands;
 import org.apache.polaris.core.PolarisCallContext;
 
 /**

--- a/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -96,7 +96,7 @@ public class TaskExecutorImpl implements TaskExecutor {
     // the task is still running.
     // Note: PolarisCallContext has request-scoped beans as well, and must be cloned.
     // FIXME replace with context propagation?
-    CallContext clone = CallContext.copyOf(callContext);
+    CallContext clone = callContext.copy();
     tryHandleTask(taskEntityId, clone, null, 1);
   }
 

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -136,25 +136,12 @@ public class FileIOFactoryTest {
             .build();
 
     callContext =
-        new CallContext() {
-          @Override
-          public RealmContext getRealmContext() {
-            return testServices.realmContext();
-          }
-
-          @Override
-          public PolarisCallContext getPolarisCallContext() {
-            return new PolarisCallContext(
-                realmContext,
-                testServices
-                    .metaStoreManagerFactory()
-                    .getOrCreateSessionSupplier(realmContext)
-                    .get(),
-                testServices.polarisDiagnostics(),
-                testServices.configurationStore(),
-                Mockito.mock(Clock.class));
-          }
-        };
+        new PolarisCallContext(
+            realmContext,
+            testServices.metaStoreManagerFactory().getOrCreateSessionSupplier(realmContext).get(),
+            testServices.polarisDiagnostics(),
+            testServices.configurationStore(),
+            Mockito.mock(Clock.class));
   }
 
   @AfterEach

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -163,22 +163,12 @@ public record TestServices(
       BasePersistence metaStoreSession =
           metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
       CallContext callContext =
-          new CallContext() {
-            @Override
-            public RealmContext getRealmContext() {
-              return realmContext;
-            }
-
-            @Override
-            public PolarisCallContext getPolarisCallContext() {
-              return new PolarisCallContext(
-                  realmContext,
-                  metaStoreSession,
-                  polarisDiagnostics,
-                  configurationStore,
-                  Mockito.mock(Clock.class));
-            }
-          };
+          new PolarisCallContext(
+              realmContext,
+              metaStoreSession,
+              polarisDiagnostics,
+              configurationStore,
+              Mockito.mock(Clock.class));
       PolarisEntityManager entityManager =
           realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
       PolarisMetaStoreManager metaStoreManager =


### PR DESCRIPTION
We want to turn CallContext class into a pure interface that can be implemented/customized by its child class. This PR removes the copyOf static function.
