### PR TITLE
Add Principal lookup helpers to PolarisMetaStoreManager

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
@@ -46,6 +46,7 @@ import org.apache.polaris.core.admin.model.PrincipalRoles;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.admin.model.Principals;
 import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 
 /**
  * A simple, non-exhaustive set of helper methods for accessing the Polaris Management API.
@@ -287,7 +288,7 @@ public class ManagementApi extends RestApi {
 
   public void dropCatalog(String catalogName) {
     listCatalogRoles(catalogName).stream()
-        .filter(cr -> !cr.getName().equals("catalog_admin"))
+        .filter(cr -> !cr.getName().equals(PolarisEntityConstants.getNameOfCatalogAdminRole()))
         .forEach(role -> deleteCatalogRole(catalogName, role));
 
     deleteCatalog(catalogName);

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1684,7 +1684,9 @@ public class PolarisManagementServiceIntegrationTest {
             .build();
     managementApi.createCatalog(catalog);
 
-    CatalogRole catalogAdminRole = managementApi.getCatalogRole(catalogName, "catalog_admin");
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
 
     PrincipalWithCredentials catalogAdminPrincipal =
@@ -1771,7 +1773,9 @@ public class PolarisManagementServiceIntegrationTest {
             .build();
     managementApi.createCatalog(catalog);
 
-    CatalogRole catalogAdminRole = managementApi.getCatalogRole(catalogName, "catalog_admin");
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
 
     PrincipalWithCredentials catalogAdminPrincipal =
@@ -1813,7 +1817,10 @@ public class PolarisManagementServiceIntegrationTest {
       // grant the admin role back to service_admin so that cleanup can happen
       client
           .managementApi(catalogAdminToken)
-          .grantCatalogRoleToPrincipalRole("service_admin", catalogName, catalogAdminRole);
+          .grantCatalogRoleToPrincipalRole(
+              PolarisEntityConstants.getNameOfPrincipalServiceAdminRole(),
+              catalogName,
+              catalogAdminRole);
     }
   }
 
@@ -1856,7 +1863,9 @@ public class PolarisManagementServiceIntegrationTest {
     managementApi.createCatalogRole(catalogName2, catalogRoleName);
 
     // Get the catalog admin role from the *first* catalog and grant that role to the principal role
-    CatalogRole catalogAdminRole = managementApi.getCatalogRole(catalogName, "catalog_admin");
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
 
     // Create a principal and grant the principal role to it

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisEntityManager.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
@@ -82,15 +81,11 @@ public class PolarisEntityManager {
       // root entity, then we must actually create a representation of this root entity in the
       // entity store itself.
       PolarisEntity serviceAdminPrincipalRole =
-          PolarisEntity.of(
-              metaStoreManager
-                  .readEntityByName(
-                      callContext.getPolarisCallContext(),
-                      null,
-                      PolarisEntityType.PRINCIPAL_ROLE,
-                      PolarisEntitySubType.NULL_SUBTYPE,
-                      PolarisEntityConstants.getNameOfPrincipalServiceAdminRole())
-                  .getEntity());
+          metaStoreManager
+              .findPrincipalRoleByName(
+                  callContext.getPolarisCallContext(),
+                  PolarisEntityConstants.getNameOfPrincipalServiceAdminRole())
+              .orElse(null);
       if (serviceAdminPrincipalRole == null) {
         throw new IllegalStateException("Failed to resolve service_admin PrincipalRole");
       }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -29,10 +29,13 @@ import org.apache.polaris.core.auth.PolarisSecretsManager;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.ChangeTrackingResult;
 import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
@@ -417,5 +420,39 @@ public interface PolarisMetaStoreManager
    */
   default boolean requiresEntityReload() {
     return true;
+  }
+
+  default Optional<PrincipalEntity> findRootPrincipal(PolarisCallContext polarisCallContext) {
+    return findPrincipalByName(polarisCallContext, PolarisEntityConstants.getRootPrincipalName());
+  }
+
+  default Optional<PrincipalEntity> findPrincipalByName(
+      PolarisCallContext polarisCallContext, String principalName) {
+    EntityResult entityResult =
+        readEntityByName(
+            polarisCallContext,
+            null,
+            PolarisEntityType.PRINCIPAL,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            principalName);
+    if (!entityResult.isSuccess()) {
+      return Optional.empty();
+    }
+    return Optional.of(entityResult.getEntity()).map(PrincipalEntity::of);
+  }
+
+  default Optional<PrincipalRoleEntity> findPrincipalRoleByName(
+      PolarisCallContext polarisCallContext, String principalRoleName) {
+    EntityResult entityResult =
+        readEntityByName(
+            polarisCallContext,
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            principalRoleName);
+    if (!entityResult.isSuccess()) {
+      return Optional.empty();
+    }
+    return Optional.of(entityResult.getEntity()).map(PrincipalRoleEntity::of);
   }
 }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
@@ -41,7 +41,6 @@ import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
-import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.apache.polaris.core.persistence.resolver.Resolver;
 import org.apache.polaris.core.persistence.resolver.ResolverPath;
