### PR TITLE
Add relational-jdbc to helm

### DIFF
--- a/helm/polaris/ci/fixtures/persistence.yaml
+++ b/helm/polaris/ci/fixtures/persistence.yaml
@@ -23,34 +23,6 @@ metadata:
   name: polaris-persistence
 type: Opaque
 stringData:
-  persistence.xml: |-
-    <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
-      <persistence-unit name="polaris" transaction-type="RESOURCE_LOCAL">
-        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelEntity</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelEntityActive</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelEntityChangeTracking</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelEntityDropped</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelGrantRecord</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelPrincipalSecrets</class>
-        <class>org.apache.polaris.extension.persistence.impl.eclipselink.models.ModelSequenceId</class>
-        <shared-cache-mode>NONE</shared-cache-mode>
-        <properties>
-          <property name="jakarta.persistence.jdbc.url"
-            value="jdbc:postgresql://postgres:5432/{realm}"/>
-          <property name="jakarta.persistence.jdbc.user" value="postgres"/>
-          <property name="jakarta.persistence.jdbc.password" value="postgres"/>
-          <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
-          <property name="eclipselink.logging.level.sql" value="FINE"/>
-          <property name="eclipselink.logging.parameters" value="true"/>
-          <property name="eclipselink.persistence-context.flush-mode" value="auto"/>
-          <property name="eclipselink.connection-pool.default.initial" value="1" />
-          <property name="eclipselink.connection-pool.default.min" value="1" />
-          <property name="eclipselink.connection-pool.default.max" value="1" />
-          <property name="eclipselink.session.customizer" value="org.apache.polaris.extension.persistence.impl.eclipselink.PolarisEclipseLinkSessionCustomizer" />
-          <property name="eclipselink.transaction.join-existing" value="true" />
-        </properties>
-      </persistence-unit>
-    </persistence>
+  username: "postgres"
+  password: "postgres"
+  jdbc_url: "jdbc:postgresql://postgres:5432/POLARIS"

--- a/helm/polaris/ci/fixtures/persistence.yaml
+++ b/helm/polaris/ci/fixtures/persistence.yaml
@@ -25,4 +25,4 @@ type: Opaque
 stringData:
   username: "postgres"
   password: "postgres"
-  jdbc_url: "jdbc:postgresql://postgres:5432/POLARIS"
+  jdbcUrl: "jdbc:postgresql://postgres:5432/POLARIS"

--- a/helm/polaris/ci/persistence-values.yaml
+++ b/helm/polaris/ci/persistence-values.yaml
@@ -33,7 +33,7 @@ logging:
       size: 50Mi
 
 persistence:
-  type: eclipse-link
-  eclipseLink:
+  type: relational-jdbc
+  relationalJdbc:
     secret:
       name: polaris-persistence

--- a/helm/polaris/ci/persistence-values.yaml
+++ b/helm/polaris/ci/persistence-values.yaml
@@ -35,5 +35,6 @@ logging:
 persistence:
   type: relational-jdbc
   relationalJdbc:
+    dbKind: postgres
     secret:
       name: polaris-persistence

--- a/helm/polaris/templates/configmap.yaml
+++ b/helm/polaris/templates/configmap.yaml
@@ -53,6 +53,11 @@ data:
     {{- $_ = set $map "polaris.persistence.eclipselink.persistence-unit" .Values.persistence.eclipseLink.persistenceUnit -}}
     {{- $_ = set $map "polaris.persistence.eclipselink.configuration-file" (printf "%s/persistence.xml" .Values.image.configDir ) -}}
     {{- end -}}
+    {{- if eq .Values.persistence.type "relational-jdbc" -}}
+    {{- if .Values.persistence.relationalJdbc.dbKind -}}
+    {{- $_ = set $map "quarkus.datasource.db-kind" .Values.persistence.relationalJdbc.dbKind -}}
+    {{- end -}}
+    {{- end -}}
 
     {{- /* File IO */ -}}
     {{- $_ = set $map "polaris.file-io.type" .Values.fileIo.type -}}

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -72,11 +72,20 @@ spec:
           {{- end }}
           image: "{{ tpl .Values.image.repository . }}:{{ tpl .Values.image.tag . | default .Chart.Version }}"
           imagePullPolicy: {{ tpl .Values.image.pullPolicy . }}
