### PR TITLE
add the schema-setup for admin tool

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -41,7 +41,6 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
-import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 import org.apache.polaris.persistence.relational.jdbc.models.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,7 +116,7 @@ public class DatasourceOperations {
     }
   }
 
-  public boolean checkSchemaExists(SchemaOptions schemaOptions) {
+  public boolean checkSchemaExists(String schemaName) {
     final boolean[] exists = {false};
 
     try {
@@ -125,7 +124,7 @@ public class DatasourceOperations {
           connection -> {
             try (ResultSet schemas = connection.getMetaData().getSchemas()) {
               while (schemas.next()) {
-                if (schemaOptions.schemaName().equalsIgnoreCase(schemas.getString("TABLE_SCHEM"))) {
+                if (schemaName.equalsIgnoreCase(schemas.getString("TABLE_SCHEM"))) {
                   exists[0] = true;
                   break;
                 }
@@ -134,8 +133,7 @@ public class DatasourceOperations {
             return true;
           });
     } catch (SQLException e) {
-      throw new RuntimeException(
-          "Failed to check schema existence: " + schemaOptions.schemaName(), e);
+      throw new RuntimeException("Failed to check schema existence: " + schemaName, e);
     }
 
     return exists[0];

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -116,6 +116,31 @@ public class DatasourceOperations {
     }
   }
 
+
+  public boolean checkSchemaExists(@Nonnull String schemaName) {
+    final String sql = "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?";
+    final boolean[] exists = {false};
+
+    try {
+      runWithinTransaction(connection -> {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+          statement.setString(1, schemaName);
+          try (ResultSet resultSet = statement.executeQuery()) {
+            exists[0] = resultSet.next();
+          }
+        }
+        return true;
+      });
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+
+    return exists[0];
+  }
+
+
+
+
   /**
    * Executes SELECT Query and returns the results after applying a transformer
    *

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -121,28 +121,25 @@ public class DatasourceOperations {
     final boolean[] exists = {false};
 
     try {
-      runWithinTransaction(connection -> {
-        try (ResultSet schemas = connection.getMetaData().getSchemas()) {
-          while (schemas.next()) {
-            if (schemaOptions.schemaName().equalsIgnoreCase(schemas.getString("TABLE_SCHEM"))) {
-              exists[0] = true;
-              break;
+      runWithinTransaction(
+          connection -> {
+            try (ResultSet schemas = connection.getMetaData().getSchemas()) {
+              while (schemas.next()) {
+                if (schemaOptions.schemaName().equalsIgnoreCase(schemas.getString("TABLE_SCHEM"))) {
+                  exists[0] = true;
+                  break;
+                }
+              }
             }
-          }
-        }
-        return true;
-      });
+            return true;
+          });
     } catch (SQLException e) {
-      throw new RuntimeException("Failed to check schema existence: " + schemaOptions.schemaName(), e);
+      throw new RuntimeException(
+          "Failed to check schema existence: " + schemaOptions.schemaName(), e);
     }
 
     return exists[0];
   }
-
-
-
-
-
 
   /**
    * Executes SELECT Query and returns the results after applying a transformer

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -116,30 +116,27 @@ public class DatasourceOperations {
     }
   }
 
-
   public boolean checkSchemaExists(@Nonnull String schemaName) {
     final String sql = "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?";
     final boolean[] exists = {false};
 
     try {
-      runWithinTransaction(connection -> {
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-          statement.setString(1, schemaName);
-          try (ResultSet resultSet = statement.executeQuery()) {
-            exists[0] = resultSet.next();
-          }
-        }
-        return true;
-      });
+      runWithinTransaction(
+          connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+              statement.setString(1, schemaName);
+              try (ResultSet resultSet = statement.executeQuery()) {
+                exists[0] = resultSet.next();
+              }
+            }
+            return true;
+          });
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
 
     return exists[0];
   }
-
-
-
 
   /**
    * Executes SELECT Query and returns the results after applying a transformer

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -149,7 +149,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
         if (bootstrapOptions.schemaOptions().setupSchema()) {
           setupSchema(bootstrapOptions.schemaOptions());
         } else {
-          if (!isSchemaPresent(POLARIS_SCHEMA_NAME)) {
+          if (!isSchemaPresent(bootstrapOptions.schemaOptions())) {
             throw new IllegalStateException(
                 "Schema does not exist for realm '"
                     + realm
@@ -297,7 +297,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
   }
 
   @Override
-  public boolean isSchemaPresent(String schemaName) {
-    return getDatasourceOperations().checkSchemaExists(schemaName);
+  public boolean isSchemaPresent(SchemaOptions schemaOptions) {
+    return getDatasourceOperations().checkSchemaExists(schemaOptions);
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -151,8 +151,10 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
         } else {
           if (!isSchemaPresent(POLARIS_SCHEMA_NAME)) {
             throw new IllegalStateException(
-                "Schema does not exist for realm '" + realm + "' and schema-setup is false. " +
-                    "Either set schema-setup is true or initialize the schema using SchemaSetupCommand.");
+                "Schema does not exist for realm '"
+                    + realm
+                    + "' and schema-setup is false. "
+                    + "Either set schema-setup is true or initialize the schema using SchemaSetupCommand.");
           }
         }
         initializeForRealm(
@@ -279,16 +281,13 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
     }
   }
 
-
   @Override
   public boolean setupSchema(SchemaOptions schemaOptions) {
     DatasourceOperations datasourceOperations = getDatasourceOperations();
     try {
       // Run the set-up script to create the tables.
       datasourceOperations.executeScript(
-          datasourceOperations
-              .getDatabaseType()
-              .openInitScriptResource(schemaOptions));
+          datasourceOperations.getDatabaseType().openInitScriptResource(schemaOptions));
 
     } catch (SQLException e) {
       throw new RuntimeException(

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -149,7 +149,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
         if (bootstrapOptions.schemaOptions().setupSchema()) {
           setupSchema(bootstrapOptions.schemaOptions());
         } else {
-          if (!isSchemaPresent(bootstrapOptions.schemaOptions())) {
+          if (!isSchemaPresent()) {
             throw new IllegalStateException(
                 "Schema does not exist for realm '"
                     + realm
@@ -296,8 +296,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory, Sch
     return true;
   }
 
-  @Override
-  public boolean isSchemaPresent(SchemaOptions schemaOptions) {
-    return getDatasourceOperations().checkSchemaExists(schemaOptions);
+  private boolean isSchemaPresent() {
+    return getDatasourceOperations()
+        .checkSchemaExists(JdbcMetaStoreManagerFactory.POLARIS_SCHEMA_NAME);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
@@ -24,6 +24,4 @@ import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 public interface SchemaInitializer {
 
   boolean setupSchema(SchemaOptions schemaOptions);
-
-  boolean isSchemaPresent(SchemaOptions schemaName);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
@@ -17,29 +17,14 @@
  * under the License.
  */
 
-package org.apache.polaris.core.persistence.bootstrap;
+package org.apache.polaris.core.persistence;
 
-import jakarta.annotation.Nullable;
-import org.apache.polaris.immutables.PolarisImmutable;
-import org.immutables.value.Value;
+import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 
-@PolarisImmutable
-public interface SchemaOptions {
-  @Nullable
-  Integer schemaVersion();
+public interface SchemaInitializer {
 
-  @Nullable
-  String schemaFile();
+  boolean setupSchema(SchemaOptions schemaOptions);
 
-  @Value.Default
-  default boolean setupSchema() {
-    return true;
-  }
+  boolean isSchemaPresent(String schemaName);
 
-  @Value.Check
-  default void validate() {
-    if (schemaVersion() != null && schemaFile() != null) {
-      throw new IllegalStateException("Only one of schemaVersion or schemaFile can be set.");
-    }
-  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
@@ -26,5 +26,4 @@ public interface SchemaInitializer {
   boolean setupSchema(SchemaOptions schemaOptions);
 
   boolean isSchemaPresent(String schemaName);
-
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/SchemaInitializer.java
@@ -25,5 +25,5 @@ public interface SchemaInitializer {
 
   boolean setupSchema(SchemaOptions schemaOptions);
 
-  boolean isSchemaPresent(String schemaName);
+  boolean isSchemaPresent(SchemaOptions schemaName);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -36,12 +36,12 @@ public interface SchemaOptions {
   default boolean setupSchema() {
     return true;
   }
+
   @NotNull
   @Value.Default
   default String schemaName() {
     return "POLARIS_SCHEMA";
   }
-
 
   @Value.Check
   default void validate() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -20,6 +20,7 @@
 package org.apache.polaris.core.persistence.bootstrap;
 
 import jakarta.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
 
@@ -35,6 +36,12 @@ public interface SchemaOptions {
   default boolean setupSchema() {
     return true;
   }
+  @NotNull
+  @Value.Default
+  default String schemaName() {
+    return "POLARIS_SCHEMA";
+  }
+
 
   @Value.Check
   default void validate() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -20,7 +20,6 @@
 package org.apache.polaris.core.persistence.bootstrap;
 
 import jakarta.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
 
@@ -35,12 +34,6 @@ public interface SchemaOptions {
   @Value.Default
   default boolean setupSchema() {
     return true;
-  }
-
-  @NotNull
-  @Value.Default
-  default String schemaName() {
-    return "POLARIS_SCHEMA";
   }
 
   @Value.Check

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
@@ -21,7 +21,6 @@ package org.apache.polaris.admintool;
 import jakarta.inject.Inject;
 import java.util.concurrent.Callable;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
-import org.apache.polaris.core.persistence.SchemaInitializer;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
@@ -33,8 +32,6 @@ public abstract class BaseCommand implements Callable<Integer> {
   public static final int EXIT_CODE_SCHEMA_ERROR = 5;
 
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
-
-  @Inject SchemaInitializer schemaInitializer;
 
   @Spec CommandSpec spec;
 }

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BaseCommand.java
@@ -21,6 +21,7 @@ package org.apache.polaris.admintool;
 import jakarta.inject.Inject;
 import java.util.concurrent.Callable;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.SchemaInitializer;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
@@ -29,8 +30,11 @@ public abstract class BaseCommand implements Callable<Integer> {
   public static final int EXIT_CODE_USAGE = 2;
   public static final int EXIT_CODE_BOOTSTRAP_ERROR = 3;
   public static final int EXIT_CODE_PURGE_ERROR = 4;
+  public static final int EXIT_CODE_SCHEMA_ERROR = 5;
 
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
+
+  @Inject SchemaInitializer schemaInitializer;
 
   @Spec CommandSpec spec;
 }

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -81,6 +81,12 @@ public class BootstrapCommand extends BaseCommand {
 
     static class SchemaInputOptions {
       @CommandLine.Option(
+          names = {"--setup-schema"},
+          description = "If true, initializes the schema at startup (default: true).",
+          defaultValue = "true")
+      boolean setupSchema;
+
+      @CommandLine.Option(
           names = {"-v", "--schema-version"},
           paramLabel = "<schema version>",
           description = "The version of the schema to load in [1, 2, LATEST].")

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/PolarisAdminTool.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/PolarisAdminTool.java
@@ -31,6 +31,7 @@ import picocli.CommandLine.HelpCommand;
       HelpCommand.class,
       BootstrapCommand.class,
       PurgeCommand.class,
+      SchemaSetupCommand.class
     })
 public class PolarisAdminTool extends BaseCommand {
 

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/SchemaSetupCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/SchemaSetupCommand.java
@@ -19,7 +19,9 @@
 
 package org.apache.polaris.admintool;
 
+import jakarta.inject.Inject;
 import org.apache.polaris.admintool.BootstrapCommand.InputOptions.SchemaInputOptions;
+import org.apache.polaris.core.persistence.SchemaInitializer;
 import org.apache.polaris.core.persistence.bootstrap.ImmutableSchemaOptions;
 import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 import picocli.CommandLine.ArgGroup;
@@ -30,6 +32,8 @@ import picocli.CommandLine.Command;
     mixinStandardHelpOptions = true,
     description = "Set up the polaris schema for Polaris metadata storage")
 public class SchemaSetupCommand extends BaseCommand {
+
+  @Inject SchemaInitializer schemaInitializer;
 
   @ArgGroup(exclusive = false)
   public SchemaInputOptions schemaInputOptions;

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/SchemaSetupCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/SchemaSetupCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.admintool;
+
+import org.apache.polaris.admintool.BootstrapCommand.InputOptions.SchemaInputOptions;
+import org.apache.polaris.core.persistence.bootstrap.ImmutableSchemaOptions;
+import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "setup",
+    mixinStandardHelpOptions = true,
+    description = "Set up the polaris schema for Polaris metadata storage")
+public class SchemaSetupCommand extends BaseCommand {
+
+  @ArgGroup(exclusive = false)
+  public SchemaInputOptions schemaInputOptions;
+
+  @Override
+  public Integer call() {
+    if (schemaInputOptions == null) {
+      return executeWith(ImmutableSchemaOptions.builder().build());
+    }
+
+    if (!schemaInputOptions.setupSchema) {
+      return reportFailure("Schema initialization is disabled.");
+    }
+
+    boolean hasExplicitSchema =
+        schemaInputOptions.schemaVersion != null
+            || (schemaInputOptions.schemaFile != null && !schemaInputOptions.schemaFile.isEmpty());
+
+    SchemaOptions schemaOptions =
+        hasExplicitSchema
+            ? ImmutableSchemaOptions.builder()
+                .schemaVersion(schemaInputOptions.schemaVersion)
+                .schemaFile(schemaInputOptions.schemaFile)
+                .build()
+            : ImmutableSchemaOptions.builder().build();
+
+    return executeWith(schemaOptions);
+  }
+
+  private int executeWith(SchemaOptions schemaOptions) {
+    return schemaInitializer.setupSchema(schemaOptions)
+        ? reportSuccess()
+        : reportFailure("Failed to initialize the schema.");
+  }
+
+  private int reportSuccess() {
+    spec.commandLine().getOut().println("Schema initialization completed successfully.");
+    return 0;
+  }
+
+  private int reportFailure(String message) {
+    spec.commandLine().getErr().println(message);
+    return EXIT_CODE_SCHEMA_ERROR;
+  }
+}

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/config/QuarkusProducers.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/config/QuarkusProducers.java
@@ -29,6 +29,7 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.SchemaInitializer;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -41,6 +42,12 @@ public class QuarkusProducers {
       @ConfigProperty(name = "polaris.persistence.type") String persistenceType,
       @Any Instance<MetaStoreManagerFactory> metaStoreManagerFactories) {
     return metaStoreManagerFactories.select(Identifier.Literal.of(persistenceType)).get();
+  }
+
+  @Produces
+  @ApplicationScoped
+  public SchemaInitializer schemaInitializer(MetaStoreManagerFactory metaStoreManagerFactory) {
+    return (SchemaInitializer) metaStoreManagerFactory;
   }
 
   // CDI dependencies of EclipseLink's MetaStoreManagerFactory:

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
@@ -92,7 +92,7 @@ public abstract class BootstrapCommandTestBase {
     assertThat(result.getErrorOutput())
         .contains(
             "(-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]) and -f=<file> "
-                + "and (-v=<schema version> | [--schema-file=<schema file>]) are mutually exclusive "
+                + "and ([--setup-schema] | -v=<schema version> | [--schema-file=<schema file>]) are mutually exclusive "
                 + "(specify only one)");
   }
 

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/SchemaSetupCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/SchemaSetupCommandTestBase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.admintool;
+
+import static org.apache.polaris.admintool.BaseCommand.EXIT_CODE_SCHEMA_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusMainTest
+public abstract class SchemaSetupCommandTestBase {
+
+  @Test
+  @Launch(value = {"setup"})
+  public void testSchemaSetup(LaunchResult result) {
+    assertThat(result.getOutput()).contains("Schema initialization completed successfully.");
+  }
+
+  @Test
+  @Launch({"setup", "--setup-schema=true"})
+  public void testSchemaSetupWithExplicitTrue(LaunchResult result) {
+    assertThat(result.getOutput()).contains("Schema initialization completed successfully.");
+  }
+
+  @Test
+  @Launch(
+      value = {"setup", "--setup-schema=false"},
+      exitCode = EXIT_CODE_SCHEMA_ERROR)
+  public void testSchemaSetupWithExplicitFalse(LaunchResult result) {
+    assertThat(result.getErrorOutput()).contains("Schema initialization is disabled.");
+  }
+}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcSchemaSetupCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcSchemaSetupCommandTest.java
@@ -17,29 +17,10 @@
  * under the License.
  */
 
-package org.apache.polaris.core.persistence.bootstrap;
+package org.apache.polaris.admintool.relational.jdbc;
 
-import jakarta.annotation.Nullable;
-import org.apache.polaris.immutables.PolarisImmutable;
-import org.immutables.value.Value;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.admintool.SchemaSetupCommandTestBase;
 
-@PolarisImmutable
-public interface SchemaOptions {
-  @Nullable
-  Integer schemaVersion();
-
-  @Nullable
-  String schemaFile();
-
-  @Value.Default
-  default boolean setupSchema() {
-    return true;
-  }
-
-  @Value.Check
-  default void validate() {
-    if (schemaVersion() != null && schemaFile() != null) {
-      throw new IllegalStateException("Only one of schemaVersion or schemaFile can be set.");
-    }
-  }
-}
+@TestProfile(RelationalJdbcAdminProfile.class)
+public class RelationalJdbcSchemaSetupCommandTest extends SchemaSetupCommandTestBase {}


### PR DESCRIPTION
### Motivation

This change is related to improving the Polaris Admin Tool.

Currently, the `bootstrap` command in the Admin Tool handles both schema initialization and realm bootstrapping. However, in JDBC persistence, multiple realms can share a single schema. Therefore, schema setup should be treated as a higher-level, one-time operation.

This PR addresses that by introducing a dedicated command.

### Description

- Introduced `SetupCommand` in the Admin Tool for running one-time persistence setup tasks (e.g., schema creation)
- Added a new interface: `SchemaInitializer`, with methods:
  - `setupSchema(SchemaOptions)`
  - `isSchemaPresent(String schemaName)`
- Refactored existing logic to delegate schema setup outside of `MetaStoreManagerFactory`
- Maintains backward compatibility (bootstrap still performs schema init if needed)

### Context

This change was proposed in the following issue:
- [Support database bootstrap in the admin tool #2010](https://github.com/apache/polaris/issues/2010
)

Based on discussion with @dimas-b.

### Next Steps

- I’m planning to mention this on the dev mailing list for broader visibility, in case there are any concerns or suggestions.

