### PR TITLE
Fix LICENSE and NOTICE in Spark plugin

### DIFF
--- a/plugins/spark/v3.5/spark/LICENSE
+++ b/plugins/spark/v3.5/spark/LICENSE
@@ -202,124 +202,368 @@
 
 --------------------------------------------------------------------------------
 
-This product includes a gradle wrapper.
-
-* gradlew
-* gradle/wrapper/gradle-wrapper.properties
-
-Copyright: 2010-2019 Gradle Authors.
-Home page: https://github.com/gradle/gradle
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product includes code from Apache Iceberg.
 
-* spec/iceberg-rest-catalog-open-api.yaml
-* spec/polaris-catalog-apis/oauth-tokens-api.yaml
-* integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationTest.java
-* service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
-* service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
 * plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisSparkCatalog.java
 * plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/PolarisInMemoryCatalog.java
 * plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
 * plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/SparkCatalog.java
 
-Copyright: Copyright 2017-2025 The Apache Software Foundation
+Copyright: 2017-2025 The Apache Software Foundation
 Home page: https://iceberg.apache.org
 License: https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product includes code from OpenAPITool openapi-generator
+This binary artifact contains Apache Iceberg.
 
-* server-templates/formParams.mustache
-* server-templates/apiService.mustache
-* server-templates/bodyParams.mustache
-* server-templates/pojo.mustache
-* server-templates/headerParams.mustache
-* server-templates/apiServiceImpl.mustache
-* server-templates/queryParams.mustache
-* server-templates/api.mustache
-
-Copyright: Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech) 
-           Copyright 2018 SmartBear Software
-Home page: https://openapi-generator.tech/
-License: https://www.apache.org/licenses/LICENSE-2.0
+Copyright: 2017-2025 The Apache Software Foundation
+Project URL: https://iceberg.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This product includes code from Google Docsy.
+This binary artifact contains Apache Spark.
 
-* site/layouts/community/list.html
-* site/layouts/docs/baseof.html
-* site/layouts/partials/community_links.html
-* site/layouts/partials/head.html
-* site/layouts/partials/navbar.html
-* site/layouts/shortcodes/redoc-polaris.html
-
-Home page: https://www.docsy.dev/
-License: https://www.apache.org/licenses/LICENSE-2.0
+Copyright: 2014 and onwards The Apache Software Foundation
+Project URL: https://spark.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This product includes code from Project Nessie.
+This binary artifact contains Guava.
 
