### PR TITLE
CI: Address failure from accessing GH API

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Run unit tests
+        env:
+          # publishToMavenLocal causes a GH API requests, use the token for those requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew check sourceTarball distTar distZip publishToMavenLocal \
             -x :polaris-runtime-service:test \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,5 +59,7 @@ jobs:
       - name: Publish SNAPSHOTs to Apache Nexus Repository
         run: ./gradlew publishToApache
         env:
+          # publishToApache causes a GH API requests, use the token for those requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_apacheUsername: ${{ secrets.NEXUS_USER }}
           ORG_GRADLE_PROJECT_apachePassword: ${{ secrets.NEXUS_PW }} 

--- a/.github/workflows/spark_client_regtests.yml
+++ b/.github/workflows/spark_client_regtests.yml
@@ -55,6 +55,9 @@ jobs:
         run: ./gradlew regeneratePythonClient
 
       - name: Project build without testing
+        env:
+          # publishToMavenLocal causes a GH API requests, use the token for those requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew assemble publishToMavenLocal
 
       - name: Image build


### PR DESCRIPTION
CI sometimes fails with this failure:
```
* What went wrong:
Execution failed for task ':generatePomFileForMavenPublication'.
> Unable to process url: https://api.github.com/repos/apache/polaris/contributors?per_page=1000
```

The sometimes failing request fetches the list of contributors to be published in the "root" POM. Unauthorized GH API requests have an hourly(?) limit of 60 requests per source IP. Authorized requests have a much higher rate limit. We do have a GitHub token available in every CI run, which can be used in GH API requests. This change adds the `Authorization` header for the failing GH API request to leverage the higher rate limit and let CI not fail (that often).