@@ -477,17 +476,10 @@ public abstract class BaseResolverTest {
                 scopes ->
                     scopes.stream()
                         .map(
-                            role ->
-                                metaStoreManager()
-                                    .readEntityByName(
-                                        callCtx(),
-                                        null,
-                                        PolarisEntityType.PRINCIPAL_ROLE,
-                                        PolarisEntitySubType.NULL_SUBTYPE,
-                                        role))
-                        .filter(EntityResult::isSuccess)
-                        .map(EntityResult::getEntity)
-                        .map(PrincipalRoleEntity::of)
+                            roleName ->
+                                metaStoreManager().findPrincipalRoleByName(callCtx(), roleName))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
                         .collect(Collectors.toList()));
     AuthenticatedPolarisPrincipal authenticatedPrincipal =
         new AuthenticatedPolarisPrincipal(
@@ -774,16 +766,10 @@ public abstract class BaseResolverTest {
       // the principal does not exist, check that this is the case
       if (principalName != null) {
         // see if the principal exists
-        EntityResult result =
-            metaStoreManager()
-                .readEntityByName(
-                    callCtx(),
-                    null,
-                    PolarisEntityType.PRINCIPAL,
-                    PolarisEntitySubType.NULL_SUBTYPE,
-                    principalName);
+        Optional<PrincipalEntity> principal =
+            metaStoreManager().findPrincipalByName(callCtx(), principalName);
         // if found, ensure properly resolved
-        if (result.getEntity() != null) {
+        if (principal.isPresent()) {
           // the principal exist, check that this is the case
           this.ensureResolved(
               resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName),

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/ManagementServiceTest.java
@@ -209,7 +209,10 @@ public class ManagementServiceTest {
           @Override
           public Principal getUserPrincipal() {
             return new AuthenticatedPolarisPrincipal(
-                new PrincipalEntity.Builder().setName("root").build(), Set.of("service_admin"));
+                new PrincipalEntity.Builder()
+                    .setName(PolarisEntityConstants.getRootPrincipalName())
+                    .build(),
+                Set.of(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole()));
           }
 
           @Override

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -61,8 +61,6 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
@@ -245,19 +243,9 @@ public abstract class PolarisAuthzTestBase {
     callContext = polarisContext;
     CallContext.setCurrentContext(callContext);
 
-    PrincipalEntity rootEntity =
-        new PrincipalEntity(
-            PolarisEntity.of(
-                metaStoreManager
-                    .readEntityByName(
-                        polarisContext,
-                        null,
-                        PolarisEntityType.PRINCIPAL,
-                        PolarisEntitySubType.NULL_SUBTYPE,
-                        "root")
-                    .getEntity()));
-
-    this.authenticatedRoot = new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    PrincipalEntity rootPrincipal =
+        metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
+    this.authenticatedRoot = new AuthenticatedPolarisPrincipal(rootPrincipal, Set.of());
 
     this.adminService =
         new PolarisAdminService(
@@ -421,30 +409,15 @@ public abstract class PolarisAuthzTestBase {
       String principalName,
       PrincipalWithCredentialsCredentials credentials,
       PolarisCallContext polarisContext) {
-    EntityResult lookupEntity =
-        metaStoreManager.readEntityByName(
-            callContext.getPolarisCallContext(),
-            null,
-            PolarisEntityType.PRINCIPAL,
-            PolarisEntitySubType.NULL_SUBTYPE,
-            principalName);
+    PrincipalEntity principal =
+        metaStoreManager.findPrincipalByName(polarisContext, principalName).orElseThrow();
     metaStoreManager.rotatePrincipalSecrets(
         callContext.getPolarisCallContext(),
         credentials.getClientId(),
-        lookupEntity.getEntity().getId(),
+        principal.getId(),
         false,
         credentials.getClientSecret()); // This should actually be the secret's hash
-
-    return new PrincipalEntity(
-        PolarisEntity.of(
-            metaStoreManager
-                .readEntityByName(
-                    polarisContext,
-                    null,
-                    PolarisEntityType.PRINCIPAL,
-                    PolarisEntitySubType.NULL_SUBTYPE,
-                    principalName)
-                .getEntity()));
+    return metaStoreManager.findPrincipalByName(polarisContext, principalName).orElseThrow();
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
@@ -104,7 +104,6 @@ import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -299,20 +298,10 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
     // the CallContext.setCurrentContext() but never clears it, whereas the NoSQL one resets it.
     CallContext.setCurrentContext(polarisContext);
 
-    PrincipalEntity rootEntity =
-        new PrincipalEntity(
-            PolarisEntity.of(
-                metaStoreManager
-                    .readEntityByName(
-                        polarisContext,
-                        null,
-                        PolarisEntityType.PRINCIPAL,
-                        PolarisEntitySubType.NULL_SUBTYPE,
-                        "root")
-                    .getEntity()));
-
+    PrincipalEntity rootPrincipal =
+        metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     AuthenticatedPolarisPrincipal authenticatedRoot =
-        new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+        new AuthenticatedPolarisPrincipal(rootPrincipal, Set.of());
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogViewTest.java
@@ -48,9 +48,6 @@ import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
-import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -172,19 +169,10 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
 
     CallContext.setCurrentContext(polarisContext);
 
-    PrincipalEntity rootEntity =
-        new PrincipalEntity(
-            PolarisEntity.of(
-                metaStoreManager
-                    .readEntityByName(
-                        polarisContext,
-                        null,
-                        PolarisEntityType.PRINCIPAL,
-                        PolarisEntitySubType.NULL_SUBTYPE,
-                        "root")
-                    .getEntity()));
+    PrincipalEntity rootPrincipal =
+        metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     AuthenticatedPolarisPrincipal authenticatedRoot =
-        new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+        new AuthenticatedPolarisPrincipal(rootPrincipal, Set.of());
 
     SecurityContext securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
@@ -49,8 +49,6 @@ import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.table.GenericTableEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -160,19 +158,9 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     entityManager = new PolarisEntityManager(metaStoreManager, resolverFactory);
 
-    PrincipalEntity rootEntity =
-        new PrincipalEntity(
-            PolarisEntity.of(
-                metaStoreManager
-                    .readEntityByName(
-                        polarisContext,
-                        null,
-                        PolarisEntityType.PRINCIPAL,
-                        PolarisEntitySubType.NULL_SUBTYPE,
-                        "root")
-                    .getEntity()));
-
-    authenticatedRoot = new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    PrincipalEntity rootPrincipal =
+        metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
+    authenticatedRoot = new AuthenticatedPolarisPrincipal(rootPrincipal, Set.of());
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolicyCatalogTest.java
@@ -57,8 +57,6 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
@@ -185,19 +183,9 @@ public abstract class AbstractPolicyCatalogTest {
 
     callContext = polarisContext;
 
-    PrincipalEntity rootEntity =
-        new PrincipalEntity(
-            PolarisEntity.of(
-                metaStoreManager
-                    .readEntityByName(
-                        polarisContext,
-                        null,
-                        PolarisEntityType.PRINCIPAL,
-                        PolarisEntitySubType.NULL_SUBTYPE,
-                        "root")
-                    .getEntity()));
-
-    authenticatedRoot = new AuthenticatedPolarisPrincipal(rootEntity, Set.of());
+    PrincipalEntity rootPrincipal =
+        metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
+    authenticatedRoot = new AuthenticatedPolarisPrincipal(rootPrincipal, Set.of());
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
@@ -38,14 +38,11 @@ import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
-import org.apache.polaris.core.entity.PolarisEntityConstants;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
-import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.apache.polaris.service.quarkus.auth.TokenUtils;
 import org.junit.jupiter.api.TestInfo;
@@ -122,14 +119,7 @@ public class PolarisIntegrationTestFixture {
     try {
       PolarisMetaStoreManager metaStoreManager =
           helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
-      EntityResult principal =
-          metaStoreManager.readEntityByName(
-              polarisContext,
-              null,
-              PolarisEntityType.PRINCIPAL,
-              PolarisEntitySubType.NULL_SUBTYPE,
-              PolarisEntityConstants.getRootPrincipalName());
-
+      PrincipalEntity principal = metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
       Map<String, String> propertiesMap = readInternalProperties(principal);
       return metaStoreManager
           .loadPrincipalSecrets(polarisContext, propertiesMap.get("client_id"))
@@ -233,10 +223,10 @@ public class PolarisIntegrationTestFixture {
     }
   }
 
-  private Map<String, String> readInternalProperties(EntityResult principal) {
+  private Map<String, String> readInternalProperties(PrincipalEntity principal) {
     try {
       return helper.objectMapper.readValue(
-          principal.getEntity().getInternalProperties(), new TypeReference<>() {});
+          principal.getInternalProperties(), new TypeReference<>() {});
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -76,13 +75,10 @@ public class DefaultAuthenticator
                     PolarisEntityType.PRINCIPAL));
       } else if (credentials.getPrincipalName() != null) {
         principal =
-            PolarisEntity.of(
-                metaStoreManager.readEntityByName(
-                    callContext.getPolarisCallContext(),
-                    null,
-                    PolarisEntityType.PRINCIPAL,
-                    PolarisEntitySubType.NULL_SUBTYPE,
-                    credentials.getPrincipalName()));
+            metaStoreManager
+                .findPrincipalByName(
+                    callContext.getPolarisCallContext(), credentials.getPrincipalName())
+                .orElse(null);
       }
     } catch (Exception e) {
       LOGGER


### PR DESCRIPTION
`PolarisMetaStoreManager.readEntityByName` is quite a low-level api, so we can simplify a lot of callers with additional helpers:

- add `PolarisMetaStoreManager.findRootPrincipal`
- add `PolarisMetaStoreManager.findPrincipalByName`
- add `PolarisMetaStoreManager.findPrincipalRoleByName`

also we now prefer `PolarisEntityConstants` where applicable