### PR TITLE
Simplify install dependency doc

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/install-dependencies.md
+++ b/site/content/in-dev/unreleased/getting-started/install-dependencies.md
@@ -114,7 +114,7 @@ Ensure that `java --version` and `javac` both return non-zero responses.
 
 ## jq
 
-Most Polaris Quickstart scripts require [jq]((https://jqlang.org/download/)). You can install jq using [homebrew](https://brew.sh/) on MacOS:
+Most Polaris Quickstart scripts require [jq]((https://jqlang.org/download/)). You can install jq using [homebrew](https://brew.sh/):
 ```shell
 brew install jq
 ```

--- a/site/content/in-dev/unreleased/getting-started/install-dependencies.md
+++ b/site/content/in-dev/unreleased/getting-started/install-dependencies.md
@@ -115,6 +115,6 @@ Ensure that `java --version` and `javac` both return non-zero responses.
 ## jq
 
 Most Polaris Quickstart scripts require [jq]((https://jqlang.org/download/)). You can install jq using [homebrew](https://brew.sh/) on MacOS:
-```
+```shell
 brew install jq
 ```

--- a/site/content/in-dev/unreleased/getting-started/install-dependencies.md
+++ b/site/content/in-dev/unreleased/getting-started/install-dependencies.md
@@ -41,8 +41,7 @@ Please follow instructions from the [Git Documentation](https://git-scm.com/book
 Then, use git to clone the Polaris repo:
 
 ```shell
-cd ~
-git clone https://github.com/apache/polaris.git
+git clone https://github.com/apache/polaris.git ~/polaris
 ```
 
 ## Docker
@@ -115,4 +114,7 @@ Ensure that `java --version` and `javac` both return non-zero responses.
 
 ## jq
 
-Most Polaris Quickstart scripts require `jq`. Follow the instructions from the [jq](https://jqlang.org/download/) website to download this tool.
+Most Polaris Quickstart scripts require [jq]((https://jqlang.org/download/)). You can install jq using [homebrew](https://brew.sh/) on MacOS:
+```
+brew install jq
+```


### PR DESCRIPTION
Minor change to simply the install dependency doc:
1. change from two lines to one line with `git clone`
2. instead of asking users to check official jq doc (which will tell them the same thing about brew) and we are using brew for `docker` and `jenv` already in this doc. Thus, I think it makes more senses to provide brew command directly.