### PR TITLE
Expose resetCredentials via api to allow root user to reset credentials for an existing principal with custom values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,4 @@ org.gradle.configuration-cache=false
 #org.gradle.configuration-cache-problems=warn
 # bump the Gradle daemon heap size (you can set bigger heap sizes as well)
 org.gradle.jvmargs=-Xms2g -Xmx4g -XX:MaxMetaspaceSize=768m
+org.gradle.daemon=true

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -809,12 +809,12 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               params));
     } catch (SQLException e) {
       LOGGER.error(
-          "Failed to rotatePrincipalSecrets  for clientId: {}, due to {}",
+          "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
           clientId,
           e.getMessage(),
           e);
       throw new RuntimeException(
-          String.format("Failed to rotatePrincipalSecrets for clientId: %s", clientId), e);
+          String.format("Failed to rest PrincipalSecrets for clientId: %s", clientId), e);
     }
 
     // return those

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -696,11 +696,11 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPrincipalSecrets rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash) {
     // load the existing secrets
     PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
 
@@ -758,38 +758,37 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     return principalSecrets;
   }
 
-
   @Nullable
   @Override
   public PolarisPrincipalSecrets resetPrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash,
-          String customClientId,
-          String customClientSecret){
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
     PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
 
     // should be found
     callCtx
-            .getDiagServices()
-            .checkNotNull(
-                    principalSecrets,
-                    "cannot_find_secrets",
-                    "client_id={} principalId={}",
-                    clientId,
-                    principalId);
+        .getDiagServices()
+        .checkNotNull(
+            principalSecrets,
+            "cannot_find_secrets",
+            "client_id={} principalId={}",
+            clientId,
+            principalId);
 
     // ensure principal id is matching
     callCtx
-            .getDiagServices()
-            .check(
-                    principalId == principalSecrets.getPrincipalId(),
-                    "principal_id_mismatch",
-                    "expectedId={} id={}",
-                    principalId,
-                    principalSecrets.getPrincipalId());
+        .getDiagServices()
+        .check(
+            principalId == principalSecrets.getPrincipalId(),
+            "principal_id_mismatch",
+            "expectedId={} id={}",
+            principalId,
+            principalSecrets.getPrincipalId());
 
     principalSecrets.setPrincipalClientId(customClientId);
     principalSecrets.resetSecrets(customClientSecret);
@@ -797,25 +796,25 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     Map<String, Object> params = Map.of("principal_client_id", clientId, "realm_id", realmId);
     try {
       ModelPrincipalAuthenticationData modelPrincipalAuthenticationData =
-              ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
+          ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
       datasourceOperations.executeUpdate(
-              QueryGenerator.generateUpdateQuery(
-                      ModelPrincipalAuthenticationData.ALL_COLUMNS,
-                      ModelPrincipalAuthenticationData.TABLE_NAME,
-                      modelPrincipalAuthenticationData
-                              .toMap(datasourceOperations.getDatabaseType())
-                              .values()
-                              .stream()
-                              .toList(),
-                      params));
+          QueryGenerator.generateUpdateQuery(
+              ModelPrincipalAuthenticationData.ALL_COLUMNS,
+              ModelPrincipalAuthenticationData.TABLE_NAME,
+              modelPrincipalAuthenticationData
+                  .toMap(datasourceOperations.getDatabaseType())
+                  .values()
+                  .stream()
+                  .toList(),
+              params));
     } catch (SQLException e) {
       LOGGER.error(
-              "Failed to rotatePrincipalSecrets  for clientId: {}, due to {}",
-              clientId,
-              e.getMessage(),
-              e);
+          "Failed to rotatePrincipalSecrets  for clientId: {}, due to {}",
+          clientId,
+          e.getMessage(),
+          e);
       throw new RuntimeException(
-              String.format("Failed to rotatePrincipalSecrets for clientId: %s", clientId), e);
+          String.format("Failed to rotatePrincipalSecrets for clientId: %s", clientId), e);
     }
 
     // return those

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
@@ -38,22 +38,24 @@ public interface PolarisSecretsManager {
   /**
    * Rotate secrets
    *
-   * @param callCtx            call context
-   * @param clientId           principal client id
-   * @param principalId        id of the principal
-   * @param reset              true if the principal's secrets should be disabled and replaced with a one-time
-   *                           password. if the principal's secret is already a one-time password, this flag is
-   *                           automatically true
-   * @param oldSecretHash      main secret hash for the principal
+   * @param callCtx call context
+   * @param clientId principal client id
+   * @param principalId id of the principal
+   * @param reset true if the principal's secrets should be disabled and replaced with a one-time
+   *     password. if the principal's secret is already a one-time password, this flag is
+   *     automatically true
+   * @param oldSecretHash main secret hash for the principal
    * @param customClientId
    * @param customClientSecret
    * @return the secrets associated to that principal amd the id of the principal
    */
   @Nonnull
   PrincipalSecretsResult rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash, String customClientId, String customClientSecret);
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
@@ -38,20 +38,22 @@ public interface PolarisSecretsManager {
   /**
    * Rotate secrets
    *
-   * @param callCtx call context
-   * @param clientId principal client id
-   * @param principalId id of the principal
-   * @param reset true if the principal's secrets should be disabled and replaced with a one-time
-   *     password. if the principal's secret is already a one-time password, this flag is
-   *     automatically true
-   * @param oldSecretHash main secret hash for the principal
+   * @param callCtx            call context
+   * @param clientId           principal client id
+   * @param principalId        id of the principal
+   * @param reset              true if the principal's secrets should be disabled and replaced with a one-time
+   *                           password. if the principal's secret is already a one-time password, this flag is
+   *                           automatically true
+   * @param oldSecretHash      main secret hash for the principal
+   * @param customClientId
+   * @param customClientSecret
    * @return the secrets associated to that principal amd the id of the principal
    */
   @Nonnull
   PrincipalSecretsResult rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash);
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash, String customClientId, String customClientSecret);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -87,7 +87,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_TABLE_LOCATION_OVERLAP")
           .catalogConfig("polaris.config.allow.overlapping.table.location")
