### PR TITLE
Ignore regenerate.sh on README.md

### DIFF
--- a/client/templates/regenerate.sh
+++ b/client/templates/regenerate.sh
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-set -e 
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pushd "$SCRIPT_DIR/../python" > /dev/null
@@ -139,6 +139,7 @@ EXCLUDE_PATHS=(
   "./poetry.lock"
   "./docker-compose.yml"
   "./.pre-commit-config.yaml"
+  "./README.md"
 )
 
 EXCLUDE_EXTENSIONS=(
@@ -161,7 +162,7 @@ find . -type f | while read -r file; do
         extension_excluded=true
       fi
     done
-    
+
     # Skip this file if its extension is excluded
     if [ "$extension_excluded" = true ]; then
       echo "${file}: skipped"
@@ -182,7 +183,7 @@ find . -type f | while read -r file; do
       if [ "$exclude" = false ]; then
         # Construct the header file path
         header_file="${SCRIPT_DIR}/header-${ext}.txt"
-      
+
         # Only process if the license file exists
         if [ -f "$header_file" ]; then
           echo "${file}: updated"
@@ -212,4 +213,3 @@ echo "Deletion complete"
 echo "Regeneration complete"
 
 popd > /dev/null
-


### PR DESCRIPTION
Currently if an end-user try to rerun `regenerate.sh` (as part of polaris repair or OpenAPI code regen, it will keep adding new headers to the existed README.nd. As this file is not part of the template, update the list to exclude this file.