### PR TITLE
Bump version in versions.txt

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-0.11.0-beta-incubating-SNAPSHOT
+1.1.0-incubating-SNAPSHOT


### PR DESCRIPTION
With the release/1.0.0 branch being cut, we should bump this to reflect the current state of main