### PR TITLE
fix: Remove runtime-immutable db kind configuration from Helm chart

### DIFF
--- a/helm/polaris/ci/persistence-values.yaml
+++ b/helm/polaris/ci/persistence-values.yaml
@@ -35,6 +35,5 @@ logging:
 persistence:
   type: relational-jdbc
   relationalJdbc:
-    dbKind: postgres
     secret:
       name: polaris-persistence

--- a/helm/polaris/templates/configmap.yaml
+++ b/helm/polaris/templates/configmap.yaml
@@ -53,11 +53,6 @@ data:
     {{- $_ = set $map "polaris.persistence.eclipselink.persistence-unit" .Values.persistence.eclipseLink.persistenceUnit -}}
     {{- $_ = set $map "polaris.persistence.eclipselink.configuration-file" (printf "%s/persistence.xml" .Values.image.configDir ) -}}
     {{- end -}}
-    {{- if eq .Values.persistence.type "relational-jdbc" -}}
-    {{- if .Values.persistence.relationalJdbc.dbKind -}}
-    {{- $_ = set $map "quarkus.datasource.db-kind" .Values.persistence.relationalJdbc.dbKind -}}
-    {{- end -}}
-    {{- end -}}
 
     {{- /* File IO */ -}}
     {{- $_ = set $map "polaris.file-io.type" .Values.fileIo.type -}}

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -1022,7 +1022,7 @@ tests:
 
   - it: should set relational-jdbc persistence environment variables
     set:
-      persistence: { type: "relational-jdbc", dbKind: postgres, relationalJdbc: { secret: { name: "polaris-persistence" } } }
+      persistence: { type: "relational-jdbc", relationalJdbc: { secret: { name: "polaris-persistence" } } }
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -526,8 +526,6 @@ persistence:
   type: in-memory  # relational-jdbc
   # -- The configuration for the relational-jdbc persistence manager.
   relationalJdbc:
-    # -- The type of database to use. Valid values are: h2, postgres.
-    dbKind: postgres  # h2
     # -- The secret name to pull the database connection properties from.
     secret:
       # -- The secret name to pull the database connection properties from.


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Through documentation review and testing, I confirmed that the **db-kind** is determined at build time and cannot be modified at runtime. 

To prevent user confusion, this PR removes the db kind configuration option from the Helm chart since it cannot be set during runtime deployment.

This change improves the user experience by eliminating a non-functional configuration parameter that could mislead users into thinking they can change the database kind after deployment.