### PR TITLE
Update release-guide.md for release dir name

### DIFF
--- a/site/content/release-guide.md
+++ b/site/content/release-guide.md
@@ -185,11 +185,11 @@ Now, we can stage the artifacts to dist dev repository:
 ```
 svn co https://dist.apache.org/repos/dist/dev/incubator/polaris polaris-dist-dev
 cd polaris-dist-dev
-mkdir apache-polaris-x.y.z
-cp /path/to/polaris/github/clone/repo/build/distribution/* apache-polaris-x.y.z
-cp /path/to/polaris/github/clone/repo/runtime/distribution/build/distributions/* apache-polaris-x.y.z
+mkdir x.y.z
+cp /path/to/polaris/github/clone/repo/build/distribution/* x.y.z
+cp /path/to/polaris/github/clone/repo/runtime/distribution/build/distributions/* x.y.z
 cp -r /path/to/polaris/github/clone/repo/helm/polaris helm-chart/x.y.z 
-svn add apache-polaris-x.y.z
+svn add x.y.z
 svn add helm-chart/x.y.z
 svn commit -m"Stage Apache Polaris x.y.z RCx"
 ```
@@ -235,7 +235,7 @@ Apache Polaris x.y.z release.
 * https://github.com/apache/polaris/tree/<SHA1>
 
 The release tarball, signature, and checksums are here:
-* https://dist.apache.org/repos/dist/dev/incubator/polaris/apache-polaris-x.y.z
+* https://dist.apache.org/repos/dist/dev/incubator/polaris/x.y.z
 
 Helm charts are available on:
 * https://dist.apache.org/repos/dist/dev/incubator/polaris/helm-chart
@@ -308,7 +308,7 @@ Vote result thread:
 * https://lists.apache.org/thread/<VOTE RESULT>
 
 The release candidate:
-* https://dist.apache.org/repos/dist/dev/incubator/polaris/apache-polaris-x.y.z
+* https://dist.apache.org/repos/dist/dev/incubator/polaris/x.y.z
 
 Git tag for the release:
 * https://github.com/apache/polaris/releases/tag/apache-polaris-x.y.z-rci
@@ -362,7 +362,7 @@ After the release votes passed, you need to release the last candidate's artifac
 First, copy the distribution from the dist dev space to the dist release space:
 
 ```
-svn mv https://dist.apache.org/repos/dist/dev/incubator/polaris/apache-polaris-x.y.z https://dist.apache.org/repos/dist/release/incubator/polaris
+svn mv https://dist.apache.org/repos/dist/dev/incubator/polaris/x.y.z https://dist.apache.org/repos/dist/release/incubator/polaris
 svn mv https://dist.apache.org/repos/dist/dev/incubator/polaris/helm-chart/x.y.z https://dist.apache.org/repos/dist/release/incubator/polaris/helm-chart
 ```
 


### PR DESCRIPTION
This PR changes the release dir name from `apache-polaris-x.y.z` to `x.y.z` to be consistent with the historical releases. Either name is fine, the intent is to make sure they are consistent. 

<img width="521" height="258" alt="Screenshot 2025-07-11 at 3 14 15 PM" src="https://github.com/user-attachments/assets/40fc1401-3a7d-4c7b-b0f1-ed7a22dd2f7c" />
