### PR TITLE
Add SUPPORTED_FEDERATION_AUTHENTICATION_TYPES feature configuration

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.config;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.connection.ConnectionType;
 import org.apache.polaris.core.context.CallContext;
@@ -259,6 +260,16 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .key("SUPPORTED_CATALOG_CONNECTION_TYPES")
           .description("The list of supported catalog connection types for federation")
           .defaultValue(List.of(ConnectionType.ICEBERG_REST.name()))
+          .buildFeatureConfiguration();
+
+  public static final FeatureConfiguration<List<String>> SUPPORTED_FEDERATION_AUTHENTICATION_TYPES =
+      PolarisConfiguration.<List<String>>builder()
+          .key("SUPPORTED_FEDERATION_AUTHENTICATION_TYPES")
+          .description("The list of supported authentication types for catalog federation")
+          .defaultValue(
+              List.of(
+                  AuthenticationParameters.AuthenticationTypeEnum.OAUTH.name(),
+                  AuthenticationParameters.AuthenticationTypeEnum.BEARER.name()))
           .buildFeatureConfiguration();
 
   public static final FeatureConfiguration<Integer> ICEBERG_COMMIT_MAX_RETRIES =

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -112,6 +112,7 @@ polaris.features."ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING"=false
 polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES"=["S3","GCS","AZURE"]
 # polaris.features."ENABLE_CATALOG_FEDERATION"=true
 polaris.features."SUPPORTED_CATALOG_CONNECTION_TYPES"=["ICEBERG_REST"]
+polaris.features."SUPPORTED_FEDERATION_AUTHENTICATION_TYPES"=["OAUTH", "BEARER"]
 
 # realm overrides
 # polaris.features.realm-overrides."my-realm"."SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION"=true

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -29,11 +29,13 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.admin.model.AddGrantRequest;
+import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogGrant;
 import org.apache.polaris.core.admin.model.CatalogRole;
 import org.apache.polaris.core.admin.model.CatalogRoles;
 import org.apache.polaris.core.admin.model.Catalogs;
+import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
 import org.apache.polaris.core.admin.model.CreateCatalogRoleRequest;
 import org.apache.polaris.core.admin.model.CreatePrincipalRequest;
@@ -145,7 +147,7 @@ public class PolarisServiceImpl
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     Catalog catalog = request.getCatalog();
     validateStorageConfig(catalog.getStorageConfigInfo());
-    validateConnectionConfigInfo(catalog);
+    validateExternalCatalog(catalog);
     Catalog newCatalog = new CatalogEntity(adminService.createCatalog(request)).asCatalog();
     LOGGER.info("Created new catalog {}", newCatalog);
     return Response.status(Response.Status.CREATED).build();
@@ -169,27 +171,48 @@ public class PolarisServiceImpl
     }
   }
 
-  private void validateConnectionConfigInfo(Catalog catalog) {
+  private void validateExternalCatalog(Catalog catalog) {
     if (catalog.getType() == Catalog.TypeEnum.EXTERNAL) {
       if (catalog instanceof ExternalCatalog externalCatalog) {
-        if (externalCatalog.getConnectionConfigInfo() != null) {
-          String connectionType =
-              externalCatalog.getConnectionConfigInfo().getConnectionType().name();
-          List<String> supportedConnectionTypes =
-              callContext
-                  .getPolarisCallContext()
-                  .getConfigurationStore()
-                  .getConfiguration(
-                      callContext.getRealmContext(),
-                      FeatureConfiguration.SUPPORTED_CATALOG_CONNECTION_TYPES)
-                  .stream()
-                  .map(s -> s.toUpperCase(Locale.ROOT))
-                  .toList();
-          if (!supportedConnectionTypes.contains(connectionType)) {
-            throw new IllegalStateException("Unsupported connection type: " + connectionType);
-          }
+        ConnectionConfigInfo connectionConfigInfo = externalCatalog.getConnectionConfigInfo();
+        if (connectionConfigInfo != null) {
+          validateConnectionConfigInfo(connectionConfigInfo);
+          validateAuthenticationParameters(connectionConfigInfo.getAuthenticationParameters());
         }
       }
+    }
+  }
+
+  private void validateConnectionConfigInfo(ConnectionConfigInfo connectionConfigInfo) {
+
+    String connectionType = connectionConfigInfo.getConnectionType().name();
+    List<String> supportedConnectionTypes =
+        callContext
+            .getPolarisCallContext()
+            .getConfigurationStore()
+            .getConfiguration(
+                callContext.getRealmContext(),
+                FeatureConfiguration.SUPPORTED_CATALOG_CONNECTION_TYPES)
+            .stream()
+            .map(s -> s.toUpperCase(Locale.ROOT))
+            .toList();
+    if (!supportedConnectionTypes.contains(connectionType)) {
+      throw new IllegalStateException("Unsupported connection type: " + connectionType);
+    }
+  }
+
+  private void validateAuthenticationParameters(AuthenticationParameters authenticationParameters) {
+
+    String authenticationType = authenticationParameters.getAuthenticationType().name();
+    List<String> supportedAuthenticationTypes =
+        callContext
+            .getPolarisCallContext()
+            .getConfigurationStore()
+            .getConfiguration(
+                callContext.getRealmContext(),
+                FeatureConfiguration.SUPPORTED_FEDERATION_AUTHENTICATION_TYPES);
+    if (!supportedAuthenticationTypes.contains(authenticationType)) {
+      throw new IllegalStateException("Unsupported authentication type: " + authenticationType);
     }
   }
 


### PR DESCRIPTION
Based on the discussion in #1925, this PR adds a SUPPORTED_FEDERATION_AUTHENTICATION_TYPES feature configuration.

I prefer the name SUPPORTED_FEDERATION_AUTHENTICATION_TYPES over SUPPORTED_CATALOG_AUTHENTICATION_TYPES because catalog in this context can be ambiguous. However, if others feel strongly, I can change it to SUPPORTED_CATALOG_AUTHENTICATION_TYPES to make it consistent with SUPPORTED_CATALOG_CONNECTION_TYPES. 

For now, we only support OAUTH and BEARER. Eventually, we can enable SIGV4 and NONE. 