-          .catalogConfigUnsafe("allow.overlapping.table.location")
+          //          .catalogConfigUnsafe("allow.overlapping.table.location")
           .description(
               "If set to true, allow one table's location to reside within another table's location. "
                   + "This is only enforced within a given namespace.")
@@ -122,7 +122,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_UNSTRUCTURED_TABLE_LOCATION")
           .catalogConfig("polaris.config.allow.unstructured.table.location")
-          .catalogConfigUnsafe("allow.unstructured.table.location")
+          //          .catalogConfigUnsafe("allow.unstructured.table.location")
           .description("If set to true, allows unstructured table locations.")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -131,7 +131,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_TABLE_LOCATION")
           .catalogConfig("polaris.config.allow.external.table.location")
-          .catalogConfigUnsafe("allow.external.table.location")
+          //          .catalogConfigUnsafe("allow.external.table.location")
           .description(
               "If set to true, allows tables to have external locations outside the default structure.")
           .defaultValue(false)
@@ -141,7 +141,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING")
           .catalogConfig("polaris.config.enable.credential.vending")
-          .catalogConfigUnsafe("enable.credential.vending")
+          //          .catalogConfigUnsafe("enable.credential.vending")
           .description("If set to true, allow credential vending for external catalogs.")
           .defaultValue(true)
           .buildFeatureConfiguration();
@@ -150,7 +150,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<List<String>>builder()
           .key("SUPPORTED_CATALOG_STORAGE_TYPES")
           .catalogConfig("polaris.config.supported.storage.types")
