### PR TITLE
Replace CommitFailedException with CommitConflictException

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
@@ -106,6 +106,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -2127,7 +2128,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
     Schema expected = update.apply();
 
     Assertions.assertThatThrownBy(() -> update.commit())
-        .isInstanceOf(CommitFailedException.class)
+        .isInstanceOf(CommitConflictException.class)
         .hasMessageContaining("conflict_table");
   }
 

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -92,6 +91,7 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.entity.table.federated.FederatedEntities;
+import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -880,7 +880,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
 
     if (currentCatalogEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
-      throw new CommitFailedException(
+      throw new CommitConflictException(
           "Failed to update Catalog; currentEntityVersion '%s', expected '%s'",
           currentCatalogEntity.getEntityVersion(), updateRequest.getCurrentEntityVersion());
     }
@@ -932,7 +932,7 @@ public class PolarisAdminService {
                             getCurrentPolarisContext(), null, updatedEntity))))
             .orElseThrow(
                 () ->
-                    new CommitFailedException(
+                    new CommitConflictException(
                         "Concurrent modification on Catalog '%s'; retry later", name));
     return returnedEntity;
   }
@@ -1048,7 +1048,7 @@ public class PolarisAdminService {
           "Cannot update a federated principal: %s", currentPrincipalEntity.getName());
     }
     if (currentPrincipalEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
-      throw new CommitFailedException(
+      throw new CommitConflictException(
           "Failed to update Principal; currentEntityVersion '%s', expected '%s'",
           currentPrincipalEntity.getEntityVersion(), updateRequest.getCurrentEntityVersion());
     }
@@ -1069,7 +1069,7 @@ public class PolarisAdminService {
                             getCurrentPolarisContext(), null, updatedEntity))))
             .orElseThrow(
                 () ->
-                    new CommitFailedException(
+                    new CommitConflictException(
                         "Concurrent modification on Principal '%s'; retry later", name));
     return returnedEntity;
   }
@@ -1220,7 +1220,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("PrincipalRole %s not found", name));
 
     if (currentPrincipalRoleEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
-      throw new CommitFailedException(
+      throw new CommitConflictException(
           "Failed to update PrincipalRole; currentEntityVersion '%s', expected '%s'",
           currentPrincipalRoleEntity.getEntityVersion(), updateRequest.getCurrentEntityVersion());
     }
@@ -1242,7 +1242,7 @@ public class PolarisAdminService {
                             getCurrentPolarisContext(), null, updatedEntity))))
             .orElseThrow(
                 () ->
-                    new CommitFailedException(
+                    new CommitConflictException(
                         "Concurrent modification on PrincipalRole '%s'; retry later", name));
     return returnedEntity;
   }
@@ -1347,7 +1347,7 @@ public class PolarisAdminService {
             .orElseThrow(() -> new NotFoundException("CatalogRole %s not found", name));
 
     if (currentCatalogRoleEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
-      throw new CommitFailedException(
+      throw new CommitConflictException(
           "Failed to update CatalogRole; currentEntityVersion '%s', expected '%s'",
           currentCatalogRoleEntity.getEntityVersion(), updateRequest.getCurrentEntityVersion());
     }
@@ -1371,7 +1371,7 @@ public class PolarisAdminService {
                             updatedEntity))))
             .orElseThrow(
                 () ->
-                    new CommitFailedException(
+                    new CommitConflictException(
                         "Concurrent modification on CatalogRole '%s'; retry later", name));
     return returnedEntity;
   }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -2354,7 +2354,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
           throw new NotFoundException("Parent path does not exist for %s", identifier);
 
         case BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED:
-          throw new CommitFailedException(
+          throw new CommitConflictException(
               "Failed to commit Table or View %s because it was concurrently modified", identifier);
 
         default:

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -51,7 +51,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
@@ -84,6 +83,7 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -997,7 +997,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
             callContext.getPolarisCallContext(), pendingUpdates);
     if (!result.isSuccess()) {
       // TODO: Retries and server-side cleanup on failure
-      throw new CommitFailedException(
+      throw new CommitConflictException(
           "Transaction commit failed with status: %s, extraInfo: %s",
           result.getReturnStatus(), result.getExtraInformation());
     }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
@@ -83,7 +84,6 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
-import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -996,8 +996,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
         metaStoreManager.updateEntitiesPropertiesIfNotChanged(
             callContext.getPolarisCallContext(), pendingUpdates);
     if (!result.isSuccess()) {
-      // TODO: Retries and server-side cleanup on failure
-      throw new CommitConflictException(
+      // TODO: Retries and server-side cleanup on failure, review possible exceptions
+      throw new CommitFailedException(
           "Transaction commit failed with status: %s, extraInfo: %s",
           result.getReturnStatus(), result.getExtraInformation());
     }

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -635,7 +635,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
+          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
           content:
             application/json:
               schema:
@@ -930,7 +930,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
+          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
           content:
             application/json:
               schema:
@@ -1140,7 +1140,7 @@ paths:
                 ViewToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchViewError'
         '409':
-          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
+          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
           content:
             application/json:
               schema:

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -635,7 +635,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
+          description: Conflict - CommitFailedException, one or more requirements failed. The client may retry.
           content:
             application/json:
               schema:
@@ -930,7 +930,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
+          description: Conflict - CommitFailedException, one or more requirements failed. The client may retry.
           content:
             application/json:
               schema:
@@ -1140,7 +1140,7 @@ paths:
                 ViewToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchViewError'
         '409':
-          description: Conflict - Transaction commit failed due to concurrent modifications. The client may retry.
+          description: Conflict - CommitFailedException. The client may retry.
           content:
             application/json:
               schema:

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -635,7 +635,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - CommitFailedException, one or more requirements failed. The client may retry.
+          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
           content:
             application/json:
               schema:
@@ -930,7 +930,7 @@ paths:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         '409':
-          description: Conflict - CommitFailedException, one or more requirements failed. The client may retry.
+          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
           content:
             application/json:
               schema:
@@ -1140,7 +1140,7 @@ paths:
                 ViewToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchViewError'
         '409':
-          description: Conflict - CommitFailedException. The client may retry.
+          description: Conflict - CommitConflictException, one or more requirements failed. The client may retry.
           content:
             application/json:
               schema:


### PR DESCRIPTION
In some cases, we were using CommitFailedException to represent commit conflicts, which returns the correct 409 response but is tied to Iceberg.

However, some of these conflicts originate from Polaris, making CommitConflictException a more appropriate and accurate choice.

This change updates those instances to improve clarity and exception handling semantics.

Resolves #2168

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
