### PR TITLE
Unify bootstrap credentials format across docker-compose and Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew build` - To build and run tests. Make sure Docker is running, as the integration tests depend on it.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew check` - To run all checks, including unit tests and integration tests.
-- `./gradlew run` - To run the Polaris server locally; the server is reachable at localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
+- `./gradlew run` - To run the Polaris server locally; the server is reachable at localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,s3cr3t` where:
   - `POLARIS` is the realm
   - `root` is the CLIENT_ID
   - `secret` is the CLIENT_SECRET
-  - If credentials are not set, it will use preset credentials `POLARIS,root,secret`
+  - If credentials are not set, it will use preset credentials `POLARIS,root,s3cr3t`
 - `./regtests/run_spark_sql.sh` - To connect from Spark SQL. Here are some example commands to run in the Spark SQL shell:
 ```sql
 create database db1;

--- a/client/python/docker-compose.yml
+++ b/client/python/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
-      POLARIS_BOOTSTRAP_CREDENTIALS: default-realm,root,s3cr3t
-      polaris.realm-context.realms: default-realm
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
+      polaris.realm-context.realms: POLARIS
       quarkus.log.file.enable: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."DROP_WITH_PURGE_ENABLED": "true"

--- a/client/python/integration_tests/conftest.py
+++ b/client/python/integration_tests/conftest.py
@@ -133,7 +133,7 @@ def root_token(
         client_id=client_id,
         client_secret=client_secret,
         grant_type="client_credentials",
-        _headers={"realm": "default-realm"},
+        _headers={"realm": "POLARIS"},
     )
     return token
 

--- a/getting-started/spark/docker-compose.yml
+++ b/getting-started/spark/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
-      POLARIS_BOOTSTRAP_CREDENTIALS: default-realm,root,s3cr3t
-      polaris.realm-context.realms: default-realm
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
+      polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"

--- a/getting-started/spark/notebooks/SparkPolaris.ipynb
+++ b/getting-started/spark/notebooks/SparkPolaris.ipynb
@@ -33,7 +33,7 @@
     "                            client_id=client_id,\n",
     "                          client_secret=client_secret,\n",
     "                          grant_type='client_credentials',\n",