-          .catalogConfigUnsafe("supported.storage.types")
+          //          .catalogConfigUnsafe("supported.storage.types")
           .description("The list of supported storage types for a catalog")
           .defaultValue(
               List.of(
@@ -163,7 +163,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_NAMESPACE_DROP")
           .catalogConfig("polaris.config.cleanup.on.namespace.drop")
-          .catalogConfigUnsafe("cleanup.on.namespace.drop")
+          //          .catalogConfigUnsafe("cleanup.on.namespace.drop")
           .description("If set to true, clean up data when a namespace is dropped")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -172,7 +172,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("CLEANUP_ON_CATALOG_DROP")
           .catalogConfig("polaris.config.cleanup.on.catalog.drop")
-          .catalogConfigUnsafe("cleanup.on.catalog.drop")
+          //          .catalogConfigUnsafe("cleanup.on.catalog.drop")
           .description("If set to true, clean up data when a catalog is dropped")
           .defaultValue(false)
           .buildFeatureConfiguration();
@@ -181,7 +181,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("DROP_WITH_PURGE_ENABLED")
           .catalogConfig("polaris.config.drop-with-purge.enabled")
-          .catalogConfigUnsafe("drop-with-purge.enabled")
+          //          .catalogConfigUnsafe("drop-with-purge.enabled")
           .description(
               "If set to true, allows tables to be dropped with the purge parameter set to true.")
           .defaultValue(false)

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
@@ -147,8 +147,8 @@ public class PolarisPrincipalSecrets {
     this.mainSecretHash = hashSecret(mainSecret);
   }
 
-  public void resetSecrets(String customClientSecret){
-    this.mainSecret =  customClientSecret;
+  public void resetSecrets(String customClientSecret) {
+    this.mainSecret = customClientSecret;
     this.mainSecretHash = hashSecret(mainSecret);
 
     this.secondarySecret = null;
@@ -163,7 +163,7 @@ public class PolarisPrincipalSecrets {
     return principalClientId;
   }
 
-  public void setPrincipalClientId(String customClientId){
+  public void setPrincipalClientId(String customClientId) {
     this.principalClientId = customClientId;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
@@ -36,7 +36,7 @@ public class PolarisPrincipalSecrets {
   private final long principalId;
 
   // the client id for that principal
-  private final String principalClientId;
+  private String principalClientId;
 
   // the main secret hash for that principal
   private String mainSecret;
@@ -147,12 +147,24 @@ public class PolarisPrincipalSecrets {
     this.mainSecretHash = hashSecret(mainSecret);
   }
 
+  public void resetSecrets(String customClientSecret){
+    this.mainSecret =  customClientSecret;
+    this.mainSecretHash = hashSecret(mainSecret);
+
+    this.secondarySecret = null;
+    this.secondarySecretHash = hashSecret(mainSecret);
+  }
+
   public long getPrincipalId() {
     return principalId;
   }
 
   public String getPrincipalClientId() {
     return principalClientId;
+  }
+
+  public void setPrincipalClientId(String customClientId){
+    this.principalClientId = customClientId;
   }
 
   public boolean matchesSecret(String potentialSecret) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -846,11 +846,13 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   /** {@inheritDoc} */
   @Override
   public @Nonnull PrincipalSecretsResult rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
@@ -875,26 +877,35 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                     PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
                 != null;
     PolarisPrincipalSecrets secrets;
-    if(customClientId !=null && customClientSecret !=null)
-    {
+    if (customClientId != null && customClientSecret != null) {
       secrets =
-              ((IntegrationPersistence) ms)
-                      .resetPrincipalSecrets(callCtx, clientId, principalId, doReset, oldSecretHash, customClientId, customClientSecret);
+          ((IntegrationPersistence) ms)
+              .resetPrincipalSecrets(
+                  callCtx,
+                  clientId,
+                  principalId,
+                  doReset,
+                  oldSecretHash,
+                  customClientId,
+                  customClientSecret);
     } else {
       secrets =
-              ((IntegrationPersistence) ms)
-                      .rotatePrincipalSecrets(callCtx, clientId, principalId, doReset, oldSecretHash);
+          ((IntegrationPersistence) ms)
+              .rotatePrincipalSecrets(callCtx, clientId, principalId, doReset, oldSecretHash);
     }
 
-    if(reset && !internalProps.containsKey(
-            PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE) && customClientId!=null && customClientSecret!=null){
+    if (reset
+        && !internalProps.containsKey(
+            PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
+        && customClientId != null
+        && customClientSecret != null) {
       internalProps.put(
-              PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE, "true");
+          PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE, "true");
       principal.setInternalProperties(
-              PolarisObjectMapperUtil.serializeProperties(callCtx, internalProps));
+          PolarisObjectMapperUtil.serializeProperties(callCtx, internalProps));
       principal.setEntityVersion(1);
       ms.writeEntity(callCtx, principal, true, originalPrincipal);
-    } else if(reset
+    } else if (reset
         && !internalProps.containsKey(
             PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)) {
       internalProps.put(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
@@ -66,30 +66,30 @@ public interface IntegrationPersistence {
    * Rotate the secrets of a principal entity, i.e. make the specified main secrets the secondary
    * and generate a new main secret
    *
-   * @param callCtx       call context
-   * @param clientId      principal client id
-   * @param principalId   principal id
-   * @param reset         true if the principal secrets should be disabled and replaced with a one-time
-   *                      password
+   * @param callCtx call context
+   * @param clientId principal client id
+   * @param principalId principal id
+   * @param reset true if the principal secrets should be disabled and replaced with a one-time
+   *     password
    * @param oldSecretHash the principal secret's old main secret hash
    */
   @Nullable
   PolarisPrincipalSecrets rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash);
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash);
 
   @Nullable
   PolarisPrincipalSecrets resetPrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash,
-          String customClientId,
-          String customClientSecret);
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret);
 
   /**
    * When dropping a principal, we also need to drop the secrets of that principal

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
@@ -66,20 +66,30 @@ public interface IntegrationPersistence {
    * Rotate the secrets of a principal entity, i.e. make the specified main secrets the secondary
    * and generate a new main secret
    *
-   * @param callCtx call context
-   * @param clientId principal client id
-   * @param principalId principal id
-   * @param reset true if the principal secrets should be disabled and replaced with a one-time
-   *     password
+   * @param callCtx       call context
+   * @param clientId      principal client id
+   * @param principalId   principal id
+   * @param reset         true if the principal secrets should be disabled and replaced with a one-time
+   *                      password
    * @param oldSecretHash the principal secret's old main secret hash
    */
   @Nullable
   PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash);
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash);
+
+  @Nullable
+  PolarisPrincipalSecrets resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret);
 
   /**
    * When dropping a principal, we also need to drop the secrets of that principal

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -151,11 +151,11 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
 
   @Override
   public PrincipalSecretsResult rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash) {
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "rotatePrincipalSecrets");

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -151,11 +151,13 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
 
   @Override
   public PrincipalSecretsResult rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
     callCtx
         .getDiagServices()
         .fail("illegal_method_in_transaction_workspace", "rotatePrincipalSecrets");

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -493,11 +493,11 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   @Override
   @Nullable
   public PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash) {
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash) {
     return runInTransaction(
         callCtx,
         () ->

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -493,17 +493,34 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   @Override
   @Nullable
   public PolarisPrincipalSecrets rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash) {
     return runInTransaction(
         callCtx,
         () ->
             this.rotatePrincipalSecretsInCurrentTxn(
                 callCtx, clientId, principalId, reset, oldSecretHash));
   }
+
+  @Override
+  public PolarisPrincipalSecrets resetPrincipalSecrets(
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
+    return runInTransaction(
+        callCtx,
+        () ->
+            this.rotatePrincipalSecretsInCurrentTxn(
+                callCtx, clientId, principalId, reset, oldSecretHash));
+  }
+  ;
 
   /** {@inheritDoc} */
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -926,11 +926,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   /** {@inheritDoc} */
   @Override
   public @Nonnull PrincipalSecretsResult rotatePrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
     // get metastore we should be using
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -926,11 +926,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   /** {@inheritDoc} */
   @Override
   public @Nonnull PrincipalSecretsResult rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash) {
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
     // get metastore we should be using
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -493,7 +493,7 @@ public class PolarisTestMetaStoreManager {
                 clientId,
                 principalEntity.getId(),
                 false,
-                secrets.getMainSecretHash())
+                secrets.getMainSecretHash(),null , null)
             .getPrincipalSecrets();
     Assertions.assertThat(secrets.getMainSecret()).isNotEqualTo(reloadSecrets.getMainSecret());
 
@@ -519,13 +519,13 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         false,
-        secrets.getMainSecretHash());
+        secrets.getMainSecretHash(), null, null);
     polarisMetaStoreManager.rotatePrincipalSecrets(
         this.polarisCallContext,
         clientId,
         principalEntity.getId(),
         false,
-        secrets.getMainSecretHash());
+        secrets.getMainSecretHash(), null, null);
 
     // reload and check that now the main should be secondary
     reloadSecrets =
