### PR TITLE
fix: Only include project LICENSE and NOTICE in Spark Client Jar

### DIFF
--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -121,8 +121,8 @@ tasks.register("addLicenseFilesToJar") {
       throw GradleException("Project NOTICE file not found at: ${projectNoticeFile.absolutePath}")
     }
 
-    println("Processing jar: ${jarFile.absolutePath}")
-    println("Using temp directory: ${tempDir.absolutePath}")
+    logger.info("Processing jar: ${jarFile.absolutePath}")
+    logger.info("Using temp directory: ${tempDir.absolutePath}")
 
     // Clean up temp directory
     if (tempDir.exists()) {
@@ -144,7 +144,7 @@ tasks.register("addLicenseFilesToJar") {
         include("META-INF/NOTICE*")
       }
       .forEach { file ->
-        println("Removing license file: ${file.relativeTo(tempDir)}")
+        logger.info("Removing license file: ${file.relativeTo(tempDir)}")
         file.delete()
       }
 
@@ -153,13 +153,13 @@ tasks.register("addLicenseFilesToJar") {
       from(projectLicenseFile)
       into(tempDir)
     }
-    println("Added project LICENSE file")
+    logger.info("Added project LICENSE file")
 
     copy {
       from(projectNoticeFile)
       into(tempDir)
     }
-    println("Added project NOTICE file")
+    logger.info("Added project NOTICE file")
 
     // Delete the original jar
     jarFile.delete()
@@ -169,7 +169,7 @@ tasks.register("addLicenseFilesToJar") {
       "jar"("destfile" to jarFile.absolutePath) { "fileset"("dir" to tempDir.absolutePath) }
     }
 
-    println("Recreated jar with only project LICENSE and NOTICE files")
+    logger.info("Recreated jar with only project LICENSE and NOTICE files")
 
     // Clean up temp directory
     tempDir.deleteRecursively()

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
+ * distributed with this work for additional debugrmation
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
@@ -138,15 +138,22 @@ tasks.register("addLicenseFilesToJar") {
 
     fileTree(tempDir)
       .matching {
-        include("LICENSE*")
-        include("NOTICE*")
-        include("META-INF/LICENSE*")
-        include("META-INF/NOTICE*")
+        include("**/*LICENSE*")
+        include("**/*NOTICE*")
+        include("**/*license*")
+        include("**/*notice*")
       }
       .forEach { file ->
         logger.info("Removing license file: ${file.relativeTo(tempDir)}")
         file.delete()
       }
+
+    // Remove META-INF/licenses directory if it exists
+    val licensesDir = File(tempDir, "META-INF/licenses")
+    if (licensesDir.exists()) {
+      licensesDir.deleteRecursively()
+      logger.info("Removed META-INF/licenses directory")
+    }
 
     // Copy our project's license files to root
     copy {

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -85,12 +85,6 @@ tasks.register<ShadowJar>("createPolarisSparkJar") {
   archiveClassifier = "bundle"
   isZip64 = true
 
-  // include the LICENSE and NOTICE files for the shadow Jar
-  from(projectDir) {
-    include("LICENSE")
-    include("NOTICE")
-  }
-
   // pack both the source code and dependencies
   from(sourceSets.main.get().output)
   configurations = listOf(project.configurations.runtimeClasspath.get())
@@ -99,9 +93,91 @@ tasks.register<ShadowJar>("createPolarisSparkJar") {
   // The iceberg-spark-runtime plugin is always packaged along with our polaris-spark plugin,
   // therefore excluded from the optimization.
   minimize { exclude(dependency("org.apache.iceberg:iceberg-spark-runtime-*.*")) }
+
+  // Always run the license file addition after this task completes
+  finalizedBy("addLicenseFilesToJar")
 }
 
-// ensure the ShadowJar job is run for both `assemble` and `build` task
+// Post-processing task to add our project's LICENSE and NOTICE files to the jar and remove any
+// other LICENSE or NOTICE files that were shaded in.
+tasks.register("addLicenseFilesToJar") {
+  dependsOn("createPolarisSparkJar")
+
+  doLast {
+    val shadowTask = tasks.named("createPolarisSparkJar", ShadowJar::class.java).get()
+    val jarFile = shadowTask.archiveFile.get().asFile
+    val tempDir =
+      File(
+        "${project.layout.buildDirectory.get().asFile}/tmp/jar-cleanup-${shadowTask.archiveBaseName.get()}-${shadowTask.archiveClassifier.get()}"
+      )
+    val projectLicenseFile = File(projectDir, "LICENSE")
+    val projectNoticeFile = File(projectDir, "NOTICE")
+
+    // Validate that required license files exist
+    if (!projectLicenseFile.exists()) {
+      throw GradleException("Project LICENSE file not found at: ${projectLicenseFile.absolutePath}")
+    }
+    if (!projectNoticeFile.exists()) {
+      throw GradleException("Project NOTICE file not found at: ${projectNoticeFile.absolutePath}")
+    }
+
+    println("Processing jar: ${jarFile.absolutePath}")
+    println("Using temp directory: ${tempDir.absolutePath}")
+
+    // Clean up temp directory
+    if (tempDir.exists()) {
+      tempDir.deleteRecursively()
+    }
+    tempDir.mkdirs()
+
+    // Extract the jar
+    copy {
+      from(zipTree(jarFile))
+      into(tempDir)
+    }
+
+    fileTree(tempDir)
+      .matching {
+        include("LICENSE*")
+        include("NOTICE*")
+        include("META-INF/LICENSE*")
+        include("META-INF/NOTICE*")
+      }
+      .forEach { file ->
+        println("Removing license file: ${file.relativeTo(tempDir)}")
+        file.delete()
+      }
+
+    // Copy our project's license files to root
+    copy {
+      from(projectLicenseFile)
+      into(tempDir)
+    }
+    println("Added project LICENSE file")
+
+    copy {
+      from(projectNoticeFile)
+      into(tempDir)
+    }
+    println("Added project NOTICE file")
+
+    // Delete the original jar
+    jarFile.delete()
+
+    // Create new jar with only project LICENSE and NOTICE files
+    ant.withGroovyBuilder {
+      "jar"("destfile" to jarFile.absolutePath) { "fileset"("dir" to tempDir.absolutePath) }
+    }
+
+    println("Recreated jar with only project LICENSE and NOTICE files")
+
+    // Clean up temp directory
+    tempDir.deleteRecursively()
+  }
+}
+
+// ensure the shadow jar job (which will automatically run license addition) is run for both
+// `assemble` and `build` task
 tasks.named("assemble") { dependsOn("createPolarisSparkJar") }
 
 tasks.named("build") { dependsOn("createPolarisSparkJar") }

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -140,8 +140,6 @@ tasks.register("addLicenseFilesToJar") {
       .matching {
         include("**/*LICENSE*")
         include("**/*NOTICE*")
-        include("**/*license*")
-        include("**/*notice*")
       }
       .forEach { file ->
         logger.info("Removing license file: ${file.relativeTo(tempDir)}")


### PR DESCRIPTION
Previously the build code would add LICENSE and NOTICE files from other shaded dependencies, some of which could potentially shade the project's LICENSE or NOTICE or cause confusion as to which file was correct.

To fix this a post-processing task is added which removes all potentially confusing files and manually adds the project LICENSE and NOTICE files back to the jar.

---

I tried fixing this via exclusions and include rules but for whatever reason the shadowJar plugin didn't seem to behave
well. The Duplication strategy apparently can only apply to the final jar so unless I was able to individually exclude the
licenses from all dependencies I was a bit stuck. To avoid the issue entirely, I just post process the jar. This adds about 10 
seconds to the task on my machine but I figure that is not a huge cost for something that won't be run that often.