### PR TITLE
Remove CallContext.CURRENT_CONTEXT

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -30,21 +30,6 @@ import org.apache.polaris.core.config.RealmConfig;
  * underlying nature of the persistence layer may differ between different realms.
  */
 public interface CallContext {
-  InheritableThreadLocal<CallContext> CURRENT_CONTEXT = new InheritableThreadLocal<>();
-
-  static CallContext setCurrentContext(CallContext context) {
-    CURRENT_CONTEXT.set(context);
-    return context;
-  }
-
-  static CallContext getCurrentContext() {
-    return CURRENT_CONTEXT.get();
-  }
-
-  static void unsetCurrentContext() {
-    CURRENT_CONTEXT.remove();
-  }
-
   /** Copy the {@link CallContext}. */
   CallContext copy();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogViewTest.java
@@ -45,7 +45,6 @@ import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PrincipalEntity;
@@ -166,8 +165,6 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
 
     PolarisEntityManager entityManager =
         new PolarisEntityManager(metaStoreManager, resolverFactory);
-
-    CallContext.setCurrentContext(polarisContext);
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/test/PolarisIntegrationTestFixture.java
@@ -36,7 +36,6 @@ import org.apache.polaris.core.admin.model.GrantPrincipalRoleRequest;
 import org.apache.polaris.core.admin.model.Principal;
 import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PrincipalEntity;
@@ -116,17 +115,13 @@ public class PolarisIntegrationTestFixture {
             helper.diagServices,
             helper.configurationStore,
             helper.clock);
-    try {
-      PolarisMetaStoreManager metaStoreManager =
-          helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
-      PrincipalEntity principal = metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
-      Map<String, String> propertiesMap = readInternalProperties(principal);
-      return metaStoreManager
-          .loadPrincipalSecrets(polarisContext, propertiesMap.get("client_id"))
-          .getPrincipalSecrets();
-    } finally {
-      CallContext.unsetCurrentContext();
-    }
+    PolarisMetaStoreManager metaStoreManager =
+        helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+    PrincipalEntity principal = metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
+    Map<String, String> propertiesMap = readInternalProperties(principal);
+    return metaStoreManager
+        .loadPrincipalSecrets(polarisContext, propertiesMap.get("client_id"))
+        .getPrincipalSecrets();
   }
 
   private SnowmanCredentials createSnowmanCredentials(TestEnvironment testEnv) {

--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -111,8 +111,6 @@ public class PolarisServiceImpl
     this.polarisAuthorizer = polarisAuthorizer;
     this.callContext = callContext;
     this.reservedProperties = reservedProperties;
-    // FIXME: This is a hack to set the current context for downstream calls.
-    CallContext.setCurrentContext(callContext);
   }
 
   private PolarisAdminService newAdminService(

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -69,9 +69,6 @@ public class GenericTableCatalogAdapter
     this.polarisAuthorizer = polarisAuthorizer;
     this.prefixParser = prefixParser;
     this.reservedProperties = reservedProperties;
-
-    // FIXME: This is a hack to set the current context for downstream calls.
-    CallContext.setCurrentContext(callContext);
   }
 
   private GenericTableCatalogHandler newHandlerWrapper(

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -70,9 +70,6 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
     this.metaStoreManager = metaStoreManager;
     this.polarisAuthorizer = polarisAuthorizer;
     this.prefixParser = prefixParser;
-
-    // FIXME: This is a hack to set the current context for downstream calls.
-    CallContext.setCurrentContext(callContext);
   }
 
   private PolicyCatalogHandler newHandlerWrapper(SecurityContext securityContext, String prefix) {


### PR DESCRIPTION
the last callers of `CallContext.getCurrentContext` had been
removed in the following commits:

- 756e535fabe150eefdfe16f3c61c1207217d2e2f
- e7eb59f6d89a5891381c805c9ed4244601d5b430
- 4d94745db36c5d4907cf34d749a3a2690f8e4fff

thus we can now remove the `CURRENT_CONTEXT` threadlocal and all
associated methods.