### PR TITLE
Abstract polaris-runtime-service tests for all persistence implementations

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -24,7 +24,6 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;
@@ -89,6 +88,7 @@ import org.apache.polaris.service.config.ReservedProperties;
 import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
 import org.apache.polaris.service.context.catalog.PolarisCallContextCatalogFactory;
 import org.apache.polaris.service.events.PolarisEventListener;
+import org.apache.polaris.service.quarkus.catalog.Profiles;
 import org.apache.polaris.service.storage.PolarisStorageIntegrationProviderImpl;
 import org.apache.polaris.service.task.TaskExecutor;
 import org.apache.polaris.service.types.PolicyIdentifier;
@@ -103,7 +103,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 /** Base class for shared test setup logic used by various Polaris authz-related tests. */
 public abstract class PolarisAuthzTestBase {
 
-  public static class Profile implements QuarkusTestProfile {
+  public static class Profile extends Profiles.DefaultProfile {
 
     @Override
     public Set<Class<?>> getEnabledAlternatives() {
@@ -112,23 +112,15 @@ public abstract class PolarisAuthzTestBase {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
-          "true",
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"ALLOW_EXTERNAL_METADATA_FILE_LOCATION\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\",\"S3\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true",
-          "polaris.features.\"ENABLE_GENERIC_TABLES\"",
-          "true",
-          "polaris.features.\"ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING\"",
-          "true",
-          "polaris.features.\"DROP_WITH_PURGE_ENABLED\"",
-          "true");
+      return ImmutableMap.<String, String>builder()
+          .putAll(super.getConfigOverrides())
+          .put("polaris.features.\"ALLOW_EXTERNAL_METADATA_FILE_LOCATION\"", "true")
+          .put("polaris.features.\"ENABLE_GENERIC_TABLES\"", "true")
+          .put(
+              "polaris.features.\"ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING\"",
+              "true")
+          .put("polaris.features.\"DROP_WITH_PURGE_ENABLED\"", "true")
+          .build();
     }
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
@@ -24,9 +24,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
@@ -59,7 +56,6 @@ import org.apache.polaris.core.entity.table.GenericTableEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.core.secrets.UserSecretsManagerFactory;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -91,25 +87,7 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
-@QuarkusTest
-@TestProfile(PolarisGenericTableCatalogTest.Profile.class)
-public class PolarisGenericTableCatalogTest {
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
-          "true",
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true");
-    }
-  }
+public abstract class AbstractPolarisGenericTableCatalogTest {
 
   protected static final Namespace NS = Namespace.of("newdb");
   protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "table");
@@ -152,6 +130,8 @@ public class PolarisGenericTableCatalogTest {
     QuarkusMock.installMockForType(mock, PolarisStorageIntegrationProviderImpl.class);
   }
 
+  protected void bootstrapRealm(String realmName) {}
+
   @BeforeEach
   @SuppressWarnings("unchecked")
   public void before(TestInfo testInfo) {
@@ -159,6 +139,8 @@ public class PolarisGenericTableCatalogTest {
         "realm_%s_%s"
             .formatted(
                 testInfo.getTestMethod().map(Method::getName).orElse("test"), System.nanoTime());
+    bootstrapRealm(realmName);
+
     RealmContext realmContext = () -> realmName;
     QuarkusMock.installMockForType(realmContext, RealmContext.class);
     metaStoreManager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
@@ -176,7 +158,8 @@ public class PolarisGenericTableCatalogTest {
         new PolarisEntityManager(
             metaStoreManager,
             storageCredentialCache,
-            new InMemoryEntityCache(polarisContext.getRealmConfig(), metaStoreManager));
+            metaStoreManagerFactory.getOrCreateEntityCache(
+                realmContext, polarisContext.getRealmConfig()));
 
     PrincipalEntity rootEntity =
         new PrincipalEntity(

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogRelationalNoEntityCacheTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogRelationalNoEntityCacheTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.catalog;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.annotation.Nullable;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
+
+@QuarkusTest
+@TestProfile(AbstractIcebergCatalogTest.Profile.class)
+public class IcebergCatalogRelationalNoEntityCacheTest extends AbstractIcebergCatalogTest {
+
+  @Nullable
+  @Override
+  protected InMemoryEntityCache createEntityCache(
+      RealmConfig realmConfig, PolarisMetaStoreManager metaStoreManager) {
+    return null;
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogRelationalWithEntityCacheTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogRelationalWithEntityCacheTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.catalog;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.annotation.Nullable;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
+
+@QuarkusTest
+@TestProfile(AbstractIcebergCatalogTest.Profile.class)
+public class IcebergCatalogRelationalWithEntityCacheTest extends AbstractIcebergCatalogTest {
+
+  @Nullable
+  @Override
+  protected InMemoryEntityCache createEntityCache(
+      RealmConfig realmConfig, PolarisMetaStoreManager metaStoreManager) {
+    return new InMemoryEntityCache(realmConfig, metaStoreManager);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergViewCatalogRelationalTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergViewCatalogRelationalTest.java
@@ -20,19 +20,7 @@ package org.apache.polaris.service.quarkus.catalog;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import jakarta.annotation.Nullable;
-import org.apache.polaris.core.config.RealmConfig;
-import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
 
 @QuarkusTest
-@TestProfile(IcebergCatalogTest.Profile.class)
-public class CatalogNoEntityCacheTest extends IcebergCatalogTest {
-
-  @Nullable
-  @Override
-  protected InMemoryEntityCache createEntityCache(
-      RealmConfig realmConfig, PolarisMetaStoreManager metaStoreManager) {
-    return null;
-  }
-}
+@TestProfile(AbstractIcebergCatalogViewTest.Profile.class)
+public class IcebergViewCatalogRelationalTest extends AbstractIcebergCatalogViewTest {}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogRelationalTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolarisGenericTableCatalogRelationalTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.catalog;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(Profiles.DefaultProfile.class)
+public class PolarisGenericTableCatalogRelationalTest
+    extends AbstractPolarisGenericTableCatalogTest {}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogRelationalTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogRelationalTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.quarkus.catalog;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(Profiles.DefaultProfile.class)
+public class PolicyCatalogRelationalTest extends AbstractPolicyCatalogTest {}

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/Profiles.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/Profiles.java
@@ -16,23 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.polaris.service.quarkus.catalog;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import jakarta.annotation.Nullable;
-import org.apache.polaris.core.config.RealmConfig;
-import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
 
-@QuarkusTest
-@TestProfile(IcebergCatalogTest.Profile.class)
-public class PolarisCatalogWithEntityCacheTest extends IcebergCatalogTest {
+public final class Profiles {
+  private Profiles() {}
 
-  @Nullable
-  @Override
-  protected InMemoryEntityCache createEntityCache(
-      RealmConfig realmConfig, PolarisMetaStoreManager metaStoreManager) {
-    return new InMemoryEntityCache(realmConfig, metaStoreManager);
+  public static class DefaultProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
+          "true",
+          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
+          "true",
+          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
+          "[\"FILE\",\"S3\"]",
+          "polaris.event-listener.type",
+          "test",
+          "polaris.readiness.ignore-severe-issues",
+          "true");
+    }
   }
 }


### PR DESCRIPTION
The NoSQL persistence implementation has to run the Iceberg table & view catalog plus the Polaris specific tests as well. Reusing existing tests is beneficial to avoid a lot of code duplcation.

This change moves the actual tests to `Abstract*` classes and refactors the existing tests to extend those. The NoSQL persistence work extends the same `Abstract*` classes but runs with different Quarkus test profiles.
