### PR TITLE
Update Spark Client license 

### DIFF
--- a/plugins/spark/v3.5/spark/LICENSE
+++ b/plugins/spark/v3.5/spark/LICENSE
@@ -204,8 +204,6 @@
 
 This product includes code from Apache Iceberg.
 
-* plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisSparkCatalog.java
-* plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/PolarisInMemoryCatalog.java
 * plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisRESTCatalog.java
 * plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/SparkCatalog.java
 


### PR DESCRIPTION
The following two files does not contain copy from Iceberg library:
 plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisSparkCatalog.java
plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/PolarisInMemoryCatalog.java

Remove them from the license