### PR TITLE
Add PolarisObjectMapper

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -27,6 +27,7 @@ import org.apache.polaris.core.config.RealmConfigImpl;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.BasePersistence;
+import org.apache.polaris.core.persistence.PolarisObjectMapper;
 
 /**
  * The Call context is allocated each time a new REST request is processed. It contains instances of
@@ -47,6 +48,7 @@ public class PolarisCallContext implements CallContext {
   private final RealmContext realmContext;
 
   private final RealmConfig realmConfig;
+  private final PolarisObjectMapper objectMapper;
 
   public PolarisCallContext(
       @Nonnull RealmContext realmContext,
@@ -60,6 +62,7 @@ public class PolarisCallContext implements CallContext {
     this.configurationStore = configurationStore;
     this.clock = clock;
     this.realmConfig = new RealmConfigImpl(this.configurationStore, this.realmContext);
+    this.objectMapper = new PolarisObjectMapper(diagServices);
   }
 
   public PolarisCallContext(
@@ -84,6 +87,10 @@ public class PolarisCallContext implements CallContext {
 
   public Clock getClock() {
     return clock;
+  }
+
+  public PolarisObjectMapper getObjectMapper() {
+    return objectMapper;
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/TaskEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/TaskEntity.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.entity;
 
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
 
 /**
  * Represents an asynchronous task entity in the persistence layer. A task executor is responsible
@@ -41,16 +40,16 @@ public class TaskEntity extends PolarisEntity {
 
   public <T> T readData(Class<T> klass) {
     PolarisCallContext polarisCallContext = CallContext.getCurrentContext().getPolarisCallContext();
-    return PolarisObjectMapperUtil.deserialize(
-        polarisCallContext, getPropertiesAsMap().get(PolarisTaskConstants.TASK_DATA), klass);
+    return polarisCallContext
+        .getObjectMapper()
+        .deserialize(getPropertiesAsMap().get(PolarisTaskConstants.TASK_DATA), klass);
   }
 
   public AsyncTaskType getTaskType() {
     PolarisCallContext polarisCallContext = CallContext.getCurrentContext().getPolarisCallContext();
-    return PolarisObjectMapperUtil.deserialize(
-        polarisCallContext,
-        getPropertiesAsMap().get(PolarisTaskConstants.TASK_TYPE),
-        AsyncTaskType.class);
+    return polarisCallContext
+        .getObjectMapper()
+        .deserialize(getPropertiesAsMap().get(PolarisTaskConstants.TASK_TYPE), AsyncTaskType.class);
   }
 
   public static class Builder extends PolarisEntity.BaseBuilder<TaskEntity, TaskEntity.Builder> {
@@ -69,8 +68,7 @@ public class TaskEntity extends PolarisEntity {
       PolarisCallContext polarisCallContext =
           CallContext.getCurrentContext().getPolarisCallContext();
       properties.put(
-          PolarisTaskConstants.TASK_TYPE,
-          PolarisObjectMapperUtil.serialize(polarisCallContext, taskType));
+          PolarisTaskConstants.TASK_TYPE, polarisCallContext.getObjectMapper().serialize(taskType));
       return this;
     }
 
@@ -78,8 +76,7 @@ public class TaskEntity extends PolarisEntity {
       PolarisCallContext polarisCallContext =
           CallContext.getCurrentContext().getPolarisCallContext();
       properties.put(
-          PolarisTaskConstants.TASK_DATA,
-          PolarisObjectMapperUtil.serialize(polarisCallContext, data));
+          PolarisTaskConstants.TASK_DATA, polarisCallContext.getObjectMapper().serialize(data));
       return this;
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
@@ -40,8 +40,7 @@ public abstract class BaseMetaStoreManager implements PolarisMetaStoreManager {
   public static PolarisStorageConfigurationInfo extractStorageConfiguration(
       @Nonnull PolarisCallContext callCtx, PolarisBaseEntity reloadedEntity) {
     Map<String, String> propMap =
-        PolarisObjectMapperUtil.deserializeProperties(
-            callCtx, reloadedEntity.getInternalProperties());
+        callCtx.getObjectMapper().deserializeProperties(reloadedEntity.getInternalProperties());
     String storageConfigInfoStr =
         propMap.get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapper.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.apache.iceberg.rest.RESTSerializers;
+import org.apache.polaris.core.PolarisDiagnostics;
+
+/** A mapper to serialize/deserialize polaris objects. */
+public class PolarisObjectMapper {
+  /** mapper, allows to serialize/deserialize properties to/from JSON */
+  private static final ObjectMapper MAPPER = configureMapper();
+
+  private static ObjectMapper configureMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+    RESTSerializers.registerAll(mapper);
+    return mapper;
+  }
+
+  private final PolarisDiagnostics diagnostics;
+
+  public PolarisObjectMapper(PolarisDiagnostics diagnostics) {
+    this.diagnostics = diagnostics;
+  }
+
+  public String serialize(Object object) {
+    try {
+      return MAPPER.writeValueAsString(object);
+    } catch (JsonProcessingException e) {
+      diagnostics.fail("got_json_processing_exception", e.getMessage());
+    }
+    return "";
+  }
+
+  public <T> T deserialize(String json, Class<T> klass) {
+    try {
+      return MAPPER.readValue(json, klass);
+    } catch (JsonProcessingException e) {
+      diagnostics.fail("got_json_processing_exception", e.getMessage());
+    }
+    return null;
+  }
+
+  /**
+   * Given the internal property as a map of key/value pairs, serialize it to a String
+   *
+   * @param properties a map of key/value pairs
+   * @return a String, the JSON representation of the map
+   */
+  public String serializeProperties(Map<String, String> properties) {
+    try {
+      // Serialize the Map<String, String> to a JSON string
+      return MAPPER.writeValueAsString(properties);
+    } catch (JsonProcessingException ex) {
+      diagnostics.fail("got_json_processing_exception", ex.getMessage());
+    }
+    return "";
+  }
+
+  /**
+   * Given the serialized properties, deserialize those to a {@code Map<String, String>}
+   *
+   * @param properties a JSON string representing the set of properties
+   * @return a Map of string
+   */
+  public Map<String, String> deserializeProperties(String properties) {
+    try {
+      // Deserialize the JSON string to a Map<String, String>
+      return MAPPER.readValue(properties, new TypeReference<>() {});
+    } catch (JsonMappingException ex) {
+      diagnostics.fail("got_json_mapping_exception", "properties={}, ex={}", properties, ex);
+    } catch (JsonProcessingException ex) {
+      diagnostics.fail("got_json_processing_exception", "properties={}, ex={}", properties, ex);
+    }
+    return null;
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
@@ -20,98 +20,19 @@ package org.apache.polaris.core.persistence;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
-import java.util.Map;
-import org.apache.iceberg.rest.RESTSerializers;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A mapper to serialize/deserialize polaris objects. */
-public class PolarisObjectMapperUtil {
+public final class PolarisObjectMapperUtil {
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisObjectMapperUtil.class);
 
-  /** mapper, allows to serialize/deserialize properties to/from JSON */
-  private static final ObjectMapper MAPPER = configureMapper();
-
-  private static ObjectMapper configureMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
-    RESTSerializers.registerAll(mapper);
-    return mapper;
-  }
-
-  /**
-   * Given the internal property as a map of key/value pairs, serialize it to a String
-   *
-   * @param properties a map of key/value pairs
-   * @return a String, the JSON representation of the map
-   */
-  public static String serializeProperties(
-      PolarisCallContext callCtx, Map<String, String> properties) {
-
-    String jsonString = null;
-    try {
-      // Deserialize the JSON string to a Map<String, String>
-      jsonString = MAPPER.writeValueAsString(properties);
-    } catch (JsonProcessingException ex) {
-      callCtx.getDiagServices().fail("got_json_processing_exception", ex.getMessage());
-    }
-
-    return jsonString;
-  }
-
-  public static String serialize(PolarisCallContext callCtx, Object object) {
-    try {
-      return MAPPER.writeValueAsString(object);
-    } catch (JsonProcessingException e) {
-      callCtx.getDiagServices().fail("got_json_processing_exception", e.getMessage());
-    }
-    return "";
-  }
-
-  public static <T> T deserialize(PolarisCallContext callCtx, String text, Class<T> klass) {
-    try {
-      return MAPPER.readValue(text, klass);
-    } catch (JsonProcessingException e) {
-      callCtx.getDiagServices().fail("got_json_processing_exception", e.getMessage());
-    }
-    return null;
-  }
-
-  /**
-   * Given the serialized properties, deserialize those to a {@code Map<String, String>}
-   *
-   * @param properties a JSON string representing the set of properties
-   * @return a Map of string
-   */
-  public static Map<String, String> deserializeProperties(
-      PolarisCallContext callCtx, String properties) {
-
-    Map<String, String> retProperties = null;
-    try {
-      // Deserialize the JSON string to a Map<String, String>
-      retProperties = MAPPER.readValue(properties, new TypeReference<>() {});
-    } catch (JsonMappingException ex) {
-      callCtx
-          .getDiagServices()
-          .fail("got_json_mapping_exception", "properties={}, ex={}", properties, ex);
-    } catch (JsonProcessingException ex) {
-      callCtx
-          .getDiagServices()
-          .fail("got_json_processing_exception", "properties={}, ex={}", properties, ex);
-    }
-
-    return retProperties;
+  private PolarisObjectMapperUtil() {
+    // utility class
   }
 
   public static class TaskExecutionState {
@@ -186,9 +107,5 @@ public class PolarisObjectMapperUtil {
           .log("Unable to parse task properties");
       return null;
     }
-  }
-
-  long now() {
-    return 0;
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -38,7 +38,6 @@ import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.ScopedCredentialsResult;
 import org.apache.polaris.core.persistence.transactional.TransactionalPersistence;
@@ -250,7 +249,7 @@ public class StorageCredentialCacheTest {
           PolarisEntityConstants.getStorageConfigInfoPropertyName(), "newStorageConfig");
       PolarisBaseEntity updateEntity =
           new PolarisBaseEntity.Builder(entity)
-              .internalProperties(PolarisObjectMapperUtil.serializeProperties(callCtx, internalMap))
+              .internalProperties(callCtx.getObjectMapper().serializeProperties(internalMap))
               .build();
       storageCredentialCache.getOrGenerateSubScopeCreds(
           metaStoreManager,
@@ -290,7 +289,7 @@ public class StorageCredentialCacheTest {
           PolarisEntityConstants.getStorageConfigInfoPropertyName(), "newStorageConfig");
       PolarisBaseEntity updateEntity =
           new PolarisBaseEntity.Builder(entity)
-              .internalProperties(PolarisObjectMapperUtil.serializeProperties(callCtx, internalMap))
+              .internalProperties(callCtx.getObjectMapper().serializeProperties(internalMap))
               .build();
       storageCredentialCache.getOrGenerateSubScopeCreds(
           metaStoreManager,

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -301,9 +301,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
             entry ->
                 Assertions.assertThat(entry)
                     .extracting(
-                        e ->
-                            PolarisObjectMapperUtil.deserializeProperties(
-                                callCtx, e.getProperties()))
+                        e -> callCtx.getObjectMapper().deserializeProperties(e.getProperties()))
                     .asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
                     .containsEntry("lastAttemptExecutorId", executorId)
                     .containsEntry("attemptCount", "1"));

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -411,6 +411,7 @@ public class PolarisTestMetaStoreManager {
   /** Create a principal */
   PolarisBaseEntity createPrincipal(String name) {
     // create new principal identity
+    PolarisObjectMapper objectMapper = this.polarisCallContext.getObjectMapper();
     PolarisBaseEntity principalEntity =
         new PolarisBaseEntity.Builder()
             .catalogId(PolarisEntityConstants.getNullId())
@@ -420,8 +421,7 @@ public class PolarisTestMetaStoreManager {
             .parentId(PolarisEntityConstants.getRootEntityId())
             .name(name)
             .internalProperties(
-                PolarisObjectMapperUtil.serializeProperties(
-                    this.polarisCallContext,
+                objectMapper.serializeProperties(
                     Map.of(
                         PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE,
                         "true")))
@@ -467,8 +467,8 @@ public class PolarisTestMetaStoreManager {
         .isEqualTo(secrets.getSecondarySecretHash());
 
     Map<String, String> internalProperties =
-        PolarisObjectMapperUtil.deserializeProperties(
-            this.polarisCallContext, createPrincipalResult.getPrincipal().getInternalProperties());
+        objectMapper.deserializeProperties(
+            createPrincipalResult.getPrincipal().getInternalProperties());
     Assertions.assertThat(
             internalProperties.get(
                 PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE))
@@ -512,8 +512,7 @@ public class PolarisTestMetaStoreManager {
                 createPrincipalResult.getPrincipal().getType())
             .getEntity();
     internalProperties =
-        PolarisObjectMapperUtil.deserializeProperties(
-            this.polarisCallContext, reloadPrincipal.getInternalProperties());
+        objectMapper.deserializeProperties(reloadPrincipal.getInternalProperties());
     Assertions.assertThat(
             internalProperties.get(
                 PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE))
@@ -569,9 +568,7 @@ public class PolarisTestMetaStoreManager {
             .loadEntity(
                 this.polarisCallContext, 0L, principalEntity.getId(), principalEntity.getType())
             .getEntity();
-    internalProperties =
-        PolarisObjectMapperUtil.deserializeProperties(
-            this.polarisCallContext, newPrincipal.getInternalProperties());
+    internalProperties = objectMapper.deserializeProperties(newPrincipal.getInternalProperties());
     Assertions.assertThat(
             internalProperties.get(
                 PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE))
@@ -604,9 +601,7 @@ public class PolarisTestMetaStoreManager {
             .loadEntity(
                 this.polarisCallContext, 0L, principalEntity.getId(), principalEntity.getType())
             .getEntity();
-    internalProperties =
-        PolarisObjectMapperUtil.deserializeProperties(
-            this.polarisCallContext, finalPrincipal.getInternalProperties());
+    internalProperties = objectMapper.deserializeProperties(finalPrincipal.getInternalProperties());
     Assertions.assertThat(
             internalProperties.get(
                 PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE))
@@ -874,20 +869,18 @@ public class PolarisTestMetaStoreManager {
       Assertions.assertThat(cleanupTask).isNotNull();
       Assertions.assertThat(cleanupTask.getType()).isEqualTo(PolarisEntityType.TASK);
       Assertions.assertThat(cleanupTask.getInternalProperties()).isNotNull();
+
+      PolarisObjectMapper objectMapper = polarisCallContext.getObjectMapper();
       Map<String, String> internalProperties =
-          PolarisObjectMapperUtil.deserializeProperties(
-              polarisCallContext, cleanupTask.getInternalProperties());
+          objectMapper.deserializeProperties(cleanupTask.getInternalProperties());
       Assertions.assertThat(internalProperties).isEqualTo(cleanupProperties);
       Map<String, String> properties =
-          PolarisObjectMapperUtil.deserializeProperties(
-              polarisCallContext, cleanupTask.getProperties());
+          objectMapper.deserializeProperties(cleanupTask.getProperties());
       Assertions.assertThat(properties).isNotNull();
       Assertions.assertThat(properties.get(PolarisTaskConstants.TASK_DATA)).isNotNull();
       PolarisBaseEntity droppedEntity =
-          PolarisObjectMapperUtil.deserialize(
-              polarisCallContext,
-              properties.get(PolarisTaskConstants.TASK_DATA),
-              PolarisBaseEntity.class);
+          objectMapper.deserialize(
+              properties.get(PolarisTaskConstants.TASK_DATA), PolarisBaseEntity.class);
       Assertions.assertThat(droppedEntity).isNotNull();
       Assertions.assertThat(droppedEntity.getId()).isEqualTo(entity.getId());
     }


### PR DESCRIPTION
all static methods that took a `PolarisCallContext` as first parameter can be moved to the new class.

if we did not need to log json-related exceptions to `PolarisDiagnostics` (which we dont do in other places) then we could keep everything as static util methods.