-          {{ if or .Values.storage.secret.name .Values.extraEnv -}}
+          {{ if or .Values.storage.secret.name .Values.persistence.relationalJdbc.secret.name .Values.extraEnv -}}
           env:
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "awsAccessKeyId" "polaris.storage.aws.access-key") | indent 12 -}}
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "awsSecretAccessKey" "polaris.storage.aws.secret-key") | indent 12 -}}
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "gcpToken" "polaris.storage.gcp.token") | indent 12 -}}
+            {{- if and ( eq .Values.persistence.type "relational-jdbc" ) .Values.persistence.relationalJdbc.secret.name }}
+            {{- range $key := list "username" "password" "jdbc_url" }}
+            - name: QUARKUS_DATASOURCE_{{ $key | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.persistence.relationalJdbc.secret.name }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.extraEnv -}}
             {{- tpl (toYaml .Values.extraEnv) . | nindent 12 -}}
             {{- end -}}

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -78,8 +78,8 @@ spec:
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "awsSecretAccessKey" "polaris.storage.aws.secret-key") | indent 12 -}}
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "gcpToken" "polaris.storage.gcp.token") | indent 12 -}}
             {{- if and ( eq .Values.persistence.type "relational-jdbc" ) .Values.persistence.relationalJdbc.secret.name }}
-            {{- range $key, $envVar := dict "username" "username" "password" "password" "jdbcUrl" "jdbc.url" }}
-            - name: quarkus.datasource.{{ $envVar }}
+            {{- range $key, $envVar := dict "username" "USERNAME" "password" "PASSWORD" "jdbcUrl" "JDBC_URL" }}
+            - name: QUARKUS_DATASOURCE_{{ $envVar }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Values.persistence.relationalJdbc.secret.name }}

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -78,8 +78,8 @@ spec:
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "awsSecretAccessKey" "polaris.storage.aws.secret-key") | indent 12 -}}
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "gcpToken" "polaris.storage.gcp.token") | indent 12 -}}
             {{- if and ( eq .Values.persistence.type "relational-jdbc" ) .Values.persistence.relationalJdbc.secret.name }}
-            {{- range $key, $envVar := dict "username" "USERNAME" "password" "PASSWORD" "jdbcUrl" "JDBC_URL" }}
-            - name: QUARKUS_DATASOURCE_{{ $envVar }}
+            {{- range $key, $envVar := dict "username" "username" "password" "password" "jdbcUrl" "jdbc.url" }}
+            - name: quarkus.datasource.{{ $envVar }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Values.persistence.relationalJdbc.secret.name }}

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -78,8 +78,8 @@ spec:
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "awsSecretAccessKey" "polaris.storage.aws.secret-key") | indent 12 -}}
             {{- include "polaris.secretToEnv" (list .Values.storage.secret "gcpToken" "polaris.storage.gcp.token") | indent 12 -}}
             {{- if and ( eq .Values.persistence.type "relational-jdbc" ) .Values.persistence.relationalJdbc.secret.name }}
-            {{- range $key := list "username" "password" "jdbc_url" }}
-            - name: QUARKUS_DATASOURCE_{{ $key | upper }}
+            {{- range $key, $envVar := dict "username" "username" "password" "password" "jdbcUrl" "jdbc.url" }}
+            - name: quarkus.datasource.{{ $envVar }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Values.persistence.relationalJdbc.secret.name }}

--- a/helm/polaris/tests/configmap_test.yaml
+++ b/helm/polaris/tests/configmap_test.yaml
@@ -110,6 +110,12 @@ tests:
       - matchRegex: { path: 'data["application.properties"]', pattern: "polaris.persistence.eclipselink.persistence-unit=polaris" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "polaris.persistence.eclipselink.configuration-file=/deployments/config/persistence.xml" }
 
+  - it: should configure relational-jdbc persistence
+    set:
+      persistence: { type: "relational-jdbc", relationalJdbc: { secret: { name: "polaris-persistence" } } }
+    asserts:
+      - matchRegex: { path: 'data["application.properties"]', pattern: "polaris.persistence.type=relational-jdbc" }
+
   - it: should configure file-io
     set:
       fileIo.type: "custom"

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -1022,7 +1022,7 @@ tests:
 
   - it: should set relational-jdbc persistence environment variables
     set:
-      persistence: { type: "relational-jdbc", relationalJdbc: { secret: { name: "polaris-persistence" } } }
+      persistence: { type: "relational-jdbc", dbKind: postgres, relationalJdbc: { secret: { name: "polaris-persistence" } } }
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -1047,7 +1047,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: polaris-persistence
-                key: jdbc_url
+                key: jdbcUrl
 
   - it: should configure volume for file logging
     set:

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -1020,6 +1020,35 @@ tests:
                       - key: custom.xml
                         path: persistence.xml
 
