### PR TITLE
Use PolarisImmutable for StorageCredentialCacheKey

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -128,7 +128,7 @@ public class StorageCredentialCache {
               credentialVendor.getSubscopedCredsForEntity(
                   callCtx,
                   k.getCatalogId(),
-                  k.getEntityId(),
+                  polarisEntity.getId(),
                   polarisEntity.getType(),
                   k.isAllowedListAction(),
                   k.getAllowedReadLocations(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -114,7 +114,7 @@ public class StorageCredentialCache {
           .fail("entity_type_not_suppported_to_scope_creds", "type={}", polarisEntity.getType());
     }
     StorageCredentialCacheKey key =
-        new StorageCredentialCacheKey(
+        StorageCredentialCacheKey.of(
             callCtx.getRealmContext().getRealmIdentifier(),
             polarisEntity,
             allowListOperation,
@@ -127,12 +127,12 @@ public class StorageCredentialCache {
           ScopedCredentialsResult scopedCredentialsResult =
               credentialVendor.getSubscopedCredsForEntity(
                   callCtx,
-                  k.getCatalogId(),
+                  k.catalogId(),
                   polarisEntity.getId(),
                   polarisEntity.getType(),
-                  k.isAllowedListAction(),
-                  k.getAllowedReadLocations(),
-                  k.getAllowedWriteLocations());
+                  k.allowedListAction(),
+                  k.allowedReadLocations(),
+                  k.allowedWriteLocations());
           if (scopedCredentialsResult.isSuccess()) {
             long maxCacheDurationMs = maxCacheDurationMs(callCtx.getRealmConfig());
             return new StorageCredentialCacheEntry(scopedCredentialsResult, maxCacheDurationMs);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
@@ -23,21 +23,28 @@ import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
 @PolarisImmutable
 public interface StorageCredentialCacheKey {
 
+  @Value.Parameter(order = 1)
   String realmId();
 
+  @Value.Parameter(order = 2)
   long catalogId();
 
+  @Value.Parameter(order = 3)
   @Nullable
   String storageConfigSerializedStr();
 
+  @Value.Parameter(order = 4)
   boolean allowedListAction();
 
+  @Value.Parameter(order = 5)
   Set<String> allowedReadLocations();
 
+  @Value.Parameter(order = 6)
   Set<String> allowedWriteLocations();
 
   static StorageCredentialCacheKey of(
@@ -50,13 +57,12 @@ public interface StorageCredentialCacheKey {
         entity
             .getInternalPropertiesAsMap()
             .get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
-    return ImmutableStorageCredentialCacheKey.builder()
-        .realmId(realmId)
-        .catalogId(entity.getCatalogId())
-        .storageConfigSerializedStr(storageConfigSerializedStr)
-        .allowedListAction(allowedListAction)
-        .allowedReadLocations(allowedReadLocations)
-        .allowedWriteLocations(allowedWriteLocations)
-        .build();
+    return ImmutableStorageCredentialCacheKey.of(
+        realmId,
+        entity.getCatalogId(),
+        storageConfigSerializedStr,
+        allowedListAction,
+        allowedReadLocations,
+        allowedWriteLocations);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
@@ -23,19 +23,13 @@ import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 
-public class StorageCredentialCacheKey {
+public final class StorageCredentialCacheKey {
 
   private final String realmId;
   private final long catalogId;
 
   /** The serialized string of the storage config. */
   private final String storageConfigSerializedStr;
-
-  /**
-   * The entity id is passed to be used to fetch subscoped creds, but is not used to do hash/equals
-   * as part of the cache key.
-   */
-  private final long entityId;
 
   private final boolean allowedListAction;
   private final Set<String> allowedReadLocations;
@@ -54,7 +48,6 @@ public class StorageCredentialCacheKey {
         entity
             .getInternalPropertiesAsMap()
             .get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
-    this.entityId = entity.getId();
     this.allowedListAction = allowedListAction;
     this.allowedReadLocations = allowedReadLocations;
     this.allowedWriteLocations = allowedWriteLocations;
@@ -70,10 +63,6 @@ public class StorageCredentialCacheKey {
 
   public String getStorageConfigSerializedStr() {
     return storageConfigSerializedStr;
-  }
-
-  public long getEntityId() {
-    return entityId;
   }
 
   public boolean isAllowedListAction() {
@@ -122,8 +111,6 @@ public class StorageCredentialCacheKey {
         + ", storageConfigSerializedStr='"
         + storageConfigSerializedStr
         + '\''
-        + ", entityId="
-        + entityId
         + ", allowedListAction="
         + allowedListAction
         + ", allowedReadLocations="

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
@@ -18,105 +18,45 @@
  */
 package org.apache.polaris.core.storage.cache;
 
-import java.util.Objects;
+import jakarta.annotation.Nullable;
 import java.util.Set;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.immutables.PolarisImmutable;
 
-public final class StorageCredentialCacheKey {
+@PolarisImmutable
+public interface StorageCredentialCacheKey {
 
-  private final String realmId;
-  private final long catalogId;
+  String realmId();
 
-  /** The serialized string of the storage config. */
-  private final String storageConfigSerializedStr;
+  long catalogId();
 
-  private final boolean allowedListAction;
-  private final Set<String> allowedReadLocations;
+  @Nullable
+  String storageConfigSerializedStr();
 
-  private final Set<String> allowedWriteLocations;
+  boolean allowedListAction();
 
-  public StorageCredentialCacheKey(
+  Set<String> allowedReadLocations();
+
+  Set<String> allowedWriteLocations();
+
+  static StorageCredentialCacheKey of(
       String realmId,
       PolarisEntity entity,
       boolean allowedListAction,
       Set<String> allowedReadLocations,
       Set<String> allowedWriteLocations) {
-    this.realmId = realmId;
-    this.catalogId = entity.getCatalogId();
-    this.storageConfigSerializedStr =
+    String storageConfigSerializedStr =
         entity
             .getInternalPropertiesAsMap()
             .get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
-    this.allowedListAction = allowedListAction;
-    this.allowedReadLocations = allowedReadLocations;
-    this.allowedWriteLocations = allowedWriteLocations;
-  }
-
-  public String getRealmId() {
-    return realmId;
-  }
-
-  public long getCatalogId() {
-    return catalogId;
-  }
-
-  public String getStorageConfigSerializedStr() {
-    return storageConfigSerializedStr;
-  }
-
-  public boolean isAllowedListAction() {
-    return allowedListAction;
-  }
-
-  public Set<String> getAllowedReadLocations() {
-    return allowedReadLocations;
-  }
-
-  public Set<String> getAllowedWriteLocations() {
-    return allowedWriteLocations;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    StorageCredentialCacheKey cacheKey = (StorageCredentialCacheKey) o;
-    return Objects.equals(realmId, cacheKey.getRealmId())
-        && catalogId == cacheKey.getCatalogId()
-        && Objects.equals(storageConfigSerializedStr, cacheKey.getStorageConfigSerializedStr())
-        && allowedListAction == cacheKey.allowedListAction
-        && Objects.equals(allowedReadLocations, cacheKey.allowedReadLocations)
-        && Objects.equals(allowedWriteLocations, cacheKey.allowedWriteLocations);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        realmId,
-        catalogId,
-        storageConfigSerializedStr,
-        allowedListAction,
-        allowedReadLocations,
-        allowedWriteLocations);
-  }
-
-  @Override
-  public String toString() {
-    return "StorageCredentialCacheKey{"
-        + "realmId="
-        + realmId
-        + ", catalogId="
-        + catalogId
-        + ", storageConfigSerializedStr='"
-        + storageConfigSerializedStr
-        + '\''
-        + ", allowedListAction="
-        + allowedListAction
-        + ", allowedReadLocations="
-        + allowedReadLocations
-        + ", allowedWriteLocations="
-        + allowedWriteLocations
-        + '}';
+    return ImmutableStorageCredentialCacheKey.builder()
+        .realmId(realmId)
+        .catalogId(entity.getCatalogId())
+        .storageConfigSerializedStr(storageConfigSerializedStr)
+        .allowedListAction(allowedListAction)
+        .allowedReadLocations(allowedReadLocations)
+        .allowedWriteLocations(allowedWriteLocations)
+        .build();
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -177,7 +177,7 @@ public class StorageCredentialCacheTest {
             1, 2, PolarisEntityType.CATALOG, PolarisEntitySubType.ICEBERG_TABLE, 0, "name");
     PolarisEntity polarisEntity = new PolarisEntity(baseEntity);
     StorageCredentialCacheKey cacheKey =
-        new StorageCredentialCacheKey(
+        StorageCredentialCacheKey.of(
             callCtx.getRealmContext().getRealmIdentifier(),
             polarisEntity,
             true,


### PR DESCRIPTION
note that `entityId` was not part of the `equals`/`hashCode` and thus did not need to be a field