### PR TITLE
Materialize Realm ID for Session Supplier in JDBC

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -99,6 +99,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       DatasourceOperations datasourceOperations,
       RealmContext realmContext,
       RootCredentialsSet rootCredentialsSet) {
+    // Materialize realmId so that background tasks that don't have an active
+    // RealmContext (request-scoped bean) can still create a JdbcBasePersistenceImpl
     String realmId = realmContext.getRealmIdentifier();
     sessionSupplierMap.put(
         realmId,


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

As a continuation of the conversation in #1765, I've reduced the scope of the PR to be solved only for JDBC as a quick workaround. Technically, the `MetastoreManagerFactory` does not imply anything about the implementation of the interface, so I take this decision to materialize the RealmIds as an implementation detail of the JDBC integration.

A quick reproduction of the original issue and the proof that this solves that issue can be found [here](https://github.com/apache/polaris/pull/1765#issuecomment-2942620712).

---

#### Background

It was discovered that the Session Supplier maps used in the `MetaStoreManagerFactory` implementations were passing in `RealmContext` objects to the supplier directly and then using the `RealmContext` objects to create `BasePersistence` implementation objects within the supplier. This supplier is cached on a per-realm basis in most `MetaStoreManagerFactory` implementations. `RealmContext` objects are request-scoped beans.

As a result, if any work is being done outside the scope of the request, such as during a Task, any calls to `getOrCreateSessionSupplier` for creating a `BasePersistence` implementation will fail as the `RealmContext` object is no longer available.

This PR will ensure for the `JdbcMetaStoreManagerFactory` that the Realm ID is materialized from the `RealmContext` and used inside the supplier so that the potentially deactivated `RealmContext` object does not need to be used in creating the BasePersistence object. Given that we are caching on a per-realm basis, this should not introduce any unforeseen behavior for the `JdbcMetaStoreManagerFactory` as the Realm ID must match exactly for the same supplier to be returned from the Session Supplier map.