### PR TITLE
Update LICENSE for binary distributions

### DIFF
--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -339,7 +339,7 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.1
 Project URL: https://github.com/ben-manes/caffeine
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -1374,37 +1374,37 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: annotations Version: 2.31.54
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: annotations Version: 2.31.59
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/admin/distribution/LICENSE
+++ b/quarkus/admin/distribution/LICENSE
@@ -749,9 +749,9 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
 Project URL: https://github.com/micrometer-metrics/micrometer
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -822,8 +822,8 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.6
-Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.6
+Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.7
+Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.7
 Project URL: https://github.com/reactor/reactor-netty
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/admin/distribution/NOTICE
+++ b/quarkus/admin/distribution/NOTICE
@@ -816,36 +816,36 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 
 NOTICE:
 | AWS SDK for Java

--- a/quarkus/admin/distribution/NOTICE
+++ b/quarkus/admin/distribution/NOTICE
@@ -107,9 +107,9 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
 
 NOTICE:
 | Micrometer

--- a/quarkus/distribution/LICENSE
+++ b/quarkus/distribution/LICENSE
@@ -447,7 +447,7 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.1
 Project URL: https://github.com/ben-manes/caffeine
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -1776,37 +1776,37 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: annotations Version: 2.31.54
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: annotations Version: 2.31.59
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/distribution/LICENSE
+++ b/quarkus/distribution/LICENSE
@@ -956,10 +956,10 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.15.1
 Project URL: https://github.com/micrometer-metrics/micrometer
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -1047,8 +1047,8 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.6
-Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.6
+Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.7
+Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.7
 Project URL: https://github.com/reactor/reactor-netty
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/distribution/NOTICE
+++ b/quarkus/distribution/NOTICE
@@ -150,10 +150,10 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.15.1
 
 NOTICE:
 | Micrometer

--- a/quarkus/distribution/NOTICE
+++ b/quarkus/distribution/NOTICE
@@ -1042,36 +1042,36 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 
 NOTICE:
 | AWS SDK for Java

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -458,7 +458,7 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.0
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 3.2.1
 Project URL: https://github.com/ben-manes/caffeine
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -1765,37 +1765,37 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: annotations Version: 2.31.54
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: annotations Version: 2.31.59
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/server/distribution/LICENSE
+++ b/quarkus/server/distribution/LICENSE
@@ -961,10 +961,10 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.15.1
 Project URL: https://github.com/micrometer-metrics/micrometer
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -1053,8 +1053,8 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.6
-Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.6
+Group: io.projectreactor.netty Name: reactor-netty-core Version: 1.2.7
+Group: io.projectreactor.netty Name: reactor-netty-http Version: 1.2.7
 Project URL: https://github.com/reactor/reactor-netty
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/quarkus/server/distribution/NOTICE
+++ b/quarkus/server/distribution/NOTICE
@@ -1032,36 +1032,36 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk Name: apache-client Version: 2.31.54
-Group: software.amazon.awssdk Name: arns Version: 2.31.54
-Group: software.amazon.awssdk Name: auth Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-core Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums Version: 2.31.54
-Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: crt-core Version: 2.31.54
-Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.54
-Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.54
-Group: software.amazon.awssdk Name: identity-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: json-utils Version: 2.31.54
-Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.54
-Group: software.amazon.awssdk Name: profiles Version: 2.31.54
-Group: software.amazon.awssdk Name: protocol-core Version: 2.31.54
-Group: software.amazon.awssdk Name: regions Version: 2.31.54
-Group: software.amazon.awssdk Name: retries Version: 2.31.54
-Group: software.amazon.awssdk Name: retries-spi Version: 2.31.54
-Group: software.amazon.awssdk Name: s3 Version: 2.31.54
-Group: software.amazon.awssdk Name: sdk-core Version: 2.31.54
-Group: software.amazon.awssdk Name: sts Version: 2.31.54
-Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.54
-Group: software.amazon.awssdk Name: utils Version: 2.31.54
+Group: software.amazon.awssdk Name: apache-client Version: 2.31.59
+Group: software.amazon.awssdk Name: arns Version: 2.31.59
+Group: software.amazon.awssdk Name: auth Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-core Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-query-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: aws-xml-protocol Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums Version: 2.31.59
+Group: software.amazon.awssdk Name: checksums-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: crt-core Version: 2.31.59
+Group: software.amazon.awssdk Name: endpoints-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-aws-eventstream Version: 2.31.59
+Group: software.amazon.awssdk Name: http-auth-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: http-client-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: iam-policy-builder Version: 2.31.59
+Group: software.amazon.awssdk Name: identity-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: json-utils Version: 2.31.59
+Group: software.amazon.awssdk Name: metrics-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: netty-nio-client Version: 2.31.59
+Group: software.amazon.awssdk Name: profiles Version: 2.31.59
+Group: software.amazon.awssdk Name: protocol-core Version: 2.31.59
+Group: software.amazon.awssdk Name: regions Version: 2.31.59
+Group: software.amazon.awssdk Name: retries Version: 2.31.59
+Group: software.amazon.awssdk Name: retries-spi Version: 2.31.59
+Group: software.amazon.awssdk Name: s3 Version: 2.31.59
+Group: software.amazon.awssdk Name: sdk-core Version: 2.31.59
+Group: software.amazon.awssdk Name: sts Version: 2.31.59
+Group: software.amazon.awssdk Name: third-party-jackson-core Version: 2.31.59
+Group: software.amazon.awssdk Name: utils Version: 2.31.59
 
 NOTICE:
 | AWS SDK for Java

--- a/quarkus/server/distribution/NOTICE
+++ b/quarkus/server/distribution/NOTICE
@@ -141,10 +141,10 @@ NOTICE:
 
 --------------------------------------------------------------------------------
 
-Group: io.micrometer Name: micrometer-commons Version: 1.14.6
-Group: io.micrometer Name: micrometer-core Version: 1.14.6
-Group: io.micrometer Name: micrometer-observation Version: 1.14.6
-Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.14.6
+Group: io.micrometer Name: micrometer-commons Version: 1.15.1
+Group: io.micrometer Name: micrometer-core Version: 1.15.1
+Group: io.micrometer Name: micrometer-observation Version: 1.15.1
+Group: io.micrometer Name: micrometer-registry-prometheus-simpleclient Version: 1.15.1
 
 NOTICE:
 | Micrometer


### PR DESCRIPTION
This is due to the lib version update by renovate bot #1842 and #1845, and this is needed in 1.0 release as 1.0.x branch has these version update. cc @jbonofre 