### PR TITLE
Cleanup collaborators in `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -72,11 +72,9 @@ github:
   ghp_path: /
 
   collaborators:
-    # Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved
+    # Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved.
+    # The list of collaborators is limited to 10 elements.
     - renovate-bot
-    - nssalian
-    - adnanhemani
-    - HotSushi
 
 notifications:
   commits:      commits@polaris.apache.org


### PR DESCRIPTION
Some devs were added in the past to `.asf.yaml` to let CI run w/o committer approval. After [INFRA-26985](https://issues.apache.org/jira/browse/INFRA-26985) this is no longer necessary, so the file can be cleaned up.