### PR TITLE
Call MetaStoreManagerFactory.getOrCreateSession once in QuarkusProducers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -151,12 +151,19 @@ public class QuarkusProducers {
   @RequestScoped
   public CallContext polarisCallContext(
       RealmContext realmContext,
-      BasePersistence metaStoreSession,
       PolarisDiagnostics diagServices,
       PolarisConfigurationStore configurationStore,
+      MetaStoreManagerFactory metaStoreManagerFactory,
       Clock clock) {
+    BasePersistence metaStoreSession = metaStoreManagerFactory.getOrCreateSession(realmContext);
     return new PolarisCallContext(
         realmContext, metaStoreSession, diagServices, configurationStore, clock);
+  }
+
+  @Produces
+  @RequestScoped
+  public BasePersistence polarisMetaStoreSession(CallContext callContext) {
+    return callContext.getPolarisCallContext().getMetaStore();
   }
 
   @Produces
@@ -376,13 +383,6 @@ public class QuarkusProducers {
   public UserSecretsManager userSecretsManager(
       RealmContext realmContext, UserSecretsManagerFactory userSecretsManagerFactory) {
     return userSecretsManagerFactory.getOrCreateUserSecretsManager(realmContext);
-  }
-
-  @Produces
-  @RequestScoped
-  public BasePersistence polarisMetaStoreSession(
-      RealmContext realmContext, MetaStoreManagerFactory metaStoreManagerFactory) {
-    return metaStoreManagerFactory.getOrCreateSession(realmContext);
   }
 
   @Produces

--- a/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/quarkus/config/QuarkusProducers.java
@@ -151,11 +151,10 @@ public class QuarkusProducers {
   @RequestScoped
   public CallContext polarisCallContext(
       RealmContext realmContext,
+      BasePersistence metaStoreSession,
       PolarisDiagnostics diagServices,
       PolarisConfigurationStore configurationStore,
-      MetaStoreManagerFactory metaStoreManagerFactory,
       Clock clock) {
-    BasePersistence metaStoreSession = metaStoreManagerFactory.getOrCreateSession(realmContext);
     return new PolarisCallContext(
         realmContext, metaStoreSession, diagServices, configurationStore, clock);
   }


### PR DESCRIPTION
we already have a RequestScoped `BasePersistence` that we should use but its not possible as some `MetaStoreManagerFactory` classes cast the `PolarisCallContext.getMetaStore` to a narrower type unconditionally, which is not possible on the `BasePersistence`-proxy created by quarkus.

so we have to do it the other way around.