### PR TITLE
SigV4 Auth Support for Catalog Federation - Part 1: Entity Transformation System

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
@@ -45,15 +46,18 @@ public class EclipseLinkPolarisMetaStoreManagerFactory
 
   @Inject EclipseLinkConfiguration eclipseLinkConfiguration;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   protected EclipseLinkPolarisMetaStoreManagerFactory() {
-    this(null, null);
+    this(null, null, null);
   }
 
   @Inject
   protected EclipseLinkPolarisMetaStoreManagerFactory(
-      PolarisDiagnostics diagnostics, PolarisConfigurationStore configurationStore) {
-    super(diagnostics, configurationStore);
+      PolarisDiagnostics diagnostics,
+      PolarisConfigurationStore configurationStore,
+      EntityTransformationEngine entityTransformationEngine) {
+    super(diagnostics, configurationStore, entityTransformationEngine);
   }
 
   @Override

--- a/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -39,6 +39,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
@@ -96,6 +97,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
             session,
             diagServices,
             new PolarisConfigurationStore() {},
+            new NoOpEntityTransformationEngine(),
             timeSource.withZone(ZoneId.systemDefault())));
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -38,6 +38,7 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -75,6 +76,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Inject Instance<DataSource> dataSource;
   @Inject RelationalJdbcConfiguration relationalJdbcConfiguration;
   @Inject PolarisConfigurationStore configurationStore;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   protected JdbcMetaStoreManagerFactory() {}
 
@@ -156,7 +158,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
       BasePersistence session = getOrCreateSessionSupplier(realmContext).get();
 
-      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagServices);
+      PolarisCallContext callContext =
+          new PolarisCallContext(realmContext, session, diagServices, entityTransformationEngine);
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
@@ -229,7 +232,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         new PolarisCallContext(
             realmContext,
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
-            diagServices);
+            diagServices,
+            entityTransformationEngine);
     if (CallContext.getCurrentContext() == null) {
       CallContext.setCurrentContext(polarisContext);
     }
@@ -280,7 +284,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         new PolarisCallContext(
             realmContext,
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
-            diagServices);
+            diagServices,
+            entityTransformationEngine);
     if (CallContext.getCurrentContext() == null) {
       CallContext.setCurrentContext(polarisContext);
     }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -29,6 +29,7 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
@@ -72,6 +73,7 @@ public class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
             basePersistence,
             diagServices,
             new PolarisConfigurationStore() {},
