### PR TITLE
Logger for python client

### DIFF
--- a/client/python/cli/command/__init__.py
+++ b/client/python/cli/command/__init__.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import argparse
+import logging
 from abc import ABC
 
 from cli.constants import Commands, Arguments
@@ -30,6 +31,10 @@ class Command(ABC):
     `execute`. The static method `Command.from_options` can be used to parse a argparse Namespace into the appropriate
     Command implementation if one exists.
     """
+
+    @property
+    def logger(self):
+        return logging.getLogger(self.__class__.__name__)
 
     @staticmethod
     def from_options(options: argparse.Namespace) -> "Command":

--- a/client/python/cli/command/catalog_roles.py
+++ b/client/python/cli/command/catalog_roles.py
@@ -76,7 +76,7 @@ class CatalogRolesCommand(Command):
         elif self.catalog_roles_subcommand == Subcommands.DELETE:
             api.delete_catalog_role(self.catalog_name, self.catalog_role_name)
         elif self.catalog_roles_subcommand == Subcommands.GET:
-            print(
+            self.logger.info(
                 api.get_catalog_role(
                     self.catalog_name, self.catalog_role_name
                 ).to_json()
@@ -86,10 +86,10 @@ class CatalogRolesCommand(Command):
                 for catalog_role in api.list_catalog_roles_for_principal_role(
                     self.principal_role_name, self.catalog_name
                 ).roles:
-                    print(catalog_role.to_json())
+                    self.logger.info(catalog_role.to_json())
             else:
                 for catalog_role in api.list_catalog_roles(self.catalog_name).roles:
-                    print(catalog_role.to_json())
+                    self.logger.info(catalog_role.to_json())
         elif self.catalog_roles_subcommand == Subcommands.UPDATE:
             catalog_role = api.get_catalog_role(
                 self.catalog_name, self.catalog_role_name

--- a/client/python/cli/command/catalogs.py
+++ b/client/python/cli/command/catalogs.py
@@ -299,10 +299,10 @@ class CatalogsCommand(Command):
         elif self.catalogs_subcommand == Subcommands.DELETE:
             api.delete_catalog(self.catalog_name)
         elif self.catalogs_subcommand == Subcommands.GET:
-            print(api.get_catalog(self.catalog_name).to_json())
+            self.logger.info(api.get_catalog(self.catalog_name).to_json())
         elif self.catalogs_subcommand == Subcommands.LIST:
             for catalog in api.list_catalogs().catalogs:
-                print(catalog.to_json())
+                self.logger.info(catalog.to_json())
         elif self.catalogs_subcommand == Subcommands.UPDATE:
             catalog = api.get_catalog(self.catalog_name)
 

--- a/client/python/cli/command/namespaces.py
+++ b/client/python/cli/command/namespaces.py
@@ -90,13 +90,13 @@ class NamespacesCommand(Command):
             else:
                 result = catalog_api.list_namespaces(prefix=self.catalog)
             for namespace in result.namespaces:
-                print(json.dumps({"namespace": ".".join(namespace)}))
+                self.logger.info(json.dumps({"namespace": ".".join(namespace)}))
         elif self.namespaces_subcommand == Subcommands.DELETE:
             catalog_api.drop_namespace(
                 prefix=self.catalog, namespace=UNIT_SEPARATOR.join(self.namespace)
             )
         elif self.namespaces_subcommand == Subcommands.GET:
-            print(
+            self.logger.info(
                 catalog_api.load_namespace_metadata(
                     prefix=self.catalog, namespace=UNIT_SEPARATOR.join(self.namespace)
                 ).to_json()

--- a/client/python/cli/command/principal_roles.py
+++ b/client/python/cli/command/principal_roles.py
@@ -74,21 +74,21 @@ class PrincipalRolesCommand(Command):
         elif self.principal_roles_subcommand == Subcommands.DELETE:
             api.delete_principal_role(self.principal_role_name)
         elif self.principal_roles_subcommand == Subcommands.GET:
-            print(api.get_principal_role(self.principal_role_name).to_json())
+            self.logger.info(api.get_principal_role(self.principal_role_name).to_json())
         elif self.principal_roles_subcommand == Subcommands.LIST:
             if self.catalog_role_name:
                 for principal_role in api.list_principal_roles(
                     self.catalog_role_name
                 ).roles:
-                    print(principal_role.to_json())
+                    self.logger.info(principal_role.to_json())
             elif self.principal_name:
                 for principal_role in api.list_principal_roles_assigned(
                     self.principal_name
                 ).roles:
-                    print(principal_role.to_json())
+                    self.logger.info(principal_role.to_json())
             else:
                 for principal_role in api.list_principal_roles().roles:
-                    print(principal_role.to_json())
+                    self.logger.info(principal_role.to_json())
         elif self.principal_roles_subcommand == Subcommands.UPDATE:
             principal_role = api.get_principal_role(self.principal_role_name)
             new_properties = principal_role.properties or {}

--- a/client/python/cli/command/principals.py
+++ b/client/python/cli/command/principals.py
@@ -106,22 +106,22 @@ class PrincipalsCommand(Command):
                     properties=self.properties,
                 )
             )
-            print(self.build_credential_json(api.create_principal(request)))
+            self.logger.info(self.build_credential_json(api.create_principal(request)))
         elif self.principals_subcommand == Subcommands.DELETE:
             api.delete_principal(self.principal_name)
         elif self.principals_subcommand == Subcommands.GET:
-            print(api.get_principal(self.principal_name).to_json())
+            self.logger.info(api.get_principal(self.principal_name).to_json())
         elif self.principals_subcommand == Subcommands.LIST:
             if self.principal_role:
                 for principal in api.list_assignee_principals_for_principal_role(
                     self.principal_role
                 ).principals:
-                    print(principal.to_json())
+                    self.logger.info(principal.to_json())
             else:
                 for principal in api.list_principals().principals:
-                    print(principal.to_json())
+                    self.logger.info(principal.to_json())
         elif self.principals_subcommand == Subcommands.ROTATE_CREDENTIALS:
-            print(
+            self.logger.info(
                 self.build_credential_json(api.rotate_credentials(self.principal_name))
             )
         elif self.principals_subcommand == Subcommands.UPDATE:
@@ -170,6 +170,6 @@ class PrincipalsCommand(Command):
                         )
                         role_data["catalog_roles"].append(catalog_data)
                 result["principal_roles"].append(role_data)
-            print(json.dumps(result))
+            self.logger.info(json.dumps(result))
         else:
             raise Exception(f"{self.principals_subcommand} is not supported in the CLI")

--- a/client/python/cli/command/privileges.py
+++ b/client/python/cli/command/privileges.py
@@ -104,7 +104,7 @@ class PrivilegesCommand(Command):
             for grant in api.list_grants_for_catalog_role(
                 self.catalog_name, self.catalog_role_name
             ).grants:
-                print(grant.to_json())
+                self.logger.info(grant.to_json())
         else:
             grant = None
             if self.privileges_subcommand == Subcommands.CATALOG:

--- a/client/python/cli/command/profiles.py
+++ b/client/python/cli/command/profiles.py
@@ -79,8 +79,8 @@ class ProfilesCommand(Command):
             }
             self._save_profiles(profiles)
         else:
-            print(f"Profile {name} already exists.")
-            sys.exit(1)
+            self.logger.info(f"Profile {name} already exists.")
+            raise Exception(f"Profile {name} already exists.")
 
     def _get_profile(self, name: str) -> Optional[Dict[str, str]]:
         profiles = self._load_profiles()
@@ -121,8 +121,8 @@ class ProfilesCommand(Command):
             }
             self._save_profiles(profiles)
         else:
-            print(f"Profile {name} does not exist.")
-            sys.exit(1)
+            self.logger.info(f"Profile {name} does not exist.")
+            raise Exception(f"Profile {name} does not exist.")
 
     def validate(self):
         pass
@@ -130,23 +130,23 @@ class ProfilesCommand(Command):
     def execute(self, api: Optional[PolarisDefaultApi] = None) -> None:
         if self.profiles_subcommand == Subcommands.CREATE:
             self._create_profile(self.profile_name)
-            print(f"Polaris profile {self.profile_name} created successfully.")
+            self.logger.info(f"Polaris profile {self.profile_name} created successfully.")
         elif self.profiles_subcommand == Subcommands.DELETE:
             self._delete_profile(self.profile_name)
-            print(f"Polaris profile {self.profile_name} deleted successfully.")
+            self.logger.info(f"Polaris profile {self.profile_name} deleted successfully.")
         elif self.profiles_subcommand == Subcommands.UPDATE:
             self._update_profile(self.profile_name)
-            print(f"Polaris profile {self.profile_name} updated successfully.")
+            self.logger.info(f"Polaris profile {self.profile_name} updated successfully.")
         elif self.profiles_subcommand == Subcommands.GET:
             profile = self._get_profile(self.profile_name)
             if profile:
-                print(f"Polaris profile {self.profile_name}: {profile}")
+                self.logger.info(f"Polaris profile {self.profile_name}: {profile}")
             else:
-                print(f"Polaris profile {self.profile_name} not found.")
+                self.logger.info(f"Polaris profile {self.profile_name} not found.")
         elif self.profiles_subcommand == Subcommands.LIST:
             profiles = self._list_profiles()
-            print("Polaris profiles:")
+            self.logger.info("Polaris profiles:")
             for profile in profiles:
-                print(f" - {profile}")
+                self.logger.info(f" - {profile}")
         else:
             raise Exception(f"{self.profiles_subcommand} is not supported in the CLI")

--- a/client/python/cli/polaris_cli.py
+++ b/client/python/cli/polaris_cli.py
@@ -20,6 +20,7 @@
 import json
 import os
 import sys
+import logging
 from json import JSONDecodeError
 
 from typing import Dict
@@ -74,26 +75,25 @@ class PolarisCli:
                     command = Command.from_options(options)
                     command.execute(admin_api)
                 except Exception as e:
-                    PolarisCli._try_print_exception(e)
+                    PolarisCli._log_exception(e)
                     sys.exit(1)
 
     @staticmethod
-    def _try_print_exception(e):
+    def _log_exception(e):
+        logger = logging.getLogger(PolarisCli.__name__)
         try:
             error = json.loads(e.body)["error"]
-            sys.stderr.write(
-                f"Exception when communicating with the Polaris server."
-                f" {error['type']}: {error['message']}{os.linesep}"
+            logger.error(
+                f"Exception when communicating with the Polaris server. "
+                f"{error['type']}: {error['message']}"
             )
         except JSONDecodeError as _:
-            sys.stderr.write(
-                f"Exception when communicating with the Polaris server."
-                f" {e.status}: {e.reason}{os.linesep}"
+            logger.error(
+                f"Exception when communicating with the Polaris server. "
+                f"{e.status}: {e.reason}"
             )
         except Exception as _:
-            sys.stderr.write(
-                f"Exception when communicating with the Polaris server. {e}{os.linesep}"
-            )
+            logger.error(f"Exception when communicating with the Polaris server. {e}")
 
     @staticmethod
     def _load_profiles() -> Dict[str, Dict[str, str]]:
@@ -192,4 +192,7 @@ class PolarisCli:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s: %(name)s: %(message)s"
+    )
     PolarisCli.execute()


### PR DESCRIPTION
To prepare for showing client request payloads with a debug flag https://apache-polaris.slack.com/archives/C084XDM50CB/p1748501485695739), this PR transitions our output from simple `print` statements to a more robust logging framework. This lays the groundwork for easily controlling debug output, making future enhancements much more straightforward than managing numerous conditional `print` statements.

Here are some sample output (current vs new):
```
# list principals (current)
➜  polaris git:(main) ./polaris --profile dev principals list
{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1753065201451, "lastUpdateTimestamp": 1753065201451, "entityVersion": 1}

# list principals (new)
➜  polaris git:(python_client_logger) ./polaris --profile dev principals list
2025-07-20 21:41:09,524 - INFO: PrincipalsCommand: {"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1753065201451, "lastUpdateTimestamp": 1753065201451, "entityVersion": 1}

# create duplicate profile to trigger Exception (current)
➜  polaris git:(main) ./polaris profiles create dev
Profile dev already exists.
➜  polaris git:(main) echo $?
1

# create duplicate profile to trigger Exception (new)
➜  polaris git:(python_client_logger) ./polaris profiles create dev
2025-07-20 21:41:22,919 - INFO: ProfilesCommand: Profile dev already exists.
Traceback (most recent call last):
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/polaris_cli.py", line 198, in <module>
    PolarisCli.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/polaris_cli.py", line 67, in execute
    command.execute()
    ~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/command/profiles.py", line 132, in execute
    self._create_profile(self.profile_name)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/command/profiles.py", line 83, in _create_profile
    raise Exception(f"Profile {name} already exists.")
Exception: Profile dev already exists.
➜  polaris git:(python_client_logger) echo $?
1
```

