### PR TITLE
Fix some typos in the release guide and add a section about Docker image staging

### DIFF
--- a/site/content/release-guide.md
+++ b/site/content/release-guide.md
@@ -101,13 +101,13 @@ If it's the first RC for the release, you have to create a release branch:
 
 ```
 git branch release/x.y.z
-git push apache/release/x.y.z
+git push apache release/x.y.z
 ```
 
 Go in the branch, and set the target release version:
 
 ```
-git checkoout release/x.y.z
+git checkout release/x.y.z
 echo "x.y.z" > version.txt
 git commit -a
 git push
@@ -121,7 +121,7 @@ On the release branch, you create a tag for the RC:
 
 ```
 git tag apache-polaris-x.y.z-rci
-git push apache/apache-polaris-x.y.z-rci
+git push apache apache-polaris-x.y.z-rci
 ```
 
 Switch to the tag:
@@ -182,6 +182,22 @@ Next, you have to close the staging repository:
 3. Select the Polaris repository
 4. At the top, select "Close" and follow the instructions
 5. In the comment field, use "Apache Polaris x.y.z RCi"
+
+### Build and stage Docker images
+
+You can build the Docker image for Polaris server using:
+
+```
+./gradlew :polaris-server:assemble :polaris-server:quarkusAppPartsBuild --rerun -Dquarkus.container-image.build=true -Dquarkus.container-image.name=apache/polaris:x.y.z-rci
+```
+
+The Docker image is in your running Docker daemon. You can now push the image to the Apache Polaris DockerHub repository:
+
+```
+docker push apache/polaris:x.y.z-rci
+```
+
+Note: this is a staging Docker image, so do not tag with `latest`.
 
 ### Start the vote thread
 


### PR DESCRIPTION
I found a few typos in the release guide.

I'm also using this PR to add a section about Docker image staging in the release guide.