+            new NoOpEntityTransformationEngine(),
             timeSource.withZone(ZoneId.systemDefault())));
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -24,6 +24,7 @@ import java.time.ZoneId;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePersistence;
 
 /**
@@ -40,6 +41,8 @@ public class PolarisCallContext implements CallContext {
 
   private final PolarisConfigurationStore configurationStore;
 
+  private final EntityTransformationEngine entityTransformationEngine;
+
   private final Clock clock;
 
   // will make it final once we remove deprecated constructor
@@ -50,22 +53,26 @@ public class PolarisCallContext implements CallContext {
       @Nonnull BasePersistence metaStore,
       @Nonnull PolarisDiagnostics diagServices,
       @Nonnull PolarisConfigurationStore configurationStore,
+      @Nonnull EntityTransformationEngine entityTransformationEngine,
       @Nonnull Clock clock) {
     this.realmContext = realmContext;
     this.metaStore = metaStore;
     this.diagServices = diagServices;
     this.configurationStore = configurationStore;
+    this.entityTransformationEngine = entityTransformationEngine;
     this.clock = clock;
   }
 
   public PolarisCallContext(
       @Nonnull RealmContext realmContext,
       @Nonnull BasePersistence metaStore,
-      @Nonnull PolarisDiagnostics diagServices) {
+      @Nonnull PolarisDiagnostics diagServices,
+      @Nonnull EntityTransformationEngine entityTransformationEngine) {
     this.realmContext = realmContext;
     this.metaStore = metaStore;
     this.diagServices = diagServices;
     this.configurationStore = new PolarisConfigurationStore() {};
+    this.entityTransformationEngine = entityTransformationEngine;
     this.clock = Clock.system(ZoneId.systemDefault());
   }
 
@@ -79,6 +86,10 @@ public class PolarisCallContext implements CallContext {
 
   public PolarisConfigurationStore getConfigurationStore() {
     return configurationStore;
+  }
+
+  public EntityTransformationEngine getEntityTransformationEngine() {
+    return entityTransformationEngine;
   }
 
   public Clock getClock() {
@@ -105,6 +116,11 @@ public class PolarisCallContext implements CallContext {
     String realmId = this.realmContext.getRealmIdentifier();
     RealmContext realmContext = () -> realmId;
     return new PolarisCallContext(
-        realmContext, this.metaStore, this.diagServices, this.configurationStore, this.clock);
+        realmContext,
+        this.metaStore,
+        this.diagServices,
+        this.configurationStore,
+        this.entityTransformationEngine,
+        this.clock);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/EntityTransformationEngine.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/EntityTransformationEngine.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.entity.transformation;
+
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+
+/**
+ * Engine responsible for applying a sequence of {@link EntityTransformer} transformations to a
+ * {@link PolarisBaseEntity}.
+ *
+ * <p>This abstraction allows Polaris to customize or enrich entities during runtime or persistence,
+ * based on configured or contextual logic (e.g., injecting service identity info, computing derived
+ * fields).
+ */
+public interface EntityTransformationEngine {
+  /**
+   * Applies all registered entity transformers to the provided entity, in order.
+   *
+   * @param transformationPoint The point in the entity lifecycle where transformers should be
+   *     applied.
+   * @param entity The original Polaris entity to mutate.
+   * @return A new transformed copy of the entity of {@link PolarisBaseEntity} after all
+   *     transformers are applied.
+   */
+  PolarisBaseEntity applyTransformers(
+      TransformationPoint transformationPoint, PolarisBaseEntity entity);
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/EntityTransformer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/EntityTransformer.java
@@ -17,21 +17,25 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.core.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
-  }
+/**
+ * A transformation hook that transforms a Polaris entity. The transformer must create a new copy of
+ * the entity rather than updating them in-place.
+ *
+ * <p>Implementations of this interface apply custom logic to modify or enrich a {@link
+ * PolarisBaseEntity}.
+ */
+public interface EntityTransformer {
+
+  /**
+   * Applies the transformation logic to the given entity. It can be also used to add custom logic
+   * around the transformation point.
+   *
+   * @param entity the entity to be transformed
+   * @return the transformed entity
+   */
+  PolarisBaseEntity apply(PolarisBaseEntity entity);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/NoOpEntityTransformationEngine.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/NoOpEntityTransformationEngine.java
@@ -17,21 +17,21 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.core.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
+/**
+ * A no-op implementation of {@link EntityTransformationEngine} that returns the input entity
+ * unchanged.
+ *
+ * <p>This can be used in environments where entity transformation is disabled or unnecessary.
+ */
+public class NoOpEntityTransformationEngine implements EntityTransformationEngine {
+
+  @Override
+  public PolarisBaseEntity applyTransformers(
+      TransformationPoint transformationPoint, final PolarisBaseEntity entity) {
+    return entity;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/TransformationPoint.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/transformation/TransformationPoint.java
@@ -17,21 +17,28 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.core.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+/**
+ * Defines points in the entity lifecycle where {@link EntityTransformer} can be applied.
+ *
+ * <p>Each transformation point corresponds to a specific hook where transformers may be executed.
+ * Transformers can declare which points they support, allowing the engine to invoke only the
+ * relevant ones.
+ */
+public enum TransformationPoint {
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
+  /** Applied before a catalog entity is persisted. */
+  CATALOG_PRE_PERSIST(0),
+  ;
+
+  private final int id;
+
+  TransformationPoint(int id) {
+    this.id = id;
+  }
+
+  public int id() {
+    return id;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -33,6 +33,7 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.cache.EntityCache;
 import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
@@ -65,13 +66,16 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
 
   private final PolarisDiagnostics diagnostics;
   private final PolarisConfigurationStore configurationStore;
+  private final EntityTransformationEngine entityTransformationEngine;
   private boolean bootstrap;
 
   protected LocalPolarisMetaStoreManagerFactory(
       @Nonnull PolarisDiagnostics diagnostics,
-      @Nonnull PolarisConfigurationStore configurationStore) {
+      @Nonnull PolarisConfigurationStore configurationStore,
+      @Nonnull EntityTransformationEngine entityTransformationEngine) {
     this.diagnostics = diagnostics;
     this.configurationStore = configurationStore;
+    this.entityTransformationEngine = entityTransformationEngine;
   }
 
   protected abstract StoreType createBackingStore(@Nonnull PolarisDiagnostics diagnostics);
@@ -139,7 +143,8 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
       TransactionalPersistence session = getOrCreateSessionSupplier(realmContext).get();
 
-      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagServices);
+      PolarisCallContext callContext =
+          new PolarisCallContext(realmContext, session, diagServices, entityTransformationEngine);
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
@@ -214,7 +219,8 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         new PolarisCallContext(
             realmContext,
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
-            diagServices);
+            diagServices,
+            entityTransformationEngine);
     if (CallContext.getCurrentContext() == null) {
       CallContext.setCurrentContext(polarisContext);
     }
@@ -263,7 +269,8 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         new PolarisCallContext(
             realmContext,
             sessionSupplierMap.get(realmContext.getRealmIdentifier()).get(),
-            diagServices);
+            diagServices,
+            entityTransformationEngine);
     if (CallContext.getCurrentContext() == null) {
       CallContext.setCurrentContext(polarisContext);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -47,6 +47,8 @@ import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.TransformationPoint;
 import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
@@ -476,6 +478,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     }
 
     ms.persistStorageIntegrationIfNeededInCurrentTxn(callCtx, catalog, integration);
+
+    // CATALOG_PRE_PERSIST transformation point
+    EntityTransformationEngine entityTransformationEngine = callCtx.getEntityTransformationEngine();
+    if (entityTransformationEngine != null) {
+      catalog =
+          entityTransformationEngine.applyTransformers(
+              TransformationPoint.CATALOG_PRE_PERSIST, catalog);
+    }
 
     // now create and persist new catalog entity
     this.persistNewEntity(callCtx, ms, catalog);

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.mockito.Mockito;
@@ -41,6 +42,7 @@ public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
             new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
             diagServices,
             new PolarisConfigurationStore() {},
+            new NoOpEntityTransformationEngine(),
             timeSource.withZone(ZoneId.systemDefault()));
 
     return new PolarisTestMetaStoreManager(new AtomicOperationMetaStoreManager(), callCtx);

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
@@ -41,6 +42,7 @@ public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreMana
             new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
             diagServices,
             new PolarisConfigurationStore() {},
+            new NoOpEntityTransformationEngine(),
             timeSource.withZone(ZoneId.systemDefault()));
 
     return new PolarisTestMetaStoreManager(new TransactionalMetaStoreManagerImpl(), callCtx);

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -22,6 +22,8 @@ import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RAND
 
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
@@ -40,7 +42,10 @@ public class ResolverTest extends BaseResolverTest {
       TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
       TreeMapTransactionalPersistenceImpl metaStore =
           new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
-      callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
+      EntityTransformationEngine entityTransformationEngine = new NoOpEntityTransformationEngine();
+      callCtx =
+          new PolarisCallContext(
+              () -> "testRealm", metaStore, diagServices, entityTransformationEngine);
     }
     return callCtx;
   }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
