### PR TITLE
Fix  maxCode generation for ConnectionTypeEnum

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
@@ -40,8 +40,8 @@ public enum ConnectionType {
   static {
     // find max array size
     int maxCode =
-        Arrays.stream(AuthenticationType.values())
-            .mapToInt(AuthenticationType::getCode)
+        Arrays.stream(ConnectionType.values())
+            .mapToInt(ConnectionType::getCode)
             .max()
             .orElse(0);
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionType.java
@@ -40,10 +40,7 @@ public enum ConnectionType {
   static {
     // find max array size
     int maxCode =
-        Arrays.stream(ConnectionType.values())
-            .mapToInt(ConnectionType::getCode)
-            .max()
-            .orElse(0);
+        Arrays.stream(ConnectionType.values()).mapToInt(ConnectionType::getCode).max().orElse(0);
 
     // allocate mapping array
     REVERSE_MAPPING_ARRAY = new ConnectionType[maxCode + 1];


### PR DESCRIPTION
Previously, the `maxCode` was generated using `AuthenticationType.values()`. It worked fine because Polaris supported the same number of Connection and Authentication types. The enum conversion would break if we add new authentication or connection types independently as in #1805 or other forms of federation.

