### PR TITLE
Python CI: pin mypy version to avoid CI failure due to new release

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -51,7 +51,7 @@ pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"
 types-python-dateutil = ">= 2.8.19.14"
-mypy = ">= 1.5, <=1.16.0"
+mypy = ">= 1.5, <=1.16.1"
 pyiceberg = "==0.9.1"
 pre-commit = "==4.2.0"
 

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -51,7 +51,7 @@ pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"
 types-python-dateutil = ">= 2.8.19.14"
-mypy = ">= 1.5"
+mypy = ">= 1.5, <=1.16.0"
 pyiceberg = "==0.9.1"
 pre-commit = "==4.2.0"
 


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Mypy did a new release 1.16.1 and it cause our CI to fail for about 20 minutes due to missing wheel (upload not completed)
```
 | Unable to find installation candidates for mypy (1.16.1)
    | 
    | This is likely not a Poetry issue.
    | 
    |   - 14 candidate(s) were identified for the package
    |   - 14 wheel(s) were skipped as your project's environment does not support the identified abi tags
    | 
    | Solutions:
    | Make sure the lockfile is up-to-date. You can try one of the following;
    | 
    |     1. Regenerate lockfile: poetry lock --no-cache --regenerate
    |     2. Update package     : poetry update --no-cache mypy
    | 
    | If neither works, please first check to verify that the mypy has published wheels available from your configured source that are compatible with your environment- ie. operating system, architecture (x86_64, arm64 etc.), python interpreter.
    | 

```
This PR temporarily restrict the mypy version to avoid the similar issue.

We may consider bring poetry.lock back to git tracking so we won't automatically update test dependencies all the time
