### PR TITLE
docs: fix broken 'Polaris Overview' link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ for contribution guidelines.
 [dev-list-subscribe]: mailto:dev-subscribe@polaris.apache.org
 
 ## Polaris Overview
-Click [here](https://polaris.apache.org/in-dev/unreleased/overview/) for a quick overview of Polaris.
+Click [here](https://polaris.apache.org/in-dev/unreleased/) for a quick overview of Polaris.
 
 ## Quickstart
 Click [here](https://polaris.apache.org/in-dev/unreleased/getting-started/install-dependencies/) for the quickstart experience, which will help you set up a Polaris instance locally or on any supported cloud provider.


### PR DESCRIPTION
### Summary
This PR fixes a broken link in the `README.md` under the **Polaris Overview** section.

### Changes Made
- Updated the "here" anchor link to point to the correct Polaris overview page.

### Context
The previous link was leading to a 404 or incorrect destination, which could mislead new contributors or readers trying to get a quick introduction to Polaris.

### Related Issue
Fixes #1847
