### PR TITLE
feat(ci): Split Java Gradle CI in many jobs to reduce execution time

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,9 +54,9 @@ github:
         # of the job's `name` property if it's present.
         contexts:
           - markdown-link-check
-          - unit-tests
-          - quarkus-tests
-          - integration-tests
+          - "Unit Tests"
+          - "Quarkus Tests"
+          - "Integration Tests"
           - regtest
           - spark-plugin-regtest
           - site

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,7 +54,9 @@ github:
         # of the job's `name` property if it's present.
         contexts:
           - markdown-link-check
-          - build
+          - unit-tests
+          - quarkus-tests
+          - integration-tests
           - regtest
           - spark-plugin-regtest
           - site

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,16 @@ on:
 
 jobs:
 
+  # TODO remove this job in a future PR
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Always succeeds
+        run: echo "Success!"
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Run unit tests
         run: |
           ./gradlew check sourceTarball distTar distZip publishToMavenLocal \
-            -x :polaris-quarkus-service:test \
-            -x :polaris-quarkus-admin:test \
+            -x :polaris-runtime-service:test \
+            -x :polaris-admin:test \
             -x intTest --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -93,8 +93,8 @@ jobs:
       - name: Run Quarkus tests
         run: |
           ./gradlew \
-            :polaris-quarkus-service:test \
-            :polaris-quarkus-admin:test \
+            :polaris-runtime-service:test \
+            :polaris-admin:test \
             --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,65 +33,111 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
 
+  style-checks:
+    name: Code Style & Publishing Checks
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
-        with:
-          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
-          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
-          validate-wrappers: false
-
-      - name: Code style checks and tests
-        run: ./gradlew --continue check
-
-      - name: Check Maven publication
-        run: ./gradlew publishToMavenLocal sourceTarball
-
-      - name: Archive test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: upload-test-artifacts
-          path: |
-            **/build/test-results/**
-
-      - name: Stop Gradle daemons
-        run: ./gradlew --stop
-
-      # Ensure that the build works properly when building against the "latest greatest" Java version
       - name: Set up JDK 23
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:
           java-version: '23'
           distribution: 'temurin'
-      - name: Show Java version
-        run: java -version
-      - name: Clean
-        run: ./gradlew clean
-      - name: Build
-        run: ./gradlew compileAll
-      - name: Run selected tests
-        run: ./gradlew :polaris-runtime-service:intTest
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        with:
+          validate-wrappers: false
+      - name: Code style checks and tests
+        #TODO add checkstyleMain and checkstyleTest
+        run: |
+          ./gradlew --continue spotlessCheck compileAll \
+            assemble publishToMavenLocal sourceTarball
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up JDK 23
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        with:
+          validate-wrappers: false
+      - name: Run unit tests
+        run: |
+          ./gradlew test \
+            -x :polaris-quarkus-server:test \
+            -x :polaris-quarkus-service:test \
+            --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: upload-test-artifacts-java-23
+          name: upload-unit-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  quarkus-tests:
+    name: Quarkus Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up JDK 23
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        with:
+          validate-wrappers: false
+      - name: Run Quarkus tests
+        run: |
+          ./gradlew \
+            :polaris-quarkus-admin:test \
+            :polaris-runtime-service:test \
+            --continue
+      - name: Archive test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: upload-quarkus-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up JDK 23
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        with:
+          validate-wrappers: false
+      - name: Run integration tests
+        run: ./gradlew intTest --continue
+      - name: Archive test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: upload-integration-test-artifacts
           path: |
             **/build/test-results/**

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,7 +52,7 @@ jobs:
           validate-wrappers: false
       - name: Run unit tests
         run: |
-          ./gradlew check publishToMavenLocal sourceTarball --continue
+          ./gradlew check publishToMavenLocal sourceTarball -x intTest --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,8 +34,8 @@ on:
 
 jobs:
 
-  style-checks:
-    name: Code Style & Publishing Checks
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,69 +50,14 @@ jobs:
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
         with:
           validate-wrappers: false
-      - name: Code style checks and tests
-        #TODO add checkstyleMain and checkstyleTest
-        run: |
-          ./gradlew --continue spotlessCheck compileAll \
-            assemble publishToMavenLocal sourceTarball
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up JDK 23
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
-        with:
-          java-version: '23'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
-        with:
-          validate-wrappers: false
       - name: Run unit tests
         run: |
-          ./gradlew test \
-            -x :polaris-quarkus-server:test \
-            -x :polaris-quarkus-service:test \
-            --continue
+          ./gradlew check publishToMavenLocal sourceTarball --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: upload-unit-test-artifacts
-          path: |
-            **/build/test-results/**
-
-  quarkus-tests:
-    name: Quarkus Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up JDK 23
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
-        with:
-          java-version: '23'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
-        with:
-          validate-wrappers: false
-      - name: Run Quarkus tests
-        run: |
-          ./gradlew \
-            :polaris-quarkus-admin:test \
-            :polaris-runtime-service:test \
-            --continue
-      - name: Archive test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: upload-quarkus-test-artifacts
           path: |
             **/build/test-results/**
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,10 +41,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up JDK 23
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -101,10 +101,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up JDK 23
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,9 +52,9 @@ jobs:
           validate-wrappers: false
       - name: Run unit tests
         run: |
-          ./gradlew check publishToMavenLocal sourceTarball \
-            -x :polaris-quarkus-server:test \
+          ./gradlew check sourceTarball distTar distZip publishToMavenLocal \
             -x :polaris-quarkus-service:test \
+            -x :polaris-quarkus-admin:test \
             -x intTest --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -83,8 +83,8 @@ jobs:
       - name: Run Quarkus tests
         run: |
           ./gradlew \
-            :polaris-quarkus-admin:test \
             :polaris-quarkus-service:test \
+            :polaris-quarkus-admin:test \
             --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,12 +52,45 @@ jobs:
           validate-wrappers: false
       - name: Run unit tests
         run: |
-          ./gradlew check publishToMavenLocal sourceTarball -x intTest --continue
+          ./gradlew check publishToMavenLocal sourceTarball \
+            -x :polaris-quarkus-server:test \
+            -x :polaris-quarkus-service:test \
+            -x intTest --continue
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: upload-unit-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  quarkus-tests:
+    name: Quarkus Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        with:
+          validate-wrappers: false
+      - name: Run Quarkus tests
+        run: |
+          ./gradlew \
+            :polaris-quarkus-admin:test \
+            :polaris-quarkus-service:test \
+            --continue
+      - name: Archive test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: upload-quarkus-test-artifacts
           path: |
             **/build/test-results/**
 


### PR DESCRIPTION
This is a simple attempt to reduce the CI execution time for pull requests. Instead of executing all tests in the same job, it parallelizes the tests in 4 jobs:

* Code style & publishing checks
* Unit tests
* Quarkus tests 
* Integration tests

This could certainly be improved further, but I observed a total execution time around 10 minutes instead of 20 minutes before (at the cost of more compute power, of course).