### PR TITLE
Add IMPLICIT authentication support to the CLI

### DIFF
--- a/client/python/cli/constants.py
+++ b/client/python/cli/constants.py
@@ -65,6 +65,7 @@ class AuthenticationType(Enum):
     OAUTH = "oauth"
     BEARER = "bearer"
     SIGV4 = "sigv4"
+    IMPLICIT = "implicit"
 
 
 class ServiceIdentityType(Enum):
@@ -241,7 +242,7 @@ class Hints:
                 "The type of external catalog in [ICEBERG, HADOOP]."
             )
             CATALOG_AUTHENTICATION_TYPE = (
-                "The type of authentication in [OAUTH, BEARER, SIGV4]"
+                "The type of authentication in [OAUTH, BEARER, SIGV4, IMPLICIT]"
             )
             CATALOG_SERVICE_IDENTITY_TYPE = "The type of service identity in [AWS_IAM]"
 

--- a/client/python/test/test_cli_parsing.py
+++ b/client/python/test/test_cli_parsing.py
@@ -507,19 +507,6 @@ class TestCliParsing(unittest.TestCase):
         check_arguments(
             mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
                           '--storage-type', 'gcs', '--default-base-location', 'dbl',
-                          '--catalog-connection-type', 'hadoop', '--hadoop-warehouse', 'h',
-                          '--catalog-uri', 'u', '--catalog-authentication-type', 'bearer',
-                          '--catalog-bearer-token', 'b']),
-            'create_catalog', {
-                (0, 'catalog.name'): 'my-catalog',
-                (0, 'catalog.type'): 'EXTERNAL',
-                (0, 'catalog.connection_config_info.connection_type'): 'HADOOP',
-                (0, 'catalog.connection_config_info.warehouse'): 'h',
-                (0, 'catalog.connection_config_info.uri'): 'u',
-            })
-        check_arguments(
-            mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
-                          '--storage-type', 'gcs', '--default-base-location', 'dbl',
                           '--catalog-connection-type', 'iceberg-rest', '--iceberg-remote-catalog-name', 'i',
                           '--catalog-uri', 'u', '--catalog-authentication-type', 'bearer',
                           '--catalog-bearer-token', 'b']),
@@ -529,24 +516,6 @@ class TestCliParsing(unittest.TestCase):
                 (0, 'catalog.connection_config_info.connection_type'): 'ICEBERG_REST',
                 (0, 'catalog.connection_config_info.remote_catalog_name'): 'i',
                 (0, 'catalog.connection_config_info.uri'): 'u',
-            })
-        check_arguments(
-            mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
-                          '--storage-type', 'gcs', '--default-base-location', 'dbl',
-                          '--catalog-connection-type', 'hadoop', '--hadoop-warehouse', 'h',
-                          '--catalog-authentication-type', 'oauth',
-                          '--catalog-token-uri', 'u', '--catalog-client-id', 'i',
-                          '--catalog-client-secret', 'k', '--catalog-client-scope', 's1',
-                          '--catalog-client-scope', 's2']),
-            'create_catalog', {
-                (0, 'catalog.name'): 'my-catalog',
-                (0, 'catalog.type'): 'EXTERNAL',
-                (0, 'catalog.connection_config_info.connection_type'): 'HADOOP',
-                (0, 'catalog.connection_config_info.warehouse'): 'h',
-                (0, 'catalog.connection_config_info.authentication_parameters.authentication_type'): 'OAUTH',
-                (0, 'catalog.connection_config_info.authentication_parameters.token_uri'): 'u',
-                (0, 'catalog.connection_config_info.authentication_parameters.client_id'): 'i',
-                (0, 'catalog.connection_config_info.authentication_parameters.scopes'): ['s1', 's2'],
             })
         check_arguments(
             mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
@@ -582,6 +551,19 @@ class TestCliParsing(unittest.TestCase):
                 (0, 'catalog.connection_config_info.authentication_parameters.role_session_name'): 'n',
                 (0, 'catalog.connection_config_info.authentication_parameters.external_id'): 'i',
                 (0, 'catalog.connection_config_info.authentication_parameters.signing_name'): 'g',
+            })
+        check_arguments(
+            mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
+                          '--storage-type', 'file', '--default-base-location', 'dbl',
+                          '--catalog-connection-type', 'hadoop', '--hadoop-warehouse', 'h',
+                          '--catalog-authentication-type', 'implicit', '--catalog-uri', 'u']),
+            'create_catalog', {
+                (0, 'catalog.name'): 'my-catalog',
+                (0, 'catalog.type'): 'EXTERNAL',
+                (0, 'catalog.connection_config_info.connection_type'): 'HADOOP',
+                (0, 'catalog.connection_config_info.warehouse'): 'h',
+                (0, 'catalog.connection_config_info.authentication_parameters.authentication_type'): 'IMPLICIT',
+                (0, 'catalog.connection_config_info.uri'): 'u',
             })
 
 

--- a/client/python/test/test_cli_parsing.py
+++ b/client/python/test/test_cli_parsing.py
@@ -520,6 +520,28 @@ class TestCliParsing(unittest.TestCase):
         check_arguments(
             mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
                           '--storage-type', 'gcs', '--default-base-location', 'dbl',
+                          '--catalog-connection-type', 'iceberg-rest',
+                          '--iceberg-remote-catalog-name', 'c',
+                          '--catalog-uri', 'u', '--catalog-authentication-type', 'oauth',
+                          '--catalog-token-uri', 'u', '--catalog-client-id', 'i',
+                          '--catalog-client-secret', 'k', '--catalog-client-scope', 's1',
+                          '--catalog-client-scope', 's2']),
+            'create_catalog', {
+                (0, 'catalog.name'): 'my-catalog',
+                (0, 'catalog.type'): 'EXTERNAL',
+                (0, 'catalog.connection_config_info.connection_type'): 'ICEBERG_REST',
+                (0, 'catalog.connection_config_info.remote_catalog_name'): 'c',
+                (0, 'catalog.connection_config_info.uri'): 'u',
+                (0, 'catalog.connection_config_info.authentication_parameters.authentication_type'): 'OAUTH',
+                (0, 'catalog.connection_config_info.authentication_parameters.token_uri'): 'u',
+                (0, 'catalog.connection_config_info.authentication_parameters.client_id'): 'i',
+                (0, 'catalog.connection_config_info.authentication_parameters.scopes'): ['s1', 's2'],
+                (0, 'catalog.storage_config_info.storage_type'): 'GCS',
+                (0, 'catalog.properties.default_base_location'): 'dbl',
+            })
+        check_arguments(
+            mock_execute(['catalogs', 'create', 'my-catalog', '--type', 'external',
+                          '--storage-type', 'gcs', '--default-base-location', 'dbl',
                           '--catalog-connection-type', 'iceberg-rest', '--iceberg-remote-catalog-name', 'i',
                           '--catalog-uri', 'u', '--catalog-authentication-type', 'sigv4',
                           '--catalog-role-arn', 'a', '--catalog-signing-region', 's']),


### PR DESCRIPTION
PRs #1925 and #1912 were merged around the same time.  This PR connects the two changes and enables the CLI to accept IMPLICIT authentication type. 

Since Hadoop federated catalogs rely purely on IMPLICIT authentication, the CLI parsing test has been updated to reflect the same. 
