### PR TITLE
Remove getCurrentContext from JWTBroker

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/DefaultOAuth2ApiService.java
@@ -110,7 +110,12 @@ public class DefaultOAuth2ApiService implements IcebergRestOAuth2ApiService {
     } else if (subjectToken != null) {
       tokenResponse =
           tokenBroker.generateFromToken(
-              subjectTokenType, subjectToken, grantType, scope, requestedTokenType);
+              subjectTokenType,
+              subjectToken,
+              grantType,
+              scope,
+              callContext.getPolarisCallContext(),
+              requestedTokenType);
     } else {
       return OAuthUtils.getResponseFromError(OAuthTokenErrorResponse.Error.invalid_request);
     }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/JWTBroker.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/JWTBroker.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -101,6 +100,7 @@ public abstract class JWTBroker implements TokenBroker {
       String subjectToken,
       String grantType,
       String scope,
+      PolarisCallContext polarisCallContext,
       TokenType requestedTokenType) {
     if (requestedTokenType != null && !TokenType.ACCESS_TOKEN.equals(requestedTokenType)) {
       return new TokenResponse(OAuthTokenErrorResponse.Error.invalid_request);
@@ -119,7 +119,7 @@ public abstract class JWTBroker implements TokenBroker {
     }
     EntityResult principalLookup =
         metaStoreManager.loadEntity(
-            CallContext.getCurrentContext().getPolarisCallContext(),
+            polarisCallContext,
             0L,
             Objects.requireNonNull(decodedToken.getPrincipalId()),
             PolarisEntityType.PRINCIPAL);

--- a/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/NoneTokenBrokerFactory.java
@@ -58,6 +58,7 @@ public class NoneTokenBrokerFactory implements TokenBrokerFactory {
             String subjectToken,
             String grantType,
             String scope,
+            PolarisCallContext polarisCallContext,
             TokenType requestedTokenType) {
           return null;
         }

--- a/service/common/src/main/java/org/apache/polaris/service/auth/TokenBroker.java
+++ b/service/common/src/main/java/org/apache/polaris/service/auth/TokenBroker.java
@@ -36,34 +36,8 @@ public interface TokenBroker {
   boolean supportsRequestedTokenType(TokenType tokenType);
 
   /**
-   * Generate a token from client secrets without specifying the requested token type
-   *
-   * @param clientId
-   * @param clientSecret
-   * @param grantType
-   * @param scope
-   * @return the response indicating an error or the requested token
-   * @deprecated - use the method with the requested token type
-   */
-  @Deprecated
-  default TokenResponse generateFromClientSecrets(
-      final String clientId,
-      final String clientSecret,
-      final String grantType,
-      final String scope,
-      PolarisCallContext polarisCallContext) {
-    return generateFromClientSecrets(
-        clientId, clientSecret, grantType, scope, polarisCallContext, TokenType.ACCESS_TOKEN);
-  }
-
-  /**
    * Generate a token from client secrets
    *
-   * @param clientId
-   * @param clientSecret
-   * @param grantType
-   * @param scope
-   * @param requestedTokenType
    * @return the response indicating an error or the requested token
    */
   TokenResponse generateFromClientSecrets(
@@ -75,31 +49,8 @@ public interface TokenBroker {
       TokenType requestedTokenType);
 
   /**
-   * Generate a token from an existing token of a specified type without specifying the requested
-   * token type
-   *
-   * @param subjectTokenType
-   * @param subjectToken
-   * @param grantType
-   * @param scope
-   * @return the response indicating an error or the requested token
-   * @deprecated - use the method with the requested token type
-   */
-  @Deprecated
-  default TokenResponse generateFromToken(
-      TokenType subjectTokenType, String subjectToken, final String grantType, final String scope) {
-    return generateFromToken(
-        subjectTokenType, subjectToken, grantType, scope, TokenType.ACCESS_TOKEN);
-  }
-
-  /**
    * Generate a token from an existing token of a specified type
    *
-   * @param subjectTokenType
-   * @param subjectToken
-   * @param grantType
-   * @param scope
-   * @param requestedTokenType
    * @return the response indicating an error or the requested token
    */
   TokenResponse generateFromToken(
@@ -107,6 +58,7 @@ public interface TokenBroker {
       String subjectToken,
       final String grantType,
       final String scope,
+      PolarisCallContext polarisCallContext,
       TokenType requestedTokenType);
 
   DecodedToken verify(String token);


### PR DESCRIPTION
this is working towards the removal of the `CallContext.CURRENT_CONTEXT` threadlocal

also remove deprecated methods which seem to be unused in the codebase