@@ -546,7 +546,7 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         true,
-        reloadSecrets.getMainSecretHash());
+        reloadSecrets.getMainSecretHash(), null, null);
     reloadSecrets =
         polarisMetaStoreManager
             .loadPrincipalSecrets(this.polarisCallContext, clientId)
@@ -578,7 +578,7 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         true,
-        reloadSecrets.getMainSecretHash());
+        reloadSecrets.getMainSecretHash(), null , null);
     PolarisPrincipalSecrets postResetCredentials =
         polarisMetaStoreManager
             .loadPrincipalSecrets(this.polarisCallContext, clientId)

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -493,7 +493,9 @@ public class PolarisTestMetaStoreManager {
                 clientId,
                 principalEntity.getId(),
                 false,
-                secrets.getMainSecretHash(),null , null)
+                secrets.getMainSecretHash(),
+                null,
+                null)
             .getPrincipalSecrets();
     Assertions.assertThat(secrets.getMainSecret()).isNotEqualTo(reloadSecrets.getMainSecret());
 
@@ -519,13 +521,17 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         false,
-        secrets.getMainSecretHash(), null, null);
+        secrets.getMainSecretHash(),
+        null,
+        null);
     polarisMetaStoreManager.rotatePrincipalSecrets(
         this.polarisCallContext,
         clientId,
         principalEntity.getId(),
         false,
-        secrets.getMainSecretHash(), null, null);
+        secrets.getMainSecretHash(),
+        null,
+        null);
 
     // reload and check that now the main should be secondary
     reloadSecrets =
