### PR TITLE
Fix invalid redirect from public page

### DIFF
--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -25,7 +25,7 @@ cascade:
 {{< blocks/cover title="Welcome to the Apache Polaris™ (incubating) web site!" image_anchor="center" color="primary" >}}
 Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. It implements Iceberg's REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™, Dremio®, StarRocks, and Trino.
 
-<a href="/in-dev/unreleased/getting-started/install-dependencies/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
+<a href="/in-dev/getting-started/install-dependencies/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
 
 {{< /blocks/cover >}}
 


### PR DESCRIPTION
The "Get Started" page from the public site is now referring to a invalid page:
<img width="2558" height="945" alt="image" src="https://github.com/user-attachments/assets/b924dc0a-ec6b-4ba0-9e37-317a389a2ce7" />
which will cause 404 as following:
<img width="2558" height="214" alt="image" src="https://github.com/user-attachments/assets/693f6aae-30a4-4b8e-a02e-4a4bb72eb36d" />

This is due to the redirect page is https://polaris.apache.org/in-dev/unreleased/getting-started/install-dependencies/ (used to be valid). But with recent page the new url is https://polaris.apache.org/in-dev/getting-started/install-dependencies/ (removed of `unreleased`)