@@ -33,6 +33,8 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
@@ -65,6 +67,9 @@ public class InMemoryEntityCacheTest {
   // the meta store manager
   private final PolarisMetaStoreManager metaStoreManager;
 
+  // the entity transformation engine
+  private final EntityTransformationEngine entityTransformationEngine;
+
   /**
    * Initialize and create the test metadata
    *
@@ -91,7 +96,10 @@ public class InMemoryEntityCacheTest {
     diagServices = new PolarisDefaultDiagServiceImpl();
     store = new TreeMapMetaStore(diagServices);
     metaStore = new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
-    callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
+    entityTransformationEngine = new NoOpEntityTransformationEngine();
+    callCtx =
+        new PolarisCallContext(
+            () -> "testRealm", metaStore, diagServices, entityTransformationEngine);
     metaStoreManager = new TransactionalMetaStoreManagerImpl();
 
     // bootstrap the mata store with our test schema

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -106,6 +107,7 @@ class InMemoryStorageIntegrationTest {
                 return (T) config.get(configName);
               }
             },
+            new NoOpEntityTransformationEngine(),
             Clock.systemUTC());
     CallContext.setCurrentContext(polarisCallContext);
     Map<String, Map<PolarisStorageActions, PolarisStorageIntegration.ValidationResult>> result =

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -37,6 +37,8 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
@@ -70,7 +72,10 @@ public class StorageCredentialCacheTest {
     // to interact with the metastore
     TransactionalPersistence metaStore =
         new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
-    callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
+    EntityTransformationEngine entityTransformationEngine = new NoOpEntityTransformationEngine();
+    callCtx =
+        new PolarisCallContext(
+            () -> "testRealm", metaStore, diagServices, entityTransformationEngine);
     metaStoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     storageCredentialCache = newStorageCredentialCache();
   }

--- a/quarkus/admin/src/main/java/org/apache/polaris/admintool/config/QuarkusProducers.java
+++ b/quarkus/admin/src/main/java/org/apache/polaris/admintool/config/QuarkusProducers.java
@@ -28,6 +28,7 @@ import java.time.Clock;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -69,6 +70,12 @@ public class QuarkusProducers {
         return null;
       }
     };
+  }
+
+  @Produces
+  public EntityTransformationEngine entityTransformationEngine() {
+    // An entity transformation engine is not required when running the admin tool.
+    return ((transformationPoint, entity) -> entity);
   }
 
   @Produces

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -188,6 +188,9 @@ polaris.oidc.principal-roles-mapper.type=default
 # polaris.storage.gcp.token=token
 # polaris.storage.gcp.lifespan=PT1H
 
+# Polaris Entity Transformation Config
+polaris.entity-transformation.transformers=no-op
+
 quarkus.arc.ignored-split-packages=\
   org.apache.polaris.service.catalog.api,\
   org.apache.polaris.service.catalog.api.impl,\

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -201,6 +201,7 @@ quarkus.arc.ignored-split-packages=\
   org.apache.polaris.service.quarkus.auth.external.mapping,\
   org.apache.polaris.service.quarkus.auth.external.tenant,\
   org.apache.polaris.service.quarkus.auth.internal,\
+  org.apache.polaris.service.quarkus.entity.transformation,\
   org.apache.polaris.service.quarkus.events,\
   org.apache.polaris.service.quarkus.task,\
   org.apache.polaris.service.quarkus.secrets,\

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -42,6 +42,7 @@ import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -127,11 +128,17 @@ public class QuarkusProducers {
       PolarisDiagnostics diagServices,
       PolarisConfigurationStore configurationStore,
       MetaStoreManagerFactory metaStoreManagerFactory,
+      EntityTransformationEngine entityTransformationEngine,
       Clock clock) {
     BasePersistence metaStoreSession =
         metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
     return new PolarisCallContext(
-        realmContext, metaStoreSession, diagServices, configurationStore, clock);
+        realmContext,
+        metaStoreSession,
+        diagServices,
+        configurationStore,
+        entityTransformationEngine,
+        clock);
   }
 
   // Polaris service beans - selected from @Identifier-annotated beans

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/entity/transformation/QuarkusEntityTransformationConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/entity/transformation/QuarkusEntityTransformationConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.quarkus.entity.transformation;
+
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
+import java.util.List;
+import java.util.Optional;
+import org.apache.polaris.core.entity.transformation.EntityTransformer;
+import org.apache.polaris.service.entity.transformation.EntityTransformationConfiguration;
+
+/**
+ * Quarkus-specific configuration interface for entity transformation behavior.
+ *
+ * <p>This configuration determines which {@link EntityTransformer}s are applied during entity
+ * transformation and in what order. Only the listed transformers will be used, and they will be
+ * executed sequentially as configured.
+ *
+ * <p>If no transformers are specified, entity transformation is effectively disabled.
+ */
+@StaticInitSafe
+@ConfigMapping(prefix = "polaris.entity-transformation")
+public interface QuarkusEntityTransformationConfiguration
+    extends EntityTransformationConfiguration {
+  @Override
+  Optional<List<String>> transformers();
+}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
@@ -75,6 +75,7 @@ public class ManagementServiceTest {
                 .get(),
             fakeServices.polarisDiagnostics(),
             fakeServices.configurationStore(),
+            fakeServices.entityTransformationEngine(),
             Mockito.mock(Clock.class));
     CallContext.setCurrentContext(polarisCallContext);
     services =
@@ -188,7 +189,8 @@ public class ManagementServiceTest {
     return new PolarisCallContext(
         realmContext,
         metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-        services.polarisDiagnostics());
+        services.polarisDiagnostics(),
+        services.entityTransformationEngine());
   }
 
   private PolarisAdminService setupPolarisAdminService(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -68,6 +68,8 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -206,6 +208,7 @@ public abstract class PolarisAuthzTestBase {
   protected PolarisAdminService adminService;
   protected PolarisEntityManager entityManager;
   protected PolarisMetaStoreManager metaStoreManager;
+  protected EntityTransformationEngine entityTransformationEngine;
   protected UserSecretsManager userSecretsManager;
   protected TransactionalPersistence metaStoreSession;
   protected PolarisBaseEntity catalogEntity;
@@ -232,6 +235,7 @@ public abstract class PolarisAuthzTestBase {
     QuarkusMock.installMockForType(realmContext, RealmContext.class);
     metaStoreManager = managerFactory.getOrCreateMetaStoreManager(realmContext);
     userSecretsManager = userSecretsManagerFactory.getOrCreateUserSecretsManager(realmContext);
+    entityTransformationEngine = new NoOpEntityTransformationEngine();
 
     polarisAuthorizer = new PolarisAuthorizerImpl(configurationStore);
 
@@ -241,6 +245,7 @@ public abstract class PolarisAuthzTestBase {
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             clock);
     this.entityManager = realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTRSAKeyPairTest.java
@@ -61,7 +61,7 @@ public class JWTRSAKeyPairTest {
     final String scope = "PRINCIPAL_ROLE:TEST";
 
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(null, null, null, configurationStore, null);
+        new PolarisCallContext(null, null, null, configurationStore, null, null);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "client-secret";
     PolarisPrincipalSecrets principalSecrets =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTSymmetricKeyGeneratorTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/auth/JWTSymmetricKeyGeneratorTest.java
@@ -45,7 +45,8 @@ public class JWTSymmetricKeyGeneratorTest {
   /** Sanity test to verify that we can generate a token */
   @Test
   public void testJWTSymmetricKeyGenerator() {
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null, null, null);
+    PolarisCallContext polarisCallContext =
+        new PolarisCallContext(null, null, null, null, null, null);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "test_secret";
     String clientId = "test_client_id";

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -89,6 +89,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -210,6 +211,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   @Inject UserSecretsManagerFactory userSecretsManagerFactory;
   @Inject PolarisDiagnostics diagServices;
   @Inject PolarisEventListener polarisEventListener;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private IcebergCatalog catalog;
   private String realmName;
@@ -257,6 +259,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             Clock.systemDefaultZone());
 
     entityManager =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -55,6 +55,7 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -132,6 +133,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisDiagnostics diagServices;
   @Inject PolarisEventListener polarisEventListener;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private IcebergCatalog catalog;
 
@@ -174,6 +176,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             Clock.systemDefaultZone());
 
     PolarisEntityManager entityManager =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogTest.java
@@ -58,6 +58,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.table.GenericTableEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -128,6 +129,7 @@ public class PolarisGenericTableCatalogTest {
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject PolarisDiagnostics diagServices;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private PolarisGenericTableCatalog genericTableCatalog;
   private IcebergCatalog icebergCatalog;
@@ -173,6 +175,7 @@ public class PolarisGenericTableCatalogTest {
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -66,6 +66,7 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -158,6 +159,7 @@ public class PolicyCatalogTest {
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject PolarisDiagnostics diagServices;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private PolicyCatalog policyCatalog;
   private IcebergCatalog icebergCatalog;
@@ -199,6 +201,7 @@ public class PolicyCatalogTest {
             managerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             Clock.systemDefaultZone());
     entityManager =
         new PolarisEntityManager(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/config/DefaultConfigurationStoreTest.java
@@ -29,6 +29,7 @@ import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.service.config.DefaultConfigurationStore;
 import org.apache.polaris.service.config.FeaturesConfiguration;
 import org.assertj.core.api.Assertions;
@@ -72,6 +73,7 @@ public class DefaultConfigurationStoreTest {
 
   @Inject PolarisConfigurationStore configurationStore;
   @Inject FeaturesConfiguration featuresConfiguration;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   @BeforeEach
   public void before(TestInfo testInfo) {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
@@ -31,6 +31,8 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.assertj.core.api.Assertions;
@@ -47,11 +49,13 @@ public class CatalogEntityTest {
   public void setup() {
     MetaStoreManagerFactory metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
     RealmContext realmContext = () -> "realm";
+    EntityTransformationEngine entityTransformationEngine = new NoOpEntityTransformationEngine();
     PolarisCallContext polarisCallContext =
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(() -> "realm").get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     this.callContext = polarisCallContext;
     CallContext.setCurrentContext(polarisCallContext);
   }

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/BatchFileCleanupTaskHandlerTest.java
@@ -51,6 +51,7 @@ import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisStorageActions;
@@ -63,6 +64,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class BatchFileCleanupTaskHandlerTest {
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
+  @Inject EntityTransformationEngine entityTransformationEngine;
   private final RealmContext realmContext = () -> "realmName";
 
   private TaskFileIOSupplier buildTaskFileIOSupplier(FileIO fileIO) {
@@ -94,7 +96,8 @@ public class BatchFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     FileIO fileIO =
         new InMemoryFileIO() {
           @Override
@@ -207,7 +210,8 @@ public class BatchFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
@@ -252,7 +256,8 @@ public class BatchFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     CallContext.setCurrentContext(polarisCallContext);
     Map<String, AtomicInteger> retryCounter = new HashMap<>();
     FileIO fileIO =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/ManifestFileCleanupTaskHandlerTest.java
@@ -49,6 +49,7 @@ import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.storage.PolarisStorageActions;
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 class ManifestFileCleanupTaskHandlerTest {
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private final RealmContext realmContext = () -> "realmName";
 
@@ -93,7 +95,8 @@ class ManifestFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
 
@@ -123,7 +126,8 @@ class ManifestFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
@@ -152,7 +156,8 @@ class ManifestFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     CallContext.setCurrentContext(polarisCallContext);
     FileIO fileIO =
         new InMemoryFileIO() {
@@ -198,7 +203,8 @@ class ManifestFileCleanupTaskHandlerTest {
         new PolarisCallContext(
             realmContext,
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
-            new PolarisDefaultDiagServiceImpl());
+            new PolarisDefaultDiagServiceImpl(),
+            entityTransformationEngine);
     CallContext.setCurrentContext(polarisCallContext);
     Map<String, AtomicInteger> retryCounter = new HashMap<>();
     FileIO fileIO =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/task/TableCleanupTaskHandlerTest.java
@@ -53,6 +53,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -75,6 +76,7 @@ class TableCleanupTaskHandlerTest {
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisDiagnostics diagServices;
+  @Inject EntityTransformationEngine entityTransformationEngine;
 
   private CallContext callContext;
 
@@ -107,6 +109,7 @@ class TableCleanupTaskHandlerTest {
             metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get(),
             diagServices,
             configurationStore,
+            entityTransformationEngine,
             Clock.systemDefaultZone());
   }
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
@@ -118,6 +118,7 @@ public class PolarisIntegrationTestFixture {
             metaStoreSession,
             helper.diagServices,
             helper.configurationStore,
+            helper.entityTransformationEngine,
             helper.clock);
     try {
       PolarisMetaStoreManager metaStoreManager =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestHelper.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestHelper.java
@@ -24,6 +24,7 @@ import jakarta.inject.Singleton;
 import java.time.Clock;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.context.RealmContextResolver;
 import org.junit.jupiter.api.TestInfo;
@@ -36,6 +37,7 @@ public class PolarisIntegrationTestHelper {
   @Inject ObjectMapper objectMapper;
   @Inject PolarisDiagnostics diagServices;
   @Inject PolarisConfigurationStore configurationStore;
+  @Inject EntityTransformationEngine entityTransformationEngine;
   @Inject Clock clock;
 
   public PolarisIntegrationTestFixture createFixture(TestEnvironment testEnv, TestInfo testInfo) {

--- a/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
+++ b/service/common/src/main/java/org/apache/polaris/service/context/DefaultCallContextResolver.java
@@ -28,6 +28,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ public class DefaultCallContextResolver implements CallContextResolver {
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisDiagnostics diagnostics;
+  @Inject EntityTransformationEngine entityTransformationEngine;
   @Inject Clock clock;
 
   @Override
@@ -67,6 +69,11 @@ public class DefaultCallContextResolver implements CallContextResolver {
     BasePersistence metaStoreSession =
         metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
     return new PolarisCallContext(
-        realmContext, metaStoreSession, diagnostics, configurationStore, clock);
+        realmContext,
+        metaStoreSession,
+        diagnostics,
+        configurationStore,
+        entityTransformationEngine,
+        clock);
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/entity/transformation/AppliesTo.java
+++ b/service/common/src/main/java/org/apache/polaris/service/entity/transformation/AppliesTo.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.entity.transformation;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.EntityTransformer;
+import org.apache.polaris.core.entity.transformation.TransformationPoint;
+
+/**
+ * Qualifier to mark an {@link EntityTransformer} as applicable to a specific {@link
+ * TransformationPoint}.
+ *
+ * <p>This is used by the {@link EntityTransformationEngine} to apply only relevant transformers
+ * based on context.
+ *
+ * <p>Supports being repeated on the same class to handle multiple transformation points.
+ */
+@Qualifier
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(AppliesTos.class)
+public @interface AppliesTo {
+
+  /** The transformation point this transformer applies to. */
+  TransformationPoint value();
+
+  /** Helper for creating {@link AppliesTo} qualifiers programmatically. */
+  final class Literal extends AnnotationLiteral<AppliesTo> implements AppliesTo {
+    private final TransformationPoint value;
+
+    public static Literal of(TransformationPoint value) {
+      return new Literal(value);
+    }
+
+    private Literal(TransformationPoint value) {
+      this.value = value;
+    }
+
+    @Override
+    public TransformationPoint value() {
+      return value;
+    }
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/entity/transformation/AppliesTos.java
+++ b/service/common/src/main/java/org/apache/polaris/service/entity/transformation/AppliesTos.java
@@ -17,21 +17,23 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.service.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.polaris.core.entity.transformation.EntityTransformer;
+import org.apache.polaris.core.entity.transformation.TransformationPoint;
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
-  }
+/**
+ * Container annotation for repeating {@link AppliesTo}.
+ *
+ * <p>Allows an {@link EntityTransformer} to declare support for multiple {@link
+ * TransformationPoint}s.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AppliesTos {
+  AppliesTo[] value();
 }

--- a/service/common/src/main/java/org/apache/polaris/service/entity/transformation/EntityTransformationConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/entity/transformation/EntityTransformationConfiguration.java
@@ -17,21 +17,11 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.service.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import java.util.List;
+import java.util.Optional;
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
-  }
+public interface EntityTransformationConfiguration {
+  Optional<List<String>> transformers();
 }

--- a/service/common/src/main/java/org/apache/polaris/service/entity/transformation/EntityTransformationEngineImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/entity/transformation/EntityTransformationEngineImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.entity.transformation;
+
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Objects;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.EntityTransformer;
+import org.apache.polaris.core.entity.transformation.TransformationPoint;
+
+@ApplicationScoped
+public class EntityTransformationEngineImpl implements EntityTransformationEngine {
+
+  private final EntityTransformationConfiguration config;
+  private final Instance<EntityTransformer> transformerInstances;
+
+  @Inject
+  public EntityTransformationEngineImpl(
+      EntityTransformationConfiguration config,
+      @Any Instance<EntityTransformer> transformerInstances) {
+    this.config = config;
+    this.transformerInstances = transformerInstances;
+  }
+
+  @Override
+  public PolarisBaseEntity applyTransformers(
+      TransformationPoint transformationPoint, PolarisBaseEntity entity) {
+    PolarisBaseEntity result = entity;
+
+    // Collect transformers in configured order, filtering only those applicable to the
+    // transformation point
+    List<EntityTransformer> orderedtransformers =
+        config.transformers().orElse(List.of()).stream()
+            .map(
+                id -> {
+                  // Resolve the transformer instance by ID
+                  Instance<EntityTransformer> matched =
+                      transformerInstances.select(Identifier.Literal.of(id));
+                  if (!matched.isResolvable()) {
+                    throw new IllegalStateException("No Entitytransformer found for ID: " + id);
+                  }
+                  // Filter by TransformationPoint via @AppliesTo
+                  Instance<EntityTransformer> filtered =
+                      matched.select(AppliesTo.Literal.of(transformationPoint));
+                  return filtered.isResolvable() ? filtered.get() : null;
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
+    for (EntityTransformer transformer : orderedtransformers) {
+      result = transformer.apply(result);
+    }
+
+    return result;
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/entity/transformation/NoOpEntityTransformer.java
+++ b/service/common/src/main/java/org/apache/polaris/service/entity/transformation/NoOpEntityTransformer.java
@@ -17,21 +17,23 @@
  * under the License.
  */
 
-package org.apache.polaris.core.storage;
+package org.apache.polaris.service.entity.transformation;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformer;
 
-public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm",
-        Mockito.mock(BasePersistence.class),
-        Mockito.mock(PolarisDiagnostics.class),
-        new NoOpEntityTransformationEngine());
+/**
+ * A no-op implementation of {@link EntityTransformer} that returns the entity unchanged.
+ *
+ * <p>This can be used as a placeholder or for testing purposes when no transformer is required.
+ */
+@ApplicationScoped
+@Identifier("no-op")
+public class NoOpEntityTransformer implements EntityTransformer {
+  @Override
+  public PolarisBaseEntity apply(PolarisBaseEntity entity) {
+    return entity;
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -37,15 +38,16 @@ public class InMemoryAtomicOperationMetaStoreManagerFactory
     extends InMemoryPolarisMetaStoreManagerFactory {
 
   public InMemoryAtomicOperationMetaStoreManagerFactory() {
-    super(null, null, null);
+    super(null, null, null, null);
   }
 
   @Inject
   public InMemoryAtomicOperationMetaStoreManagerFactory(
       PolarisStorageIntegrationProvider storageIntegration,
       PolarisDiagnostics diagnostics,
-      PolarisConfigurationStore configurationStore) {
-    super(storageIntegration, diagnostics, configurationStore);
+      PolarisConfigurationStore configurationStore,
+      EntityTransformationEngine entityTransformationEngine) {
+    super(storageIntegration, diagnostics, configurationStore, entityTransformationEngine);
   }
 
   @Override

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
@@ -49,15 +50,16 @@ public class InMemoryPolarisMetaStoreManagerFactory
   private final Set<String> bootstrappedRealms = new HashSet<>();
 
   public InMemoryPolarisMetaStoreManagerFactory() {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   @Inject
   public InMemoryPolarisMetaStoreManagerFactory(
       PolarisStorageIntegrationProvider storageIntegration,
       PolarisDiagnostics diagnostics,
-      PolarisConfigurationStore configurationStore) {
-    super(diagnostics, configurationStore);
+      PolarisConfigurationStore configurationStore,
+      EntityTransformationEngine entityTransformationEngine) {
+    super(diagnostics, configurationStore, entityTransformationEngine);
     this.storageIntegration = storageIntegration;
   }
 

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -142,6 +142,7 @@ public class FileIOFactoryTest {
             testServices.metaStoreManagerFactory().getOrCreateSessionSupplier(realmContext).get(),
             testServices.polarisDiagnostics(),
             testServices.configurationStore(),
+            testServices.entityTransformationEngine(),
             Clock.systemUTC());
   }
 

--- a/service/common/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -50,7 +50,11 @@ public class TaskExecutorImplTest {
     BasePersistence bp = metaStoreManagerFactory.getOrCreateSessionSupplier(realmContext).get();
 
     PolarisCallContext polarisCallCtx =
-        new PolarisCallContext(realmContext, bp, testServices.polarisDiagnostics());
+        new PolarisCallContext(
+            realmContext,
+            bp,
+            testServices.polarisDiagnostics(),
+            testServices.entityTransformationEngine());
 
     // This task doesn't have a type so it won't be handle-able by a real handler. We register a
     // test TaskHandler below that can handle any task.

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -39,6 +39,8 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.polaris.core.entity.transformation.EntityTransformationEngine;
+import org.apache.polaris.core.entity.transformation.NoOpEntityTransformationEngine;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -75,6 +77,7 @@ public record TestServices(
     IcebergRestConfigurationApi restConfigurationApi,
     PolarisConfigurationStore configurationStore,
     PolarisDiagnostics polarisDiagnostics,
+    EntityTransformationEngine entityTransformationEngine,
     RealmEntityManagerFactory entityManagerFactory,
     MetaStoreManagerFactory metaStoreManagerFactory,
     RealmContext realmContext,
@@ -152,9 +155,13 @@ public record TestServices(
               () -> stsClient,
               Optional.empty(),
               () -> GoogleCredentials.create(new AccessToken(GCP_ACCESS_TOKEN, new Date())));
+      EntityTransformationEngine entityTransformationEngine = new NoOpEntityTransformationEngine();
       InMemoryPolarisMetaStoreManagerFactory metaStoreManagerFactory =
           new InMemoryPolarisMetaStoreManagerFactory(
-              storageIntegrationProvider, polarisDiagnostics, configurationStore);
+              storageIntegrationProvider,
+              polarisDiagnostics,
+              configurationStore,
+              entityTransformationEngine);
       RealmEntityManagerFactory realmEntityManagerFactory =
           new RealmEntityManagerFactory(metaStoreManagerFactory) {};
       UserSecretsManagerFactory userSecretsManagerFactory =
@@ -168,6 +175,7 @@ public record TestServices(
               metaStoreSession,
               polarisDiagnostics,
               configurationStore,
+              entityTransformationEngine,
               Clock.systemUTC());
       PolarisEntityManager entityManager =
           realmEntityManagerFactory.getOrCreateEntityManager(realmContext);
@@ -264,6 +272,7 @@ public record TestServices(
           restConfigurationApi,
           configurationStore,
           polarisDiagnostics,
+          entityTransformationEngine,
           realmEntityManagerFactory,
           metaStoreManagerFactory,
           realmContext,


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

## Milestones

This is Part 1 of the [[Splitting] Initial SigV4 Auth Support for Catalog Federation](https://github.com/apache/polaris/pull/1805). Upcoming parts will build on this system:
* #1899
* #2190
* SigV4 Auth Support for Catalog Federation - Part 3: Service Identity Info Injection
* SigV4 Auth Support for Catalog Federation - Part 4: Connection Credential Manager


## Introduction

This PR introduces a general-purpose `Entity Transformation System` to support future features like injecting service identity metadata into catalog entities for federated access (e.g. AWS Glue using SigV4). It provides a clean and extensible hook mechanism for enriching entities during specific lifecycle phases.

This system is intended to serve as the foundation for service identity injection and other dynamic transformations in subsequent parts of the SigV4 support work.

## Key Components
* `EntityTransformer`: A functional interface representing a single transformation to be applied to a PolarisBaseEntity.
* `EntityTransformationEngine`: A runtime engine that applies a sequence of `EntityTransformer`s to an entity based on the configured `TransformationPoint`.
* `TransformationPoint`: Enum representing defined hook points in the entity lifecycle (e.g. `CATALOG_PRE_PERSIST`).
* `@AppliesTo` annotation: A repeatable qualifier that marks a transformer as applicable to a given TransformationPoint.
* `EntityTransformationConfiguration`: Optional config-driven registration of transformers by identifier (preserving ordering).

## Example Configuration:
```properties
polaris.entity-mutation.mutators=no-op,catalog-connection-config
```

## Flowchart
![Catalog Federation - Creds Management](https://github.com/user-attachments/assets/e6d34d3a-723d-44f3-b6ca-5d372a6dbdb2)
