### PR TITLE
Add Polaris Delegation Service for Processing DROP TABLE WITH PURGE

### DIFF
--- a/api/delegation-service/build.gradle.kts
+++ b/api/delegation-service/build.gradle.kts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  id("polaris-client")
+  alias(libs.plugins.jandex)
+}
+
+dependencies {
+  // Jackson for JSON serialization/deserialization
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.core:jackson-core")
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
+  // Jakarta annotations and validation
+  implementation(libs.jakarta.annotation.api)
+  implementation(libs.jakarta.validation.api)
+
+  // Test dependencies
+  testImplementation(platform(libs.junit.bom))
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testImplementation(platform(libs.jackson.bom))
+  testImplementation("com.fasterxml.jackson.core:jackson-databind")
+}
+
+tasks.named("javadoc") { dependsOn("jandex") }

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/CommonPayload.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/CommonPayload.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * Common payload data included in all delegation tasks.
+ *
+ * <p>Contains global task information that applies to all task types within the delegation service.
+ * Uses the {@link TaskType} enum to ensure type safety for operation types.
+ */
+public class CommonPayload {
+
+  @NotNull private final TaskType taskType;
+
+  @NotNull private final OffsetDateTime requestTimestampUtc;
+
+  @NotNull private final String realmIdentifier;
+
+  @JsonCreator
+  public CommonPayload(
+      @JsonProperty("operation_type") @NotNull TaskType taskType,
+      @JsonProperty("request_timestamp_utc") @NotNull OffsetDateTime requestTimestampUtc,
+      @JsonProperty("realm_identifier") @NotNull String realmIdentifier) {
+    this.taskType = taskType;
+    this.requestTimestampUtc = requestTimestampUtc;
+    this.realmIdentifier = realmIdentifier;
+  }
+
+  @JsonProperty("operation_type")
+  public TaskType getTaskType() {
+    return taskType;
+  }
+
+  @JsonProperty("request_timestamp_utc")
+  public OffsetDateTime getRequestTimestampUtc() {
+    return requestTimestampUtc;
+  }
+
+  @JsonProperty("realm_identifier")
+  public String getRealmIdentifier() {
+    return realmIdentifier;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CommonPayload that = (CommonPayload) o;
+    return Objects.equals(taskType, that.taskType)
+        && Objects.equals(requestTimestampUtc, that.requestTimestampUtc)
+        && Objects.equals(realmIdentifier, that.realmIdentifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(taskType, requestTimestampUtc, realmIdentifier);
+  }
+
+  @Override
+  public String toString() {
+    return "CommonPayload{"
+        + "taskType="
+        + taskType
+        + ", requestTimestampUtc="
+        + requestTimestampUtc
+        + ", realmIdentifier='"
+        + realmIdentifier
+        + '\''
+        + '}';
+  }
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/OperationParameters.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/OperationParameters.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+/**
+ * Base class for operation-specific parameters in delegation tasks.
+ *
+ * <p>This abstract class serves as the base for all operation-specific parameter types. Each
+ * concrete subclass represents parameters for a specific type of delegation operation, providing
+ * type safety and clear separation of concerns.
+ *
+ * <p>Uses Jackson polymorphism to serialize/deserialize different parameter types based on the
+ * operation type. This allows the API to handle different parameter structures while maintaining
+ * type safety.
+ *
+ * <p><strong>Supported Operation Types:</strong>
+ *
+ * <ul>
+ *   <li>{@link TablePurgeParameters} - For TABLE_PURGE operations
+ * </ul>
+ *
+ * <p><strong>Adding New Operation Types:</strong>
+ *
+ * <ol>
+ *   <li>Create a new concrete subclass extending {@code OperationParameters}
+ *   <li>Add the subclass to the {@link JsonSubTypes} annotation
+ *   <li>Define the operation-specific fields and validation
+ * </ol>
+ */
+public abstract class OperationParameters {
+  // This class is now a marker class and does not contain any fields or methods.
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TableIdentity.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TableIdentity.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Table identity information for delegation tasks.
+ *
+ * <p>Provides the complete hierarchical path to identify a table within the Polaris catalog system.
+ */
+public class TableIdentity {
+
+  @NotNull private final String catalogName;
+
+  @NotNull private final List<String> namespaceLevels;
+
+  @NotNull private final String tableName;
+
+  @JsonCreator
+  public TableIdentity(
+      @JsonProperty("catalog_name") @NotNull String catalogName,
+      @JsonProperty("namespace_levels") @NotNull List<String> namespaceLevels,
+      @JsonProperty("table_name") @NotNull String tableName) {
+    this.catalogName = catalogName;
+    this.namespaceLevels = namespaceLevels;
+    this.tableName = tableName;
+  }
+
+  @JsonProperty("catalog_name")
+  public String getCatalogName() {
+    return catalogName;
+  }
+
+  @JsonProperty("namespace_levels")
+  public List<String> getNamespaceLevels() {
+    return namespaceLevels;
+  }
+
+  @JsonProperty("table_name")
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TableIdentity that = (TableIdentity) o;
+    return Objects.equals(catalogName, that.catalogName)
+        && Objects.equals(namespaceLevels, that.namespaceLevels)
+        && Objects.equals(tableName, that.tableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(catalogName, namespaceLevels, tableName);
+  }
+
+  @Override
+  public String toString() {
+    return "TableIdentity{"
+        + "catalogName='"
+        + catalogName
+        + '\''
+        + ", namespaceLevels="
+        + namespaceLevels
+        + ", tableName='"
+        + tableName
+        + '\''
+        + '}';
+  }
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TablePurgeParameters.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TablePurgeParameters.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Operation parameters for table purge operations.
+ *
+ * <p>Contains all the information needed to perform a table purge operation, including the table
+ * identity and optional configuration properties.
+ *
+ * <p>This class represents parameters for {@code PURGE_TABLE} operations, which handle the deletion
+ * of data files associated with dropped tables.
+ *
+ * <p><strong>Example Usage:</strong>
+ *
+ * <pre>
+ * TablePurgeParameters params = new TablePurgeParameters(
+ *     new TableIdentity("catalog", List.of("namespace"), "table"),
+ *     Map.of("skipTrash", "true", "batchSize", "1000")
+ * );
+ * </pre>
+ */
+public class TablePurgeParameters extends OperationParameters {
+
+  @NotNull private final TableIdentity tableIdentity;
+
+  private final Map<String, String> properties;
+
+  @JsonCreator
+  public TablePurgeParameters(
+      @JsonProperty("table_identity") @NotNull TableIdentity tableIdentity,
+      @JsonProperty("properties") Map<String, String> properties) {
+    this.tableIdentity = tableIdentity;
+    this.properties = properties;
+  }
+
+  public TablePurgeParameters(@NotNull TableIdentity tableIdentity) {
+    this(tableIdentity, null);
+  }
+
+  @JsonProperty("table_identity")
+  @NotNull
+  public TableIdentity getTableIdentity() {
+    return tableIdentity;
+  }
+
+  @JsonProperty("properties")
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * Gets a property value by key.
+   *
+   * @param key the property key
+   * @return the property value, or null if not found
+   */
+  public String getProperty(String key) {
+    return properties != null ? properties.get(key) : null;
+  }
+
+  /**
+   * Checks if a property is set to "true".
+   *
+   * @param key the property key
+   * @return true if the property exists and equals "true" (case-insensitive)
+   */
+  public boolean getBooleanProperty(String key) {
+    String value = getProperty(key);
+    return "true".equalsIgnoreCase(value);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TablePurgeParameters that = (TablePurgeParameters) o;
+    return Objects.equals(tableIdentity, that.tableIdentity)
+        && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableIdentity, properties);
+  }
+
+  @Override
+  public String toString() {
+    return "TablePurgeParameters{"
+        + "tableIdentity="
+        + tableIdentity
+        + ", properties="
+        + properties
+        + '}';
+  }
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskExecutionRequest.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskExecutionRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+/**
+ * Request to execute a delegated task.
+ *
+ * <p>Contains all the information needed to submit a task to the delegation service, structured
+ * according to the delegation service task payload schema.
+ */
+public class TaskExecutionRequest {
+
+  @NotNull private final CommonPayload commonPayload;
+
+  @NotNull private final TablePurgeParameters operationParameters;
+
+  @JsonCreator
+  public TaskExecutionRequest(
+      @JsonProperty("common_payload") @NotNull CommonPayload commonPayload,
+      @JsonProperty("operation_parameters") @NotNull TablePurgeParameters operationParameters) {
+    this.commonPayload = commonPayload;
+    this.operationParameters = operationParameters;
+  }
+
+  @JsonProperty("common_payload")
+  public CommonPayload getCommonPayload() {
+    return commonPayload;
+  }
+
+  @JsonProperty("operation_parameters")
+  public TablePurgeParameters getOperationParameters() {
+    return operationParameters;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskExecutionRequest that = (TaskExecutionRequest) o;
+    return Objects.equals(commonPayload, that.commonPayload)
+        && Objects.equals(operationParameters, that.operationParameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(commonPayload, operationParameters);
+  }
+
+  @Override
+  public String toString() {
+    return "TaskExecutionRequest{"
+        + "commonPayload="
+        + commonPayload
+        + ", operationParameters="
+        + operationParameters
+        + '}';
+  }
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskExecutionResponse.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskExecutionResponse.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+/**
+ * Response from executing a delegated task.
+ *
+ * <p>Contains the execution result and timing information for the completed task. Since the
+ * delegation service executes tasks synchronously in the MVP, this response indicates the task has
+ * already been completed.
+ */
+public class TaskExecutionResponse {
+
+  @NotNull private final String status;
+
+  private final String resultSummary;
+
+  @JsonCreator
+  public TaskExecutionResponse(
+      @JsonProperty("status") @NotNull String status,
+      @JsonProperty("result_summary") String resultSummary) {
+    this.status = status;
+    this.resultSummary = resultSummary;
+  }
+
+  @JsonProperty("status")
+  public String getStatus() {
+    return status;
+  }
+
+  @JsonProperty("result_summary")
+  public String getResultSummary() {
+    return resultSummary;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskExecutionResponse that = (TaskExecutionResponse) o;
+    return Objects.equals(status, that.status) && Objects.equals(resultSummary, that.resultSummary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, resultSummary);
+  }
+
+  @Override
+  public String toString() {
+    return "TaskExecutionResponse{"
+        + "status='"
+        + status
+        + '\''
+        + ", resultSummary='"
+        + resultSummary
+        + '\''
+        + '}';
+  }
+}

--- a/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskType.java
+++ b/api/delegation-service/src/main/java/org/apache/polaris/delegation/api/model/TaskType.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Types of tasks that can be delegated to the Delegation Service.
+ *
+ * <p>This enum defines the various long-running, resource-intensive operations that can be
+ * offloaded from the main Polaris catalog service.
+ */
+public enum TaskType {
+
+  /**
+   * Data file deletion task for DROP TABLE WITH PURGE operations. This is the initial task type
+   * supported by the delegation service.
+   */
+  PURGE_TABLE("TABLE_PURGE");
+
+  private final String value;
+
+  TaskType(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static TaskType fromValue(String value) {
+    for (TaskType taskType : TaskType.values()) {
+      if (taskType.value.equals(value)) {
+        return taskType;
+      }
+    }
+    throw new IllegalArgumentException("Unknown TaskType: " + value);
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/delegation-service/build.gradle.kts
+++ b/delegation-service/build.gradle.kts
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.JavaCompile
+
+plugins {
+  id("polaris-java")
+  application
+}
+
+tasks.withType(JavaCompile::class.java).configureEach { options.release = 21 }
+
+application { mainClass.set("org.apache.polaris.delegation.DelegationServiceApplication") }
+
+dependencies {
+  // Core dependencies
+  implementation(project(":polaris-core"))
+  implementation(project(":polaris-service-common"))
+  implementation(project(":polaris-api-delegation-service"))
+
+  // JAX-RS and REST APIs
+  implementation(libs.jakarta.ws.rs.api)
+  implementation(libs.jakarta.inject.api)
+  implementation(libs.jakarta.validation.api)
+  implementation(libs.jakarta.enterprise.cdi.api)
+
+  // JSON processing
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-core")
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
+  // Iceberg for file operations
+  implementation(platform(libs.iceberg.bom))
+  implementation("org.apache.iceberg:iceberg-core")
+  implementation("org.apache.iceberg:iceberg-api")
+  implementation("org.apache.iceberg:iceberg-common")
+
+  // Storage backends
+  implementation("org.apache.iceberg:iceberg-aws") // S3 support
+  implementation("org.apache.iceberg:iceberg-azure") // Azure support
+  implementation("org.apache.iceberg:iceberg-gcp") // GCP support
+
+  // Hadoop dependency for FileIO operations
+  implementation(libs.hadoop.common)
+
+  // Logging
+  implementation(libs.slf4j.api)
+  implementation(libs.logback.classic)
+
+  // Testing
+  testImplementation(platform(libs.junit.bom))
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.assertj.core)
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.register<Jar>("fatJar") {
+  archiveBaseName.set("polaris-delegation-service")
+  archiveClassifier.set("all")
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  manifest {
+    attributes["Main-Class"] = "org.apache.polaris.delegation.DelegationServiceApplication"
+  }
+  from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+  with(tasks.jar.get())
+}
+
+tasks.build { dependsOn(tasks.named("fatJar")) }

--- a/delegation-service/src/main/java/org/apache/polaris/delegation/DelegationServiceApplication.java
+++ b/delegation-service/src/main/java/org/apache/polaris/delegation/DelegationServiceApplication.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import org.apache.polaris.delegation.api.DelegationApi;
+import org.apache.polaris.delegation.api.model.TaskExecutionRequest;
+import org.apache.polaris.delegation.api.model.TaskExecutionResponse;
+import org.apache.polaris.delegation.service.TaskExecutionService;
+import org.apache.polaris.delegation.service.storage.StorageFileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import com.sun.net.httpserver.HttpExchange;
+
+/**
+ * Main application class for the Polaris Delegation Service.
+ *
+ * <p>This service handles long-running tasks delegated from the main Polaris catalog to maintain
+ * low-latency performance in the catalog operations.
+ */
+@ApplicationPath("/")
+public class DelegationServiceApplication extends Application {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DelegationServiceApplication.class);
+
+  @Override
+  public Set<Class<?>> getClasses() {
+    LOGGER.info("Initializing Polaris Delegation Service");
+
+    // Return the set of JAX-RS resource classes
+    return Set.of(
+        DelegationApi.class,
+        // Add other resource classes here as needed
+        JacksonJsonProvider.class // For JSON serialization
+        );
+  }
+
+  /**
+   * Main entry point for standalone execution.
+   *
+   * <p>This method can be used to run the delegation service as a standalone application using an
+   * embedded server like Jetty or Undertow.
+   *
+   * @param args command line arguments
+   */
+  public static void main(String[] args) {
+    LOGGER.info("Starting Polaris Delegation Service...");
+
+    // Get configuration from command line arguments first, then environment, then defaults
+    String port = "8282";
+    String host = "localhost";
+
+    // Parse command line arguments
+    if (args.length > 0) {
+      port = args[0];
+    } else {
+      // Fallback to environment variables
+      port = System.getenv().getOrDefault("POLARIS_DELEGATION_PORT", "8282");
+    }
+
+    if (args.length > 1) {
+      host = args[1];
+    } else {
+      // Fallback to environment variables
+      host = System.getenv().getOrDefault("POLARIS_DELEGATION_HOST", "localhost");
+    }
+
+    LOGGER.info("Delegation Service Configuration:");
+    LOGGER.info("  - Host: {}", host);
+    LOGGER.info("  - Port: {}", port);
+    LOGGER.info("  - Base URL: http://{}:{}", host, port);
+
+    try {
+      // For POC, we'll use a simple embedded server
+      // In production, this would be deployed to a proper application server
+      startEmbeddedServer(host, Integer.parseInt(port));
+
+    } catch (Exception e) {
+      LOGGER.error("Failed to start Polaris Delegation Service", e);
+      System.exit(1);
+    }
+  }
+
+  /**
+   * Starts an embedded server for POC demonstration. In production, this would be replaced with
+   * proper deployment to an application server.
+   */
+  private static void startEmbeddedServer(String host, int port) throws Exception {
+    LOGGER.info("Starting embedded server for POC demonstration...");
+
+    // Create virtual thread executor for concurrent request handling
+    ExecutorService requestExecutor = Executors.newVirtualThreadPerTaskExecutor();
+
+    // Create actual service instances
+    StorageFileManager storageFileManager = new StorageFileManager();
+    TaskExecutionService taskExecutionService = new TaskExecutionService();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // Configure ObjectMapper to handle JSR310 date/time types
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    // Manually inject dependencies (in production, this would be handled by CDI)
+    // Use reflection to set the private field
+    java.lang.reflect.Field field =
+        TaskExecutionService.class.getDeclaredField("storageFileManager");
+    field.setAccessible(true);
+    field.set(taskExecutionService, storageFileManager);
+
+    // Create a simple HTTP server using Java's built-in HTTP server
+    com.sun.net.httpserver.HttpServer server =
+        com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress(host, port), 0);
+
+    // Create a simple context for health checks
+    server.createContext(
+        "/health",
+        exchange -> {
+          String response = "{\"status\":\"healthy\",\"service\":\"polaris-delegation-service\"}";
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, response.getBytes(StandardCharsets.UTF_8).length);
+          exchange.getResponseBody().write(response.getBytes(StandardCharsets.UTF_8));
+          exchange.close();
+        });
+
+    // Create the actual API endpoint using virtual threads for concurrent request handling
+    server.createContext(
+        "/api/v1/tasks/execute/synchronous",
+        exchange -> {
+          // Handle each request asynchronously using virtual threads
+          @SuppressWarnings("FutureReturnValueIgnored")
+          var unused = requestExecutor.submit(() -> {
+            try {
+              handleDelegationRequest(exchange, objectMapper, taskExecutionService);
+            } catch (Exception e) {
+              LOGGER.error("Unexpected error in request handler", e);
+              try {
+                if (!exchange.getResponseBody().toString().isEmpty()) {
+                  return; // Response already sent
+                }
+                String errorResponse = "{\"status\":\"failed\",\"result_summary\":\"Internal server error\"}";
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(500, errorResponse.getBytes(StandardCharsets.UTF_8).length);
+                exchange.getResponseBody().write(errorResponse.getBytes(StandardCharsets.UTF_8));
+                exchange.close();
+              } catch (Exception responseError) {
+                LOGGER.error("Failed to send error response", responseError);
+              }
+            }
+          });
+        });
+
+    // Start the server
+    server.start();
+
+    LOGGER.info("Polaris Delegation Service started successfully!");
+    LOGGER.info("   Health check: http://{}:{}/health", host, port);
+    LOGGER.info("   API endpoint: http://{}:{}/api/v1/tasks/execute/synchronous", host, port);
+    LOGGER.info("   Press Ctrl+C to stop the service");
+
+    // Keep the server running
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  LOGGER.info("Shutting down Polaris Delegation Service...");
+                  requestExecutor.shutdown();
+                  try {
+                    if (!requestExecutor.awaitTermination(30, java.util.concurrent.TimeUnit.SECONDS)) {
+                      LOGGER.warn("Request executor did not terminate gracefully, forcing shutdown");
+                      requestExecutor.shutdownNow();
+                    }
+                  } catch (InterruptedException e) {
+                    LOGGER.warn("Interrupted while waiting for request executor shutdown");
+                    requestExecutor.shutdownNow();
+                  }
+                  server.stop(5);
+                  LOGGER.info("Delegation Service stopped.");
+                }));
+
+    // Wait for shutdown
+    Thread.currentThread().join();
+  }
+
+  /**
+   * Handles a single delegation request. This method contains all the request processing logic
+   * and runs in a virtual thread for concurrent request handling.
+   */
+  private static void handleDelegationRequest(
+      HttpExchange exchange, ObjectMapper objectMapper, TaskExecutionService taskExecutionService) {
+
+    LOGGER.info("DELEGATION REQUEST RECEIVED!");
+    LOGGER.info("   Method: {}", exchange.getRequestMethod());
+    LOGGER.info("   URI: {}", exchange.getRequestURI());
+    LOGGER.info("   Headers: {}", exchange.getRequestHeaders());
+
+    if (!"POST".equals(exchange.getRequestMethod())) {
+      LOGGER.warn("   Method not allowed: {}", exchange.getRequestMethod());
+      try {
+        exchange.sendResponseHeaders(405, -1);
+        exchange.close();
+      } catch (Exception e) {
+        LOGGER.error("Failed to send 405 response", e);
+      }
+      return;
+    }
+
+    try {
+      // Read request body
+      String requestBody =
+          new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+      LOGGER.info("   Request body: {}", requestBody);
+
+      // Parse request using Jackson
+      TaskExecutionRequest request =
+          objectMapper.readValue(requestBody, TaskExecutionRequest.class);
+
+      // Execute the task using the real implementation
+      TaskExecutionResponse response = taskExecutionService.executeTask(request);
+
+      // Serialize response to JSON
+      String responseJson = objectMapper.writeValueAsString(response);
+
+      LOGGER.info("   Task executed successfully. Response: {}", responseJson);
+
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(200, responseJson.getBytes(StandardCharsets.UTF_8).length);
+      exchange.getResponseBody().write(responseJson.getBytes(StandardCharsets.UTF_8));
+      exchange.close();
+
+    } catch (Exception e) {
+      LOGGER.error("   Error processing request", e);
+
+      try {
+        String errorResponse =
+            "{\"status\":\"failed\",\"result_summary\":\"Error processing request: "
+                + e.getMessage()
+                + "\"}";
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(
+            500, errorResponse.getBytes(StandardCharsets.UTF_8).length);
+        exchange.getResponseBody().write(errorResponse.getBytes(StandardCharsets.UTF_8));
+        exchange.close();
+      } catch (Exception responseError) {
+        LOGGER.error("Failed to send error response", responseError);
+      }
+    }
+  }
+
+  /**
+   * Jackson JSON provider for JAX-RS. This would normally be provided by the application server or
+   * framework.
+   */
+  public static class JacksonJsonProvider {
+    // Placeholder - in a real application, this would be configured properly
+    // For POC, we'll use the simple embedded server approach above
+  }
+}

--- a/delegation-service/src/main/java/org/apache/polaris/delegation/api/DelegationApi.java
+++ b/delegation-service/src/main/java/org/apache/polaris/delegation/api/DelegationApi.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.api;
+
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.polaris.delegation.api.model.TaskExecutionRequest;
+import org.apache.polaris.delegation.api.model.TaskExecutionResponse;
+import org.apache.polaris.delegation.api.model.TaskType;
+import org.apache.polaris.delegation.service.TaskExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * REST API for the Polaris Delegation Service.
+ *
+ * <p>Provides endpoints for submitting long-running tasks for synchronous execution. This API
+ * allows the main Polaris catalog to offload resource-intensive operations to maintain low-latency
+ * performance.
+ *
+ * <p><strong>Note:</strong> This is the initial API framework implementation. The actual task
+ * execution logic will be implemented in future development phases.
+ */
+@Path("/api/v1/tasks/execute")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class DelegationApi {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DelegationApi.class);
+
+  @Inject private TaskExecutionService taskExecutionService;
+
+  /**
+   * Submit a task for delegated execution.
+   *
+   * <p>The task will be executed synchronously and the response will contain the execution result.
+   * This is a blocking operation that will wait for the task to complete before returning.
+   *
+   * @param request the task execution request
+   * @return the task execution response with completion information
+   */
+  @POST
+  @Path("/synchronous")
+  public Response submitTask(@Valid @NotNull TaskExecutionRequest request) {
+    TaskType taskType = request.getCommonPayload().getTaskType();
+    String realmId = request.getCommonPayload().getRealmIdentifier();
+    LOGGER.info("Delegation API called - task_type={}, realm_id={}", taskType, realmId);
+
+    try {
+      // Execute the task synchronously using the TaskExecutionService
+      TaskExecutionResponse response = taskExecutionService.executeTask(request);
+
+      LOGGER.info(
+          "Task execution completed - task_type={}, status={}", taskType, response.getStatus());
+      return Response.ok(response).build();
+
+    } catch (Exception e) {
+      LOGGER.error("Failed to process task request", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity(new ErrorResponse("Task processing failed: " + e.getMessage()))
+          .build();
+    }
+  }
+
+  /** Simple error response model. */
+  public static class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+}

--- a/delegation-service/src/main/java/org/apache/polaris/delegation/service/TaskExecutionService.java
+++ b/delegation-service/src/main/java/org/apache/polaris/delegation/service/TaskExecutionService.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.polaris.delegation.api.model.TableIdentity;
+import org.apache.polaris.delegation.api.model.TablePurgeParameters;
+import org.apache.polaris.delegation.api.model.TaskExecutionRequest;
+import org.apache.polaris.delegation.api.model.TaskExecutionResponse;
+import org.apache.polaris.delegation.api.model.TaskType;
+import org.apache.polaris.delegation.service.storage.StorageFileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service responsible for executing delegated tasks.
+ *
+ * <p>This service handles the actual execution of tasks delegated from the main Polaris catalog,
+ * including data file cleanup, table purging, and other long-running operations.
+ */
+@ApplicationScoped
+public class TaskExecutionService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecutionService.class);
+
+  @Inject private StorageFileManager storageFileManager;
+
+  /**
+   * Executes a delegated task synchronously.
+   *
+   * @param request the task execution request
+   * @return the task execution response with completion status
+   */
+  public TaskExecutionResponse executeTask(TaskExecutionRequest request) {
+    TaskType taskType = request.getCommonPayload().getTaskType();
+    String realmId = request.getCommonPayload().getRealmIdentifier();
+
+    LOGGER.info("Starting task execution: type={}, realm={}", taskType, realmId);
+
+    try {
+      switch (taskType) {
+        case PURGE_TABLE:
+          return executePurgeTableTask(request);
+        default:
+          LOGGER.warn("Unknown task type: {}", taskType);
+          return new TaskExecutionResponse("failed", "Unknown task type: " + taskType);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Task execution failed for type={}, realm={}", taskType, realmId, e);
+      return new TaskExecutionResponse("failed", "Task execution failed: " + e.getMessage());
+    }
+  }
+
+  /** Executes a table purge task by cleaning up data files. */
+  private TaskExecutionResponse executePurgeTableTask(TaskExecutionRequest request) {
+    // No need to check instanceof since TaskExecutionRequest now uses TablePurgeParameters directly
+    TablePurgeParameters purgeParams = request.getOperationParameters();
+    TableIdentity tableIdentity = purgeParams.getTableIdentity();
+
+    LOGGER.info(
+        "Executing table purge for table: {}.{}.{}",
+        tableIdentity.getCatalogName(),
+        String.join(".", tableIdentity.getNamespaceLevels()),
+        tableIdentity.getTableName());
+
+    try {
+      // Execute the actual data file cleanup
+      long startTime = System.currentTimeMillis();
+
+      // This is the core operation: delete data files from storage
+      StorageFileManager.CleanupResult result = storageFileManager.cleanupTableFiles(tableIdentity);
+
+      long duration = System.currentTimeMillis() - startTime;
+
+      if (result.isSuccess()) {
+        String summary =
+            String.format(
+                "Successfully cleaned up %d data files in %d ms",
+                result.getFilesDeleted(), duration);
+        LOGGER.info("Table purge completed successfully: {}", summary);
+        return new TaskExecutionResponse("success", summary);
+      } else {
+        String errorSummary =
+            String.format("Failed to clean up table files: %s", result.getErrorMessage());
+        LOGGER.error("Table purge failed: {}", errorSummary);
+        return new TaskExecutionResponse("failed", errorSummary);
+      }
+
+    } catch (Exception e) {
+      LOGGER.error("Error during table purge execution", e);
+      return new TaskExecutionResponse("failed", "Table purge execution failed: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Executes a task asynchronously with timeout (for future use). Currently not used as we're
+   * implementing synchronous execution for MVP.
+   */
+  public CompletableFuture<TaskExecutionResponse> executeTaskAsync(
+      TaskExecutionRequest request, long timeoutSeconds) {
+    return CompletableFuture.supplyAsync(() -> executeTask(request))
+        .orTimeout(timeoutSeconds, TimeUnit.SECONDS)
+        .exceptionally(
+            throwable -> {
+              LOGGER.error("Async task execution failed or timed out", throwable);
+              return new TaskExecutionResponse(
+                  "failed", "Task execution failed or timed out: " + throwable.getMessage());
+            });
+  }
+}

--- a/delegation-service/src/main/java/org/apache/polaris/delegation/service/storage/StorageFileManager.java
+++ b/delegation-service/src/main/java/org/apache/polaris/delegation/service/storage/StorageFileManager.java
@@ -1,0 +1,750 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.delegation.service.storage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileIO;
+import org.apache.polaris.delegation.api.model.TableIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages storage file operations for delegated tasks.
+ *
+ * <p>This service handles the actual deletion of data files from cloud storage (S3, Azure Blob
+ * Storage, Google Cloud Storage) for table cleanup operations. The implementation is identical to
+ * the local Polaris cleanup logic with the same retry mechanisms, batching, and error handling.
+ */
+@ApplicationScoped
+public class StorageFileManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StorageFileManager.class);
+  private static final String STORAGE_LOCATION = "storageLocation";
+
+  // Retry configuration - identical to local Polaris implementation
+  public static final int MAX_ATTEMPTS = 3;
+  public static final int FILE_DELETION_RETRY_MILLIS = 100;
+  private static final int METADATA_BATCH_SIZE = 10;
+
+  // Use virtual threads for file operations (matches Polaris local implementation)
+  private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+
+  // Polaris API client configuration
+  private final HttpClient httpClient =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  // Configuration for Polaris authentication
+  private final String polarisBaseUrl;
+  private final String polarisClientId;
+  private final String polarisClientSecret;
+
+  public StorageFileManager() {
+    this.polarisBaseUrl =
+        System.getProperty(
+            "polaris.base.url",
+            System.getenv().getOrDefault("POLARIS_BASE_URL", "http://localhost:8181"));
+    this.polarisClientId =
+        System.getProperty(
+            "polaris.delegation.client.id",
+            System.getenv().getOrDefault("POLARIS_DELEGATION_CLIENT_ID", "root"));
+    this.polarisClientSecret =
+        System.getProperty(
+            "polaris.delegation.client.secret",
+            System.getenv().getOrDefault("POLARIS_DELEGATION_CLIENT_SECRET", "s3cr3t"));
+  }
+
+  /**
+   * Cleans up all data files associated with a table using Polaris's loadTable API.
+   *
+   * <p>This method performs the actual data file deletion by:
+   *
+   * <ol>
+   *   <li>Authenticating with Polaris using delegation service credentials
+   *   <li>Loading table metadata via Polaris's REST API
+   *   <li>Extracting storage credentials from the response
+   *   <li>Identifying all data files across all snapshots
+   *   <li>Deleting data files using the configured FileIO implementation
+   *   <li>Deleting manifest files and metadata files
+   * </ol>
+   *
+   * @param tableIdentity the table to clean up
+   * @return cleanup result with success status and file counts
+   */
+  public CleanupResult cleanupTableFiles(TableIdentity tableIdentity) {
+    LOGGER.info(
+        "Starting storage cleanup for table: {}.{}.{} using Polaris loadTable API",
+        tableIdentity.getCatalogName(),
+        String.join(".", tableIdentity.getNamespaceLevels()),
+        tableIdentity.getTableName());
+
+    try {
+      // Step 1: Authenticate with Polaris
+      String bearerToken = authenticateWithPolaris();
+
+      // Step 2: Load table metadata via Polaris API
+      PolarisTableResponse tableResponse = loadTableViaPolaris(tableIdentity, bearerToken);
+
+      // Step 3: Create FileIO using credentials from Polaris
+      FileIO fileIO = createFileIOFromPolarisResponse(tableResponse);
+
+      // Step 4: Perform the actual data file cleanup - identical to local implementation
+      return performComprehensiveTableCleanup(tableIdentity, tableResponse.metadata, fileIO);
+
+    } catch (Exception e) {
+      LOGGER.error("Failed to cleanup table files via Polaris API", e);
+      return CleanupResult.failure("Storage cleanup failed: " + e.getMessage());
+    }
+  }
+
+  /** Authenticates with Polaris using delegation service credentials. */
+  private String authenticateWithPolaris() throws Exception {
+    String tokenUrl = polarisBaseUrl + "/api/catalog/v1/oauth/tokens";
+
+    String requestBody =
+        String.format(
+            "grant_type=client_credentials&client_id=%s&client_secret=%s&scope=PRINCIPAL_ROLE:ALL",
+            polarisClientId, polarisClientSecret);
+
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(tokenUrl))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+            .build();
+
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    if (response.statusCode() != 200) {
+      throw new RuntimeException(
+          "Failed to authenticate with Polaris: "
+              + response.statusCode()
+              + " - "
+              + response.body());
+    }
+
+    JsonNode responseJson = objectMapper.readTree(response.body());
+    String accessToken = responseJson.get("access_token").asText();
+
+    LOGGER.debug("Successfully authenticated with Polaris");
+    return accessToken;
+  }
+
+  /** Loads table metadata via Polaris's REST API. */
+  private PolarisTableResponse loadTableViaPolaris(TableIdentity tableIdentity, String bearerToken)
+      throws Exception {
+    String namespace = String.join(".", tableIdentity.getNamespaceLevels());
+    String tableUrl =
+        String.format(
+            "%s/api/catalog/v1/%s/namespaces/%s/tables/%s",
+            polarisBaseUrl,
+            tableIdentity.getCatalogName(),
+            namespace,
+            tableIdentity.getTableName());
+
+    // Add access delegation header to get storage credentials
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(tableUrl))
+            .header("Authorization", "Bearer " + bearerToken)
+            // .header("X-Iceberg-Access-Delegation", "vended-credentials")  // Commented out for
+            // demo
+            .GET()
+            .build();
+
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    if (response.statusCode() != 200) {
+      throw new RuntimeException(
+          "Failed to load table from Polaris: " + response.statusCode() + " - " + response.body());
+    }
+
+    JsonNode responseJson = objectMapper.readTree(response.body());
+
+    // Extract table metadata
+    JsonNode metadataNode = responseJson.get("metadata");
+    if (metadataNode == null) {
+      throw new RuntimeException("No metadata found in Polaris response");
+    }
+
+    TableMetadata tableMetadata = TableMetadataParser.fromJson(metadataNode.toString());
+
+    // Extract storage credentials
+    Map<String, String> storageCredentials = new HashMap<>();
+    JsonNode configNode = responseJson.get("config");
+    if (configNode != null) {
+      configNode
+          .fieldNames()
+          .forEachRemaining(
+              fieldName -> storageCredentials.put(fieldName, configNode.get(fieldName).asText()));
+    }
+
+    LOGGER.info(
+        "Successfully loaded table metadata from Polaris for table: {}.{}.{}",
+        tableIdentity.getCatalogName(),
+        namespace,
+        tableIdentity.getTableName());
+
+    return new PolarisTableResponse(tableMetadata, storageCredentials);
+  }
+
+  /** Creates FileIO instance using credentials returned from Polaris. */
+  private FileIO createFileIOFromPolarisResponse(PolarisTableResponse tableResponse)
+      throws Exception {
+    Map<String, String> storageCredentials = tableResponse.credentials;
+
+    // Get the FileIO implementation class from credentials or use default
+    String fileIOImpl = storageCredentials.get(CatalogProperties.FILE_IO_IMPL);
+    if (fileIOImpl == null) {
+      fileIOImpl = "org.apache.iceberg.io.ResolvingFileIO"; // Default
+    }
+
+    // Create FileIO instance
+    FileIO fileIO = (FileIO) Class.forName(fileIOImpl).getDeclaredConstructor().newInstance();
+
+    // Initialize with storage credentials from Polaris
+    fileIO.initialize(storageCredentials);
+
+    LOGGER.debug("Created FileIO instance: {} with Polaris credentials", fileIOImpl);
+    return fileIO;
+  }
+
+  /**
+   * Performs comprehensive table cleanup identical to local Polaris implementation. This follows
+   * the exact same pattern as TableCleanupTaskHandler and ManifestFileCleanupTaskHandler.
+   */
+  private CleanupResult performComprehensiveTableCleanup(
+      TableIdentity tableIdentity, TableMetadata tableMetadata, FileIO fileIO) {
+
+    AtomicLong totalDeletedFiles = new AtomicLong(0);
+    List<String> allErrors = new ArrayList<>();
+
+    // Convert TableIdentity to TableIdentifier for consistency with local implementation
+    Namespace namespace = Namespace.of(tableIdentity.getNamespaceLevels().toArray(new String[0]));
+    TableIdentifier tableIdentifier = TableIdentifier.of(namespace, tableIdentity.getTableName());
+
+    try {
+      LOGGER.info(
+          "Starting comprehensive table cleanup for table: {} - Found {} snapshots",
+          tableIdentifier,
+          tableMetadata.snapshots().size());
+
+      // Step 1: Clean up all manifest files and their data files
+      // This matches the ManifestFileCleanupTaskHandler logic exactly
+      long manifestCleanupResult =
+          cleanupAllManifestFiles(tableMetadata, fileIO, tableIdentifier, allErrors);
+      totalDeletedFiles.addAndGet(manifestCleanupResult);
+
+      // Step 2: Clean up metadata files in batches
+      // This matches the BatchFileCleanupTaskHandler logic exactly
+      long metadataCleanupResult =
+          cleanupMetadataFilesInBatches(tableMetadata, fileIO, tableIdentifier, allErrors);
+      totalDeletedFiles.addAndGet(metadataCleanupResult);
+
+      // Step 3: Clean up the main table metadata file (if exists)
+      // This matches the TableCleanupTaskHandler final step
+      String metadataLocation =
+          tableMetadata.location() + "/metadata/" + tableMetadata.metadataFileLocation();
+      if (exists(metadataLocation, fileIO)) {
+        try {
+          tryDelete(tableIdentifier, fileIO, metadataLocation, metadataLocation, null, 1)
+              .get(1, TimeUnit.MINUTES);
+          totalDeletedFiles.incrementAndGet();
+          LOGGER.info("Successfully deleted table metadata file: {}", metadataLocation);
+        } catch (Exception e) {
+          String error =
+              "Failed to delete table metadata file: " + metadataLocation + " - " + e.getMessage();
+          LOGGER.error(error, e);
+          allErrors.add(error);
+        }
+      }
+
+      // Return results
+      if (allErrors.isEmpty()) {
+        LOGGER.info(
+            "Successfully cleaned up {} total files for table {}",
+            totalDeletedFiles.get(),
+            tableIdentifier);
+        return CleanupResult.success(totalDeletedFiles.get());
+      } else {
+        String errorSummary =
+            String.format(
+                "Completed with %d errors: %s",
+                allErrors.size(),
+                allErrors.size() > 5 ? allErrors.subList(0, 5) + "..." : allErrors);
+        LOGGER.error("Cleanup completed with errors: {}", errorSummary);
+        return CleanupResult.failure(errorSummary);
+      }
+
+    } catch (Exception e) {
+      LOGGER.error("Failed to perform comprehensive table cleanup", e);
+      return CleanupResult.failure("Comprehensive table cleanup failed: " + e.getMessage());
+    } finally {
+      // Clean up FileIO resources
+      if (fileIO != null) {
+        try {
+          fileIO.close();
+        } catch (Exception e) {
+          LOGGER.warn("Failed to close FileIO", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Cleans up all manifest files and their data files. This replicates the exact logic from
+   * ManifestFileCleanupTaskHandler.
+   */
+  private long cleanupAllManifestFiles(
+      TableMetadata tableMetadata,
+      FileIO fileIO,
+      TableIdentifier tableIdentifier,
+      List<String> errors) {
+
+    AtomicLong deletedFiles = new AtomicLong(0);
+
+    // Get all unique manifest files (deduplicated) - identical to local implementation
+    Map<String, ManifestFile> uniqueManifests =
+        tableMetadata.snapshots().stream()
+            .flatMap(snapshot -> snapshot.allManifests(fileIO).stream())
+            .collect(Collectors.toMap(ManifestFile::path, Function.identity(), (mf1, mf2) -> mf1));
+
+    LOGGER.info("Found {} unique manifest files to clean up", uniqueManifests.size());
+
+    List<CompletableFuture<Void>> manifestCleanupFutures = new ArrayList<>();
+
+    for (ManifestFile manifestFile : uniqueManifests.values()) {
+      if (!exists(manifestFile.path(), fileIO)) {
+        LOGGER.warn(
+            "Manifest cleanup scheduled, but manifest file doesn't exist: {}", manifestFile.path());
+        continue;
+      }
+
+      // Clean up this manifest file and its data files asynchronously
+      CompletableFuture<Void> manifestCleanupFuture =
+          CompletableFuture.runAsync(
+              () -> {
+                try {
+                  long filesDeleted =
+                      cleanupSingleManifestFile(manifestFile, fileIO, tableIdentifier, errors);
+                  deletedFiles.addAndGet(filesDeleted);
+                } catch (Exception e) {
+                  String error =
+                      "Failed to cleanup manifest file: "
+                          + manifestFile.path()
+                          + " - "
+                          + e.getMessage();
+                  LOGGER.error(error, e);
+                  synchronized (errors) {
+                    errors.add(error);
+                  }
+                }
+              },
+              executorService);
+
+      manifestCleanupFutures.add(manifestCleanupFuture);
+    }
+
+    // Wait for all manifest cleanups to complete
+    try {
+      CompletableFuture.allOf(manifestCleanupFutures.toArray(new CompletableFuture[0]))
+          .get(30, TimeUnit.MINUTES); // Generous timeout for large tables
+    } catch (Exception e) {
+      LOGGER.error("Timeout or error waiting for manifest cleanups to complete", e);
+    }
+
+    return deletedFiles.get();
+  }
+
+  /**
+   * Cleans up a single manifest file and all its data files. This replicates the exact logic from
+   * ManifestFileCleanupTaskHandler.cleanUpManifestFile.
+   */
+  private long cleanupSingleManifestFile(
+      ManifestFile manifestFile,
+      FileIO fileIO,
+      TableIdentifier tableIdentifier,
+      List<String> errors) {
+
+    AtomicLong deletedFiles = new AtomicLong(0);
+
+    try {
+      // Read all data files from this manifest
+      ManifestReader<DataFile> dataFiles = ManifestFiles.read(manifestFile, fileIO);
+      List<CompletableFuture<Void>> dataFileDeletes =
+          StreamSupport.stream(dataFiles.spliterator(), false)
+              .map(
+                  dataFile -> {
+                    CompletableFuture<Void> deleteFuture =
+                        tryDelete(
+                            tableIdentifier,
+                            fileIO,
+                            manifestFile.path(),
+                            dataFile.location(),
+                            null,
+                            1);
+                    return deleteFuture.whenComplete(
+                        (result, ex) -> {
+                          if (ex == null) {
+                            deletedFiles.incrementAndGet();
+                            LOGGER.debug("Deleted data file: {}", dataFile.location());
+                          } else {
+                            String error =
+                                "Failed to delete data file: "
+                                    + dataFile.location()
+                                    + " - "
+                                    + ex.getMessage();
+                            LOGGER.warn(error);
+                            synchronized (errors) {
+                              errors.add(error);
+                            }
+                          }
+                        });
+                  })
+              .collect(Collectors.toList());
+
+      LOGGER.debug(
+          "Scheduled {} data files to be deleted from manifest {}",
+          dataFileDeletes.size(),
+          manifestFile.path());
+
+      // Wait for all data files to be deleted, then delete the manifest itself
+      CompletableFuture.allOf(dataFileDeletes.toArray(new CompletableFuture[0]))
+          .thenCompose(
+              v -> {
+                LOGGER.info(
+                    "All data files in manifest deleted - deleting manifest: {}",
+                    manifestFile.path());
+                return tryDelete(
+                    tableIdentifier, fileIO, manifestFile.path(), manifestFile.path(), null, 1);
+              })
+          .whenComplete(
+              (result, ex) -> {
+                if (ex == null) {
+                  deletedFiles.incrementAndGet();
+                  LOGGER.debug("Deleted manifest file: {}", manifestFile.path());
+                } else {
+                  String error =
+                      "Failed to delete manifest file: "
+                          + manifestFile.path()
+                          + " - "
+                          + ex.getMessage();
+                  LOGGER.error(error, ex);
+                  synchronized (errors) {
+                    errors.add(error);
+                  }
+                }
+              })
+          .get(5, TimeUnit.MINUTES); // Timeout per manifest
+
+    } catch (Exception e) {
+      String error =
+          "Error processing manifest file: " + manifestFile.path() + " - " + e.getMessage();
+      LOGGER.error(error, e);
+      synchronized (errors) {
+        errors.add(error);
+      }
+    }
+
+    return deletedFiles.get();
+  }
+
+  /**
+   * Cleans up metadata files in batches. This replicates the exact logic from
+   * BatchFileCleanupTaskHandler.
+   */
+  private long cleanupMetadataFilesInBatches(
+      TableMetadata tableMetadata,
+      FileIO fileIO,
+      TableIdentifier tableIdentifier,
+      List<String> errors) {
+
+    AtomicLong deletedFiles = new AtomicLong(0);
+
+    // Get all metadata files - identical to local implementation
+    List<List<String>> metadataFileBatches =
+        getMetadataFileBatches(tableMetadata, METADATA_BATCH_SIZE);
+
+    LOGGER.info("Found {} metadata file batches to clean up", metadataFileBatches.size());
+
+    List<CompletableFuture<Void>> batchCleanupFutures = new ArrayList<>();
+
+    for (List<String> batch : metadataFileBatches) {
+      CompletableFuture<Void> batchCleanupFuture =
+          CompletableFuture.runAsync(
+              () -> {
+                try {
+                  long filesDeleted =
+                      cleanupMetadataFileBatch(batch, fileIO, tableIdentifier, errors);
+                  deletedFiles.addAndGet(filesDeleted);
+                } catch (Exception e) {
+                  String error =
+                      "Failed to cleanup metadata file batch: " + batch + " - " + e.getMessage();
+                  LOGGER.error(error, e);
+                  synchronized (errors) {
+                    errors.add(error);
+                  }
+                }
+              },
+              executorService);
+
+      batchCleanupFutures.add(batchCleanupFuture);
+    }
+
+    // Wait for all batch cleanups to complete
+    try {
+      CompletableFuture.allOf(batchCleanupFutures.toArray(new CompletableFuture[0]))
+          .get(10, TimeUnit.MINUTES); // Timeout for all batches
+    } catch (Exception e) {
+      LOGGER.error("Timeout or error waiting for metadata batch cleanups to complete", e);
+    }
+
+    return deletedFiles.get();
+  }
+
+  /**
+   * Cleans up a single batch of metadata files. This replicates the exact logic from
+   * BatchFileCleanupTaskHandler.
+   */
+  private long cleanupMetadataFileBatch(
+      List<String> batchFiles,
+      FileIO fileIO,
+      TableIdentifier tableIdentifier,
+      List<String> errors) {
+
+    AtomicLong deletedFiles = new AtomicLong(0);
+
+    // Filter to only existing files - identical to local implementation
+    List<String> validFiles =
+        batchFiles.stream().filter(file -> exists(file, fileIO)).collect(Collectors.toList());
+
+    if (validFiles.isEmpty()) {
+      LOGGER.warn(
+          "File batch cleanup scheduled, but none of the files in batch exists: {}", batchFiles);
+      return 0;
+    }
+
+    if (validFiles.size() < batchFiles.size()) {
+      List<String> missingFiles =
+          batchFiles.stream().filter(file -> !exists(file, fileIO)).collect(Collectors.toList());
+      LOGGER.warn(
+          "File batch cleanup scheduled, but {} files in the batch are missing: {}",
+          missingFiles.size(),
+          missingFiles);
+    }
+
+    // Schedule the deletion for each file asynchronously
+    List<CompletableFuture<Void>> deleteFutures =
+        validFiles.stream()
+            .map(
+                file -> {
+                  CompletableFuture<Void> deleteFuture =
+                      tryDelete(tableIdentifier, fileIO, null, file, null, 1);
+                  return deleteFuture.whenComplete(
+                      (result, ex) -> {
+                        if (ex == null) {
+                          deletedFiles.incrementAndGet();
+                          LOGGER.debug("Deleted metadata file: {}", file);
+                        } else {
+                          String error =
+                              "Failed to delete metadata file: " + file + " - " + ex.getMessage();
+                          LOGGER.warn(error);
+                          synchronized (errors) {
+                            errors.add(error);
+                          }
+                        }
+                      });
+                })
+            .collect(Collectors.toList());
+
+    try {
+      // Wait for all delete operations to finish
+      CompletableFuture.allOf(deleteFutures.toArray(new CompletableFuture[0]))
+          .get(2, TimeUnit.MINUTES); // Timeout per batch
+    } catch (Exception e) {
+      LOGGER.error("Exception detected during batch files deletion", e);
+    }
+
+    return deletedFiles.get();
+  }
+
+  /** Gets metadata files organized in batches - identical to local implementation. */
+  private List<List<String>> getMetadataFileBatches(TableMetadata tableMetadata, int batchSize) {
+    List<List<String>> result = new ArrayList<>();
+
+    // Collect all metadata files - identical to local implementation
+    List<String> metadataFiles =
+        Stream.of(
+                tableMetadata.previousFiles().stream().map(TableMetadata.MetadataLogEntry::file),
+                tableMetadata.snapshots().stream().map(Snapshot::manifestListLocation),
+                tableMetadata.statisticsFiles().stream().map(StatisticsFile::path),
+                tableMetadata.partitionStatisticsFiles().stream()
+                    .map(PartitionStatisticsFile::path))
+            .flatMap(s -> s)
+            .collect(Collectors.toList());
+
+    // Create batches
+    for (int i = 0; i < metadataFiles.size(); i += batchSize) {
+      result.add(metadataFiles.subList(i, Math.min(i + batchSize, metadataFiles.size())));
+    }
+
+    return result;
+  }
+
+  /**
+   * Tries to delete a file with retry logic - identical to local implementation. This replicates
+   * the exact logic from FileCleanupTaskHandler.tryDelete.
+   */
+  private CompletableFuture<Void> tryDelete(
+      TableIdentifier tableIdentifier,
+      FileIO fileIO,
+      String baseFile,
+      String file,
+      Throwable e,
+      int attempt) {
+
+    if (e != null && attempt <= MAX_ATTEMPTS) {
+      LOGGER.warn(
+          "Error encountered attempting to delete file: {} (attempt {}): {}",
+          file,
+          attempt,
+          e.getMessage());
+    }
+
+    if (attempt > MAX_ATTEMPTS && e != null) {
+      return CompletableFuture.failedFuture(e);
+    }
+
+    return CompletableFuture.runAsync(
+            () -> {
+              // Totally normal for a file to already be missing, e.g. a data file
+              // may be in multiple manifests. There's a possibility we check the
+              // file's existence, but then it is deleted before we have a chance to
+              // send the delete request. In such a case, we should retry and find
+              if (exists(file, fileIO)) {
+                fileIO.deleteFile(file);
+              } else {
+                LOGGER.info(
+                    "Table file cleanup scheduled, but file doesn't exist: {} (table: {}, baseFile: {})",
+                    file,
+                    tableIdentifier,
+                    baseFile != null ? baseFile : "");
+              }
+            },
+            executorService)
+        .exceptionallyComposeAsync(
+            newEx -> {
+              LOGGER.warn(
+                  "Exception caught deleting file: {} (table: {}, baseFile: {})",
+                  file,
+                  tableIdentifier,
+                  baseFile != null ? baseFile : "",
+                  newEx);
+              return tryDelete(tableIdentifier, fileIO, baseFile, file, newEx, attempt + 1);
+            },
+            CompletableFuture.delayedExecutor(
+                FILE_DELETION_RETRY_MILLIS, TimeUnit.MILLISECONDS, executorService));
+  }
+
+  /** Checks if a file exists in storage - identical to TaskUtils.exists. */
+  private boolean exists(String path, FileIO fileIO) {
+    try {
+      return fileIO.newInputFile(path).exists();
+    } catch (Exception e) {
+      LOGGER.debug("Error checking if file exists: {}", path, e);
+      return false;
+    }
+  }
+
+  /** Result of a cleanup operation. */
+  public static class CleanupResult {
+    private final boolean success;
+    private final long filesDeleted;
+    private final String errorMessage;
+
+    private CleanupResult(boolean success, long filesDeleted, String errorMessage) {
+      this.success = success;
+      this.filesDeleted = filesDeleted;
+      this.errorMessage = errorMessage;
+    }
+
+    public static CleanupResult success(long filesDeleted) {
+      return new CleanupResult(true, filesDeleted, null);
+    }
+
+    public static CleanupResult failure(String errorMessage) {
+      return new CleanupResult(false, 0, errorMessage);
+    }
+
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public long getFilesDeleted() {
+      return filesDeleted;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
+    }
+  }
+
+  /** Response object for Polaris table loading. */
+  private static class PolarisTableResponse {
+    final TableMetadata metadata;
+    final Map<String, String> credentials;
+
+    PolarisTableResponse(TableMetadata metadata, Map<String, String> credentials) {
+      this.metadata = metadata;
+      this.credentials = credentials;
+    }
+  }
+}

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -24,6 +24,7 @@ polaris-api-iceberg-service=api/iceberg-service
 polaris-api-management-model=api/management-model
 polaris-api-management-service=api/management-service
 polaris-api-catalog-service=api/polaris-catalog-service
+polaris-api-delegation-service=api/delegation-service
 polaris-service-common=service/common
 polaris-runtime-defaults=runtime/defaults
 polaris-runtime-service=runtime/service
@@ -43,6 +44,7 @@ polaris-minio-testcontainer=tools/minio-testcontainer
 polaris-version=tools/version
 polaris-misc-types=tools/misc-types
 polaris-persistence-varint=nosql/persistence/varint
+polaris-delegation-service=delegation-service
 
 polaris-config-docs-annotations=tools/config-docs/annotations
 polaris-config-docs-generator=tools/config-docs/generator

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -113,6 +113,7 @@ polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES"=["S3","GCS","AZURE"]
 # polaris.features."ENABLE_CATALOG_FEDERATION"=true
 polaris.features."SUPPORTED_CATALOG_CONNECTION_TYPES"=["ICEBERG_REST"]
 polaris.features."SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES"=["OAUTH", "BEARER"]
+polaris.features."DROP_WITH_PURGE_ENABLED"=true
 
 # realm overrides
 # polaris.features.realm-overrides."my-realm"."SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION"=true
@@ -126,6 +127,13 @@ polaris.secrets-manager.type=in-memory
 polaris.file-io.type=default
 
 polaris.event-listener.type=no-op
+
+# Polaris Delegation Service Configuration
+# Enable delegation service to handle long-running tasks (e.g., table purging)
+polaris.delegation.enabled=true
+polaris.delegation.baseUrl=http://localhost:8282
+polaris.delegation.timeoutSeconds=30
+polaris.delegation.maxRetries=3
 
 polaris.log.request-id-header-name=Polaris-Request-Id
 # polaris.log.mdc.aid=polaris

--- a/service/common/build.gradle.kts
+++ b/service/common/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation(project(":polaris-api-management-service"))
   implementation(project(":polaris-api-iceberg-service"))
   implementation(project(":polaris-api-catalog-service"))
+  implementation(project(":polaris-api-delegation-service"))
 
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")

--- a/service/common/src/main/java/org/apache/polaris/service/config/DelegationServiceConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/config/DelegationServiceConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+/**
+ * Configuration for the Polaris Delegation Service client.
+ *
+ * <p>Contains settings for connecting to and interacting with the delegation service.
+ */
+public class DelegationServiceConfiguration {
+
+  private boolean enabled = false;
+  private String baseUrl = "http://localhost:8282";
+  private int timeoutSeconds = 30;
+  private int maxRetries = 3;
+  private boolean fallbackToLocal = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  public int getTimeoutSeconds() {
+    return timeoutSeconds;
+  }
+
+  public void setTimeoutSeconds(int timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+  }
+
+  public int getMaxRetries() {
+    return maxRetries;
+  }
+
+  public void setMaxRetries(int maxRetries) {
+    this.maxRetries = maxRetries;
+  }
+
+  public boolean isFallbackToLocal() {
+    return fallbackToLocal;
+  }
+
+  public void setFallbackToLocal(boolean fallbackToLocal) {
+    this.fallbackToLocal = fallbackToLocal;
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationClient.java
+++ b/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationClient.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.delegation;
+
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.entity.TaskEntity;
+
+/**
+ * Client for interacting with the Polaris Delegation Service.
+ *
+ * <p>This client is responsible for delegating long-running tasks from the main Polaris catalog
+ * service to the delegation service for execution, maintaining low-latency performance in the
+ * catalog.
+ *
+ * <p>The client handles all delegation orchestration including decision-making, HTTP communication,
+ * fallback to local execution, and proper operation ordering.
+ */
+public interface DelegationClient {
+
+  /**
+   * Delegate a task to the delegation service for synchronous execution.
+   *
+   * @param task the task entity to delegate
+   * @param callContext the call context for the operation
+   * @return true if the task was successfully delegated and completed, false otherwise
+   * @throws DelegationException if delegation fails due to communication or service errors
+   */
+  boolean delegateTask(TaskEntity task, CallContext callContext) throws DelegationException;
+
+  /**
+   * SYNCHRONOUSLY delegates table data file cleanup to the delegation service.
+   *
+   * <p>This method:
+   *
+   * <ol>
+   *   <li>Checks if delegation is enabled and appropriate
+   *   <li>If delegation is enabled, makes a BLOCKING HTTP call to delegate ONLY the data file
+   *       cleanup
+   *   <li>WAITS for the delegation service to complete the data file deletion
+   *   <li>Returns true ONLY after delegation service confirms completion
+   *   <li>If delegation is disabled, returns false to indicate local execution should be used
+   *   <li>If delegation fails, returns false (no fallback - operation should fail)
+   * </ol>
+   *
+   * <p><strong>CRITICAL TIMING:</strong> This method blocks the calling thread until the delegation
+   * service completes the data file cleanup operation. Do NOT proceed with metadata removal until
+   * this method returns true.
+   *
+   * <p>NOTE: This only handles data file deletion from storage. Metadata removal from the catalog
+   * is still handled by Polaris after successful delegation.
+   *
+   * @param catalogName the name of the catalog
+   * @param tableIdentifier the identifier of the table to purge
+   * @param tableMetadata the metadata of the table to purge
+   * @param storageProperties storage configuration properties
+   * @param callContext the call context
+   * @return true if delegation is enabled and data cleanup was COMPLETED successfully, false if
+   *     delegation disabled or failed
+   */
+  boolean delegatePurge(
+      String catalogName,
+      TableIdentifier tableIdentifier,
+      TableMetadata tableMetadata,
+      Map<String, String> storageProperties,
+      CallContext callContext);
+
+  /**
+   * Check if delegation is available and enabled for the given task type.
+   *
+   * @param task the task to check
+   * @param callContext the call context
+   * @return true if the task can be delegated, false if it should be executed locally
+   */
+  boolean canDelegate(TaskEntity task, CallContext callContext);
+}

--- a/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationClientImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationClientImpl.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.delegation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.entity.AsyncTaskType;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.delegation.api.model.CommonPayload;
+import org.apache.polaris.delegation.api.model.TableIdentity;
+import org.apache.polaris.delegation.api.model.TablePurgeParameters;
+import org.apache.polaris.delegation.api.model.TaskExecutionRequest;
+import org.apache.polaris.delegation.api.model.TaskExecutionResponse;
+import org.apache.polaris.delegation.api.model.TaskType;
+import org.apache.polaris.service.config.DelegationServiceConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of DelegationClient that communicates with the delegation service via HTTP.
+ *
+ * <p>This client converts Polaris internal task entities to delegation service API contracts and
+ * handles HTTP communication with the delegation service.
+ */
+public class DelegationClientImpl implements DelegationClient {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DelegationClientImpl.class);
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final DelegationServiceConfiguration config;
+
+  public DelegationClientImpl(
+      HttpClient httpClient, ObjectMapper objectMapper, DelegationServiceConfiguration config) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.config = config;
+  }
+
+  @Override
+  public boolean delegateTask(TaskEntity task, CallContext callContext) throws DelegationException {
+    if (!canDelegate(task, callContext)) {
+      return false;
+    }
+
+    try {
+      // Convert TaskEntity to delegation service request
+      TaskExecutionRequest request = convertToRequest(task, callContext);
+
+      // Make HTTP call to delegation service
+      String requestBody = objectMapper.writeValueAsString(request);
+      HttpRequest httpRequest =
+          HttpRequest.newBuilder()
+              .uri(URI.create(config.getBaseUrl() + "/api/v1/tasks/execute/synchronous"))
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .timeout(Duration.ofSeconds(config.getTimeoutSeconds()))
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+              .build();
+
+      LOGGER.info(
+          "Delegating task {} to delegation service at {}", task.getId(), config.getBaseUrl());
+
+      HttpResponse<String> response =
+          httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() == 200) {
+        TaskExecutionResponse delegationResponse =
+            objectMapper.readValue(response.body(), TaskExecutionResponse.class);
+        LOGGER.info(
+            "Task {} delegated successfully: status={}, summary={}",
+            task.getId(),
+            delegationResponse.getStatus(),
+            delegationResponse.getResultSummary());
+        return "COMPLETED".equals(delegationResponse.getStatus());
+      } else {
+        throw new DelegationException(
+            String.format(
+                "Delegation service returned error: %d %s",
+                response.statusCode(), response.body()));
+      }
+
+    } catch (IOException | InterruptedException e) {
+      throw new DelegationException("Failed to communicate with delegation service", e);
+    }
+  }
+
+  @Override
+  public boolean delegatePurge(
+      String catalogName,
+      TableIdentifier tableIdentifier,
+      TableMetadata tableMetadata,
+      Map<String, String> storageProperties,
+      CallContext callContext) {
+
+    if (!isDelegationEnabled()) {
+      LOGGER.debug("Delegation service is not enabled for table {}", tableIdentifier);
+      return false;
+    }
+
+    try {
+      LOGGER.info(
+          "Sending synchronous request to delegation service for data file cleanup of table {}",
+          tableIdentifier);
+
+      // Send synchronous HTTP request to delegation service for data file cleanup
+      // This call will BLOCK until delegation service completes the operation or fails
+      boolean delegationSuccessful =
+          delegateTablePurge(catalogName, tableIdentifier, storageProperties, callContext);
+
+      if (delegationSuccessful) {
+        LOGGER.info(
+            "Delegation service SYNCHRONOUSLY COMPLETED data file cleanup for table {}",
+            tableIdentifier);
+        return true;
+      } else {
+        LOGGER.error(
+            "Delegation service failed to complete data file cleanup for table {}",
+            tableIdentifier);
+        return false;
+      }
+
+    } catch (Exception e) {
+      LOGGER.error("Error during delegation for table {}", tableIdentifier, e);
+      return false;
+    }
+  }
+
+  /** Delegates the actual purge operation to the delegation service. */
+  private boolean delegateTablePurge(
+      String catalogName,
+      TableIdentifier tableIdentifier,
+      Map<String, String> storageProperties,
+      CallContext callContext)
+      throws DelegationException {
+
+    try {
+      String[] namespaceLevels = tableIdentifier.namespace().levels();
+      List<String> namespaceLevelsList = Arrays.asList(namespaceLevels);
+
+      // Create common payload
+      CommonPayload commonPayload =
+          new CommonPayload(
+              TaskType.PURGE_TABLE,
+              OffsetDateTime.now(),
+              callContext.getRealmContext().getRealmIdentifier());
+
+      // Create table identity
+      TableIdentity tableIdentity =
+          new TableIdentity(
+              catalogName,
+              Arrays.asList(tableIdentifier.namespace().levels()), // namespace levels
+              tableIdentifier.name()); // table name
+
+      // Create operation parameters but without passing credentials
+      TablePurgeParameters operationParameters = new TablePurgeParameters(tableIdentity);
+
+      // Create request
+      TaskExecutionRequest request = new TaskExecutionRequest(commonPayload, operationParameters);
+
+      // Make HTTP call to delegation service
+      String requestBody = objectMapper.writeValueAsString(request);
+      HttpRequest httpRequest =
+          HttpRequest.newBuilder()
+              .uri(URI.create(config.getBaseUrl() + "/api/v1/tasks/execute/synchronous"))
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .timeout(Duration.ofSeconds(config.getTimeoutSeconds()))
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+              .build();
+
+      LOGGER.info(
+          "Sending BLOCKING HTTP request to delegation service at {} for table {}",
+          config.getBaseUrl(),
+          tableIdentifier);
+
+      // CRITICAL: This is a SYNCHRONOUS/BLOCKING call that waits for delegation service to complete
+      // The HTTP client will block this thread until:
+      // 1. Delegation service completes data file cleanup and responds, OR
+      // 2. Request times out (configured timeout: {} seconds), OR
+      // 3. Network/service error occurs
+      LOGGER.debug(
+          "Waiting for delegation service to complete data file cleanup (timeout: {}s)...",
+          config.getTimeoutSeconds());
+
+      HttpResponse<String> response =
+          httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() == 200) {
+        TaskExecutionResponse delegationResponse =
+            objectMapper.readValue(response.body(), TaskExecutionResponse.class);
+        LOGGER.info(
+            "Delegation service responded: status={}, summary={}",
+            delegationResponse.getStatus(),
+            delegationResponse.getResultSummary());
+
+        boolean success = "success".equals(delegationResponse.getStatus());
+        if (success) {
+          LOGGER.info(
+              "Delegation service completed data file cleanup for table {}", tableIdentifier);
+        } else {
+          LOGGER.error(
+              "Delegation service reported failure for table {}: {}",
+              tableIdentifier,
+              delegationResponse.getResultSummary());
+        }
+        return success;
+      } else {
+        LOGGER.error(
+            "Delegation service returned HTTP error: {} {} for table {}",
+            response.statusCode(),
+            response.body(),
+            tableIdentifier);
+        return false;
+      }
+
+    } catch (IOException | InterruptedException e) {
+      throw new DelegationException("Failed to communicate with delegation service", e);
+    }
+  }
+
+  /** Checks if delegation service is enabled. */
+  private boolean isDelegationEnabled() {
+    String delegationEnabled =
+        System.getProperty(
+            "polaris.delegation.enabled",
+            System.getenv().getOrDefault("POLARIS_DELEGATION_ENABLED", "false"));
+    return "true".equalsIgnoreCase(delegationEnabled) && config.isEnabled();
+  }
+
+  @Override
+  public boolean canDelegate(TaskEntity task, CallContext callContext) {
+    if (!config.isEnabled()) {
+      return false;
+    }
+
+    // Only delegate table cleanup tasks for now
+    AsyncTaskType taskType = task.getTaskType();
+    if (taskType != AsyncTaskType.ENTITY_CLEANUP_SCHEDULER) {
+      return false;
+    }
+
+    // Check if this is a table cleanup task
+    try {
+      PolarisBaseEntity entity = task.readData(PolarisBaseEntity.class);
+      return IcebergTableLikeEntity.of(entity) != null;
+    } catch (Exception e) {
+      LOGGER.warn("Failed to read task data for delegation check", e);
+      return false;
+    }
+  }
+
+  private TaskExecutionRequest convertToRequest(TaskEntity task, CallContext callContext)
+      throws DelegationException {
+    try {
+      // Read the table entity from the task
+      IcebergTableLikeEntity tableEntity = task.readData(IcebergTableLikeEntity.class);
+      if (tableEntity == null) {
+        throw new DelegationException("Task does not contain table entity data");
+      }
+
+      // Create common payload
+      CommonPayload commonPayload =
+          new CommonPayload(
+              TaskType.PURGE_TABLE,
+              OffsetDateTime.now(),
+              callContext.getRealmContext().getRealmIdentifier());
+
+      // Create table identity
+      TableIdentifier tableId = tableEntity.getTableIdentifier();
+      TableIdentity tableIdentity =
+          new TableIdentity(
+              tableId.namespace().level(0),
+              Arrays.asList(tableId.namespace().levels()).subList(1, tableId.namespace().length()),
+              tableId.name());
+
+      // Create operation parameters
+      TablePurgeParameters operationParameters = new TablePurgeParameters(tableIdentity);
+
+      return new TaskExecutionRequest(commonPayload, operationParameters);
+
+    } catch (Exception e) {
+      throw new DelegationException("Failed to convert task to delegation request", e);
+    }
+  }
+}

--- a/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationException.java
+++ b/service/common/src/main/java/org/apache/polaris/service/delegation/DelegationException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.delegation;
+
+/**
+ * Exception thrown when delegation to the delegation service fails.
+ *
+ * <p>This can occur due to network issues, service unavailability, invalid requests, or other
+ * communication failures with the delegation service.
+ */
+public class DelegationException extends Exception {
+
+  public DelegationException(String message) {
+    super(message);
+  }
+
+  public DelegationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DelegationException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
This PR introduces support for delegating table purge operations to an external Delegation Service, enabling Polaris to offload long-running data cleanup tasks while maintaining low-latency catalog operations.