### PR TITLE
Remove the maintainer list in Helm Chart

### DIFF
--- a/helm/polaris/Chart.yaml
+++ b/helm/polaris/Chart.yaml
@@ -30,7 +30,7 @@ sources:
 keywords:
   - polaris
   - iceberg
-maintainers: # Maintainers section is kept only to satisfy the Helm Chart Spec and downstream linters.
+maintainers:  # Maintainers section is kept only to satisfy the Helm Chart Spec and downstream linters.
   - name: MonkeyCanCode
   - name: adutra
   - name: collado-mike

--- a/helm/polaris/Chart.yaml
+++ b/helm/polaris/Chart.yaml
@@ -30,3 +30,10 @@ sources:
 keywords:
   - polaris
   - iceberg
+maintainers: # Maintainers section is kept only to satisfy the Helm Chart Spec and downstream linters.
+  - name: MonkeyCanCode
+  - name: adutra
+  - name: collado-mike
+  - name: gerrit-k
+  - name: snazy
+  - name: flyrain

--- a/helm/polaris/Chart.yaml
+++ b/helm/polaris/Chart.yaml
@@ -30,10 +30,3 @@ sources:
 keywords:
   - polaris
   - iceberg
-maintainers:
-  - name: MonkeyCanCode
-  - name: adutra
-  - name: collado-mike
-  - name: gerrit-k
-  - name: snazy
-  - name: flyrain

--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -33,14 +33,6 @@ A Helm chart for Apache Polaris (incubating).
 
 **Homepage:** <https://polaris.apache.org/>
 
-## Maintainers
-* [MonkeyCanCode](https://github.com/MonkeyCanCode)
-* [adutra](https://github.com/adutra)
-* [collado-mike](https://github.com/collado-mike)
-* [gerrit-k](https://github.com/gerrit-k)
-* [snazy](https://github.com/snazy)
-* [flyrain](https://github.com/flyrain)
-
 ## Source Code
 
 * <https://github.com/apache/polaris>


### PR DESCRIPTION
The reason to remove it
1. The maintainer list is optional. 
2. It adds code maintenance burden, which make it inaccurate inevitably.
3. We don't do that in elsewhere of the project. 

More discussions are here, https://github.com/apache/polaris/pull/1957#discussion_r2170162461. 