### PR TITLE
Fix the issue where the Polaris Server exposes backend metadata in the error response body when the database is not bootstrapped.

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -194,7 +194,7 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
       if (e.toString().toLowerCase(Locale.ROOT).contains("duplicate key")) {
         throw new AlreadyExistsException("Duplicate key error when persisting entity", e);
       } else {
-        throw e;
+        throw new RuntimeException("Error persisting entity", e);
       }
     }
   }

--- a/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -69,7 +69,8 @@ public class IcebergExceptionMapperTest {
                 new FileIOUnknownHostException(
                     "mybucket.blob.core.windows.net: Name or service not known",
                     new RuntimeException(new UnknownHostException())),
-                404)),
+                404),
+            Arguments.of(new RuntimeException("Error persisting entity"), 500)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(
                 entry ->


### PR DESCRIPTION

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Fix by wrapping jakarta.persistence.PersistenceException thrown in the EclipseLink module within a RuntimeException.
Issue: #608 