### PR TITLE
Publish helm doc to hugo site

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -1,21 +1,26 @@
-<!---
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+Title: Polaris Helm Chart
+type: docs
+weight: 675
+---
 
 <!---
   This README.md file was generated with:
@@ -24,8 +29,6 @@
   To re-generate the README.md file, install helm-docs then run from the repo root:
   helm-docs --chart-search-root=helm
 -->
-
-# Polaris Helm chart
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0-incubating-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.0.0--incubating--SNAPSHOT-informational?style=flat-square)
 

--- a/helm/polaris/README.md.gotmpl
+++ b/helm/polaris/README.md.gotmpl
@@ -1,21 +1,26 @@
-<!---
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+Title: Polaris Helm Chart
+type: docs
+weight: 675
+---
 
 <!---
   This README.md file was generated with:
@@ -24,8 +29,6 @@
   To re-generate the README.md file, install helm-docs then run from the repo root:
   helm-docs --chart-search-root=helm
 -->
-
-# Polaris Helm chart
 
 {{ template "chart.deprecationWarning" . }}
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -217,6 +217,15 @@ module:
     - path: github.com/google/docsy
       # Pin to this release, newer releases _might_ break the customized layouts
       version: v0.10.0
+  mounts:
+    # Keep project's own content explicitly mounted
+    - source: content
+      target: content
+    # Mount from ../../polaris/helm/polaris into the virtual content/in-dev/unreleased/helm path
+    - source: ../../polaris/helm/polaris
+      target: content/in-dev/unreleased/helm
+      excludeFiles: ["**"]
+      includeFiles: ["README.md"]
 
 outputs:
   section:


### PR DESCRIPTION
The challenge with publishing helm doc to hugo site is the helm doc is outside of the `content` dir used by hugo (quick test with symbolic link doesn't appear to be working and hugo doesn't read the content from symbolic link). Thus, I am using `mounts` option from hugo to mount the current `content` into a `virtual content` then mount the relative path from helm chart README.md into the same `virtual  content` but one directory under. By doing so, hugo is able to read this file without us duplicating the file.

One problem I see with this route is if we need to promo the current `unreleased` doc into `<version>` doc, we will need to duplicate the mounts entry such as following to allow same doc be read-able from both versions:
```
    # Mount from ../../polaris/helm/polaris into the virtual content/in-dev/unreleased/helm path
    - source: ../../polaris/helm/polaris
      target: content/in-dev/unreleased/helm
      excludeFiles: ["**"]
      includeFiles: ["README.md"]
    # Mount from ../../polaris/helm/polaris into the virtual content/in-dev/1.0.0/helm path
    - source: ../../polaris/helm/polaris
      target: content/in-dev/1.0.0/helm
      excludeFiles: ["**"]
      includeFiles: ["README.md"]
```

Also, as now we are trying to read chart's README file as web page, I had removed header as it will show duplicate header if we do so. Here is the rendered page with this solution:
![image](https://github.com/user-attachments/assets/c4632515-6006-489a-a460-363f66eb35f2)

