### PR TITLE
Fix admin tool doc

### DIFF
--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -36,8 +36,7 @@ example, to build the tool with support for Postgres, run the following:
 
 The above command will generate:
 
-- One standalone JAR in `runtime/admin/build/polaris-admin-*-runner.jar`
-- Two distribution archives in `runtime/admin/build/distributions`
+- One fast-jar in `runtime/admin/build/quarkus-app/quarkus-run.jar`
 - Two Docker images named `apache/polaris-admin-tool:latest` and `apache/polaris-admin-tool:<version>`
 
 ## Usage
@@ -46,7 +45,7 @@ Please make sure the admin tool and Polaris server are with the same version bef
 To run the standalone JAR, use the following command:
 
 ```shell
-java -jar runtime/admin/build/polaris-admin-*-runner.jar --help
+java -jar runtime/admin/build/quarkus-app/quarkus-run.jar --help
 ```
 
 To run the Docker image, use the following command:

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -36,7 +36,7 @@ example, to build the tool with support for Postgres, run the following:
 
 The above command will generate:
 
-- One fast-jar in `runtime/admin/build/quarkus-app/quarkus-run.jar`
+- One Fast-JAR in `runtime/admin/build/quarkus-app/quarkus-run.jar`
 - Two Docker images named `apache/polaris-admin-tool:latest` and `apache/polaris-admin-tool:<version>`
 
 ## Usage
@@ -88,7 +88,7 @@ issues. If a realm is already bootstrapped, running the `bootstrap` command agai
 effect on that realm.
 
 ```shell
-java -jar runtime/admin/build/polaris-admin-*-runner.jar bootstrap --help
+java -jar runtime/admin/build/quarkus-app/quarkus-run.jar bootstrap --help
 ```
 
 The basic usage of the `bootstrap` command is outlined below:
@@ -109,7 +109,7 @@ For example, to bootstrap the `realm1` realm and create its root principal crede
 client ID `admin` and client secret `admin`, you can run the following command:
 
 ```shell
-java -jar runtime/admin/build/polaris-admin-*-runner.jar bootstrap -r realm1 -c realm1,admin,admin
+java -jar runtime/admin/build/quarkus-app/quarkus-run.jar bootstrap -r realm1 -c realm1,admin,admin
 ```
 
 ## Purging Realms and Principal Credentials
@@ -122,7 +122,7 @@ The `purge` command is used to remove realms and principal credentials from the 
   credentials, grants, and any other data associated with the realms.
 
 ```shell
-java -jar runtime/admin/build/polaris-admin-*-runner.jar purge --help
+java -jar runtime/admin/build/quarkus-app/quarkus-run.jar purge --help
 ```
 
 The basic usage of the `purge` command is outlined below:
@@ -138,5 +138,5 @@ Purge realms and all associated entities.
 For example, to purge the `realm1` realm, you can run the following command:
 
 ```shell
-java -jar runtime/admin/build/polaris-admin-*-runner.jar purge -r realm1
+java -jar runtime/admin/build/quarkus-app/quarkus-run.jar purge -r realm1
 ```


### PR DESCRIPTION
Fix admin tool doc with following changes:
1. Remove refs for `Two distribution archives in...` as this command no longer does so
2. Change wording from standalone JAR (often refs to as uber-JAR to Fast-JAR) 
3. Update JAR refs in the sample commands