### PR TITLE
Fix the sign failure

### DIFF
--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -18,6 +18,7 @@
  */
 
 import publishing.GenerateDigest
+import publishing.PublishingHelperPlugin
 
 plugins {
     id("distribution")
@@ -25,6 +26,8 @@ plugins {
 }
 
 description = "Apache Polaris Binary Distribution"
+
+apply<PublishingHelperPlugin>()
 
 val adminProject = project(":polaris-admin")
 val serverProject = project(":polaris-server")
@@ -104,7 +107,6 @@ distZip.configure { finalizedBy(digestDistZip) }
 
 if (project.hasProperty("release") || project.hasProperty("signArtifacts")) {
     signing {
-        useGpgCmd();
         sign(distTar.get())
         sign(distZip.get())
     }

--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -104,6 +104,7 @@ distZip.configure { finalizedBy(digestDistZip) }
 
 if (project.hasProperty("release") || project.hasProperty("signArtifacts")) {
     signing {
+        useGpgCmd();
         sign(distTar.get())
         sign(distZip.get())
     }


### PR DESCRIPTION
This PR is to fix the sign failure of this command: `./gradlew build sourceTarball -Prelease -PuseGpgAgent -PsignArtifacts -x test -x intTest`. Here are error message: 
```
> Task :polaris-distribution:signDistTar FAILED

[Incubating] Problems report is available at: file:///Users/ygu/asf/polaris/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':polaris-distribution:signDistTar'.
> Cannot perform signing task ':polaris-distribution:signDistTar' because it has no configured signatory
```