### PR TITLE
Fix CI (no 2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,3 +238,11 @@ changelog {
   )
   version.set(provider { project.version.toString() })
 }
+
+tasks.register("showVersion") {
+  actions.add {
+    logger.lifecycle(
+      "Polaris version is ${project.file("version.txt").readText(Charsets.UTF_8).trim()}"
+    )
+  }
+}


### PR DESCRIPTION
The newly added `store-gradle-cache` CI job has run some Gradle task to trigger Gradle's automatic cache cleanup. In the source project Nessie we used a simple task `showVersion` to do this. As having this task in Polaris might be useful, adding this task as there's no other suitable task (cheap and not generating much output) seems legit.
