### PR TITLE
Fix NPE in listCatalogs

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/TestPolarisMetaStoreManager.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/TestPolarisMetaStoreManager.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.quarkus.admin;
+
+import jakarta.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
+import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
+
+/**
+ * Intended to be a delegate to TransactionalMetaStoreManagerImpl with the ability to inject faults.
+ * Currently, you can force loadEntity() to return ENTITY_NOT_FOUND for a set of entity IDs.
+ */
+public class TestPolarisMetaStoreManager extends TransactionalMetaStoreManagerImpl {
+  public Set<Long> fakeEntityNotFoundIds = new HashSet<>();
+
+  @Override
+  public @Nonnull EntityResult loadEntity(
+      @Nonnull PolarisCallContext callCtx,
+      long entityCatalogId,
+      long entityId,
+      @Nonnull PolarisEntityType entityType) {
+    if (fakeEntityNotFoundIds.contains(entityId)) {
+      return new EntityResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, "");
+    }
+    return super.loadEntity(callCtx, entityCatalogId, entityId, entityType);
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -614,7 +614,6 @@ public class PolarisAdminService {
 
     Set<String> newCatalogLocations = getCatalogLocations(catalogEntity);
     return listCatalogsUnsafe().stream()
-        .filter(Objects::nonNull)
         .map(CatalogEntity::new)
         .anyMatch(
             existingCatalog -> {
@@ -923,18 +922,24 @@ public class PolarisAdminService {
     return returnedEntity;
   }
 
+  /**
+   * List all catalogs after checking for permission. Nulls due to non-atomic list-then-get are
+   * filtered out.
+   */
   public List<PolarisEntity> listCatalogs() {
     authorizeBasicRootOperationOrThrow(PolarisAuthorizableOperation.LIST_CATALOGS);
     return listCatalogsUnsafe();
   }
 
   /**
-   * List all catalogs without checking for permission. May contain NULLs due to multiple non-atomic
-   * API calls to the persistence layer. Specifically, this can happen when a PolarisEntity is
-   * returned by listCatalogs, but cannot be loaded afterward because it was purged by another
-   * process before it could be loaded.
+   * List all catalogs without checking for permission. Nulls due to non-atomic list-then-get are
+   * filtered out.
    */
   private List<PolarisEntity> listCatalogsUnsafe() {
+    // loadEntity may return null due to multiple non-atomic
+    // API calls to the persistence layer. Specifically, this can happen when a PolarisEntity is
+    // returned by listCatalogs, but cannot be loaded afterward because it was purged by another
+    // process before it could be loaded.
     return metaStoreManager
         .listEntities(
             getCurrentPolarisContext(),
@@ -949,6 +954,7 @@ public class PolarisAdminService {
                 PolarisEntity.of(
                     metaStoreManager.loadEntity(
                         getCurrentPolarisContext(), 0, nameAndId.getId(), nameAndId.getType())))
+        .filter(Objects::nonNull)
         .toList();
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
@@ -231,7 +230,6 @@ public class PolarisServiceImpl
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<Catalog> catalogList =
         adminService.listCatalogs().stream()
-            .filter(Objects::nonNull)
             .map(CatalogEntity::new)
             .map(CatalogEntity::asCatalog)
             .toList();

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
@@ -230,6 +231,7 @@ public class PolarisServiceImpl
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     List<Catalog> catalogList =
         adminService.listCatalogs().stream()
+            .filter(Objects::nonNull)
             .map(CatalogEntity::new)
             .map(CatalogEntity::asCatalog)
             .toList();


### PR DESCRIPTION
listCatalogs is non-atomic. It first atomically lists all entities and then iterates through each one and does an individual loadEntity call. This causes an NPE when calling `CatalogEntity::new`.

I don't think it's ever useful for listCatalogsUnsafe to return null since the caller isn't expecting a certain length of elements, so I just filtered it there.