### PR TITLE
Add STS clients pool

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -32,6 +32,7 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.core.storage.StorageUtil;
+import org.apache.polaris.core.storage.aws.StsClientSupplier.StsDestination;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.policybuilder.iam.IamConditionOperator;
 import software.amazon.awssdk.policybuilder.iam.IamEffect;
@@ -45,17 +46,21 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 /** Credential vendor that supports generating */
 public class AwsCredentialsStorageIntegration
     extends InMemoryStorageIntegration<AwsStorageConfigurationInfo> {
-  private final StsClient stsClient;
+  private final StsClientSupplier stsClientSupplier;
   private final Optional<AwsCredentialsProvider> credentialsProvider;
 
-  public AwsCredentialsStorageIntegration(StsClient stsClient) {
-    this(stsClient, Optional.empty());
+  public AwsCredentialsStorageIntegration(StsClient fixedClient) {
+    this((destination) -> fixedClient);
+  }
+
+  public AwsCredentialsStorageIntegration(StsClientSupplier stsClientSupplier) {
+    this(stsClientSupplier, Optional.empty());
   }
 
   public AwsCredentialsStorageIntegration(
-      StsClient stsClient, Optional<AwsCredentialsProvider> credentialsProvider) {
+      StsClientSupplier stsClientSupplier, Optional<AwsCredentialsProvider> credentialsProvider) {
     super(AwsCredentialsStorageIntegration.class.getName());
-    this.stsClient = stsClient;
+    this.stsClientSupplier = stsClientSupplier;
     this.credentialsProvider = credentialsProvider;
   }
 
@@ -87,6 +92,11 @@ public class AwsCredentialsStorageIntegration
             .durationSeconds(storageCredentialDurationSeconds);
     credentialsProvider.ifPresent(
         cp -> request.overrideConfiguration(b -> b.credentialsProvider(cp)));
+
+    @SuppressWarnings("resource")
+    StsClient stsClient =
+        stsClientSupplier.stsClient(StsDestination.of(null, storageConfig.getRegion()));
+
     AssumeRoleResponse response = stsClient.assumeRole(request.build());
     EnumMap<StorageAccessProperty, String> credentialMap =
         new EnumMap<>(StorageAccessProperty.class);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/StsClientSupplier.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/StsClientSupplier.java
@@ -16,31 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.storage;
 
-import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithName;
-import java.time.Duration;
+package org.apache.polaris.core.storage.aws;
+
+import jakarta.annotation.Nullable;
+import java.net.URI;
 import java.util.Optional;
-import org.apache.polaris.service.storage.StorageConfiguration;
-import org.apache.polaris.service.storage.aws.S3AccessConfig;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+import software.amazon.awssdk.services.sts.StsClient;
 
-@ConfigMapping(prefix = "polaris.storage")
-public interface QuarkusStorageConfiguration extends StorageConfiguration, S3AccessConfig {
+public interface StsClientSupplier {
 
-  @WithName("aws.access-key")
-  @Override
-  Optional<String> awsAccessKey();
+  StsClient stsClient(StsDestination destination);
 
-  @WithName("aws.secret-key")
-  @Override
-  Optional<String> awsSecretKey();
+  @PolarisImmutable
+  interface StsDestination {
+    @Value.Parameter(order = 1)
+    Optional<URI> endpoint();
 
-  @WithName("gcp.token")
-  @Override
-  Optional<String> gcpAccessToken();
+    @Value.Parameter(order = 2)
+    Optional<String> region();
 
-  @WithName("gcp.lifespan")
-  @Override
-  Optional<Duration> gcpAccessTokenLifespan();
+    static StsDestination of(@Nullable URI endpoint, @Nullable String region) {
+      return ImmutableStsDestination.of(Optional.ofNullable(endpoint), Optional.ofNullable(region));
+    }
+  }
 }

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
   implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:iam-policy-builder")
   implementation("software.amazon.awssdk:s3")
+  implementation("software.amazon.awssdk:apache-client") {
+    exclude("commons-logging", "commons-logging")
+  }
   implementation(platform(libs.azuresdk.bom))
   implementation("com.azure:azure-core")
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.quarkus.config;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.context.SmallRyeManagedExecutor;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -75,12 +76,16 @@ import org.apache.polaris.service.quarkus.ratelimiter.QuarkusTokenBucketConfigur
 import org.apache.polaris.service.quarkus.secrets.QuarkusSecretsManagerConfiguration;
 import org.apache.polaris.service.ratelimiter.RateLimiter;
 import org.apache.polaris.service.ratelimiter.TokenBucketFactory;
+import org.apache.polaris.service.storage.aws.S3AccessConfig;
+import org.apache.polaris.service.storage.aws.StsClientsPool;
 import org.apache.polaris.service.task.TaskHandlerConfiguration;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 public class QuarkusProducers {
   private static final Logger LOGGER = LoggerFactory.getLogger(QuarkusProducers.class);
@@ -168,6 +173,34 @@ public class QuarkusProducers {
       QuarkusSecretsManagerConfiguration config,
       @Any Instance<UserSecretsManagerFactory> userSecretsManagerFactories) {
     return userSecretsManagerFactories.select(Identifier.Literal.of(config.type())).get();
+  }
+
+  @Produces
+  @Singleton
+  @Identifier("http-client-s3")
+  public SdkHttpClient sdkHttpClient(S3AccessConfig config) {
+    ApacheHttpClient.Builder httpClient = ApacheHttpClient.builder();
+    config.maxHttpConnections().ifPresent(httpClient::maxConnections);
+    config.readTimeout().ifPresent(httpClient::socketTimeout);
+    config.connectTimeout().ifPresent(httpClient::connectionTimeout);
+    config.connectionAcquisitionTimeout().ifPresent(httpClient::connectionAcquisitionTimeout);
+    config.connectionMaxIdleTime().ifPresent(httpClient::connectionMaxIdleTime);
+    config.connectionTimeToLive().ifPresent(httpClient::connectionTimeToLive);
+    config.expectContinueEnabled().ifPresent(httpClient::expectContinueEnabled);
+    return httpClient.build();
+  }
+
+  public void closeSdkHttpClient(@Disposes @Identifier("http-client-s3") SdkHttpClient client) {
+    client.close();
+  }
+
+  @Produces
+  @ApplicationScoped
+  public StsClientsPool stsClientsPool(
+      @Identifier("http-client-s3") SdkHttpClient httpClient,
+      S3AccessConfig config,
+      MeterRegistry meterRegistry) {
+    return new StsClientsPool(config, httpClient, meterRegistry);
   }
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/S3AccessConfig.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/S3AccessConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.storage.aws;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public interface S3AccessConfig {
+  /** Default value for {@link #sessionCacheMaxSize()}. */
+  int DEFAULT_MAX_SESSION_CREDENTIAL_CACHE_ENTRIES = 1000;
+
+  /** Default value for {@link #clientsCacheMaxSize()}. */
+  int DEFAULT_MAX_STS_CLIENT_CACHE_ENTRIES = 50;
+
+  /** Default value for {@link #sessionGracePeriod()}. */
+  Duration DEFAULT_SESSION_REFRESH_GRACE_PERIOD = Duration.ofMinutes(5);
+
+  /**
+   * The time period to subtract from the S3 session credentials (assumed role credentials) expiry
+   * time to define the time when those credentials become eligible for refreshing.
+   */
+  Optional<Duration> sessionGracePeriod();
+
+  default Duration effectiveSessionGracePeriod() {
+    return sessionGracePeriod().orElse(DEFAULT_SESSION_REFRESH_GRACE_PERIOD);
+  }
+
+  /**
+   * Maximum number of entries to keep in the session credentials cache (assumed role credentials).
+   */
+  OptionalInt sessionCacheMaxSize();
+
+  default int effectiveSessionCacheMaxSize() {
+    return sessionCacheMaxSize().orElse(DEFAULT_MAX_SESSION_CREDENTIAL_CACHE_ENTRIES);
+  }
+
+  /** Maximum number of entries to keep in the STS clients cache. */
+  OptionalInt clientsCacheMaxSize();
+
+  default int effectiveClientsCacheMaxSize() {
+    return clientsCacheMaxSize().orElse(DEFAULT_MAX_STS_CLIENT_CACHE_ENTRIES);
+  }
+
+  /** Override the default maximum number of pooled connections. */
+  OptionalInt maxHttpConnections();
+
+  /** Override the default connection read timeout. */
+  Optional<Duration> readTimeout();
+
+  /** Override the default TCP connect timeout. */
+  Optional<Duration> connectTimeout();
+
+  /**
+   * Override default connection acquisition timeout. This is the time a request will wait for a
+   * connection from the pool.
+   */
+  Optional<Duration> connectionAcquisitionTimeout();
+
+  /** Override default max idle time of a pooled connection. */
+  Optional<Duration> connectionMaxIdleTime();
+
+  /** Override default time-time of a pooled connection. */
+  Optional<Duration> connectionTimeToLive();
+
+  /** Override default behavior whether to expect an HTTP/100-Continue. */
+  Optional<Boolean> expectContinueEnabled();
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/StsClientsPool.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/StsClientsPool.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.storage.aws;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.cache.CaffeineStatsCounter;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.apache.polaris.core.storage.aws.StsClientSupplier;
+import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+
+/** Maintains a pool of STS clients. */
+public class StsClientsPool implements StsClientSupplier {
+  // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
+
+  private static final String CACHE_NAME = "sts-clients";
+
+  private final Cache<StsDestination, StsClient> clients;
+  private final Function<StsDestination, StsClient> clientBuilder;
+
+  public StsClientsPool(
+      S3AccessConfig effectiveSts, SdkHttpClient sdkHttpClient, MeterRegistry meterRegistry) {
+    this(
+        effectiveSts.effectiveClientsCacheMaxSize(),
+        key -> defaultStsClient(key, sdkHttpClient),
+        Optional.ofNullable(meterRegistry));
+  }
+
+  @VisibleForTesting
+  StsClientsPool(
+      int maxSize,
+      Function<StsDestination, StsClient> clientBuilder,
+      Optional<MeterRegistry> meterRegistry) {
+    this.clientBuilder = clientBuilder;
+    this.clients =
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .recordStats(() -> statsCounter(meterRegistry, maxSize))
+            .build();
+  }
+
+  @Override
+  public StsClient stsClient(StsDestination destination) {
+    return clients.get(destination, clientBuilder);
+  }
+
+  private static StsClient defaultStsClient(StsDestination parameters, SdkHttpClient sdkClient) {
+    StsClientBuilder builder = StsClient.builder();
+    builder.httpClient(sdkClient);
+    if (parameters.endpoint().isPresent()) {
+      CompletableFuture<Endpoint> endpointFuture =
+          completedFuture(Endpoint.builder().url(parameters.endpoint().get()).build());
+      builder.endpointProvider(params -> endpointFuture);
+    }
+
+    parameters.region().ifPresent(r -> builder.region(Region.of(r)));
+
+    return builder.build();
+  }
+
+  static StatsCounter statsCounter(Optional<MeterRegistry> meterRegistry, int maxSize) {
+    if (meterRegistry.isPresent()) {
+      meterRegistry
+          .get()
+          .gauge("max_entries", singletonList(Tag.of("cache", CACHE_NAME)), "", x -> maxSize);
+
+      return new CaffeineStatsCounter(meterRegistry.get(), CACHE_NAME);
+    }
+    return StatsCounter.disabledStatsCounter();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -98,6 +98,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.sts.StsClient;
 
 /** Base class for shared test setup logic used by various Polaris authz-related tests. */
 public abstract class PolarisAuthzTestBase {
@@ -218,9 +219,10 @@ public abstract class PolarisAuthzTestBase {
 
   @BeforeAll
   public static void setUpMocks() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
     PolarisStorageIntegrationProviderImpl mock =
         new PolarisStorageIntegrationProviderImpl(
-            Mockito::mock,
+            destination -> stsClient,
             Optional.empty(),
             () -> GoogleCredentials.create(new AccessToken("abc", new Date())));
     QuarkusMock.installMockForType(mock, PolarisStorageIntegrationProviderImpl.class);

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -38,28 +38,29 @@ import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.aws.StsClientSupplier;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.services.sts.StsClient;
 
 @ApplicationScoped
 public class PolarisStorageIntegrationProviderImpl implements PolarisStorageIntegrationProvider {
 
-  private final Supplier<StsClient> stsClientSupplier;
+  private final StsClientSupplier stsClientSupplier;
   private final Optional<AwsCredentialsProvider> stsCredentials;
   private final Supplier<GoogleCredentials> gcpCredsProvider;
 
   @Inject
-  public PolarisStorageIntegrationProviderImpl(StorageConfiguration storageConfiguration) {
+  public PolarisStorageIntegrationProviderImpl(
+      StorageConfiguration storageConfiguration, StsClientSupplier stsClientSupplier) {
     this(
-        storageConfiguration.stsClientSupplier(false),
+        stsClientSupplier,
         Optional.ofNullable(storageConfiguration.stsCredentials()),
         storageConfiguration.gcpCredentialsSupplier());
   }
 
   public PolarisStorageIntegrationProviderImpl(
-      Supplier<StsClient> stsClientSupplier,
+      StsClientSupplier stsClientSupplier,
       Optional<AwsCredentialsProvider> stsCredentials,
       Supplier<GoogleCredentials> gcpCredsProvider) {
     this.stsClientSupplier = stsClientSupplier;
@@ -80,7 +81,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
       case S3:
         storageIntegration =
             (PolarisStorageIntegration<T>)
-                new AwsCredentialsStorageIntegration(stsClientSupplier.get(), stsCredentials);
+                new AwsCredentialsStorageIntegration(stsClientSupplier, stsCredentials);
         break;
       case GCS:
         storageIntegration =

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -149,7 +149,7 @@ public record TestServices(
       // Application level
       PolarisStorageIntegrationProviderImpl storageIntegrationProvider =
           new PolarisStorageIntegrationProviderImpl(
-              () -> stsClient,
+              (destination) -> stsClient,
               Optional.empty(),
               () -> GoogleCredentials.create(new AccessToken(GCP_ACCESS_TOKEN, new Date())));
       InMemoryPolarisMetaStoreManagerFactory metaStoreManagerFactory =


### PR DESCRIPTION
No functional change.

Introduce a dedicated interface for StsClient suppliers and implement it using a pool of cached clients.

All client are "thin" and share the same `SdkHttpClient`. The latter is closed when the server shuts down.

This is a step towards supporting non-AWS S3 storage (#1530). For this reason the STS endpoint is present in new interfaces, but is not used yet.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
