### PR TITLE
Add new contributors

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,8 +73,8 @@ github:
 
   collaborators:
     # Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved
+    # Capped at 10 entries to prevent parser errors
     - renovate-bot
-    - nssalian
     - adnanhemani
     - HotSushi
     - rahil-c
@@ -84,7 +84,6 @@ github:
     - XJDKC
     - pavibhai
     - fabio-rizzo-01
-    - fivetran-ashokborra
 
 notifications:
   commits:      commits@polaris.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,6 +77,14 @@ github:
     - nssalian
     - adnanhemani
     - HotSushi
+    - rahil-c
+    - williamhyun
+    - poojanilangekar
+    - travis-bowen
+    - XJDKC
+    - pavibhai
+    - fabio-rizzo-01
+    - fivetran-ashokborra
 
 notifications:
   commits:      commits@polaris.apache.org


### PR DESCRIPTION
It's great to see a lot of new contributors. Add them to avoid manual triggering the github CI. 