-    "                          _headers={'realm': 'default-realm'})\n"
+    "                          _headers={'realm': 'POLARIS'})\n"
    ]
   },
   {
@@ -420,7 +420,7 @@
     "                            client_id=engineer_principal.credentials.client_id,\n",
     "                          client_secret=engineer_principal.credentials.client_secret.get_secret_value(),\n",
     "                          grant_type='client_credentials',\n",
-    "                          _headers={'realm': 'default-realm'})\n",
+    "                          _headers={'realm': 'POLARIS'})\n",
     "\n",
     "# Now create a catalog client that uses the token in its Authentication header\n",
     "client = CatalogApiClient(CatalogApiClientConfiguration(access_token=collado_token.access_token,\n",
@@ -573,7 +573,7 @@
     "                            client_id=reader_principal.credentials.client_id,\n",
     "                          client_secret=reader_principal.credentials.client_secret.get_secret_value(),\n",
     "                          grant_type='client_credentials',\n",
-    "                          _headers={'realm': 'default-realm'})\n",
+    "                          _headers={'realm': 'POLARIS'})\n",
     "\n",
     "# Now create a catalog client that uses the token in its Authentication header\n",
     "pm_client = IcebergCatalogAPI(CatalogApiClient(CatalogApiClientConfiguration(access_token=pm_token.access_token,\n",
@@ -767,7 +767,7 @@
     "                            client_id=engineer_principal.credentials.client_id,\n",
     "                          client_secret=engineer_principal.credentials.client_secret.get_secret_value(),\n",
     "                          grant_type='client_credentials',\n",
-    "                          _headers={'realm': 'default-realm'})\n",
+    "                          _headers={'realm': 'POLARIS'})\n",
     "\n",
     "# The returned token is scoped to _only_ the privileges granted to the ops_engineer role\n",
     "# The ops_client fails to do any real damage even though the engineer normally has DROP_TABLE privileges\n",

--- a/plugins/spark/v3.5/getting-started/docker-compose.yml
+++ b/plugins/spark/v3.5/getting-started/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
-      POLARIS_BOOTSTRAP_CREDENTIALS: default-realm,root,s3cr3t
-      polaris.realm-context.realms: default-realm
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
+      polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"

--- a/plugins/spark/v3.5/getting-started/notebooks/SparkPolaris.ipynb
+++ b/plugins/spark/v3.5/getting-started/notebooks/SparkPolaris.ipynb
@@ -33,7 +33,7 @@
     "                            client_id=client_id,\n",
     "                          client_secret=client_secret,\n",
     "                          grant_type='client_credentials',\n",
-    "                          _headers={'realm': 'default-realm'})\n"
+    "                          _headers={'realm': 'POLARIS'})\n"
    ]
   },
   {

--- a/plugins/spark/v3.5/regtests/docker-compose.yml
+++ b/plugins/spark/v3.5/regtests/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - "8182"
     environment:
       AWS_REGION: us-west-2
-      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,secret
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
       quarkus.log.file.enable: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"

--- a/plugins/spark/v3.5/regtests/run.sh
+++ b/plugins/spark/v3.5/regtests/run.sh
@@ -41,7 +41,7 @@ if [[ -z "$REGTEST_ROOT_BEARER_TOKEN" ]]; then
   if ! output=$(curl -X POST -H "Polaris-Realm: POLARIS" "http://${POLARIS_HOST:-localhost}:8181/api/catalog/v1/oauth/tokens" \
     -d "grant_type=client_credentials" \
     -d "client_id=root" \
-    -d "client_secret=secret" \
+    -d "client_secret=s3cr3t" \
     -d "scope=PRINCIPAL_ROLE:ALL"); then
     logred "Error: Failed to retrieve bearer token"
     exit 1

--- a/regtests/docker-compose.yml
+++ b/regtests/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       AZURE_TENANT_ID: $AZURE_TENANT_ID
       AZURE_CLIENT_ID: $AZURE_CLIENT_ID
       AZURE_CLIENT_SECRET: $AZURE_CLIENT_SECRET
-      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,secret
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
       quarkus.log.file.enable: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."DROP_WITH_PURGE_ENABLED": "true"

--- a/regtests/run.sh
+++ b/regtests/run.sh
@@ -74,7 +74,7 @@ if [[ -z "$REGTEST_ROOT_BEARER_TOKEN" ]]; then
   if ! output=$(curl -X POST -H "Polaris-Realm: POLARIS" "http://${POLARIS_HOST:-localhost}:8181/api/catalog/v1/oauth/tokens" \
     -d "grant_type=client_credentials" \
     -d "client_id=root" \
-    -d "client_secret=secret" \
+    -d "client_secret=s3cr3t" \
     -d "scope=PRINCIPAL_ROLE:ALL"); then
     logred "Error: Failed to retrieve bearer token"
     exit 1

--- a/regtests/run_spark_sql.sh
+++ b/regtests/run_spark_sql.sh
@@ -59,7 +59,7 @@ fi
 if ! output=$(curl -X POST -H "Polaris-Realm: POLARIS" "http://${POLARIS_HOST:-localhost}:8181/api/catalog/v1/oauth/tokens" \
   -d "grant_type=client_credentials" \
   -d "client_id=root" \
-  -d "client_secret=secret" \
+  -d "client_secret=s3cr3t" \
   -d "scope=PRINCIPAL_ROLE:ALL"); then
   echo "Error: Failed to retrieve bearer token"
   exit 1

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -77,7 +77,7 @@ tasks.register("run") { dependsOn("quarkusRun") }
 tasks.named<QuarkusRun>("quarkusRun") {
   jvmArgs =
     listOf(
-      "-Dpolaris.bootstrap.credentials=POLARIS,root,secret",
+      "-Dpolaris.bootstrap.credentials=POLARIS,root,s3cr3t",
       "-Dquarkus.console.color=true",
       "-Dpolaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"=true",
       "-Dpolaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"=[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]",


### PR DESCRIPTION
This PR addresses an inconsistency in bootstrap credential settings across various parts of the project.
It is originated from the following issue: [#1869](https://github.com/apache/polaris/issues/1869#issuecomment-2976500860)

## Previously:

### docker-compose.yml used:
`POLARIS_BOOTSTRAP_CREDENTIALS: default-realm,root,s3cr3t`

### whereas other configurations (e.g., gradle.properties, README examples) used:
`-Dpolaris.bootstrap.credentials=POLARIS,root,secret`

This inconsistency caused errors when running commands like `./regtests/run_spark_sql.sh.`

## Summary of Changes

Unified all credential formats to use `POLARIS,root,s3cr3t`

Modified:

- gradle.properties
- docker-compose.yml
- README.md
- run_spark.sql.sh


This change ensures consistent local development setup across the project.