### PR TITLE
Remove PolarisCallContext from TreeMapMetaStore

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
@@ -193,6 +193,7 @@ public class TreeMapMetaStore {
   private Transaction tr;
 
   // diagnostic services
+  private final PolarisDiagnostics initialDiagnosticServices;
   private PolarisDiagnostics diagnosticServices;
 
   // all entities
@@ -300,6 +301,7 @@ public class TreeMapMetaStore {
                     policyMappingRecord.getTargetId()),
             PolarisPolicyMappingRecord::new);
 
+    this.initialDiagnosticServices = diagnostics;
     // no transaction open yet
     this.diagnosticServices = diagnostics;
     this.tr = null;
@@ -428,7 +430,7 @@ public class TreeMapMetaStore {
         throw e;
       } finally {
         this.tr = null;
-        this.diagnosticServices = null;
+        this.diagnosticServices = this.initialDiagnosticServices;
       }
     }
   }
@@ -452,7 +454,7 @@ public class TreeMapMetaStore {
         throw e;
       } finally {
         this.tr = null;
-        this.diagnosticServices = null;
+        this.diagnosticServices = this.initialDiagnosticServices;
       }
     }
   }
@@ -474,7 +476,7 @@ public class TreeMapMetaStore {
         return transactionCode.get();
       } finally {
         this.tr = null;
-        this.diagnosticServices = null;
+        this.diagnosticServices = this.initialDiagnosticServices;
       }
     }
   }