@@ -546,7 +552,9 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         true,
-        reloadSecrets.getMainSecretHash(), null, null);
+        reloadSecrets.getMainSecretHash(),
+        null,
+        null);
     reloadSecrets =
         polarisMetaStoreManager
             .loadPrincipalSecrets(this.polarisCallContext, clientId)
@@ -578,7 +586,9 @@ public class PolarisTestMetaStoreManager {
         clientId,
         principalEntity.getId(),
         true,
-        reloadSecrets.getMainSecretHash(), null , null);
+        reloadSecrets.getMainSecretHash(),
+        null,
+        null);
     PolarisPrincipalSecrets postResetCredentials =
         polarisMetaStoreManager
             .loadPrincipalSecrets(this.polarisCallContext, clientId)

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -104,7 +104,7 @@ quarkus.fault-tolerance.global.timeout.enabled=false
 # quarkus.fault-tolerance.global.timeout.value=10
 
 polaris.realm-context.type=default
-polaris.realm-context.realms=POLARIS
+polaris.realm-context.realms=default-realm
 polaris.realm-context.header-name=Polaris-Realm
 polaris.realm-context.require-header=false
 
@@ -118,7 +118,14 @@ polaris.features."SUPPORTED_CATALOG_CONNECTION_TYPES"=["ICEBERG_REST"]
 
 # polaris.persistence.type=eclipse-link
 # polaris.persistence.type=in-memory-atomic
