### PR TITLE
Gradle: python code format/check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
   alias(libs.plugins.jetbrains.changelog)
   // workaround for https://github.com/kordamp/jandex-gradle-plugin/issues/25
   alias(libs.plugins.jandex) apply false
+  alias(libs.plugins.use.python)
 }
 
 val projectName = rootProject.file("ide-name.txt").readText().trim()
@@ -237,4 +238,23 @@ changelog {
     )
   )
   version.set(provider { project.version.toString() })
+}
+
+python {
+  installVirtualenv = true
+  pip("ruff:${libs.versions.ruff.get()}")
+}
+
+tasks.register<Exec>("ruffFormat") {
+  description = "Run ruff format for python code"
+
+  commandLine("/bin/bash", "-c", "./.gradle/python/bin/ruff format client/python")
+  dependsOn("pipInstall")
+}
+
+tasks.register<Exec>("ruffCheck") {
+  description = "Run ruff check for python code"
+
+  commandLine("/bin/bash", "-c", "./.gradle/python/bin/ruff check --fix client/python")
+  dependsOn("pipInstall")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ scala212 = "2.12.19"
 spark35 = "3.5.6"
 slf4j = "2.0.17"
 swagger = "1.6.16"
+ruff = "0.12.1"
 
 [bundles]
 
@@ -103,3 +104,4 @@ openapi-generator = { id = "org.openapi.generator", version = "7.12.0" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
 jetbrains-changelog = { id = "org.jetbrains.changelog",  version = "2.2.1"}
+use-python = { id = "ru.vyarus.use-python", version = "4.1.0" }


### PR DESCRIPTION
Here is a sample PR for enable python code format/check from conclusion derived from https://github.com/apache/polaris/pull/1954 (as it is a sample PR, I didn't update the doc as I would like to get more feedback from community first).

Now with this approach, I am using `use-python` module from gradle to setup `ruff` which later get uses for code check/format/auto-fix etc. Then based off `ruff`, I introduced two tasks within gradle for code check and code format. 

Here is the sample output from the two commands mentioned above that are newly added:
```
➜  polaris git:(gradle_python) ./gradlew ruffCheck
Configuration on demand is an incubating feature.

> Task :checkPython
Using python 3.9.6 from /Users/yong/Desktop/GitHome/polaris/.gradle/python (.gradle/python/bin/python)
Using pip 21.2.4 from /Users/yong/Desktop/GitHome/polaris/.gradle/python/lib/python3.9/site-packages/pip (python 3.9)

> Task :pipInstall
All required modules are already installed with correct versions
[python] .gradle/python/bin/python -m pip list --format=columns
         Package    Version
         ---------- -------
         pip        21.2.4
         ruff       0.12.1
         setuptools 58.0.4
         WARNING: You are using pip version 21.2.4; however, version 25.1.1 is available.
         You should consider upgrading via the '/Users/yong/Desktop/GitHome/polaris/.gradle/python/bin/python -m pip install --upgrade pip' command.

> Task :ruffCheck
All checks passed!

[Incubating] Problems report is available at: file:///Users/yong/Desktop/GitHome/polaris/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 2s
12 actionable tasks: 3 executed, 9 up-to-date
➜  polaris git:(gradle_python) ./gradlew ruffFormat
Configuration on demand is an incubating feature.

> Task :checkPython
Using python 3.9.6 from /Users/yong/Desktop/GitHome/polaris/.gradle/python (.gradle/python/bin/python)
Using pip 21.2.4 from /Users/yong/Desktop/GitHome/polaris/.gradle/python/lib/python3.9/site-packages/pip (python 3.9)

> Task :pipInstall
All required modules are already installed with correct versions
[python] .gradle/python/bin/python -m pip list --format=columns
         Package    Version
         ---------- -------
         pip        21.2.4
         ruff       0.12.1
         setuptools 58.0.4
         WARNING: You are using pip version 21.2.4; however, version 25.1.1 is available.
         You should consider upgrading via the '/Users/yong/Desktop/GitHome/polaris/.gradle/python/bin/python -m pip install --upgrade pip' command.

> Task :ruffFormat
17 files left unchanged

[Incubating] Problems report is available at: file:///Users/yong/Desktop/GitHome/polaris/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1s
12 actionable tasks: 3 executed, 9 up-to-date
➜  polaris git:(gradle_python)
```


Here are the concerns/questions on my end:
1. there doesn't appear to be a well maintain python module for gradle (pygradle from LinkedIn has no new release since 2020 and the one I am using only have 6 developers and last release is end of 2024) 
2. from the Makefile created for python module (https://github.com/apache/polaris/blob/main/client/python/Makefile#L34), there appear to be some effort went in around python code base. Does it makes more sense to move away from gradle for python code base and use Makefile route instead? 

@eric-maynard @HonahX 