### PR TITLE
Site: Remove non-OSS query engines from front page

### DIFF
--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -23,7 +23,7 @@ cascade:
   no_list: true
 ---
 {{< blocks/cover title="Welcome to the Apache Polaris™ (incubating) web site!" image_anchor="center" color="primary" >}}
-Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. It implements Iceberg's REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™, Dremio®, StarRocks, and Trino.
+Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. It implements Iceberg's REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™, StarRocks, and Trino.
 
 <a href="/in-dev/unreleased/getting-started/install-dependencies/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
 


### PR DESCRIPTION
I noticed that a non-OSS query engine is included on the front page. It doesn't feel right to include commercial offerings front and center.

As a solution, I suggest that we remove the mention, focus on OSS engines here, and, perhaps, add a different page in the future to include vendors.