### PR TITLE
Renovate PRs, branch name + PR subject

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,8 +35,6 @@
     "main",
     "release/1.0.x",
   ],
-  additionalBranchPrefix: "{{baseBranch}}/",
-  commitMessagePrefix: "{{baseBranch}}: ",
 
   pip_requirements: {
     // fileMatch default: (^|/)([\\w-]*)requirements\\.(txt|pip)$


### PR DESCRIPTION
Until June, Renovate PRs behaved a little bit different than today. The difference is the branch name. Before it was something like `renovate-bot/renovate/main/org.openapi.generator-7.x`, now it's like `renovate-bot/renovate/main-main/actions-stale-digest` (branch name is duplicated).

I also noticed that the branch name is repeated in the PR subject, which started to be that way some longer ago.

This change removes both duplications.