### PR TITLE
Unify RealmEntityManagerFactory usage in tests

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -56,17 +56,14 @@ import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
-import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandler;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
-import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
 import org.apache.polaris.service.context.catalog.PolarisCallContextCatalogFactory;
 import org.apache.polaris.service.http.IfNoneMatch;
@@ -1791,12 +1788,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
 
     PolarisCallContextCatalogFactory factory =
         new PolarisCallContextCatalogFactory(
-            new RealmEntityManagerFactory(null, null, null) {
-              @Override
-              public PolarisEntityManager getOrCreateEntityManager(RealmContext realmContext) {
-                return entityManager;
-              }
-            },
+            realmEntityManagerFactory,
             managerFactory,
             userSecretsManagerFactory,
             Mockito.mock(),

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -251,6 +251,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
   private PolarisCallContext polarisContext;
   private PolarisAdminService adminService;
   private StorageCredentialCache storageCredentialCache;
+  private RealmEntityManagerFactory realmEntityManagerFactory;
   private PolarisEntityManager entityManager;
   private FileIOFactory fileIOFactory;
   private InMemoryFileIO fileIO;
@@ -356,7 +357,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
                     .build()
                     .asCatalog()));
 
-    RealmEntityManagerFactory realmEntityManagerFactory =
+    realmEntityManagerFactory =
         new RealmEntityManagerFactory(
             metaStoreManagerFactory, configurationStore, storageCredentialCache);
     this.fileIOFactory =
@@ -990,11 +991,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new PolarisPassthroughResolutionView(
             polarisContext, entityManager, securityContext, catalog().name());
     FileIOFactory fileIOFactory =
-        spy(
-            new DefaultFileIOFactory(
-                new RealmEntityManagerFactory(
-                    metaStoreManagerFactory, configurationStore, storageCredentialCache),
-                metaStoreManagerFactory));
+        spy(new DefaultFileIOFactory(realmEntityManagerFactory, metaStoreManagerFactory));
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
@@ -1883,10 +1880,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         .containsEntry(StorageAccessProperty.AWS_TOKEN, SESSION_TOKEN);
     FileIO fileIO =
         new TaskFileIOSupplier(
-                new DefaultFileIOFactory(
-                    new RealmEntityManagerFactory(
-                        metaStoreManagerFactory, configurationStore, storageCredentialCache),
-                    metaStoreManagerFactory))
+                new DefaultFileIOFactory(realmEntityManagerFactory, metaStoreManagerFactory))
             .apply(taskEntity, polarisContext);
     Assertions.assertThat(fileIO).isNotNull().isInstanceOf(ExceptionMappingFileIO.class);
     Assertions.assertThat(((ExceptionMappingFileIO) fileIO).getInnerIo())
@@ -2028,10 +2022,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
             polarisContext, entityManager, securityContext, CATALOG_NAME);
 
     MeasuredFileIOFactory measured =
-        new MeasuredFileIOFactory(
-            new RealmEntityManagerFactory(
-                metaStoreManagerFactory, configurationStore, storageCredentialCache),
-            metaStoreManagerFactory);
+        new MeasuredFileIOFactory(realmEntityManagerFactory, metaStoreManagerFactory);
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -238,11 +238,11 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             polarisContext, entityManager, securityContext, CATALOG_NAME);
+    RealmEntityManagerFactory realmEntityManagerFactory =
+        new RealmEntityManagerFactory(
+            metaStoreManagerFactory, configurationStore, storageCredentialCache);
     FileIOFactory fileIOFactory =
-        new DefaultFileIOFactory(
-            new RealmEntityManagerFactory(
-                metaStoreManagerFactory, configurationStore, storageCredentialCache),
-            metaStoreManagerFactory);
+        new DefaultFileIOFactory(realmEntityManagerFactory, metaStoreManagerFactory);
 
     testPolarisEventListener = (TestPolarisEventListener) polarisEventListener;
     this.catalog =


### PR DESCRIPTION
since all ctor params are created in `IcebergCatalogTest.before` we can do the same for `RealmEntityManagerFactory`

`PolarisAuthzTestBase.entityManager` was already getting derived from `realmEntityManagerFactory` here:
https://github.com/apache/polaris/blob/2c2052c28f899aaa85e5f11a9131d9812ec62679/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java#L247