### PR TITLE
Expose resetCredentials via api to allow root user to reset credentials for an existing principal with custom values 

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -785,4 +785,10 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
           @Nonnull PolarisCallContext callContext, T entity) {
     return Optional.empty();
   }
+
+  @Nullable
+  @Override
+  public PolarisPrincipalSecrets resetPrincipalSecrets(@Nonnull PolarisCallContext callCtx, @Nonnull String clientId, long principalId, boolean reset, @Nonnull String oldSecretHash, String customClientId, String customClientSecret) {
+    return null;
+  }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -774,38 +774,37 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     return principalSecrets;
   }
 
-
   @Nullable
   @Override
   public PolarisPrincipalSecrets resetPrincipalSecrets(
-          @Nonnull PolarisCallContext callCtx,
-          @Nonnull String clientId,
-          long principalId,
-          boolean reset,
-          @Nonnull String oldSecretHash,
-          String customClientId,
-          String customClientSecret) {
+      @Nonnull PolarisCallContext callCtx,
+      @Nonnull String clientId,
+      long principalId,
+      boolean reset,
+      @Nonnull String oldSecretHash,
+      String customClientId,
+      String customClientSecret) {
     PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
 
     // should be found
     callCtx
-            .getDiagServices()
-            .checkNotNull(
-                    principalSecrets,
-                    "cannot_find_secrets",
-                    "client_id={} principalId={}",
-                    clientId,
-                    principalId);
+        .getDiagServices()
+        .checkNotNull(
+            principalSecrets,
+            "cannot_find_secrets",
+            "client_id={} principalId={}",
+            clientId,
+            principalId);
 
     // ensure principal id is matching
     callCtx
-            .getDiagServices()
-            .check(
-                    principalId == principalSecrets.getPrincipalId(),
-                    "principal_id_mismatch",
-                    "expectedId={} id={}",
-                    principalId,
-                    principalSecrets.getPrincipalId());
+        .getDiagServices()
+        .check(
+            principalId == principalSecrets.getPrincipalId(),
+            "principal_id_mismatch",
+            "expectedId={} id={}",
+            principalId,
+            principalSecrets.getPrincipalId());
 
     principalSecrets.setPrincipalClientId(customClientId);
     principalSecrets.resetSecrets(customClientSecret);
@@ -813,25 +812,25 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     Map<String, Object> params = Map.of("principal_client_id", clientId, "realm_id", realmId);
     try {
       ModelPrincipalAuthenticationData modelPrincipalAuthenticationData =
-              ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
+          ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
       datasourceOperations.executeUpdate(
-              QueryGenerator.generateUpdateQuery(
-                      ModelPrincipalAuthenticationData.ALL_COLUMNS,
-                      ModelPrincipalAuthenticationData.TABLE_NAME,
-                      modelPrincipalAuthenticationData
-                              .toMap(datasourceOperations.getDatabaseType())
-                              .values()
-                              .stream()
-                              .toList(),
-                      params));
+          QueryGenerator.generateUpdateQuery(
+              ModelPrincipalAuthenticationData.ALL_COLUMNS,
+              ModelPrincipalAuthenticationData.TABLE_NAME,
+              modelPrincipalAuthenticationData
+                  .toMap(datasourceOperations.getDatabaseType())
+                  .values()
+                  .stream()
+                  .toList(),
+              params));
     } catch (SQLException e) {
       LOGGER.error(
-              "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
-              clientId,
-              e.getMessage(),
-              e);
+          "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
+          clientId,
+          e.getMessage(),
+          e);
       throw new RuntimeException(
-              String.format("Failed to reset PrincipalSecrets for clientId: %s", clientId), e);
+          String.format("Failed to reset PrincipalSecrets for clientId: %s", clientId), e);
     }
 
     // return those

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -774,6 +774,70 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     return principalSecrets;
   }
 
