### PR TITLE
Disable renovatebot on release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,13 +79,6 @@
         "io.quarkus:io.quarkus.gradle.plugin",
       ],
     },
-
-    // Turn off major & minor version updates on version-branches
-    {
-      matchBaseBranches: ["/^release/.*/"],
-      matchUpdateTypes: ["major", "minor"],
-      enabled: false
-    },
   ],
 
   // Max 50 PRs in total, 5 per hour.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,6 @@
   // BE CAREFUL WITH THIS OPTION and make sure that the changes work.
   baseBranches: [
     "main",
-    "release/1.0.x",
   ],
   additionalBranchPrefix: "{{baseBranch}}/",
   commitMessagePrefix: "{{baseBranch}}: ",


### PR DESCRIPTION
Per the mailing list thread "[DISCUSS] Disable renovatebot on release branches", we should not do automatic dependency upgrades for release branches. Since it seems `release/1.0.x` is a release branch, we can remove this regex from renovate's list.