### PR TITLE
Exclude unused dependency for polaris spark client dependency

### DIFF
--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -55,6 +55,15 @@ dependencies {
     exclude("io.smallrye.common", "*")
     exclude("io.swagger", "*")
     exclude("org.apache.commons", "*")
+    exclude("com.fasterxml.jackson", "*")
+    exclude("com.fasterxml.jackson.core", "*")
+    exclude("jakarta.inject", "*")
+    exclude("jakarta.validation", "*")
+    exclude("jakarta.ws.rs", "")
+    exclude("com.github.ben-manes.caffeine", "*")
+    exclude("commons-codec", "*")
+    exclude("com.google.guava", "*")
+    exclude("org.apache.polaris", "polaris-api-management-model")
   }
 
   implementation(


### PR DESCRIPTION
Today, when use the polaris spark client with Spark using --package, it also tries to download the following unused package
```
	found org.apache.polaris#polaris-api-management-model;1.1.0-incubating-SNAPSHOT in local-m2-cache
	found com.fasterxml.jackson.core#jackson-annotations;2.19.0 in central
	found com.fasterxml.jackson.core#jackson-core;2.19.0 in central
	found com.fasterxml.jackson.core#jackson-databind;2.19.0 in central
	found com.github.ben-manes.caffeine#caffeine;3.2.1 in central

```
Exclude those dependency to avoid downloading unnecessary package when using the Polaris Spark Client with spark using --packages. 
After exclusion, only the following dependency are pulled 
```
found org.apache.polaris#polaris-spark-3.5_2.12;1.1.0-incubating-SNAPSHOT in local-m2-cache
found org.apache.polaris#polaris-core;1.1.0-incubating-SNAPSHOT in local-m2-cache
found org.slf4j#slf4j-api;2.0.17 in central
found org.apache.iceberg#iceberg-spark-runtime-3.5_2.12;1.9.0 in central
```