-* build-logic/src/main/kotlin/LicenseFileValidation.kt
-* build-logic/src/main/kotlin/copiedcode/CopiedCodeCheckerPlugin.kt
-* build-logic/src/main/kotlin/copiedcode/CopiedCodeCheckerExtension.kt
-* build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
-* build-logic/src/main/kotlin/Utilities.kt
-* build-logic/src/main/kotlin/polaris-shadow-jar.gradle.kts
-* build-logic/src/main/kotlin/polaris-quarkus.gradle.kts
-* tools/config-docs/annotations/src/main/java/org/apache/polaris/docs/ConfigDocs.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/DocGenDoclet.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/MarkdownFormatter.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/MarkdownPropertyFormatter.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/MarkdownTypeFormatter.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertiesConfigItem.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertiesConfigPageGroup.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertiesConfigs.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertyInfo.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/SmallRyeConfigMappingInfo.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/SmallRyeConfigPropertyInfo.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/SmallRyeConfigs.java
-* tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/ReferenceConfigDocsGenerator.java
-* tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
-* tools/config-docs/generator/src/test/java/tests/properties/ConfigProps.java
-* tools/config-docs/generator/src/test/java/tests/properties/MoreProps.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/AllTypes.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/ExtremelyNested.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/InterfaceOne.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/InterfaceThree.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/InterfaceTwo.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/MappedA.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedA.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedA1.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedA11.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedA2.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedB.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedB1.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedB12.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionA.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionB.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionC.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionTypeA.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionTypeB.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/NestedSectionsRoot.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/OtherMapped.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/SomeEnum.java
-* tools/config-docs/generator/src/test/java/tests/smallrye/VeryNested.java
-* tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
-* quarkus/admin/src/main/java/org/apache/polaris/admintool/PolarisAdminTool.java
-* helm/polaris/tests/logging_storage_test.yaml
-* helm/polaris/tests/quantity_test.yaml
-* helm/polaris/tests/service_monitor_test.yaml
-* helm/polaris/templates/_helpers.tpl
-* helm/polaris/templates/serviceaccount.yaml
-* helm/polaris/templates/servicemonitor.yaml
-* helm/polaris/templates/storage.yaml
+Copyright: 2006-2020 The Guava Authors
+Project URL: https://github.com/google/guava
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright: Copyright 2015-2025 Dremio Corporation
-Home page: https://projectnessie.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
+--------------------------------------------------------------------------------
+
+This binary artifact contains jspecify.
+
+Copyright: Google LLC - SpotBugs Team
+Project URL: https://github.com/jspecify/jspecify
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Datasketches.
+
+Copyright: 2020 The Apache Software Foundation
+           2015-2018 Yahoo
+           2019 Verizon Media
+Project URL: https://datasketches.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Parquet.
+
+Copyright: 2014-2024 The Apache Software Foundation
+Project URL: https://parquet.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains FastUtil.
+
+Copyright: 2002-2014 Sebastiano Vigna
+Project URL: http://fastutil.di.unimi.it/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache ORC.
+
+Copyright: 2013 and onwards The Apache Software Foundation.
+Project URL: https://orc.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Arrow.
+
+Copyright: 2016-2025 The Apache Software Foundation
+Project URL: https://arrow.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Caffeine by Ben Manes.
+
+Copyright: 2014-2019 Ben Manes and contributors
+Project URL: https://github.com/ben-manes/caffeine
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains RoaringBitmap.
+
+Copyright: (c) 2013-... the RoaringBitmap authors
+Project URL: https://github.com/RoaringBitmap/RoaringBitmap
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Project URL: https://failsafe.dev/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Project Nessie.
+
+Copyright: 2015-2025 Dremio Corporation
+Project URL: https://projectnessie.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Avro.
+
+Copyright: 2010-2019 The Apache Software Foundation
+Project URL: https://avro.apache.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains the Jackson JSON processor.
+
+Copyright: 2007-2020 Tatu Saloranta and other contributors
+Project URL: http://jackson.codehaus.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Airlift Aircompressor.
+
+Copyright: 2011-2020 Aircompressor authors.
+Project URL: https://github.com/airlift/aircompressor
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache HttpComponents Client.
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://hc.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Netty's buffer library.
+
+Copyright: 2014-2020 The Netty Project
+Project URL: https://netty.io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Thrift.
+
+Copyright: 2006-2017 The Apache Software Foundation.
+Project URL: https://thrift.apache.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Jetbrains Annotations.
+
+Copyright: 2000-2020 JetBrains s.r.o.
+Project URL: https://github.com/JetBrains/java-annotations
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains ThreeTen.
+
+Copyright: 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+Project URL: https://www.threeten.org/threeten-extra/
+License: BSD 3-Clause
+| All rights reserved.
+|
+| * Redistribution and use in source and binary forms, with or without
+|   modification, are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+|
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Eclipse Collections.
+
+Copyright: 2021 Goldman Sachs.
+Project URL: https://github.com/eclipse-collections/eclipse-collections/
+License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains checkerframework checker-qual Annotations.
+
+Copyright: 2004-2019 the Checker Framework developers
+Project URL: https://github.com/typetools/checker-framework
+License: MIT License
+| The annotations are licensed under the MIT License.  (The text of this
+| license appears below.)  More specifically, all the parts of the Checker
+| Framework that you might want to include with your own program use the
+| MIT License.  This is the checker-qual.jar file and all the files that
+| appear in it:  every file in a qual/ directory, plus utility files such
+| as NullnessUtil.java, RegexUtil.java, SignednessUtil.java, etc.
+| In addition, the cleanroom implementations of third-party annotations,
+| which the Checker Framework recognizes as aliases for its own
+| annotations, are licensed under the MIT License.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Google Error Prone Annotations.
+
+Copyright: Copyright 2011-2019 The Error Prone Authors
+Project URL: https://github.com/google/error-prone
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Eclipse MicroProfile OpenAPI.
+
+Copyright: 2017 Contributors to the Eclipse Foundation
+Project URL: https://github.com/microprofile/microprofile-open-api
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Jakarta Annotation.
+
+Project URL: https://projects.eclipse.org/projects/ee4j.ca
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Jakarta Validation.
+
+Project URL: https://beanvalidation.org
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Jakarta Servlet.
+
+Project URL: https://projects.eclipse.org/projects/ee4j.servlet
+License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Micrometer.
+
+Copyright: 2017-Present VMware, Inc. All Rights Reserved.
+Project URL: https://github.com/micrometer-metrics/micrometer
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Commons Compress.
+
+Copyright: 2002-2025 The Apache Software Foundation
+Project URL: https://commons.apache.org/proper/commons-compress/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Commons Codec.
+
+Copyright: 2002-2025 The Apache Software Foundation
+Project URL: https://commons.apache.org/proper/commons-codec/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains SLF4J.
+
+Copyright: 2004-2022 QOS.ch Sarl (Switzerland)
+Project URL: http://www.slf4j.org
+License: MIT License
+| Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+| All rights reserved.
+|
+| Permission is hereby granted, free  of charge, to any person obtaining
+| a  copy  of this  software  and  associated  documentation files  (the
+| "Software"), to  deal in  the Software without  restriction, including
+| without limitation  the rights to  use, copy, modify,  merge, publish,
+| distribute,  sublicense, and/or sell  copies of  the Software,  and to
+| permit persons to whom the Software  is furnished to do so, subject to
+| the following conditions:
+|
+| The  above  copyright  notice  and  this permission  notice  shall  be
+| included in all copies or substantial portions of the Software.
+|
+| THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+| EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+| MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+| NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+| LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+| OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+| WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains j2objc.
+
+Project URL: https://github.com/google/j2objc/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Commons IO.
+
+Copyright: 2002-2025 The Apache Software Foundation
+Project URL: https://commons.apache.org/proper/commons-io/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Commons Lang3.
+
+Copyright: 2001-2025 The Apache Software Foundation
+Project URL: https://commons.apache.org/proper/commons-lang/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------

