### PR TITLE
Attempt to make Renovate work again

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,9 +30,10 @@
 
   // Added for posterity how to let Renovate manage version-branches, assuming that release branches
   // have the `release/` prefix.
+  // BE CAREFUL WITH THIS OPTION and make sure that the changes work.
   baseBranches: [
     "main",
-    "/^release\\/1[.].*",
+    "release/1.0.x",
   ],
   additionalBranchPrefix: "{{baseBranch}}/",
   commitMessagePrefix: "{{baseBranch}}: ",


### PR DESCRIPTION
Looks that I accidentally broke Renovate with #1891. This was made under the impression of the [Renovate change to support `baseBranches` in forking-renovate] (https://github.com/renovatebot/renovate/pull/36054). However, a [later Renovate change](https://github.com/renovatebot/renovate/pull/35579)  seems to break that.

The plan here is to:
1. remove the regex from our `baseBranches` option - if that doesn't work then
2. just use the default branch

Relevant [renovate issue](https://github.com/renovatebot/renovate/issues/28700#issuecomment-3073312040)