+  - it: should set relational-jdbc persistence environment variables
+    set:
+      persistence: { type: "relational-jdbc", relationalJdbc: { secret: { name: "polaris-persistence" } } }
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_DATASOURCE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: polaris-persistence
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_DATASOURCE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: polaris-persistence
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_DATASOURCE_JDBC_URL
+            valueFrom:
+              secretKeyRef:
+                name: polaris-persistence
+                key: jdbc_url
+
   - it: should configure volume for file logging
     set:
       logging.file.enabled: true

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -1027,7 +1027,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: QUARKUS_DATASOURCE_USERNAME
+            name: quarkus.datasource.username
             valueFrom:
               secretKeyRef:
                 name: polaris-persistence
@@ -1035,7 +1035,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: QUARKUS_DATASOURCE_PASSWORD
+            name: quarkus.datasource.password
             valueFrom:
               secretKeyRef:
                 name: polaris-persistence
@@ -1043,7 +1043,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: QUARKUS_DATASOURCE_JDBC_URL
+            name: quarkus.datasource.jdbc.url
             valueFrom:
               secretKeyRef:
                 name: polaris-persistence

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -521,7 +521,8 @@ features:
 
 # -- Polaris persistence configuration.
 persistence:
-  # -- The type of persistence to use. Two built-in types are supported: in-memory and eclipse-link.
+  # -- The type of persistence to use. Two built-in types are supported: in-memory and relational-jdbc.
+  # The eclipse-link type is also supported but is deprecated.
   type: ~  # in-memory
   # -- The configuration for the relational-jdbc persistence manager.
   relationalJdbc:

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -522,7 +522,16 @@ features:
 # -- Polaris persistence configuration.
 persistence:
   # -- The type of persistence to use. Two built-in types are supported: in-memory and eclipse-link.
-  type: eclipse-link  # in-memory
+  type: ~ # in-memory
+  # -- The configuration for the relational-jdbc persistence manager.
+  relationalJdbc:
+    # -- The type of database to use. Valid values are: h2, postgres.
+    dbKind: ~
+
+    # -- The secret name to pull the database connection properties from.
+    secret:
+      name: ~
+
   # -- The configuration for the eclipse-link persistence manager.
   eclipseLink:
     # -- The secret name to pull persistence.xml from.

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -522,14 +522,14 @@ features:
 # -- Polaris persistence configuration.
 persistence:
   # -- The type of persistence to use. Two built-in types are supported: in-memory and eclipse-link.
-  type: ~ # in-memory
+  type: ~  # in-memory
   # -- The configuration for the relational-jdbc persistence manager.
   relationalJdbc:
     # -- The type of database to use. Valid values are: h2, postgres.
     dbKind: ~
-
     # -- The secret name to pull the database connection properties from.
     secret:
+      # -- The secret name to pull the database connection properties from.
       name: ~
 
   # -- The configuration for the eclipse-link persistence manager.

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -523,11 +523,11 @@ features:
 persistence:
   # -- The type of persistence to use. Two built-in types are supported: in-memory and relational-jdbc.
   # The eclipse-link type is also supported but is deprecated.
-  type: ~  # in-memory
+  type: in-memory # relational-jdbc
   # -- The configuration for the relational-jdbc persistence manager.
   relationalJdbc:
     # -- The type of database to use. Valid values are: h2, postgres.
-    dbKind: ~
+    dbKind: postgres # h2
     # -- The secret name to pull the database connection properties from.
     secret:
       # -- The secret name to pull the database connection properties from.

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -523,11 +523,11 @@ features:
 persistence:
   # -- The type of persistence to use. Two built-in types are supported: in-memory and relational-jdbc.
   # The eclipse-link type is also supported but is deprecated.
-  type: in-memory # relational-jdbc
+  type: in-memory  # relational-jdbc
   # -- The configuration for the relational-jdbc persistence manager.
   relationalJdbc:
     # -- The type of database to use. Valid values are: h2, postgres.
-    dbKind: postgres # h2
+    dbKind: postgres  # h2
     # -- The secret name to pull the database connection properties from.
     secret:
       # -- The secret name to pull the database connection properties from.


### PR DESCRIPTION
## Motivation for the Change
  Polaris needs to support relational-jdbc as the default persistence type for simpler database configuration and better cloud-native deployment experience.

## Description of the Status Quo (Current Behavior)
  Currently, the Helm chart only supports eclipse-link persistence type as the default, which requires complex JPA configuration with persistence.xml files.

## Desired Behavior
  - Add relational-jdbc persistence type support to Helm chart
  - Use relational-jdbc as the default persistence type
  - Inject JDBC configuration (username, password, jdbc_url) through Kubernetes Secrets as environment variables
  - Maintain backward compatibility with eclipse-link

## Additional Details
  - Updated persistence-values.yaml for CI testing
  - Updated test coverage for relational-jdbc configuration
  - JDBC credentials are injected via QUARKUS_DATASOURCE_* environment variables from Secret
  - Secret keys: username, password, jdbc_url