+
+  @Nullable
+  @Override
+  public PolarisPrincipalSecrets resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret) {
+    PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
+
+    // should be found
+    callCtx
+            .getDiagServices()
+            .checkNotNull(
+                    principalSecrets,
+                    "cannot_find_secrets",
+                    "client_id={} principalId={}",
+                    clientId,
+                    principalId);
+
+    // ensure principal id is matching
+    callCtx
+            .getDiagServices()
+            .check(
+                    principalId == principalSecrets.getPrincipalId(),
+                    "principal_id_mismatch",
+                    "expectedId={} id={}",
+                    principalId,
+                    principalSecrets.getPrincipalId());
+
+    principalSecrets.setPrincipalClientId(customClientId);
+    principalSecrets.resetSecrets(customClientSecret);
+
+    Map<String, Object> params = Map.of("principal_client_id", clientId, "realm_id", realmId);
+    try {
+      ModelPrincipalAuthenticationData modelPrincipalAuthenticationData =
+              ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
+      datasourceOperations.executeUpdate(
+              QueryGenerator.generateUpdateQuery(
+                      ModelPrincipalAuthenticationData.ALL_COLUMNS,
+                      ModelPrincipalAuthenticationData.TABLE_NAME,
+                      modelPrincipalAuthenticationData
+                              .toMap(datasourceOperations.getDatabaseType())
+                              .values()
+                              .stream()
+                              .toList(),
+                      params));
+    } catch (SQLException e) {
+      LOGGER.error(
+              "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
+              clientId,
+              e.getMessage(),
+              e);
+      throw new RuntimeException(
+              String.format("Failed to reset PrincipalSecrets for clientId: %s", clientId), e);
+    }
+
+    // return those
+    return principalSecrets;
+  }
+
   @Nullable
   @Override
   public PolarisPrincipalSecrets rotatePrincipalSecrets(

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisSecretsManager.java
@@ -54,4 +54,18 @@ public interface PolarisSecretsManager {
       long principalId,
       boolean reset,
       @Nonnull String oldSecretHash);
+
+  @Nonnull
+  PrincipalSecretsResult resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret);
+
+
 }
+
+

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisPrincipalSecrets.java
@@ -36,7 +36,7 @@ public class PolarisPrincipalSecrets {
   private final long principalId;
 
   // the client id for that principal
-  private final String principalClientId;
+  private String principalClientId;
 
   // the main secret hash for that principal
   private String mainSecret;
@@ -145,6 +145,19 @@ public class PolarisPrincipalSecrets {
 
     this.mainSecret = this.generateRandomHexString(32);
     this.mainSecretHash = hashSecret(mainSecret);
+  }
+
+  /** Reset the main secrets */
+  public void resetSecrets(String customClientSecret) {
+    this.mainSecret = customClientSecret;
+    this.mainSecretHash = hashSecret(mainSecret);
+
+    this.secondarySecret = null;
+    this.secondarySecretHash = hashSecret(mainSecret);
+  }
+
+  public void setPrincipalClientId(String customClientId) {
+    this.principalClientId = customClientId;
   }
 
   public long getPrincipalId() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -897,6 +897,59 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         : new PrincipalSecretsResult(secrets);
   }
 
