### PR TITLE
Fix doc to remove outdated note about fine-grained access control support

### DIFF
--- a/site/content/in-dev/unreleased/access-control.md
+++ b/site/content/in-dev/unreleased/access-control.md
@@ -103,10 +103,6 @@ This section describes the privileges that are available in the Polaris access c
 roles are granted to principal roles, and principal roles are granted to service principals to specify the operations that service principals can
 perform on objects in Polaris.
 
-> [!IMPORTANT]
-> You can only grant privileges at the catalog level. Fine-grained access controls are not available. For example, you can grant read
-> privileges to all tables in a catalog but not to an individual table in the catalog.
-
 To grant the full set of privileges (drop, list, read, write, etc.) on an object, you can use the *full privilege* option.
 
 ### Table privileges


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
Minor update for the access control doc:

1. Remove the misleading section on privileges can only be granted at catalog level. I've tested the fine-grained access controls and confirmed that privileges can be applied to an individual table in the catalog.