### PR TITLE
Enable patch version updates for maintained Polaris version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,10 @@
 
   // Added for posterity how to let Renovate manage version-branches, assuming that release branches
   // have the `release/` prefix.
-  baseBranches: ["main"],
+  baseBranches: [
+    "main",
+    "/^release\\/1[.].*",
+  ],
   additionalBranchPrefix: "{{baseBranch}}/",
   commitMessagePrefix: "{{baseBranch}}: ",
 


### PR DESCRIPTION
Polaris 1.x will be a supported/maintained release. It is crucial to apply bug and security fixes to such releases.

Therefore, this change enables patch-version updates for Polaris 1.*