+  @Override
+  public @Nonnull PrincipalSecretsResult resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret) {
+    // get metastore we should be using
+    BasePersistence ms = callCtx.getMetaStore();
+
+    // if not found, the principal must have been dropped
+    EntityResult loadEntityResult =
+            loadEntity(
+                    callCtx, PolarisEntityConstants.getNullId(), principalId, PolarisEntityType.PRINCIPAL);
+    if (loadEntityResult.getReturnStatus() != BaseResult.ReturnStatus.SUCCESS) {
+      return new PrincipalSecretsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
+    }
+
+    PolarisBaseEntity principal = loadEntityResult.getEntity();
+    Map<String, String> internalProps =
+            PolarisObjectMapperUtil.deserializeProperties(
+                    principal.getInternalProperties() == null ? "{}" : principal.getInternalProperties());
+
+    boolean doReset =
+            reset
+                    || internalProps.get(
+                    PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
+                    != null;
+    PolarisPrincipalSecrets secrets =
+            ((IntegrationPersistence) ms)
+                    .resetPrincipalSecrets(callCtx, clientId, principalId, doReset, oldSecretHash,customClientId, customClientSecret);
+
+    PolarisBaseEntity.Builder principalBuilder = new PolarisBaseEntity.Builder(principal);
+    if (reset
+            && !internalProps.containsKey(
+            PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
+            && customClientId != null
+            && customClientSecret != null) {
+      internalProps.put(
+              PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE, "true");
+      principalBuilder.internalProperties(
+              PolarisObjectMapperUtil.serializeProperties(internalProps));
+      principalBuilder.entityVersion(principal.getEntityVersion() + 1);
+      ms.writeEntity(callCtx, principalBuilder.build(), true, principal);
+    }
+
+    return (secrets == null)
+            ? new PrincipalSecretsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null)
+            : new PrincipalSecretsResult(secrets);
+  }
+
   /** {@inheritDoc} */
   @Override
   public @Nonnull EntityResult createEntityIfNotExists(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
@@ -82,6 +82,29 @@ public interface IntegrationPersistence {
       @Nonnull String oldSecretHash);
 
   /**
+   * Reset the secrets of a principal entity, i.e. make the specified secrets as main and secondary
+   * and assign a new client id
+   *
+   * @param callCtx call context
+   * @param clientId principal client id
+   * @param principalId principal id
+   * @param reset true if the principal secrets should be disabled and replaced with a one-time
+   *     password
+   * @param oldSecretHash the principal secret's old main secret hash
+   * @param customClientId the principal secret's old main secret hash
+   * @param customClientSecret the principal secret's old main secret hash
+   */
+  @Nullable
+  PolarisPrincipalSecrets resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret);
+
+  /**
    * When dropping a principal, we also need to drop the secrets of that principal
    *
    * @param callCtx the call context

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -165,6 +165,21 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   }
 
   @Override
+  public PrincipalSecretsResult resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret) {
+    callCtx
+            .getDiagServices()
+            .fail("illegal_method_in_transaction_workspace", "resetPrincipalSecrets");
+    return null;
+  }
+
+  @Override
   public CreateCatalogResult createCatalog(
       @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity catalog,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -952,6 +952,22 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         : new PrincipalSecretsResult(secrets);
   }
 
+  @Override
+  public @Nonnull PrincipalSecretsResult resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret) {
+    // get metastore we should be using
+    callCtx
+            .getDiagServices()
+            .fail("illegal_method_in_transaction_workspace", "resetPrincipalSecrets");
+    return null;
+  }
+
   /** {@inheritDoc} */
   @Override
   public @Nonnull CreateCatalogResult createCatalog(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -528,6 +528,22 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
     return principalSecrets;
   }
 
+  @Override
+  public @Nonnull PolarisPrincipalSecrets resetPrincipalSecrets(
+          @Nonnull PolarisCallContext callCtx,
+          @Nonnull String clientId,
+          long principalId,
+          boolean reset,
+          @Nonnull String oldSecretHash,
+          String customClientId,
+          String customClientSecret) {
+    // get metastore we should be using
+    callCtx
+            .getDiagServices()
+            .fail("illegal_method_in_transaction_workspace", "resetPrincipalSecrets");
+    return null;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void deletePrincipalSecretsInCurrentTxn(

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -245,8 +245,7 @@ public class PolarisAdminService {
         resolutionManifest.getResolvedTopLevelEntity(topLevelEntityName, entityType);
 
     if (op.equals(PolarisAuthorizableOperation.RESET_CREDENTIALS)) {
-      boolean isRoot = authenticatedPrincipal.getPrincipalEntity().getId() == getRootEntityId()
-              && getRootPrincipalName().equals(authenticatedPrincipal.getPrincipalEntity().getName());
+      boolean isRoot = getRootPrincipalName().equals(authenticatedPrincipal.getPrincipalEntity().getName());
       if (!isRoot) {
         throw new ForbiddenException("Only root principal can reset credentials");
       }

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -20,10 +20,13 @@ package org.apache.polaris.service.admin;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.polaris.core.entity.PolarisEntityConstants.getRootEntityId;
+import static org.apache.polaris.core.entity.PolarisEntityConstants.getRootPrincipalName;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,6 +66,7 @@ import org.apache.polaris.core.admin.model.PolicyGrant;
 import org.apache.polaris.core.admin.model.PolicyPrivilege;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
+import org.apache.polaris.core.admin.model.ResetPrincipalRequest;
 import org.apache.polaris.core.admin.model.TableGrant;
 import org.apache.polaris.core.admin.model.TablePrivilege;
 import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
@@ -240,12 +244,24 @@ public class PolarisAdminService {
     PolarisResolvedPathWrapper topLevelEntityWrapper =
         resolutionManifest.getResolvedTopLevelEntity(topLevelEntityName, entityType);
 
+    if (op.equals(PolarisAuthorizableOperation.RESET_CREDENTIALS)) {
+      boolean isRoot = authenticatedPrincipal.getPrincipalEntity().getId() == getRootEntityId()
+              && getRootPrincipalName().equals(authenticatedPrincipal.getPrincipalEntity().getName());
+      if (!isRoot) {
+        throw new ForbiddenException("Only root principal can reset credentials");
+      }
+      LOGGER
+              .atDebug()
+              .addKeyValue("principalName", topLevelEntityName)
+              .log("Root principal allowed to reset credentials");
+      return;
+    }
+
     // TODO: If we do add more "self" privilege operations for PRINCIPAL targets this should
     // be extracted into an EnumSet and/or pushed down into PolarisAuthorizer.
     if (topLevelEntityWrapper.getResolvedLeafEntity().getEntity().getId()
             == authenticatedPrincipal.getPrincipalEntity().getId()
-        && (op.equals(PolarisAuthorizableOperation.ROTATE_CREDENTIALS)
-            || op.equals(PolarisAuthorizableOperation.RESET_CREDENTIALS))) {
+        && (op.equals(PolarisAuthorizableOperation.ROTATE_CREDENTIALS))) {
       LOGGER
           .atDebug()
           .addKeyValue("principalName", topLevelEntityName)
@@ -651,7 +667,7 @@ public class PolarisAdminService {
    * references to the stored secret.
    */
   private Map<String, UserSecretReference> extractSecretReferences(
-      CreateCatalogRequest catalogRequest, PolarisEntity forEntity) {
+          CreateCatalogRequest catalogRequest, PolarisEntity forEntity) {
     Map<String, UserSecretReference> secretReferences = new HashMap<>();
     Catalog catalog = catalogRequest.getCatalog();
     UserSecretsManager secretsManager = getUserSecretsManager();
@@ -1120,6 +1136,70 @@ public class PolarisAdminService {
             newSecrets.getPrincipalClientId(), newSecrets.getMainSecret()));
   }
 
+  private @Nonnull PrincipalWithCredentials resetCredentialsHelper(
+          String principalName, boolean shouldReset, String customClientId, String customClientSecret) {
+    PrincipalEntity currentPrincipalEntity =
+            findPrincipalByName(principalName)
+                    .orElseThrow(() -> new NotFoundException("Principal %s not found", principalName));
+
+    if (FederatedEntities.isFederated(currentPrincipalEntity)) {
+      throw new ValidationException(
+              "Cannot reset credentials for a federated principal: %s", principalName);
+    }
+    PolarisPrincipalSecrets currentSecrets =
+            metaStoreManager
+                    .loadPrincipalSecrets(getCurrentPolarisContext(), currentPrincipalEntity.getClientId())
+                    .getPrincipalSecrets();
+    if (currentSecrets == null) {
+      throw new IllegalArgumentException(
+              String.format("Failed to load current secrets for principal '%s'", principalName));
+    }
+    PolarisPrincipalSecrets newSecrets =
+            metaStoreManager
+                    .resetPrincipalSecrets(
+                            getCurrentPolarisContext(),
+                            currentPrincipalEntity.getClientId(),
+                            currentPrincipalEntity.getId(),
+                            shouldReset,
+                            currentSecrets.getMainSecretHash(),
+                            customClientId,
+                            customClientSecret)
+                    .getPrincipalSecrets();
+    if (newSecrets == null) {
+      throw new IllegalStateException(
+              String.format("Failed to %s secrets for principal '%s'", "reset", principalName));
+    }
+    PolarisEntity newPrincipal =
+            PolarisEntity.of(
+                    metaStoreManager.loadEntity(
+                            getCurrentPolarisContext(),
+                            0L,
+                            currentPrincipalEntity.getId(),
+                            currentPrincipalEntity.getType()));
+
+    PrincipalEntity newPrincipalEntity = PrincipalEntity.of(newPrincipal);
+    if (customClientId != null && customClientSecret != null) {
+      PrincipalEntity.Builder updateBuilder = new PrincipalEntity.Builder(newPrincipalEntity);
+      updateBuilder.setClientId(newSecrets.getPrincipalClientId());
+      PrincipalEntity updatedNewPrincipalEntity = updateBuilder.build();
+      updatedNewPrincipalEntity =
+              Optional.ofNullable(
+                              PrincipalEntity.of(
+                                      PolarisEntity.of(
+                                              metaStoreManager.updateEntityPropertiesIfNotChanged(
+                                                      getCurrentPolarisContext(), null, updatedNewPrincipalEntity))))
+                      .orElseThrow(
+                              () ->
+                                      new CommitFailedException(
+                                              "Concurrent modification on Principal '%s'; retry later", principalName));
+      newPrincipalEntity = updatedNewPrincipalEntity;
+    }
+    return new PrincipalWithCredentials(
+            newPrincipalEntity.asPrincipal(),
+            new PrincipalWithCredentialsCredentials(
+                    newSecrets.getPrincipalClientId(), newSecrets.getMainSecret()));
+  }
+
   public @Nonnull PrincipalWithCredentials rotateCredentials(String principalName) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.ROTATE_CREDENTIALS;
     authorizeBasicTopLevelEntityOperationOrThrow(op, principalName, PolarisEntityType.PRINCIPAL);
@@ -1127,11 +1207,12 @@ public class PolarisAdminService {
     return rotateOrResetCredentialsHelper(principalName, false);
   }
 
-  public @Nonnull PrincipalWithCredentials resetCredentials(String principalName) {
+  public @Nonnull PrincipalWithCredentials resetCredentials(String principalName, ResetPrincipalRequest resetPrincipalRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.RESET_CREDENTIALS;
     authorizeBasicTopLevelEntityOperationOrThrow(op, principalName, PolarisEntityType.PRINCIPAL);
-
-    return rotateOrResetCredentialsHelper(principalName, true);
+    var customClientId = resetPrincipalRequest.getClientId();
+    var customClientSecret = resetPrincipalRequest.getClientSecret();
+    return resetCredentialsHelper(principalName, true, customClientId, customClientSecret);
   }
 
   public List<PolarisEntity> listPrincipals() {

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -51,6 +51,7 @@ import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.PrincipalRoles;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.admin.model.Principals;
+import org.apache.polaris.core.admin.model.ResetPrincipalRequest;
 import org.apache.polaris.core.admin.model.RevokeGrantRequest;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.admin.model.TableGrant;
@@ -142,7 +143,7 @@ public class PolarisServiceImpl
   /** From PolarisCatalogsApiService */
   @Override
   public Response createCatalog(
-      CreateCatalogRequest request, RealmContext realmContext, SecurityContext securityContext) {
+          CreateCatalogRequest request, RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     Catalog catalog = request.getCatalog();
     validateStorageConfig(catalog.getStorageConfigInfo());
@@ -257,7 +258,7 @@ public class PolarisServiceImpl
   /** From PolarisPrincipalsApiService */
   @Override
   public Response createPrincipal(
-      CreatePrincipalRequest request, RealmContext realmContext, SecurityContext securityContext) {
+          CreatePrincipalRequest request, RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
     PrincipalEntity principal =
         new PrincipalEntity.Builder()
@@ -273,6 +274,16 @@ public class PolarisServiceImpl
     PrincipalWithCredentials createdPrincipal = adminService.createPrincipal(principal);
     LOGGER.info("Created new principal {}", createdPrincipal);
     return Response.status(Response.Status.CREATED).entity(createdPrincipal).build();
+  }
+
+  @Override
+  public Response resetCredentials(
+          String principalName,
+          ResetPrincipalRequest resetPrincipalRequest,
+          RealmContext realmContext,
+          SecurityContext securityContext) {
+    PolarisAdminService adminService = newAdminService(realmContext, securityContext);
+    return Response.ok(adminService.resetCredentials(principalName, resetPrincipalRequest)).build();
   }
 
   /** From PolarisPrincipalsApiService */

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -199,6 +199,42 @@ paths:
         404:
           description: "The catalog or principal does not exist"
 
+  /principals/{principalName}/reset:
+    parameters:
+      - name: principalName
+        in: path
+        description: The principal's name
+        required: true
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+    post:
+      operationId: resetCredentials
+      description: >
+        Reset a principal's credentials to a new set. By default, the system generates random credentials unless
+        explicitly allowed to accept user-provided credentials via configuration.  
+        This API is *not* idempotent and will return the newly created credentials.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPrincipalRequest'
+      responses:
+        200:
+          description: The principal details along with the newly reset credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PrincipalWithCredentials"
+        403:
+          description: The caller does not have permission to reset credentials
+        404:
+          description: The principal does not exist
+
+
     put:
       operationId: updatePrincipal
       description: Update an existing principal
@@ -1226,6 +1262,22 @@ components:
       required:
         - currentEntityVersion
         - properties
+
+    ResetPrincipalRequest:
+      type: object
+      properties:
+        clientId:
+          type: string
+          description: Optional client ID to set for the principal.
+          minLength: 16
+          maxLength: 16
+          pattern: '^[0-9a-f]{16}$'
+        clientSecret:
+          type: string
+          description: Optional client secret to set for the principal.
+          minLength: 32
+          maxLength: 32
+          pattern: '^[0-9a-f]{32}$'
 
     PrincipalRoles:
       type: object


### PR DESCRIPTION
Background:
See Issue -https://github.com/apache/polaris/issues/1929 and based on Dev email discussion
WHAT

1. Exposes the resetCredentials operation via the api
2. Only Root user can reset the credentials of the existing principal
3. Requires the custom clientId and custom secret via root user to reset the random credentials already created via CreatePrincipal API
4. Needs ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING to be set to true

**Local Testing:**
Happy Scenario
<img width="760" height="817" alt="image" src="https://github.com/user-attachments/assets/54dffd98-9875-4b75-9c9c-edebcfb2ecae" />


Failure scenario:
<img width="756" height="819" alt="image" src="https://github.com/user-attachments/assets/7d5d74e8-a926-4447-bfae-9200ce9c1c59" />

