### PR TITLE
Remove unnecessary `InputStream.close` call

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -82,37 +82,38 @@ public class DatasourceOperations {
    * @throws SQLException : Exception while executing the script.
    */
   public void executeScript(InputStream scriptInputStream) throws SQLException {
-    runWithinTransaction(
-        connection -> {
-          try (Statement statement = connection.createStatement();
-              BufferedReader reader =
-                  new BufferedReader(
-                      new InputStreamReader(Objects.requireNonNull(scriptInputStream), UTF_8))) {
-            StringBuilder sqlBuffer = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-              line = line.trim();
-              if (!line.isEmpty() && !line.startsWith("--")) { // Ignore empty lines and comments
-                sqlBuffer.append(line).append("\n");
-                if (line.endsWith(";")) { // Execute statement when semicolon is found
-                  String sql = sqlBuffer.toString().trim();
-                  try {
-                    // since SQL is directly read from the file, there is close to 0 possibility
-                    // of this being injected plus this run via an Admin tool, if attacker can
-                    // fiddle with this that means lot of other things are already compromised.
-                    statement.execute(sql);
-                  } catch (SQLException e) {
-                    throw new RuntimeException(e);
+    try (BufferedReader scriptReader =
+        new BufferedReader(
+            new InputStreamReader(Objects.requireNonNull(scriptInputStream), UTF_8))) {
+      List<String> scriptLines = scriptReader.lines().toList();
+      runWithinTransaction(
+          connection -> {
+            try (Statement statement = connection.createStatement()) {
+              StringBuilder sqlBuffer = new StringBuilder();
+              for (String line : scriptLines) {
+                line = line.trim();
+                if (!line.isEmpty() && !line.startsWith("--")) { // Ignore empty lines and comments
+                  sqlBuffer.append(line).append("\n");
+                  if (line.endsWith(";")) { // Execute statement when semicolon is found
+                    String sql = sqlBuffer.toString().trim();
+                    try {
+                      // since SQL is directly read from the file, there is close to 0 possibility
+                      // of this being injected plus this run via an Admin tool, if attacker can
+                      // fiddle with this that means lot of other things are already compromised.
+                      statement.execute(sql);
+                    } catch (SQLException e) {
+                      throw new RuntimeException(e);
+                    }
+                    sqlBuffer.setLength(0); // Clear the buffer for the next statement
                   }
-                  sqlBuffer.setLength(0); // Clear the buffer for the next statement
                 }
               }
+              return true;
             }
-            return true;
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -82,45 +82,37 @@ public class DatasourceOperations {
    * @throws SQLException : Exception while executing the script.
    */
   public void executeScript(InputStream scriptInputStream) throws SQLException {
-    try {
-      runWithinTransaction(
-          connection -> {
-            try (Statement statement = connection.createStatement();
-                BufferedReader reader =
-                    new BufferedReader(
-                        new InputStreamReader(Objects.requireNonNull(scriptInputStream), UTF_8))) {
-              StringBuilder sqlBuffer = new StringBuilder();
-              String line;
-              while ((line = reader.readLine()) != null) {
-                line = line.trim();
-                if (!line.isEmpty() && !line.startsWith("--")) { // Ignore empty lines and comments
-                  sqlBuffer.append(line).append("\n");
-                  if (line.endsWith(";")) { // Execute statement when semicolon is found
-                    String sql = sqlBuffer.toString().trim();
-                    try {
-                      // since SQL is directly read from the file, there is close to 0 possibility
-                      // of this being injected plus this run via an Admin tool, if attacker can
-                      // fiddle with this that means lot of other things are already compromised.
-                      statement.execute(sql);
-                    } catch (SQLException e) {
-                      throw new RuntimeException(e);
-                    }
-                    sqlBuffer.setLength(0); // Clear the buffer for the next statement
+    runWithinTransaction(
+        connection -> {
+          try (Statement statement = connection.createStatement();
+              BufferedReader reader =
+                  new BufferedReader(
+                      new InputStreamReader(Objects.requireNonNull(scriptInputStream), UTF_8))) {
+            StringBuilder sqlBuffer = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+              line = line.trim();
+              if (!line.isEmpty() && !line.startsWith("--")) { // Ignore empty lines and comments
+                sqlBuffer.append(line).append("\n");
+                if (line.endsWith(";")) { // Execute statement when semicolon is found
+                  String sql = sqlBuffer.toString().trim();
+                  try {
+                    // since SQL is directly read from the file, there is close to 0 possibility
+                    // of this being injected plus this run via an Admin tool, if attacker can
+                    // fiddle with this that means lot of other things are already compromised.
+                    statement.execute(sql);
+                  } catch (SQLException e) {
+                    throw new RuntimeException(e);
                   }
+                  sqlBuffer.setLength(0); // Clear the buffer for the next statement
                 }
               }
-              return true;
-            } catch (IOException e) {
-              throw new RuntimeException(e);
             }
-          });
-    } finally {
-      try {
-        scriptInputStream.close();
-      } catch (IOException e) {
-        LOGGER.error("Failed to close input stream: {}", e.getMessage());
-      }
-    }
+            return true;
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
#1942 changed the way that the bootstrap init script is handled, but it added an extra `InputStream.close` call that shouldn't be needed after the BufferedReader [here](https://github.com/apache/polaris/pull/1942/files#diff-de43b240b5b5e07aba7e89f5515a417cefd908845b85432f3fcc0819911f3e2eR89) is closed. This PR removes that extra call.