### PR TITLE
Enable python client debug flag

### DIFF
--- a/client/python/cli/constants.py
+++ b/client/python/cli/constants.py
@@ -164,6 +164,7 @@ class Arguments:
     REGION = "region"
     PROFILE = "profile"
     PROXY = "proxy"
+    DEBUG = "debug"
     HADOOP_WAREHOUSE = "hadoop_warehouse"
     ICEBERG_REMOTE_CATALOG_NAME = "iceberg_remote_catalog_name"
     ENDPOINT = "endpoint"

--- a/client/python/cli/options/parser.py
+++ b/client/python/cli/options/parser.py
@@ -57,6 +57,7 @@ class Parser(object):
         ),
         Argument(Arguments.PROFILE, str, hint="profile for token-based authentication"),
         Argument(Arguments.PROXY, str, hint="proxy URL"),
+        Argument(Arguments.DEBUG, bool, hint="Enable debug mode"),
     ]
 
     @staticmethod
@@ -64,15 +65,16 @@ class Parser(object):
         parser = TreeHelpParser(description="Polaris CLI")
 
         for arg in Parser._ROOT_ARGUMENTS:
+            kwargs = {"help": arg.hint}
             if arg.default is not None:
-                parser.add_argument(
-                    arg.get_flag_name(),
-                    type=arg.type,
-                    help=arg.hint,
-                    default=arg.default,
-                )
+                kwargs["default"] = arg.default
+
+            if arg.type is bool:
+                kwargs["action"] = "store_true"
             else:
-                parser.add_argument(arg.get_flag_name(), type=arg.type, help=arg.hint)
+                kwargs["type"] = arg.type
+
+            parser.add_argument(arg.get_flag_name(), **kwargs)
 
         # Add everything from the option tree to the parser:
         def add_arguments(parser, args: List[Argument]):

--- a/client/python/cli/polaris_cli.py
+++ b/client/python/cli/polaris_cli.py
@@ -67,8 +67,6 @@ class PolarisCli:
             command = Command.from_options(options)
             command.execute()
         else:
-            if options.debug:
-                PolarisCli._enable_api_request_logging()
             client_builder = PolarisCli._get_client_builder(options)
             with client_builder() as api_client:
                 try:
@@ -76,6 +74,8 @@ class PolarisCli:
 
                     admin_api = PolarisDefaultApi(api_client)
                     command = Command.from_options(options)
+                    if options.debug:
+                        PolarisCli._enable_api_request_logging()
                     command.execute(admin_api)
                 except Exception as e:
                     PolarisCli._try_print_exception(e)
@@ -90,12 +90,12 @@ class PolarisCli:
         # Define the wrapper function
         @functools.wraps(urllib3.PoolManager.original_urlopen)
         def urlopen_wrapper(self, method, url, **kwargs):
-            print(f"Request: {method} {url}")
+            sys.stderr.write(f"Request: {method} {url}\n")
             if "headers" in kwargs:
-                print(f"Headers: {kwargs['headers']}")
+                sys.stderr.write(f"Headers: {kwargs['headers']}\n")
             if "body" in kwargs:
-                print(f"Body: {kwargs['body']}")
-            print()
+                sys.stderr.write(f"Body: {kwargs['body']}\n")
+            sys.stderr.write("\n")
             # Call the original urlopen method
             return urllib3.PoolManager.original_urlopen(self, method, url, **kwargs)
 


### PR DESCRIPTION
Enable request tracing via money patching:

Original:
```
➜  polaris git:(python_client_debug_flag) ./polaris --profile dev principals list
{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1753151091780, "lastUpdateTimestamp": 1753151091780, "entityVersion": 1}
```

With debug mode (dummy password from the getting start example):
```
➜  polaris git:(python_client_debug_flag) ./polaris --profile dev --debug principals list
Request: POST http://localhost:8181/api/catalog/v1/oauth/tokens
Headers: HTTPHeaderDict({'Content-Type': 'application/x-www-form-urlencoded'})
Body: grant_type=client_credentials&client_id=root&client_secret=s3cr3t&scope=PRINCIPAL_ROLE%3AALL

Request: GET http://localhost:8181/api/management/v1/principals
Headers: {'Accept': 'application/json', 'User-Agent': 'OpenAPI-Generator/1.0.0/python', 'Authorization': 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJwb2xhcmlzIiwic3ViIjoiMSIsImlhdCI6MTc1MzE1NjUwMiwiZXhwIjoxNzUzMTYwMTAyLCJqdGkiOiIyMjc3NTc4Yi1mOGQ2LTQ3NjctODc2Yy0xZjg0YjVhOTFjOWIiLCJhY3RpdmUiOnRydWUsImNsaWVudF9pZCI6InJvb3QiLCJwcmluY2lwYWxJZCI6MSwic2NvcGUiOiJQUklOQ0lQQUxfUk9MRTpBTEwifQ.CXHMjqgGtGZZ9hUtS_Tqi4hr2Zt5kIdifqWVH0sWO2Ycbju3J6f4KWu4TgBB7FT6PQUbFqIAZiNBOAkZRpCDygUPEZ3-bt3cbTt9LWfkQYRXFnJF7-fM42zSK3Go7t1AVfYShDLozexgBvZGg700SYdcffKdCpARke7IX8VjLl_0uqZ4ygtjWwmoIHxfVH8WCTXajdvTOH7MF6aPgdVr5_y4KiCfZoTu5DG9gSJLYYAu1sVfUtQ07hGWs6wJUENLt9ZBjBBJI80Um70Oq3U508MC4y10FBWIKRrs8655le976TfcRjY_BPxpJaekBQIrxP7qz1hqP8XGSPRuFTgWbQ'}

{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1753151091780, "lastUpdateTimestamp": 1753151091780, "entityVersion": 1}
```

Also, as the current code will requires an user to provide an argument even if the type is bool. To fix that (assuming that is not intensional), a code fix is provided (otherwise, we will need to do `--debug XXX`.