### PR TITLE
Update CatalogEntity::Builder to set default CatalogType as INTERNAL

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -106,17 +106,8 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
         CatalogProperties.builder(propertiesMap.get(DEFAULT_BASE_LOCATION_KEY))
             .putAll(propertiesMap)
             .build();
-    return catalogType == Catalog.TypeEnum.INTERNAL
-        ? PolarisCatalog.builder()
-            .setType(Catalog.TypeEnum.INTERNAL)
-            .setName(getName())
-            .setProperties(catalogProps)
-            .setCreateTimestamp(getCreateTimestamp())
-            .setLastUpdateTimestamp(getLastUpdateTimestamp())
-            .setEntityVersion(getEntityVersion())
-            .setStorageConfigInfo(getStorageInfo(internalProperties))
-            .build()
-        : ExternalCatalog.builder()
+    return catalogType == Catalog.TypeEnum.EXTERNAL
+        ? ExternalCatalog.builder()
             .setType(Catalog.TypeEnum.EXTERNAL)
             .setName(getName())
             .setProperties(catalogProps)
@@ -125,6 +116,15 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setEntityVersion(getEntityVersion())
             .setStorageConfigInfo(getStorageInfo(internalProperties))
             .setConnectionConfigInfo(getConnectionInfo(internalProperties))
+            .build()
+        : PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(getName())
+            .setProperties(catalogProps)
+            .setCreateTimestamp(getCreateTimestamp())
+            .setLastUpdateTimestamp(getLastUpdateTimestamp())
+            .setEntityVersion(getEntityVersion())
+            .setStorageConfigInfo(getStorageInfo(internalProperties))
             .build();
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
@@ -266,4 +266,72 @@ public class CatalogEntityTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);
   }
+
+  @Test
+  public void testCatalogTypeDefaultsToInternal() {
+    String baseLocation = "s3://test-bucket/path";
+    AwsStorageConfigInfo storageConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::012345678901:role/test-role")
+            .setExternalId("externalId")
+            .setUserArn("aws::a:user:arn")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of(baseLocation))
+            .build();
+    CatalogEntity catalogEntity =
+        new CatalogEntity.Builder()
+            .setName("test-catalog")
+            .setDefaultBaseLocation(baseLocation)
+            .setStorageConfigurationInfo(callContext, storageConfigModel, baseLocation)
+            .build();
+
+    Catalog catalog = catalogEntity.asCatalog();
+    Assertions.assertThat(catalog.getType()).isEqualTo(Catalog.TypeEnum.INTERNAL);
+  }
+
+  @Test
+  public void testCatalogTypeExternalPreserved() {
+    String baseLocation = "s3://test-bucket/path";
+    AwsStorageConfigInfo storageConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::012345678901:role/test-role")
+            .setExternalId("externalId")
+            .setUserArn("aws::a:user:arn")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of(baseLocation))
+            .build();
+    CatalogEntity catalogEntity =
+        new CatalogEntity.Builder()
+            .setName("test-external-catalog")
+            .setDefaultBaseLocation(baseLocation)
+            .setCatalogType(Catalog.TypeEnum.EXTERNAL.name())
+            .setStorageConfigurationInfo(callContext, storageConfigModel, baseLocation)
+            .build();
+
+    Catalog catalog = catalogEntity.asCatalog();
+    Assertions.assertThat(catalog.getType()).isEqualTo(Catalog.TypeEnum.EXTERNAL);
+  }
+
+  @Test
+  public void testCatalogTypeInternalExplicitlySet() {
+    String baseLocation = "s3://test-bucket/path";
+    AwsStorageConfigInfo storageConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::012345678901:role/test-role")
+            .setExternalId("externalId")
+            .setUserArn("aws::a:user:arn")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of(baseLocation))
+            .build();
+    CatalogEntity catalogEntity =
+        new CatalogEntity.Builder()
+            .setName("test-internal-catalog")
+            .setDefaultBaseLocation(baseLocation)
+            .setCatalogType(Catalog.TypeEnum.INTERNAL.name())
+            .setStorageConfigurationInfo(callContext, storageConfigModel, baseLocation)
+            .build();
+
+    Catalog catalog = catalogEntity.asCatalog();
+    Assertions.assertThat(catalog.getType()).isEqualTo(Catalog.TypeEnum.INTERNAL);
+  }
 }


### PR DESCRIPTION
Encountered the issue while adding additional validations to `ExternalCatalog`. The `CatalogEntity::Builder` checks if the `Catalog::type` is set to `INTERNAL`, if not it defaults to `EXTERNAL`. However this is the opposite of the behavior defined in polaris-management-service.yml where the default is set to `INTERNAL`. This change only affects tests because in other cases the catalog entity is generated from the REST request.  

Testing:
Updated CatalogEntityTest to ensure that the default is set to `INTERNAL`. 