-polaris.persistence.type=in-memory
+# polaris-specific config
+polaris.persistence.type=relational-jdbc
+
+# Quarkus datasource config
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=myuser
+quarkus.datasource.password=mypassword
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/default-realm
 
 polaris.secrets-manager.type=in-memory
 

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -434,7 +434,9 @@ public abstract class PolarisAuthzTestBase {
         credentials.getClientId(),
         lookupEntity.getEntity().getId(),
         false,
-        credentials.getClientSecret(), null, null ); // This should actually be the secret's hash
+        credentials.getClientSecret(),
+        null,
+        null); // This should actually be the secret's hash
 
     return new PrincipalEntity(
         PolarisEntity.of(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/admin/PolarisAuthzTestBase.java
@@ -434,7 +434,7 @@ public abstract class PolarisAuthzTestBase {
         credentials.getClientId(),
         lookupEntity.getEntity().getId(),
         false,
-        credentials.getClientSecret()); // This should actually be the secret's hash
+        credentials.getClientSecret(), null, null ); // This should actually be the secret's hash
 
     return new PrincipalEntity(
         PolarisEntity.of(

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1030,7 +1030,7 @@ public class PolarisAdminService {
     return returnedEntity;
   }
 
-  private @Nonnull PrincipalWithCredentials resetCredentialsHelper(
+  private @Nonnull PrincipalWithCredentials rotateCredentialsHelper(
           String principalName, boolean shouldReset) {
     PrincipalEntity currentPrincipalEntity =
             findPrincipalByName(principalName)
@@ -1149,7 +1149,7 @@ public class PolarisAdminService {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.ROTATE_CREDENTIALS;
     authorizeBasicTopLevelEntityOperationOrThrow(op, principalName, PolarisEntityType.PRINCIPAL);
 
-    return resetCredentialsHelper(principalName, false);
+    return rotateCredentialsHelper(principalName, false);
   }
 
   public @Nonnull PrincipalWithCredentials resetCredentials(

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1087,7 +1087,7 @@ public class PolarisAdminService {
 
     if (FederatedEntities.isFederated(currentPrincipalEntity)) {
       throw new ValidationException(
-          "Cannot rotate/reset credentials for a federated principal: %s", principalName);
+          "Cannot reset credentials for a federated principal: %s", principalName);
     }
     PolarisPrincipalSecrets currentSecrets =
         metaStoreManager
@@ -1112,7 +1112,7 @@ public class PolarisAdminService {
       throw new IllegalStateException(
           String.format(
               "Failed to %s secrets for principal '%s'",
-              shouldReset ? "reset" : "rotate", principalName));
+              "reset", principalName));
     }
     PolarisEntity newPrincipal =
         PolarisEntity.of(
@@ -1121,10 +1121,8 @@ public class PolarisAdminService {
                 0L,
                 currentPrincipalEntity.getId(),
                 currentPrincipalEntity.getType()));
-    LOGGER.error(newPrincipal.toString());
 
     PrincipalEntity newPrincipalEntity = PrincipalEntity.of(newPrincipal);
-
     if(customClientId!=null && customClientSecret!=null) {
       PrincipalEntity.Builder updateBuilder = new PrincipalEntity.Builder(newPrincipalEntity);
       updateBuilder.setClientId(newSecrets.getPrincipalClientId());
@@ -1140,10 +1138,7 @@ public class PolarisAdminService {
                                       new CommitFailedException(
                                               "Concurrent modification on Principal '%s'; retry later", principalName));
       newPrincipalEntity =updatedNewPrincipalEntity;
-      LOGGER.error(updatedNewPrincipalEntity.asPrincipal().toString());
     }
-    LOGGER.error(newPrincipalEntity.asPrincipal().toString());
-
     return new PrincipalWithCredentials(
         newPrincipalEntity.asPrincipal(),
         new PrincipalWithCredentialsCredentials(

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1072,8 +1072,31 @@ public class PolarisAdminService {
                 0L,
                 currentPrincipalEntity.getId(),
                 currentPrincipalEntity.getType()));
+    LOGGER.error(newPrincipal.toString());
+
+    PrincipalEntity newPrincipalEntity = PrincipalEntity.of(newPrincipal);
+
+    if(customClientId!=null && customClientSecret!=null) {
+      PrincipalEntity.Builder updateBuilder = new PrincipalEntity.Builder(newPrincipalEntity);
+      updateBuilder.setClientId(newSecrets.getPrincipalClientId());
+      PrincipalEntity updatedNewPrincipalEntity = updateBuilder.build();
+      updatedNewPrincipalEntity =
+              Optional.ofNullable(
+                              PrincipalEntity.of(
+                                      PolarisEntity.of(
+                                              metaStoreManager.updateEntityPropertiesIfNotChanged(
+                                                      getCurrentPolarisContext(), null, updatedNewPrincipalEntity))))
+                      .orElseThrow(
+                              () ->
+                                      new CommitFailedException(
+                                              "Concurrent modification on Principal '%s'; retry later", principalName));
+      newPrincipalEntity =updatedNewPrincipalEntity;
+      LOGGER.error(updatedNewPrincipalEntity.asPrincipal().toString());
+    }
+    LOGGER.error(newPrincipalEntity.asPrincipal().toString());
+
     return new PrincipalWithCredentials(
-        PrincipalEntity.of(newPrincipal).asPrincipal(),
+        newPrincipalEntity.asPrincipal(),
         new PrincipalWithCredentialsCredentials(
             newSecrets.getPrincipalClientId(), newSecrets.getMainSecret()));
   }

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1031,7 +1031,7 @@ public class PolarisAdminService {
   }
 
   private @Nonnull PrincipalWithCredentials rotateOrResetCredentialsHelper(
-          String principalName, boolean shouldReset, String customClientId, String customClientSecret) {
+      String principalName, boolean shouldReset, String customClientId, String customClientSecret) {
     PrincipalEntity currentPrincipalEntity =
         findPrincipalByName(principalName)
             .orElseThrow(() -> new NotFoundException("Principal %s not found", principalName));
@@ -1055,7 +1055,9 @@ public class PolarisAdminService {
                 currentPrincipalEntity.getClientId(),
                 currentPrincipalEntity.getId(),
                 shouldReset,
-                currentSecrets.getMainSecretHash(), customClientId, customClientSecret)
+                currentSecrets.getMainSecretHash(),
+                customClientId,
+                customClientSecret)
             .getPrincipalSecrets();
     if (newSecrets == null) {
       throw new IllegalStateException(
@@ -1083,7 +1085,8 @@ public class PolarisAdminService {
     return rotateOrResetCredentialsHelper(principalName, false, null, null);
   }
 
-  public @Nonnull PrincipalWithCredentials resetCredentials(String principalName, ResetPrincipalRequest resetPrincipalRequest) {
+  public @Nonnull PrincipalWithCredentials resetCredentials(
+      String principalName, ResetPrincipalRequest resetPrincipalRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.RESET_CREDENTIALS;
     authorizeBasicTopLevelEntityOperationOrThrow(op, principalName, PolarisEntityType.PRINCIPAL);
     var customClientId = resetPrincipalRequest.getClientId();

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -28,36 +28,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.admin.model.AddGrantRequest;
-import org.apache.polaris.core.admin.model.Catalog;
-import org.apache.polaris.core.admin.model.CatalogGrant;
-import org.apache.polaris.core.admin.model.CatalogRole;
-import org.apache.polaris.core.admin.model.CatalogRoles;
-import org.apache.polaris.core.admin.model.Catalogs;
-import org.apache.polaris.core.admin.model.CreateCatalogRequest;
-import org.apache.polaris.core.admin.model.CreateCatalogRoleRequest;
-import org.apache.polaris.core.admin.model.CreatePrincipalRequest;
-import org.apache.polaris.core.admin.model.CreatePrincipalRoleRequest;
-import org.apache.polaris.core.admin.model.ExternalCatalog;
-import org.apache.polaris.core.admin.model.GrantCatalogRoleRequest;
-import org.apache.polaris.core.admin.model.GrantPrincipalRoleRequest;
-import org.apache.polaris.core.admin.model.GrantResource;
-import org.apache.polaris.core.admin.model.GrantResources;
-import org.apache.polaris.core.admin.model.NamespaceGrant;
-import org.apache.polaris.core.admin.model.PolicyGrant;
-import org.apache.polaris.core.admin.model.Principal;
-import org.apache.polaris.core.admin.model.PrincipalRole;
-import org.apache.polaris.core.admin.model.PrincipalRoles;
-import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
-import org.apache.polaris.core.admin.model.Principals;
-import org.apache.polaris.core.admin.model.RevokeGrantRequest;
-import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.apache.polaris.core.admin.model.TableGrant;
-import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
-import org.apache.polaris.core.admin.model.UpdateCatalogRoleRequest;
-import org.apache.polaris.core.admin.model.UpdatePrincipalRequest;
-import org.apache.polaris.core.admin.model.UpdatePrincipalRoleRequest;
-import org.apache.polaris.core.admin.model.ViewGrant;
+import org.apache.polaris.core.admin.model.*;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -287,6 +258,13 @@ public class PolarisServiceImpl
     return Response.ok(adminService.updatePrincipal(principalName, updateRequest).asPrincipal())
         .build();
   }
+
+      @Override
+      public Response resetCredentials(
+              String principalName, ResetPrincipalRequest resetPrincipalRequest, RealmContext realmContext, SecurityContext securityContext) {
+        PolarisAdminService adminService = newAdminService(realmContext, securityContext);
+        return Response.ok(adminService.resetCredentials(principalName, resetPrincipalRequest)).build();
+      }
 
   /** From PolarisPrincipalsApiService */
   @Override

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -259,12 +259,15 @@ public class PolarisServiceImpl
         .build();
   }
 
-      @Override
-      public Response resetCredentials(
-              String principalName, ResetPrincipalRequest resetPrincipalRequest, RealmContext realmContext, SecurityContext securityContext) {
-        PolarisAdminService adminService = newAdminService(realmContext, securityContext);
-        return Response.ok(adminService.resetCredentials(principalName, resetPrincipalRequest)).build();
-      }
+  @Override
+  public Response resetCredentials(
+      String principalName,
+      ResetPrincipalRequest resetPrincipalRequest,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
+    return Response.ok(adminService.resetCredentials(principalName, resetPrincipalRequest)).build();
+  }
 
   /** From PolarisPrincipalsApiService */
   @Override

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -167,6 +167,42 @@ paths:
         403:
           description: "The caller does not have permission to add a principal"
 
+  /principals/{principalName}/reset:
+    parameters:
+      - name: principalName
+        in: path
+        description: The principal's name
+        required: true
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+    post:
+      operationId: resetCredentials
+      description: >
+        Reset a principal's credentials to a new set. By default, the system generates random credentials unless
+        explicitly allowed to accept user-provided credentials via configuration.  
+        This API is *not* idempotent and will return the newly created credentials.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPrincipalRequest'
+      responses:
+        200:
+          description: The principal details along with the newly reset credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PrincipalWithCredentials"
+        403:
+          description: The caller does not have permission to reset credentials
+        404:
+          description: The principal does not exist
+
+
   /principals/{principalName}:
     parameters:
       - name: principalName
@@ -1154,6 +1190,20 @@ components:
         credentialRotationRequired:
           type: boolean
           description: If true, the initial credentials can only be used to call rotateCredentials
+
+    ResetPrincipalRequest:
+      type: object
+      properties:
+        clientId:
+          type: string
+          description: Optional client ID to set for the principal.
+          minLength: 1
+          maxLength: 256
+        clientSecret:
+          type: string
+          description: Optional client secret to set for the principal.
+          minLength: 1
+          maxLength: 256
 
     Principal:
       description: A Polaris principal.

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1197,13 +1197,15 @@ components:
         clientId:
           type: string
           description: Optional client ID to set for the principal.
-          minLength: 1
-          maxLength: 256
+          minLength: 16
+          maxLength: 16
+          pattern: '^[0-9a-f]{16}$'
         clientSecret:
           type: string
           description: Optional client secret to set for the principal.
-          minLength: 1
-          maxLength: 256
+          minLength: 32
+          maxLength: 32
+          pattern: '^[0-9a-f]{32}$'
 
     Principal:
       description: A Polaris principal.


### PR DESCRIPTION
 **Background:**
See Issue -[1929](https://github.com/apache/polaris/issues/1929) and based on Dev email discussion
**WHAT**
- Exposes the resetCredentials operation via the api 
- Requires the custom clientId and custom secret via root user to reset the random credentials already created via CreatePrincipal API
- Needs ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING to be set to true

Local Testing:
<img width="889" height="913" alt="image" src="https://github.com/user-attachments/assets/4e464ad7-4da9-4c0c-a33b-cf28f0480332" />

