### PR TITLE
Only pass `RealmConfig` to `PolarisStorageIntegration`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1613,7 +1613,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     try {
       AccessConfig accessConfig =
           storageIntegration.getSubscopedCreds(
-              callCtx,
+              callCtx.getRealmConfig(),
               storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2060,7 +2060,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     try {
       AccessConfig accessConfig =
           storageIntegration.getSubscopedCreds(
-              callCtx,
+              callCtx.getRealmConfig(),
               storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -22,7 +22,6 @@ import jakarta.annotation.Nonnull;
 import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.config.RealmConfig;
-import org.apache.polaris.core.context.CallContext;
 
 /**
  * Abstract of Polaris Storage Integration. It holds the reference to an object that having the
@@ -45,7 +44,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
   /**
    * Subscope the creds against the allowed read and write locations.
    *
-   * @param callContext the call context
+   * @param realmConfig the call context
    * @param storageConfig storage configuration
    * @param allowListOperation whether to allow LIST on all the provided allowed read/write
    *     locations
@@ -54,7 +53,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
    * @return An enum map including the scoped credentials
    */
   public abstract AccessConfig getSubscopedCreds(
-      @Nonnull CallContext callContext,
+      @Nonnull RealmConfig realmConfig,
       @Nonnull T storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.AccessConfig;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.StorageAccessProperty;
@@ -67,13 +67,13 @@ public class AwsCredentialsStorageIntegration
   /** {@inheritDoc} */
   @Override
   public AccessConfig getSubscopedCreds(
-      @Nonnull CallContext callContext,
+      @Nonnull RealmConfig realmConfig,
       @Nonnull AwsStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations) {
     int storageCredentialDurationSeconds =
-        callContext.getRealmConfig().getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
+        realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
     AssumeRoleRequest.Builder request =
         AssumeRoleRequest.builder()
             .externalId(storageConfig.getExternalId())

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -47,7 +47,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.AccessConfig;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.StorageAccessProperty;
@@ -73,7 +73,7 @@ public class AzureCredentialsStorageIntegration
 
   @Override
   public AccessConfig getSubscopedCreds(
-      @Nonnull CallContext callContext,
+      @Nonnull RealmConfig realmConfig,
       @Nonnull AzureStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
@@ -125,8 +125,7 @@ public class AzureCredentialsStorageIntegration
     // Azure strictly requires the end time to be <= 7 days from the current time, -1 min to avoid
     // clock skew between the client and server,
     OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
-    int intendedDurationSeconds =
-        callContext.getRealmConfig().getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
+    int intendedDurationSeconds = realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =
@@ -145,7 +144,7 @@ public class AzureCredentialsStorageIntegration
         .addKeyValue("container", location.getContainer())
         .addKeyValue("filePath", filePath)
         .log("Subscope Azure SAS");
-    String sasToken = "";
+    String sasToken;
     if (location.getEndpoint().equalsIgnoreCase(AzureLocation.BLOB_ENDPOINT)) {
       sasToken =
           getBlobUserDelegationSas(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.AccessConfig;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -70,7 +70,7 @@ public class GcpCredentialsStorageIntegration
 
   @Override
   public AccessConfig getSubscopedCreds(
-      @Nonnull CallContext callContext,
+      @Nonnull RealmConfig realmConfig,
       @Nonnull GcpStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/BaseStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/BaseStorageIntegrationTest.java
@@ -19,15 +19,11 @@
 
 package org.apache.polaris.core.storage;
 
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
-import org.apache.polaris.core.persistence.BasePersistence;
-import org.mockito.Mockito;
+import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.config.RealmConfigImpl;
 
 public abstract class BaseStorageIntegrationTest {
-  protected CallContext newCallContext() {
-    return new PolarisCallContext(
-        () -> "realm", Mockito.mock(BasePersistence.class), Mockito.mock(PolarisDiagnostics.class));
-  }
+
+  protected static final RealmConfigImpl EMPTY_REALM_CONFIG =
+      new RealmConfigImpl(new PolarisConfigurationStore() {}, () -> "realm");
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.config.RealmConfigImpl;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.assertj.core.api.Assertions;
@@ -209,7 +208,7 @@ class InMemoryStorageIntegrationTest {
 
     @Override
     public AccessConfig getSubscopedCreds(
-        @Nonnull CallContext callContext,
+        @Nonnull RealmConfig realmConfig,
         @Nonnull PolarisStorageConfigurationInfo storageConfig,
         boolean allowListOperation,
         @Nonnull Set<String> allowedReadLocations,

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -88,7 +88,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     AccessConfig accessConfig =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                newCallContext(),
+                EMPTY_REALM_CONFIG,
                 new AwsStorageConfigurationInfo(
                     S3, List.of(warehouseDir), roleARN, externalId, null),
                 true,
@@ -232,7 +232,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            newCallContext(),
+                            EMPTY_REALM_CONFIG,
                             new AwsStorageConfigurationInfo(
                                 storageType,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -249,7 +249,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         AccessConfig accessConfig =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    newCallContext(),
+                    EMPTY_REALM_CONFIG,
                     new AwsStorageConfigurationInfo(
                         storageType,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -350,7 +350,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     AccessConfig accessConfig =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                newCallContext(),
+                EMPTY_REALM_CONFIG,
                 new AwsStorageConfigurationInfo(
                     S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -445,7 +445,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     AccessConfig accessConfig =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                newCallContext(),
+                EMPTY_REALM_CONFIG,
                 new AwsStorageConfigurationInfo(
                     storageType,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -510,7 +510,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     AccessConfig accessConfig =
         new AwsCredentialsStorageIntegration(stsClient)
             .getSubscopedCreds(
-                newCallContext(),
+                EMPTY_REALM_CONFIG,
                 new AwsStorageConfigurationInfo(
                     S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -550,7 +550,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            newCallContext(),
+                            EMPTY_REALM_CONFIG,
                             new AwsStorageConfigurationInfo(
                                 PolarisStorageConfigurationInfo.StorageType.S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -567,7 +567,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         AccessConfig accessConfig =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    newCallContext(),
+                    EMPTY_REALM_CONFIG,
                     new AwsStorageConfigurationInfo(
                         S3,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
@@ -605,7 +605,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         AccessConfig accessConfig =
             new AwsCredentialsStorageIntegration(stsClient)
                 .getSubscopedCreds(
-                    newCallContext(),
+                    EMPTY_REALM_CONFIG,
                     new AwsStorageConfigurationInfo(
                         S3, List.of(s3Path(bucket, warehouseKeyPrefix)), roleARN, externalId, null),
                     true, /* allowList = true */
@@ -621,7 +621,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 () ->
                     new AwsCredentialsStorageIntegration(stsClient)
                         .getSubscopedCreds(
-                            newCallContext(),
+                            EMPTY_REALM_CONFIG,
                             new AwsStorageConfigurationInfo(
                                 PolarisStorageConfigurationInfo.StorageType.S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -348,7 +348,7 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
     AzureCredentialsStorageIntegration azureCredsIntegration =
         new AzureCredentialsStorageIntegration();
     return azureCredsIntegration.getSubscopedCreds(
-        newCallContext(),
+        EMPTY_REALM_CONFIG,
         azureConfig,
         allowListAction,
         new HashSet<>(allowedReadLoc),

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -169,7 +169,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             GoogleCredentials.getApplicationDefault(),
             ServiceOptions.getFromServiceLoader(HttpTransportFactory.class, NetHttpTransport::new));
     return gcpCredsIntegration.getSubscopedCreds(
-        newCallContext(),
+        EMPTY_REALM_CONFIG,
         gcpConfig,
         allowListAction,
         new HashSet<>(allowedReadLoc),

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.polaris.core.config.RealmConfig;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.storage.AccessConfig;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -100,7 +99,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
             new PolarisStorageIntegration<>("file") {
               @Override
               public AccessConfig getSubscopedCreds(
-                  @Nonnull CallContext callContext,
+                  @Nonnull RealmConfig realmConfig,
                   @Nonnull T storageConfig,
                   boolean allowListOperation,
                   @Nonnull Set<String> allowedReadLocations,


### PR DESCRIPTION
All `PolarisStorageIntegration` requite only the `RealmConfig`, not the whole `CallContext`. This makes it easier for the new tasks impleemntations (both proposals).