@@ -492,7 +494,7 @@ public class TreeMapMetaStore {
         transactionCode.run();
       } finally {
         this.tr = null;
-        this.diagnosticServices = null;
+        this.diagnosticServices = this.initialDiagnosticServices;
       }
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
@@ -68,7 +68,7 @@ public class TreeMapMetaStore {
      * @param key key for that value
      */
     public T read(String key) {
-      TreeMapMetaStore.this.ensureReadTr();
+      ensureReadTr();
       T value = this.slice.getOrDefault(key, null);
       return (value != null) ? this.copyRecord.apply(value) : null;
     }
@@ -79,7 +79,7 @@ public class TreeMapMetaStore {
      * @param prefix key prefix
      */
     public List<T> readRange(String prefix) {
-      TreeMapMetaStore.this.ensureReadTr();
+      ensureReadTr();
       if (prefix.isEmpty()) {
         return new ArrayList<>(this.slice.values());
       }
@@ -99,7 +99,7 @@ public class TreeMapMetaStore {
      * @param value value to write
      */
     public void write(T value) {
-      TreeMapMetaStore.this.ensureReadWriteTr();
+      ensureReadWriteTr();
       T valueToWrite = (value != null) ? this.copyRecord.apply(value) : null;
       String key = this.buildKey(valueToWrite);
       // write undo if needs be
@@ -115,7 +115,7 @@ public class TreeMapMetaStore {
      * @param key key for the record to remove
      */
     public void delete(String key) {
-      TreeMapMetaStore.this.ensureReadWriteTr();
+      ensureReadWriteTr();
       if (slice.containsKey(key)) {
         // write undo if needs be
         if (!this.undoSlice.containsKey(key)) {
@@ -131,7 +131,7 @@ public class TreeMapMetaStore {
      * @param prefix key prefix for the record to remove
      */
     public void deleteRange(String prefix) {
-      TreeMapMetaStore.this.ensureReadWriteTr();
+      ensureReadWriteTr();
       List<T> elements = this.readRange(prefix);
       for (T element : elements) {
         this.delete(element);
@@ -139,7 +139,7 @@ public class TreeMapMetaStore {
     }
 
     void deleteAll() {
-      TreeMapMetaStore.this.ensureReadWriteTr();
+      ensureReadWriteTr();
       slice.clear();
       undoSlice.clear();
     }
@@ -155,7 +155,7 @@ public class TreeMapMetaStore {
 
     /** Rollback all changes made to this slice since transaction started */
     private void rollback() {
-      TreeMapMetaStore.this.ensureReadWriteTr();
+      ensureReadWriteTr();
       undoSlice.forEach(
           (key, value) -> {
             if (value == null) {
@@ -398,7 +398,7 @@ public class TreeMapMetaStore {
   }
 
   /** Ensure that a read/write FDB transaction has been started */
-  public void ensureReadWriteTr() {
+  private void ensureReadWriteTr() {
     this.diagnosticServices.check(
         this.tr != null && this.tr.isWrite(), "no_write_transaction_started");
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapMetaStore.java
@@ -25,7 +25,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
@@ -410,18 +409,16 @@ public class TreeMapMetaStore {
   /**
    * Run inside a read/write transaction
    *
-   * @param callCtx call context to use
-   * @param transactionCode transaction code
    * @return the result of the execution
    */
   public <T> T runInTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode) {
+      @Nonnull PolarisDiagnostics diagnostics, @Nonnull Supplier<T> transactionCode) {
 
     synchronized (lock) {
       // execute transaction
       try {
         // init diagnostic services
-        this.diagnosticServices = callCtx.getDiagServices();
+        this.diagnosticServices = diagnostics;
         this.startWriteTransaction();
         return transactionCode.get();
       } catch (Throwable e) {
@@ -436,21 +433,16 @@ public class TreeMapMetaStore {
     }
   }
 
-  /**
-   * Run inside a read/write transaction
-   *
-   * @param callCtx call context to use
-   * @param transactionCode transaction code
-   */
+  /** Run inside a read/write transaction */
   public void runActionInTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode) {
+      @Nonnull PolarisDiagnostics diagnostics, @Nonnull Runnable transactionCode) {
 
     synchronized (lock) {
 
       // execute transaction
       try {
         // init diagnostic services
-        this.diagnosticServices = callCtx.getDiagServices();
+        this.diagnosticServices = diagnostics;
         this.startWriteTransaction();
         transactionCode.run();
       } catch (Throwable e) {
@@ -468,18 +460,16 @@ public class TreeMapMetaStore {
   /**
    * Run inside a read only transaction
    *
-   * @param callCtx call context to use
-   * @param transactionCode transaction code
    * @return the result of the execution
    */
   public <T> T runInReadTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode) {
+      @Nonnull PolarisDiagnostics diagnostics, @Nonnull Supplier<T> transactionCode) {
     synchronized (lock) {
 
       // execute transaction
       try {
         // init diagnostic services
-        this.diagnosticServices = callCtx.getDiagServices();
+        this.diagnosticServices = diagnostics;
         this.startReadTransaction();
         return transactionCode.get();
       } finally {
@@ -489,20 +479,15 @@ public class TreeMapMetaStore {
     }
   }
 
-  /**
-   * Run inside a read only transaction
-   *
-   * @param callCtx call context to use
-   * @param transactionCode transaction code
-   */
+  /** Run inside a read only transaction */
   public void runActionInReadTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode) {
+      @Nonnull PolarisDiagnostics diagnostics, @Nonnull Runnable transactionCode) {
     synchronized (lock) {
 
       // execute transaction
       try {
         // init diagnostic services
-        this.diagnosticServices = callCtx.getDiagServices();
+        this.diagnosticServices = diagnostics;
         this.startReadTransaction();
         transactionCode.run();
       } finally {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -79,7 +79,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
       @Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode) {
 
     // run transaction on our underlying store
-    return store.runInTransaction(callCtx, transactionCode);
+    return store.runInTransaction(callCtx.getDiagServices(), transactionCode);
   }
 
   /** {@inheritDoc} */
@@ -88,7 +88,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
       @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode) {
 
     // run transaction on our underlying store
-    store.runActionInTransaction(callCtx, transactionCode);
+    store.runActionInTransaction(callCtx.getDiagServices(), transactionCode);
   }
 
   /** {@inheritDoc} */
@@ -96,7 +96,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
   public <T> T runInReadTransaction(
       @Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode) {
     // run transaction on our underlying store
-    return store.runInReadTransaction(callCtx, transactionCode);
+    return store.runInReadTransaction(callCtx.getDiagServices(), transactionCode);
   }
 
   /** {@inheritDoc} */
@@ -105,7 +105,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
       @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode) {
 
     // run transaction on our underlying store
-    store.runActionInReadTransaction(callCtx, transactionCode);
+    store.runActionInReadTransaction(callCtx.getDiagServices(), transactionCode);
   }
 
   /**


### PR DESCRIPTION
the concrete class `TreeMapMetaStore` only uses `PolarisDiagnostics` from the given `PolarisCallContext`.

we also remember `initialDiagnosticServices` and reset it after a transaction for consistency (not sure if it will ever get used outside a transaction context though)