### PR TITLE
Fix Namespace resolution on grant/revoke privilege operations

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
@@ -18,9 +18,12 @@
  */
 package org.apache.polaris.core.persistence;
 
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityType;
 
 /**
  * Holds fully-resolved path of PolarisEntities representing the targetEntity with all its grants
@@ -75,6 +78,38 @@ public class PolarisResolvedPathWrapper {
     return getResolvedParentPath().stream()
         .map(ResolvedPolarisEntity::getEntity)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Checks if a namespace is fully resolved.
+   *
+   * @param catalogName the name of the catalog
+   * @param namespace the namespace we're trying to resolve
+   * @return true if the namespace is considered fully resolved for the given catalog type
+   */
+  public boolean isFullyResolvedNamespace(
+      @Nonnull String catalogName, @Nonnull Namespace namespace) {
+    if (resolvedPath == null) {
+      return false;
+    }
+
+    List<PolarisEntity> fullPath = getRawFullPath();
+    int expectedPathLength = 1 + namespace.levels().length;
+    if (fullPath.size() != expectedPathLength) {
+      return false;
+    }
+
+    if (!fullPath.get(0).getName().equals(catalogName)) {
+      return false;
+    }
+
+    for (int i = 0; i < namespace.levels().length; i++) {
+      if (!fullPath.get(i + 1).getName().equals(namespace.levels()[i])
+          || fullPath.get(i + 1).getType() != PolarisEntityType.NAMESPACE) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
@@ -103,9 +104,14 @@ public class PolarisResolvedPathWrapper {
       return false;
     }
 
-    for (int i = 0; i < namespace.levels().length; i++) {
-      if (!fullPath.get(i + 1).getName().equals(namespace.levels()[i])
-          || fullPath.get(i + 1).getType() != PolarisEntityType.NAMESPACE) {
+    String[] namespaceLevels = namespace.levels();
+    int levelsLength = namespaceLevels.length;
+    Iterator<PolarisEntity> fullPathIterator = fullPath.iterator();
+    fullPathIterator.next();
+    for (int i = 0; i < levelsLength; i++) {
+      PolarisEntity entity = fullPathIterator.next();
+      if (!entity.getName().equals(namespaceLevels[i])
+          || entity.getType() != PolarisEntityType.NAMESPACE) {
         return false;
       }
     }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapperTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapperTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.junit.jupiter.api.Test;
+
+public class PolarisResolvedPathWrapperTest {
+
+  @Test
+  void testIsFullyResolvedNamespace_NullResolvedPath() {
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(null);
+
+    boolean result = wrapper.isFullyResolvedNamespace("test-catalog", Namespace.of("ns1"));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_InsufficientPathLength() {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    List<ResolvedPolarisEntity> shortPath = List.of(createResolvedEntity(catalogEntity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(shortPath);
+
+    assertFalse(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_WrongCatalogName() {
+    String catalogName = "test-catalog";
+    String wrongCatalogName = "wrong-catalog";
+    Namespace namespace = Namespace.of("ns1");
+
+    PolarisEntity wrongCatalogEntity = createEntity(wrongCatalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespaceEntity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    List<ResolvedPolarisEntity> path =
+        List.of(createResolvedEntity(wrongCatalogEntity), createResolvedEntity(namespaceEntity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
+
+    assertFalse(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_WrongNamespaceNames() {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespace1Entity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    PolarisEntity namespace2WrongEntity = createEntity("wrong-ns2", PolarisEntityType.NAMESPACE);
+    List<ResolvedPolarisEntity> path =
+        List.of(
+            createResolvedEntity(catalogEntity),
+            createResolvedEntity(namespace1Entity),
+            createResolvedEntity(namespace2WrongEntity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
+
+    assertFalse(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_CorrectPath() {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespace1Entity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    PolarisEntity namespace2Entity = createEntity("ns2", PolarisEntityType.NAMESPACE);
+    List<ResolvedPolarisEntity> path =
+        List.of(
+            createResolvedEntity(catalogEntity),
+            createResolvedEntity(namespace1Entity),
+            createResolvedEntity(namespace2Entity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
+
+    assertTrue(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_WrongEntityType() {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity wrongTypeEntity = createEntity("ns1", PolarisEntityType.TABLE_LIKE);
+    List<ResolvedPolarisEntity> path =
+        List.of(createResolvedEntity(catalogEntity), createResolvedEntity(wrongTypeEntity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
+
+    assertFalse(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  @Test
+  void testIsFullyResolvedNamespace_EmptyNamespace() {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.empty();
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    List<ResolvedPolarisEntity> path = List.of(createResolvedEntity(catalogEntity));
+    PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
+
+    assertTrue(wrapper.isFullyResolvedNamespace(catalogName, namespace));
+  }
+
+  private PolarisEntity createEntity(String name, PolarisEntityType type) {
+    return new PolarisEntity.Builder()
+        .setName(name)
+        .setType(type)
+        .setId(1L)
+        .setCatalogId(1L)
+        .setParentId(1L)
+        .setCreateTimestamp(System.currentTimeMillis())
+        .build();
+  }
+
+  private ResolvedPolarisEntity createResolvedEntity(PolarisEntity entity) {
+    return new ResolvedPolarisEntity(entity, null, null);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapperTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapperTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.persistence;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,9 +33,7 @@ public class PolarisResolvedPathWrapperTest {
   void testIsFullyResolvedNamespace_NullResolvedPath() {
     PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(null);
 
-    boolean result = wrapper.isFullyResolvedNamespace("test-catalog", Namespace.of("ns1"));
-
-    assertThat(result).isFalse();
+    assertFalse(wrapper.isFullyResolvedNamespace("test-catalog", Namespace.of("ns1")));
   }
 
   @Test
@@ -105,12 +102,16 @@ public class PolarisResolvedPathWrapperTest {
   @Test
   void testIsFullyResolvedNamespace_WrongEntityType() {
     String catalogName = "test-catalog";
-    Namespace namespace = Namespace.of("ns1");
+    Namespace namespace = Namespace.of("ns1", "ns2");
 
     PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
-    PolarisEntity wrongTypeEntity = createEntity("ns1", PolarisEntityType.TABLE_LIKE);
+    PolarisEntity correctEntityType = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    PolarisEntity wrongEntityType = createEntity("ns2", PolarisEntityType.TABLE_LIKE);
     List<ResolvedPolarisEntity> path =
-        List.of(createResolvedEntity(catalogEntity), createResolvedEntity(wrongTypeEntity));
+        List.of(
+            createResolvedEntity(catalogEntity),
+            createResolvedEntity(correctEntityType),
+            createResolvedEntity(wrongEntityType));
     PolarisResolvedPathWrapper wrapper = new PolarisResolvedPathWrapper(path);
 
     assertFalse(wrapper.isFullyResolvedNamespace(catalogName, namespace));

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1672,6 +1672,42 @@ public class PolarisAdminService {
         .isSuccess();
   }
 
+  /**
+   * Checks if a namespace is fully resolved.
+   *
+   * @param resolvedPathWrapper the resolved path wrapper from resolution
+   * @param catalogName the name of the catalog
+   * @param namespace the namespace we're trying to resolve
+   * @return true if the namespace is considered fully resolved for the given catalog type
+   */
+  private boolean isNamespaceFullyResolved(
+      @Nullable PolarisResolvedPathWrapper resolvedPathWrapper,
+      @Nonnull String catalogName,
+      @Nonnull Namespace namespace) {
+    if (resolvedPathWrapper == null) {
+      return false;
+    }
+
+    List<PolarisEntity> fullPath = resolvedPathWrapper.getRawFullPath();
+    int expectedPathLength = 1 + namespace.levels().length;
+    if (fullPath.size() < expectedPathLength) {
+      return false;
+    }
+
+    if (!fullPath.get(0).getName().equals(catalogName)) {
+      return false;
+    }
+
+    for (int i = 0; i < namespace.levels().length; i++) {
+      if (!fullPath.get(i + 1).getName().equals(namespace.levels()[i])
+          || fullPath.get(i + 1).getType() != PolarisEntityType.NAMESPACE) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /** Adds a namespace-level grant on {@code namespace} to {@code catalogRoleName}. */
   public boolean grantPrivilegeOnNamespaceToRole(
       String catalogName, String catalogRoleName, Namespace namespace, PolarisPrivilege privilege) {
@@ -1684,7 +1720,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("CatalogRole %s not found", catalogRoleName));
 
     PolarisResolvedPathWrapper resolvedPathWrapper = resolutionManifest.getResolvedPath(namespace);
-    if (resolvedPathWrapper == null) {
+    if (!isNamespaceFullyResolved(resolvedPathWrapper, catalogName, namespace)) {
       throw new NotFoundException("Namespace %s not found", namespace);
     }
     List<PolarisEntity> catalogPath = resolvedPathWrapper.getRawParentPath();
@@ -1712,7 +1748,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("CatalogRole %s not found", catalogRoleName));
 
     PolarisResolvedPathWrapper resolvedPathWrapper = resolutionManifest.getResolvedPath(namespace);
-    if (resolvedPathWrapper == null) {
+    if (!isNamespaceFullyResolved(resolvedPathWrapper, catalogName, namespace)) {
       throw new NotFoundException("Namespace %s not found", namespace);
     }
     List<PolarisEntity> catalogPath = resolvedPathWrapper.getRawParentPath();

--- a/service/common/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -137,7 +137,7 @@ public class PolarisAdminServiceTest {
       throws Exception {
     String catalogName = "test-catalog";
     String catalogRoleName = "test-role";
-    Namespace namespace = Namespace.of("incomplete-ns");
+    Namespace namespace = Namespace.of("complete-ns", "incomplete-ns");
     PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
 
     when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
@@ -151,7 +151,10 @@ public class PolarisAdminServiceTest {
 
     when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(resolvedPathWrapper);
     when(resolvedPathWrapper.getRawFullPath())
-        .thenReturn(List.of(createEntity("wrong-catalog", PolarisEntityType.CATALOG)));
+        .thenReturn(
+            List.of(
+                createEntity("test-catalog", PolarisEntityType.CATALOG),
+                createEntity("complete-ns", PolarisEntityType.NAMESPACE)));
     when(resolvedPathWrapper.isFullyResolvedNamespace(eq(catalogName), eq(namespace)))
         .thenReturn(false);
 

--- a/service/common/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.SecurityContext;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.persistence.PolarisEntityManager;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.ResolverStatus;
+import org.apache.polaris.core.secrets.UserSecretsManager;
+import org.apache.polaris.service.config.ReservedProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class PolarisAdminServiceTest {
+
+  @Mock private CallContext callContext;
+  @Mock private PolarisCallContext polarisCallContext;
+  @Mock private PolarisDiagnostics polarisDiagnostics;
+  @Mock private PolarisEntityManager entityManager;
+  @Mock private PolarisMetaStoreManager metaStoreManager;
+  @Mock private UserSecretsManager userSecretsManager;
+  @Mock private SecurityContext securityContext;
+  @Mock private PolarisAuthorizer authorizer;
+  @Mock private ReservedProperties reservedProperties;
+  @Mock private AuthenticatedPolarisPrincipal authenticatedPrincipal;
+  @Mock private PolarisResolutionManifest resolutionManifest;
+  @Mock private PolarisResolvedPathWrapper resolvedPathWrapper;
+
+  private PolarisAdminService adminService;
+  private Method isNamespaceFullyResolvedMethod;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(securityContext.getUserPrincipal()).thenReturn(authenticatedPrincipal);
+    when(callContext.getPolarisCallContext()).thenReturn(polarisCallContext);
+    when(polarisCallContext.getDiagServices()).thenReturn(polarisDiagnostics);
+
+    adminService =
+        new PolarisAdminService(
+            callContext,
+            entityManager,
+            metaStoreManager,
+            userSecretsManager,
+            securityContext,
+            authorizer,
+            reservedProperties);
+
+    isNamespaceFullyResolvedMethod =
+        PolarisAdminService.class.getDeclaredMethod(
+            "isNamespaceFullyResolved",
+            PolarisResolvedPathWrapper.class,
+            String.class,
+            Namespace.class);
+    isNamespaceFullyResolvedMethod.setAccessible(true);
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_NullWrapper() throws Exception {
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, null, "test-catalog", Namespace.of("ns1"));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_InsufficientPathLength() throws Exception {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    List<PolarisEntity> shortPath = List.of(catalogEntity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(shortPath);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_WrongCatalogName() throws Exception {
+    String catalogName = "test-catalog";
+    String wrongCatalogName = "wrong-catalog";
+    Namespace namespace = Namespace.of("ns1");
+
+    PolarisEntity wrongCatalogEntity = createEntity(wrongCatalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespaceEntity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    List<PolarisEntity> path = List.of(wrongCatalogEntity, namespaceEntity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(path);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_WrongNamespaceNames() throws Exception {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespace1Entity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    PolarisEntity namespace2WrongEntity = createEntity("wrong-ns2", PolarisEntityType.NAMESPACE);
+    List<PolarisEntity> path = List.of(catalogEntity, namespace1Entity, namespace2WrongEntity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(path);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_CorrectPath() throws Exception {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1", "ns2");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespace1Entity = createEntity("ns1", PolarisEntityType.NAMESPACE);
+    PolarisEntity namespace2Entity = createEntity("ns2", PolarisEntityType.NAMESPACE);
+    List<PolarisEntity> path = List.of(catalogEntity, namespace1Entity, namespace2Entity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(path);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_WrongEntityType() throws Exception {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.of("ns1");
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity wrongTypeEntity = createEntity("ns1", PolarisEntityType.TABLE_LIKE);
+    List<PolarisEntity> path = List.of(catalogEntity, wrongTypeEntity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(path);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsNamespaceFullyResolved_EmptyNamespace() throws Exception {
+    String catalogName = "test-catalog";
+    Namespace namespace = Namespace.empty();
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    List<PolarisEntity> path = List.of(catalogEntity);
+
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(path);
+
+    boolean result =
+        (boolean)
+            isNamespaceFullyResolvedMethod.invoke(
+                adminService, resolvedPathWrapper, catalogName, namespace);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testGrantPrivilegeOnNamespaceToRole() throws Exception {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("existing-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    setupSuccessfulNamespaceResolution(catalogName, catalogRoleName, namespace);
+
+    PrivilegeResult successResult = mock(PrivilegeResult.class);
+    when(successResult.isSuccess()).thenReturn(true);
+    when(metaStoreManager.grantPrivilegeOnSecurableToRole(any(), any(), any(), any(), any()))
+        .thenReturn(successResult);
+
+    boolean result =
+        adminService.grantPrivilegeOnNamespaceToRole(
+            catalogName, catalogRoleName, namespace, privilege);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testGrantPrivilegeOnNamespaceToRole_ThrowsNamespaceNotFoundException() {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("non-existent-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
+        .thenReturn(resolutionManifest);
+    when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(eq(catalogRoleName))).thenReturn(catalogRoleWrapper);
+
+    when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(null);
+
+    assertThatThrownBy(
+            () ->
+                adminService.grantPrivilegeOnNamespaceToRole(
+                    catalogName, catalogRoleName, namespace, privilege))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Namespace " + namespace + " not found");
+  }
+
+  @Test
+  void testGrantPrivilegeOnNamespaceToRole_IncompleteNamespaceThrowsNamespaceNotFoundException()
+      throws Exception {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("incomplete-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
+        .thenReturn(resolutionManifest);
+    when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(eq(catalogRoleName))).thenReturn(catalogRoleWrapper);
+
+    when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(resolvedPathWrapper);
+    when(resolvedPathWrapper.getRawFullPath())
+        .thenReturn(List.of(createEntity("wrong-catalog", PolarisEntityType.CATALOG)));
+
+    assertThatThrownBy(
+            () ->
+                adminService.grantPrivilegeOnNamespaceToRole(
+                    catalogName, catalogRoleName, namespace, privilege))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Namespace " + namespace + " not found");
+  }
+
+  @Test
+  void testRevokePrivilegeOnNamespaceFromRole() throws Exception {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("existing-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    setupSuccessfulNamespaceResolution(catalogName, catalogRoleName, namespace);
+
+    PrivilegeResult successResult = mock(PrivilegeResult.class);
+    when(successResult.isSuccess()).thenReturn(true);
+    when(metaStoreManager.revokePrivilegeOnSecurableFromRole(any(), any(), any(), any(), any()))
+        .thenReturn(successResult);
+
+    boolean result =
+        adminService.revokePrivilegeOnNamespaceFromRole(
+            catalogName, catalogRoleName, namespace, privilege);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testRevokePrivilegeOnNamespaceFromRole_ThrowsNamespaceNotFoundException() {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("non-existent-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
+        .thenReturn(resolutionManifest);
+    when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(eq(catalogRoleName))).thenReturn(catalogRoleWrapper);
+
+    when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(null);
+
+    assertThatThrownBy(
+            () ->
+                adminService.revokePrivilegeOnNamespaceFromRole(
+                    catalogName, catalogRoleName, namespace, privilege))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Namespace " + namespace + " not found");
+  }
+
+  @Test
+  void testRevokePrivilegeOnNamespaceFromRole_IncompletelNamespaceThrowsNamespaceNotFoundException()
+      throws Exception {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("incomplete-ns");
+    PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
+
+    when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
+        .thenReturn(resolutionManifest);
+    when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(eq(catalogRoleName))).thenReturn(catalogRoleWrapper);
+
+    when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(resolvedPathWrapper);
+    when(resolvedPathWrapper.getRawFullPath())
+        .thenReturn(List.of(createEntity("wrong-catalog", PolarisEntityType.CATALOG)));
+
+    assertThatThrownBy(
+            () ->
+                adminService.revokePrivilegeOnNamespaceFromRole(
+                    catalogName, catalogRoleName, namespace, privilege))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Namespace " + namespace + " not found");
+  }
+
+  private PolarisEntity createEntity(String name, PolarisEntityType type) {
+    return new PolarisEntity.Builder()
+        .setName(name)
+        .setType(type)
+        .setId(1L)
+        .setCatalogId(1L)
+        .setParentId(1L)
+        .setCreateTimestamp(System.currentTimeMillis())
+        .build();
+  }
+
+  private ResolverStatus createSuccessfulResolverStatus() {
+    return new ResolverStatus(ResolverStatus.StatusEnum.SUCCESS);
+  }
+
+  private void setupSuccessfulNamespaceResolution(
+      String catalogName, String catalogRoleName, Namespace namespace) throws Exception {
+
+    when(entityManager.prepareResolutionManifest(any(), any(), eq(catalogName)))
+        .thenReturn(resolutionManifest);
+    when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
+    when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(resolvedPathWrapper);
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    PolarisEntity namespaceEntity =
+        createEntity(namespace.levels()[0], PolarisEntityType.NAMESPACE);
+    List<PolarisEntity> fullPath = List.of(catalogEntity, namespaceEntity);
+    when(resolvedPathWrapper.getRawFullPath()).thenReturn(fullPath);
+    when(resolvedPathWrapper.getRawParentPath()).thenReturn(List.of(catalogEntity));
+    when(resolvedPathWrapper.getRawLeafEntity()).thenReturn(namespaceEntity);
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(eq(catalogRoleName))).thenReturn(catalogRoleWrapper);
+  }
+}


### PR DESCRIPTION
I encountered the bug while implementing RBAC for federation. 
For grant/revoke operations on tables, polaris checks the subtype of the leaf entity and make sure it matches. However, for namespace the only check is that the resolved path is not null. 

Ideally we should check that the entire path matches the one sent in the request. Further, all entities except the root should be of the type NAMESPACE. 


Testing: 
Added unit tests. 