### PR TITLE
Add retry logic to handle concurrent updates for namespace properties

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1017,6 +1017,28 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     return new EntitiesResult(Page.fromItems(updatedEntities));
   }
 
+  @Nonnull
+  @Override
+  public EntityResult retryUpdateEntityProperties(
+      @Nonnull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisBaseEntity entity,
+      Map<String, String> properties,
+      int numOfRetries) {
+    return updateEntityPropertiesIfNotChanged(callCtx, catalogPath, entity);
+  }
+
+  @Nonnull
+  @Override
+  public EntityResult retryRemoveEntityProperties(
+      @Nonnull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisBaseEntity entity,
+      Set<String> keys,
+      int numOfRetries) {
+    return updateEntityPropertiesIfNotChanged(callCtx, catalogPath, entity);
+  }
+
   /** {@inheritDoc} */
   @Override
   public @Nonnull EntityResult renameEntity(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -213,6 +213,34 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
     return null;
   }
 
+  @Nonnull
+  @Override
+  public EntityResult retryUpdateEntityProperties(
+      @Nonnull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisBaseEntity entity,
+      Map<String, String> properties,
+      int numOfRetries) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "updateEntityPropertiesWithRetry");
+    return null;
+  }
+
+  @Nonnull
+  @Override
+  public EntityResult retryRemoveEntityProperties(
+      @Nonnull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @Nonnull PolarisBaseEntity entity,
+      Set<String> keys,
+      int numOfRetries) {
+    callCtx
+        .getDiagServices()
+        .fail("illegal_method_in_transaction_workspace", "updateEntityPropertiesWithRetry");
+    return null;
+  }
+
   @Override
   public EntityResult renameEntity(
       @Nonnull PolarisCallContext callCtx,

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -167,6 +167,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             && (isStorageProviderRetryableException(ex)
                 || isStorageProviderRetryableException(ExceptionUtils.getRootCause(ex)));
       };
+  private static final int NUM_OF_RETRIES = 3;
 
   private final StorageCredentialCache storageCredentialCache;
   private final ResolverFactory resolverFactory;
@@ -708,10 +709,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     PolarisEntity returnedEntity =
         Optional.ofNullable(
                 getMetaStoreManager()
-                    .updateEntityPropertiesIfNotChanged(
+                    .retryUpdateEntityProperties(
                         getCurrentPolarisContext(),
                         PolarisEntity.toCoreList(parentPath),
-                        updatedEntity)
+                        updatedEntity,
+                        properties,
+                        NUM_OF_RETRIES)
                     .getEntity())
             .map(PolarisEntity::new)
             .orElse(null);
@@ -740,10 +743,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     PolarisEntity returnedEntity =
         Optional.ofNullable(
                 getMetaStoreManager()
-                    .updateEntityPropertiesIfNotChanged(
+                    .retryRemoveEntityProperties(
                         getCurrentPolarisContext(),
                         PolarisEntity.toCoreList(parentPath),
-                        updatedEntity)
+                        updatedEntity,
+                        properties,
+                        NUM_OF_RETRIES)
                     .getEntity())
             .map(PolarisEntity::new)
             .orElse(null);


### PR DESCRIPTION
Retry logic only added for update of namespace properties. Added the new methods in PolarisMetaStoreManger and retry logic implemented only for TransactionMetastoreManagerImpl.

Fixes #2183 