--- a/plugins/spark/v3.5/spark/NOTICE
+++ b/plugins/spark/v3.5/spark/NOTICE
@@ -9,8 +9,475 @@ to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
 
 --------------------------------------------------------------------------------
 
-This project includes code from Project Nessie, developed at Dremio,
-with the following copyright notice:
-
+This binary artifact includes Project Nessie with the following in its NOTICE
+file:
 | Nessie
 | Copyright 2015-2025 Dremio Corporation
+|
+| ---------------------------------------
+| This project includes code from Apache Polaris (incubating), with the following in its NOTICE file:
+|
+| | Apache Polaris (incubating)
+| | Copyright 2024 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (http://www.apache.org/).
+| |
+| | The initial code for the Polaris project was donated
+| | to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains the Jackson JSON processor with the following in its NOTICE
+file:
+| # Jackson JSON processor
+|
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+|
+| ## Copyright
+|
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+|
+| ## Licensing
+|
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+|
+| ## Credits
+|
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+|
+| ## FastDoubleParser
+|
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+|
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+|
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Airlift Aircompressor with the following in its NOTICE
+file:
+
+| Snappy Copyright Notices
+| =========================
+|
+| * Copyright 2011 Dain Sundstrom <dain@iq80.com>
+| * Copyright 2011, Google Inc.<opensource@google.com>
+|
+|
+| Snappy License
+| ===============
+| Copyright 2011, Google Inc.
+| All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Netty's buffer library with the following in its NOTICE
+file:
+|                             The Netty Project
+|                             =================
+|
+| Please visit the Netty web site for more information:
+|
+|   * https://netty.io/
+|
+| Copyright 2014 The Netty Project
+|
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+|
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+|
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+|
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+|
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+|
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+|
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.slf4j.org/
+|
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+|
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://archive.apache.org/dist/harmony/
+|
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+|
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+|
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+|
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+|
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+|
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+|
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+|
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+|
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+|
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.bouncycastle.org/
+|
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+|
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+|
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+|
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://commons.apache.org/logging/
+|
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://logging.apache.org/log4j/
+|
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://wiki.fasterxml.com/AaltoHome
+|
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+|
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+|
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+|
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+|
+|
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+|
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+|
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+|
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Eclipse MicroProfile OpenAPI with the following in its NOTICE
+file:
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for MicroProfile OpenAPI                 ==
+| =========================================================================
+| 
+| The majority of this software were originally based on the following:
+| * Swagger Core
+|   https://github.com/swagger-api/swagger-core
+|   under Apache License, v2.0
+| 
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse MicroProfile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Arthur De Magalhaes arthurdm@ca.ibm.com
+| </text>
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Jakarta Validation with the following in its NOTICE
+file:
+| # Notices for Eclipse Jakarta Validation
+| 
+| This content is produced and maintained by the Eclipse Jakarta Validation
+| project.
+| 
+| * Project home: https://projects.eclipse.org/projects/ee4j.validation
+| 
+| ## Trademarks
+| 
+|  Jakarta Validation is a trademark of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License, Version 2.0 which is available at
+| https://www.apache.org/licenses/LICENSE-2.0.
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+| * [The specification repository](https://github.com/jakartaee/validation-spec)
+| * [The API repository](https://github.com/jakartaee/validation)
+| * [The TCK repository](https://github.com/jakartaee/validation-tck)
+| 
+| ## Third-party Content
+| 
+| This project leverages the following third party content.
+| 
+| Test dependencies:
+| 
+|  * [TestNG](https://github.com/cbeust/testng) - Apache License 2.0
+|  * [JCommander](https://github.com/cbeust/jcommander) - Apache License 2.0
+|  * [SnakeYAML](https://bitbucket.org/asomov/snakeyaml/src) - Apache License 2.0
+|
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Micrometer with the following in its NOTICE
+file:
+| Micrometer
+| 
+| Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|    https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -------------------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'io.netty.util.internal.logging',
+| in the Netty/Common library distributed by The Netty Project:
+| 
+|   * Copyright 2013 The Netty Project
+|   * License: Apache License v2.0
+|   * Homepage: https://netty.io
+| 
+| This product contains a modified portion of 'StringUtils.isBlank()',
+| in the Commons Lang library distributed by The Apache Software Foundation:
+| 
+|   * Copyright 2001-2019 The Apache Software Foundation
+|   * License: Apache License v2.0
+|   * Homepage: https://commons.apache.org/proper/commons-lang/
+| 
+| This product contains a modified portion of 'JsonUtf8Writer',
+| in the Moshi library distributed by Square, Inc:
+| 
+|   * Copyright 2010 Google Inc.
+|   * License: Apache License v2.0
+|   * Homepage: https://github.com/square/moshi
+| 
+| This product contains a modified portion of the 'org.springframework.lang'
+| package in the Spring Framework library, distributed by VMware, Inc:
+| 
+|   * Copyright 2002-2019 the original author or authors.
+|   * License: Apache License v2.0
+|   * Homepage: https://spring.io/projects/spring-framework
+
+--------------------------------------------------------------------------------

--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -1018,8 +1018,15 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 Group: org.checkerframework Name: checker-qual Version: 3.49.1
 Project URL: https://checkerframework.org/
 License: MIT License
-| The Checker Framework
-| Copyright 2004-present by the Checker Framework developers
+| The annotations are licensed under the MIT License.  (The text of this
+| license appears below.)  More specifically, all the parts of the Checker
+| Framework that you might want to include with your own program use the
+| MIT License.  This is the checker-qual.jar file and all the files that
+| appear in it:  every file in a qual/ directory, plus utility files such
+| as NullnessUtil.java, RegexUtil.java, SignednessUtil.java, etc.
+| In addition, the cleanroom implementations of third-party annotations,
+| which the Checker Framework recognizes as aliases for its own
+| annotations, are licensed under the MIT License.
 |
 | Permission is hereby granted, free of charge, to any person obtaining a copy
 | of this software and associated documentation files (the "Software"), to deal
@@ -1027,10 +1034,10 @@ License: MIT License
 | to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 | copies of the Software, and to permit persons to whom the Software is
 | furnished to do so, subject to the following conditions:
-| 
+|
 | The above copyright notice and this permission notice shall be included in
 | all copies or substantial portions of the Software.
-| 
+|
 | THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 | IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 | FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/quarkus/distribution/LICENSE
+++ b/quarkus/distribution/LICENSE
@@ -1346,8 +1346,15 @@ License: MIT License
 Group: org.checkerframework Name: checker-qual Version: 3.49.1
 Project URL: https://checkerframework.org/
 License: MIT License
-| The Checker Framework
-| Copyright 2004-present by the Checker Framework developers
+| The annotations are licensed under the MIT License.  (The text of this
+| license appears below.)  More specifically, all the parts of the Checker
+| Framework that you might want to include with your own program use the
+| MIT License.  This is the checker-qual.jar file and all the files that
+| appear in it:  every file in a qual/ directory, plus utility files such
+| as NullnessUtil.java, RegexUtil.java, SignednessUtil.java, etc.
+| In addition, the cleanroom implementations of third-party annotations,
+| which the Checker Framework recognizes as aliases for its own
+| annotations, are licensed under the MIT License.
 |
 | Permission is hereby granted, free of charge, to any person obtaining a copy
 | of this software and associated documentation files (the "Software"), to deal
@@ -1355,10 +1362,10 @@ License: MIT License
 | to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 | copies of the Software, and to permit persons to whom the Software is
 | furnished to do so, subject to the following conditions:
-| 
+|
 | The above copyright notice and this permission notice shall be included in
 | all copies or substantial portions of the Software.
-| 
+|
 | THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 | IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 | FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -1340,45 +1340,33 @@ License: MIT License
 Group: org.checkerframework Name: checker-qual Version: 3.49.1
 Project URL: https://checkerframework.org/
 License: MIT License
-| The Checker Framework
-| Copyright 2004-present by the Checker Framework developers
-| 
-| 
-| Most of the Checker Framework is licensed under the GNU General Public
-| License, version 2 (GPL2), with the classpath exception.  The text of this
-| license appears below.  This is the same license used for OpenJDK.
-| 
-| A few parts of the Checker Framework have more permissive licenses, notably
-| the parts that you might want to include with your own program.
-| 
-|  * The annotations and utility files are licensed under the MIT License.
-|    (The text of this license also appears below.)  This applies to
-|    checker-qual*.jar and checker-util.jar and all the files that appear in
-|    them, which is all files in checker-qual and checker-util directories.
-|    It also applies to the cleanroom implementations of
-|    third-party annotations (in checker/src/testannotations/,
-|    framework/src/main/java/org/jmlspecs/, and
-|    framework/src/main/java/com/google/).
-| 
-| The Checker Framework includes annotations for some libraries.  Those in
-| .astub files use the MIT License.  Those in https://github.com/typetools/jdk
-| (which appears in the annotated-jdk directory of file checker.jar) use the
-| GPL2 license.
-| 
-| Some external libraries that are included with the Checker Framework
-| distribution have different licenses.  Here are some examples.
-| 
-|  * JavaParser is dual licensed under the LGPL or the Apache license -- you
-|    may use it under whichever one you want.  (The JavaParser source code
-|    contains a file with the text of the GPL, but it is not clear why, since
-|    JavaParser does not use the GPL.)  See
-|    https://github.com/typetools/stubparser .
-| 
-|  * Annotation Tools (https://github.com/typetools/annotation-tools) uses
-|    the MIT license.
-| 
-|  * Libraries in plume-lib (https://github.com/plume-lib/) are licensed
-|    under the MIT License.
+| The annotations are licensed under the MIT License.  (The text of this
+| license appears below.)  More specifically, all the parts of the Checker
+| Framework that you might want to include with your own program use the
+| MIT License.  This is the checker-qual.jar file and all the files that
+| appear in it:  every file in a qual/ directory, plus utility files such
+| as NullnessUtil.java, RegexUtil.java, SignednessUtil.java, etc.
+| In addition, the cleanroom implementations of third-party annotations,
+| which the Checker Framework recognizes as aliases for its own
+| annotations, are licensed under the MIT License.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes `LICENSE` and `NOTICE` in the Polaris Spark plugin.

@flyrain @gh-yzou I'm observing some "issues" in the Spark plugin. I see some packages are shaded multiple times. For instance Jackson is shaded in Iceberg and we shade again in Polaris Spark plugin.
Imho, the Polaris Spark plugin needs some cleanup in the bundle artifact.