### PR TITLE
Improve createPrincipal example in API docs

### DIFF
--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -157,6 +157,12 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreatePrincipalRequest"
+          example:
+            principal:
+              name: "alice"
+              properties:
+                department: "engineering"
+            credentialRotationRequired: falseg
       responses:
         201:
           description: "Successful response"

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -157,12 +157,12 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreatePrincipalRequest"
-          example:
-            principal:
-              name: "alice"
-              properties:
-                department: "engineering"
-            credentialRotationRequired: falseg
+              example:
+                principal:
+                  name: "alice"
+                  properties:
+                    department: "engineering"
+                credentialRotationRequired: false
       responses:
         201:
           description: "Successful response"


### PR DESCRIPTION
In #1929 it was pointed out that the example in the Polaris docs suggests that users can provide a client ID during principal creation:

![image](https://github.com/user-attachments/assets/5712ff56-f6a7-4580-b705-d44471e7d0a1)

This PR attempts to fix this by adding an explicit example to the spec.