### PR TITLE
Remove config parameter from `PolarisStorageIntegration#getSubscopedCreds`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1607,14 +1607,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             catalogId,
             entityId);
 
-    PolarisStorageConfigurationInfo storageConfigurationInfo =
-        BaseMetaStoreManager.extractStorageConfiguration(
-            callCtx.getDiagServices(), reloadedEntity.getEntity());
     try {
       AccessConfig accessConfig =
           storageIntegration.getSubscopedCreds(
               callCtx.getRealmConfig(),
-              storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,
               allowedWriteLocations);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2054,14 +2054,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             catalogId,
             entityId);
 
-    PolarisStorageConfigurationInfo storageConfigurationInfo =
-        BaseMetaStoreManager.extractStorageConfiguration(
-            callCtx.getDiagServices(), reloadedEntity.getEntity());
     try {
       AccessConfig accessConfig =
           storageIntegration.getSubscopedCreds(
               callCtx.getRealmConfig(),
-              storageConfigurationInfo,
               allowListOperation,
               allowedReadLocations,
               allowedWriteLocations);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/InMemoryStorageIntegration.java
@@ -39,8 +39,8 @@ import org.apache.polaris.core.config.RealmConfig;
 public abstract class InMemoryStorageIntegration<T extends PolarisStorageConfigurationInfo>
     extends PolarisStorageIntegration<T> {
 
-  public InMemoryStorageIntegration(String identifierOrId) {
-    super(identifierOrId);
+  protected InMemoryStorageIntegration(T config, String identifierOrId) {
+    super(config, identifierOrId);
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -32,9 +32,15 @@ import org.apache.polaris.core.config.RealmConfig;
 public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigurationInfo> {
 
   private final String integrationIdentifierOrId;
+  private final T config;
 
-  public PolarisStorageIntegration(String identifierOrId) {
+  public PolarisStorageIntegration(T config, String identifierOrId) {
+    this.config = config;
     this.integrationIdentifierOrId = identifierOrId;
+  }
+
+  protected T config() {
+    return config;
   }
 
   public String getStorageIdentifierOrId() {
@@ -45,7 +51,6 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
    * Subscope the creds against the allowed read and write locations.
    *
    * @param realmConfig the call context
-   * @param storageConfig storage configuration
    * @param allowListOperation whether to allow LIST on all the provided allowed read/write
    *     locations
    * @param allowedReadLocations a set of allowed to read locations
@@ -54,7 +59,6 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
    */
   public abstract AccessConfig getSubscopedCreds(
       @Nonnull RealmConfig realmConfig,
-      @Nonnull T storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
@@ -25,7 +25,6 @@ import jakarta.annotation.Nullable;
  * PolarisStorageConfigurationInfo}.
  */
 public interface PolarisStorageIntegrationProvider {
-  @SuppressWarnings("unchecked")
   <T extends PolarisStorageConfigurationInfo>
       @Nullable PolarisStorageIntegration<T> getStorageIntegrationForConfig(
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -49,17 +49,21 @@ public class AwsCredentialsStorageIntegration
   private final StsClientProvider stsClientProvider;
   private final Optional<AwsCredentialsProvider> credentialsProvider;
 
-  public AwsCredentialsStorageIntegration(StsClient fixedClient) {
-    this((destination) -> fixedClient);
-  }
-
-  public AwsCredentialsStorageIntegration(StsClientProvider stsClientProvider) {
-    this(stsClientProvider, Optional.empty());
+  public AwsCredentialsStorageIntegration(
+      AwsStorageConfigurationInfo config, StsClient fixedClient) {
+    this(config, (destination) -> fixedClient);
   }
 
   public AwsCredentialsStorageIntegration(
-      StsClientProvider stsClientProvider, Optional<AwsCredentialsProvider> credentialsProvider) {
-    super(AwsCredentialsStorageIntegration.class.getName());
+      AwsStorageConfigurationInfo config, StsClientProvider stsClientProvider) {
+    this(config, stsClientProvider, Optional.empty());
+  }
+
+  public AwsCredentialsStorageIntegration(
+      AwsStorageConfigurationInfo config,
+      StsClientProvider stsClientProvider,
+      Optional<AwsCredentialsProvider> credentialsProvider) {
+    super(config, AwsCredentialsStorageIntegration.class.getName());
     this.stsClientProvider = stsClientProvider;
     this.credentialsProvider = credentialsProvider;
   }
@@ -68,12 +72,12 @@ public class AwsCredentialsStorageIntegration
   @Override
   public AccessConfig getSubscopedCreds(
       @Nonnull RealmConfig realmConfig,
-      @Nonnull AwsStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations) {
     int storageCredentialDurationSeconds =
         realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
+    AwsStorageConfigurationInfo storageConfig = config();
     AssumeRoleRequest.Builder request =
         AssumeRoleRequest.builder()
             .externalId(storageConfig.getExternalId())

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -64,8 +64,8 @@ public class AzureCredentialsStorageIntegration
 
   final DefaultAzureCredential defaultAzureCredential;
 
-  public AzureCredentialsStorageIntegration() {
-    super(AzureCredentialsStorageIntegration.class.getName());
+  public AzureCredentialsStorageIntegration(AzureStorageConfigurationInfo config) {
+    super(config, AzureCredentialsStorageIntegration.class.getName());
     // The DefaultAzureCredential will by default load the environment variables for client id,
     // client secret, tenant id
     defaultAzureCredential = new DefaultAzureCredentialBuilder().build();
@@ -74,7 +74,6 @@ public class AzureCredentialsStorageIntegration
   @Override
   public AccessConfig getSubscopedCreds(
       @Nonnull RealmConfig realmConfig,
-      @Nonnull AzureStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations) {
@@ -119,7 +118,7 @@ public class AzureCredentialsStorageIntegration
         OffsetDateTime.ofInstant(
             start.plusSeconds(3600), ZoneOffset.UTC); // 1 hr to sync with AWS and GCP Access token
 
-    AccessToken accessToken = getAccessToken(storageConfig.getTenantId());
+    AccessToken accessToken = getAccessToken(config().getTenantId());
     // Get user delegation key.
     // Set the new generated user delegation key expiry to 7 days and minute 1 min
     // Azure strictly requires the end time to be <= 7 days from the current time, -1 min to avoid

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -59,8 +59,10 @@ public class GcpCredentialsStorageIntegration
   private final HttpTransportFactory transportFactory;
 
   public GcpCredentialsStorageIntegration(
-      GoogleCredentials sourceCredentials, HttpTransportFactory transportFactory) {
-    super(GcpCredentialsStorageIntegration.class.getName());
+      GcpStorageConfigurationInfo config,
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory) {
+    super(config, GcpCredentialsStorageIntegration.class.getName());
     // Needed for when environment variable GOOGLE_APPLICATION_CREDENTIALS points to google service
     // account key json
     this.sourceCredentials =
@@ -71,7 +73,6 @@ public class GcpCredentialsStorageIntegration
   @Override
   public AccessConfig getSubscopedCreds(
       @Nonnull RealmConfig realmConfig,
-      @Nonnull GcpStorageConfigurationInfo storageConfig,
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations) {

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 class InMemoryStorageIntegrationTest {
 
@@ -203,13 +204,14 @@ class InMemoryStorageIntegrationTest {
   private static final class MockInMemoryStorageIntegration
       extends InMemoryStorageIntegration<PolarisStorageConfigurationInfo> {
     public MockInMemoryStorageIntegration() {
-      super(MockInMemoryStorageIntegration.class.getName());
+      super(
+          Mockito.mock(PolarisStorageConfigurationInfo.class),
+          MockInMemoryStorageIntegration.class.getName());
     }
 
     @Override
     public AccessConfig getSubscopedCreds(
         @Nonnull RealmConfig realmConfig,
-        @Nonnull PolarisStorageConfigurationInfo storageConfig,
         boolean allowListOperation,
         @Nonnull Set<String> allowedReadLocations,
         @Nonnull Set<String> allowedWriteLocations) {

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -86,11 +86,12 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             });
     String warehouseDir = scheme + "://bucket/path/to/warehouse";
     AccessConfig accessConfig =
-        new AwsCredentialsStorageIntegration(stsClient)
-            .getSubscopedCreds(
-                EMPTY_REALM_CONFIG,
+        new AwsCredentialsStorageIntegration(
                 new AwsStorageConfigurationInfo(
                     S3, List.of(warehouseDir), roleARN, externalId, null),
+                stsClient)
+            .getSubscopedCreds(
+                EMPTY_REALM_CONFIG,
                 true,
                 Set.of(warehouseDir + "/namespace/table"),
                 Set.of(warehouseDir + "/namespace/table"));
@@ -107,8 +108,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   @ParameterizedTest
   @ValueSource(strings = {AWS_PARTITION, "aws-cn", "aws-us-gov"})
   public void testGetSubscopedCredsInlinePolicy(String awsPartition) {
-    PolarisStorageConfigurationInfo.StorageType storageType =
-        PolarisStorageConfigurationInfo.StorageType.S3;
+    PolarisStorageConfigurationInfo.StorageType storageType = S3;
     String roleARN;
     String region;
     switch (awsPartition) {
@@ -230,15 +230,16 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
       case "aws-cn":
         Assertions.assertThatThrownBy(
                 () ->
-                    new AwsCredentialsStorageIntegration(stsClient)
-                        .getSubscopedCreds(
-                            EMPTY_REALM_CONFIG,
+                    new AwsCredentialsStorageIntegration(
                             new AwsStorageConfigurationInfo(
                                 storageType,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
                                 roleARN,
                                 externalId,
                                 region),
+                            stsClient)
+                        .getSubscopedCreds(
+                            EMPTY_REALM_CONFIG,
                             true,
                             Set.of(s3Path(bucket, firstPath), s3Path(bucket, secondPath)),
                             Set.of(s3Path(bucket, firstPath))))
@@ -247,15 +248,16 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
       case AWS_PARTITION:
       case "aws-us-gov":
         AccessConfig accessConfig =
-            new AwsCredentialsStorageIntegration(stsClient)
-                .getSubscopedCreds(
-                    EMPTY_REALM_CONFIG,
+            new AwsCredentialsStorageIntegration(
                     new AwsStorageConfigurationInfo(
                         storageType,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
                         roleARN,
                         externalId,
                         region),
+                    stsClient)
+                .getSubscopedCreds(
+                    EMPTY_REALM_CONFIG,
                     true,
                     Set.of(s3Path(bucket, firstPath), s3Path(bucket, secondPath)),
                     Set.of(s3Path(bucket, firstPath)));
@@ -345,18 +347,17 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                       });
               return ASSUME_ROLE_RESPONSE;
             });
-    PolarisStorageConfigurationInfo.StorageType storageType =
-        PolarisStorageConfigurationInfo.StorageType.S3;
     AccessConfig accessConfig =
-        new AwsCredentialsStorageIntegration(stsClient)
-            .getSubscopedCreds(
-                EMPTY_REALM_CONFIG,
+        new AwsCredentialsStorageIntegration(
                 new AwsStorageConfigurationInfo(
                     S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
                     roleARN,
                     externalId,
                     "us-east-2"),
+                stsClient)
+            .getSubscopedCreds(
+                EMPTY_REALM_CONFIG,
                 false, /* allowList = false*/
                 Set.of(s3Path(bucket, firstPath), s3Path(bucket, secondPath)),
                 Set.of(s3Path(bucket, firstPath)));
@@ -440,18 +441,17 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                       });
               return ASSUME_ROLE_RESPONSE;
             });
-    PolarisStorageConfigurationInfo.StorageType storageType =
-        PolarisStorageConfigurationInfo.StorageType.S3;
     AccessConfig accessConfig =
-        new AwsCredentialsStorageIntegration(stsClient)
-            .getSubscopedCreds(
-                EMPTY_REALM_CONFIG,
+        new AwsCredentialsStorageIntegration(
                 new AwsStorageConfigurationInfo(
-                    storageType,
+                    S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
                     roleARN,
                     externalId,
                     "us-east-2"),
+                stsClient)
+            .getSubscopedCreds(
+                EMPTY_REALM_CONFIG,
                 true, /* allowList = true */
                 Set.of(s3Path(bucket, firstPath), s3Path(bucket, secondPath)),
                 Set.of());
@@ -508,18 +508,15 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
               return ASSUME_ROLE_RESPONSE;
             });
     AccessConfig accessConfig =
-        new AwsCredentialsStorageIntegration(stsClient)
-            .getSubscopedCreds(
-                EMPTY_REALM_CONFIG,
+        new AwsCredentialsStorageIntegration(
                 new AwsStorageConfigurationInfo(
                     S3,
                     List.of(s3Path(bucket, warehouseKeyPrefix)),
                     roleARN,
                     externalId,
                     "us-east-2"),
-                true, /* allowList = true */
-                Set.of(),
-                Set.of());
+                stsClient)
+            .getSubscopedCreds(EMPTY_REALM_CONFIG, true, /* allowList = true */ Set.of(), Set.of());
     assertThat(accessConfig.credentials())
         .isNotEmpty()
         .containsEntry(StorageAccessProperty.AWS_TOKEN.getPropertyName(), "sess")
@@ -548,35 +545,31 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
       case "aws-cn":
         Assertions.assertThatThrownBy(
                 () ->
-                    new AwsCredentialsStorageIntegration(stsClient)
-                        .getSubscopedCreds(
-                            EMPTY_REALM_CONFIG,
+                    new AwsCredentialsStorageIntegration(
                             new AwsStorageConfigurationInfo(
-                                PolarisStorageConfigurationInfo.StorageType.S3,
+                                S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
                                 roleARN,
                                 externalId,
                                 clientRegion),
-                            true, /* allowList = true */
-                            Set.of(),
-                            Set.of()))
+                            stsClient)
+                        .getSubscopedCreds(
+                            EMPTY_REALM_CONFIG, true, /* allowList = true */ Set.of(), Set.of()))
             .isInstanceOf(IllegalArgumentException.class);
         break;
       case AWS_PARTITION:
       case "aws-us-gov":
         AccessConfig accessConfig =
-            new AwsCredentialsStorageIntegration(stsClient)
-                .getSubscopedCreds(
-                    EMPTY_REALM_CONFIG,
+            new AwsCredentialsStorageIntegration(
                     new AwsStorageConfigurationInfo(
                         S3,
                         List.of(s3Path(bucket, warehouseKeyPrefix)),
                         roleARN,
                         externalId,
                         clientRegion),
-                    true, /* allowList = true */
-                    Set.of(),
-                    Set.of());
+                    stsClient)
+                .getSubscopedCreds(
+                    EMPTY_REALM_CONFIG, true, /* allowList = true */ Set.of(), Set.of());
         assertThat(accessConfig.credentials())
             .isNotEmpty()
             .containsEntry(StorageAccessProperty.CLIENT_REGION.getPropertyName(), clientRegion);
@@ -603,14 +596,12 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     switch (awsPartition) {
       case AWS_PARTITION:
         AccessConfig accessConfig =
-            new AwsCredentialsStorageIntegration(stsClient)
-                .getSubscopedCreds(
-                    EMPTY_REALM_CONFIG,
+            new AwsCredentialsStorageIntegration(
                     new AwsStorageConfigurationInfo(
                         S3, List.of(s3Path(bucket, warehouseKeyPrefix)), roleARN, externalId, null),
-                    true, /* allowList = true */
-                    Set.of(),
-                    Set.of());
+                    stsClient)
+                .getSubscopedCreds(
+                    EMPTY_REALM_CONFIG, true, /* allowList = true */ Set.of(), Set.of());
         assertThat(accessConfig.credentials())
             .isNotEmpty()
             .doesNotContainKey(StorageAccessProperty.CLIENT_REGION.getPropertyName());
@@ -619,18 +610,16 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
       case "aws-us-gov":
         Assertions.assertThatThrownBy(
                 () ->
-                    new AwsCredentialsStorageIntegration(stsClient)
-                        .getSubscopedCreds(
-                            EMPTY_REALM_CONFIG,
+                    new AwsCredentialsStorageIntegration(
                             new AwsStorageConfigurationInfo(
                                 PolarisStorageConfigurationInfo.StorageType.S3,
                                 List.of(s3Path(bucket, warehouseKeyPrefix)),
                                 roleARN,
                                 externalId,
                                 null),
-                            true, /* allowList = true */
-                            Set.of(),
-                            Set.of()))
+                            stsClient)
+                        .getSubscopedCreds(
+                            EMPTY_REALM_CONFIG, true, /* allowList = true */ Set.of(), Set.of()))
             .isInstanceOf(IllegalArgumentException.class);
         break;
       default:

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -346,10 +346,9 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
     AzureStorageConfigurationInfo azureConfig =
         new AzureStorageConfigurationInfo(allowedLoc, tenantId);
     AzureCredentialsStorageIntegration azureCredsIntegration =
-        new AzureCredentialsStorageIntegration();
+        new AzureCredentialsStorageIntegration(azureConfig);
     return azureCredsIntegration.getSubscopedCreds(
         EMPTY_REALM_CONFIG,
-        azureConfig,
         allowListAction,
         new HashSet<>(allowedReadLoc),
         new HashSet<>(allowedWriteLoc));

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -31,15 +31,12 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.CredentialAccessBoundary;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -166,11 +163,11 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     GcpStorageConfigurationInfo gcpConfig = new GcpStorageConfigurationInfo(allowedLoc);
     GcpCredentialsStorageIntegration gcpCredsIntegration =
         new GcpCredentialsStorageIntegration(
+            gcpConfig,
             GoogleCredentials.getApplicationDefault(),
             ServiceOptions.getFromServiceLoader(HttpTransportFactory.class, NetHttpTransport::new));
     return gcpCredsIntegration.getSubscopedCreds(
         EMPTY_REALM_CONFIG,
-        gcpConfig,
         allowListAction,
         new HashSet<>(allowedReadLoc),
         new HashSet<>(allowedWriteLoc));
@@ -178,17 +175,8 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testGenerateAccessBoundary() throws IOException {
-    GcpCredentialsStorageIntegration integration =
-        new GcpCredentialsStorageIntegration(
-            GoogleCredentials.newBuilder()
-                .setAccessToken(
-                    new AccessToken(
-                        "my_token",
-                        new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli())))
-                .build(),
-            new HttpTransportOptions.DefaultHttpTransportFactory());
     CredentialAccessBoundary credentialAccessBoundary =
-        integration.generateAccessBoundaryRules(
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true, Set.of("gs://bucket1/path/to/data"), Set.of("gs://bucket1/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
     ObjectMapper mapper = new ObjectMapper();
@@ -207,17 +195,8 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testGenerateAccessBoundaryWithMultipleBuckets() throws IOException {
-    GcpCredentialsStorageIntegration integration =
-        new GcpCredentialsStorageIntegration(
-            GoogleCredentials.newBuilder()
-                .setAccessToken(
-                    new AccessToken(
-                        "my_token",
-                        new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli())))
-                .build(),
-            new HttpTransportOptions.DefaultHttpTransportFactory());
     CredentialAccessBoundary credentialAccessBoundary =
-        integration.generateAccessBoundaryRules(
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true,
             Set.of(
                 "gs://bucket1/normal/path/to/data",
@@ -241,17 +220,8 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testGenerateAccessBoundaryWithoutList() throws IOException {
-    GcpCredentialsStorageIntegration integration =
-        new GcpCredentialsStorageIntegration(
-            GoogleCredentials.newBuilder()
-                .setAccessToken(
-                    new AccessToken(
-                        "my_token",
-                        new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli())))
-                .build(),
-            new HttpTransportOptions.DefaultHttpTransportFactory());
     CredentialAccessBoundary credentialAccessBoundary =
-        integration.generateAccessBoundaryRules(
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             false,
             Set.of("gs://bucket1/path/to/data", "gs://bucket1/another/path/to/data"),
             Set.of("gs://bucket1/path/to/data"));
@@ -272,17 +242,8 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testGenerateAccessBoundaryWithoutWrites() throws IOException {
-    GcpCredentialsStorageIntegration integration =
-        new GcpCredentialsStorageIntegration(
-            GoogleCredentials.newBuilder()
-                .setAccessToken(
-                    new AccessToken(
-                        "my_token",
-                        new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli())))
-                .build(),
-            new HttpTransportOptions.DefaultHttpTransportFactory());
     CredentialAccessBoundary credentialAccessBoundary =
-        integration.generateAccessBoundaryRules(
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             false,
             Set.of("gs://bucket1/normal/path/to/data", "gs://bucket1/awesome/path/to/data"),
             Set.of());

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractIcebergCatalogTest.java
@@ -358,7 +358,10 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
                         .build())
                 .build());
     PolarisStorageIntegration<AwsStorageConfigurationInfo> storageIntegration =
-        new AwsCredentialsStorageIntegration(stsClient);
+        new AwsCredentialsStorageIntegration(
+            (AwsStorageConfigurationInfo)
+                CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
+            stsClient);
     when(storageIntegrationProvider.getStorageIntegrationForConfig(
             isA(AwsStorageConfigurationInfo.class)))
         .thenReturn((PolarisStorageIntegration) storageIntegration);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolarisGenericTableCatalogTest.java
@@ -222,7 +222,10 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
                         .build())
                 .build());
     PolarisStorageIntegration<AwsStorageConfigurationInfo> storageIntegration =
-        new AwsCredentialsStorageIntegration(stsClient);
+        new AwsCredentialsStorageIntegration(
+            (AwsStorageConfigurationInfo)
+                CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
+            stsClient);
     when(storageIntegrationProvider.getStorageIntegrationForConfig(
             isA(AwsStorageConfigurationInfo.class)))
         .thenReturn((PolarisStorageIntegration) storageIntegration);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/catalog/AbstractPolicyCatalogTest.java
@@ -245,7 +245,10 @@ public abstract class AbstractPolicyCatalogTest {
                         .build())
                 .build());
     PolarisStorageIntegration<AwsStorageConfigurationInfo> storageIntegration =
-        new AwsCredentialsStorageIntegration(stsClient);
+        new AwsCredentialsStorageIntegration(
+            (AwsStorageConfigurationInfo)
+                CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
+            stsClient);
     when(storageIntegrationProvider.getStorageIntegrationForConfig(
             isA(AwsStorageConfigurationInfo.class)))
         .thenReturn((PolarisStorageIntegration) storageIntegration);

--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -37,9 +37,12 @@ import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.StsClientProvider;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 @ApplicationScoped
@@ -49,6 +52,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
   private final Optional<AwsCredentialsProvider> stsCredentials;
   private final Supplier<GoogleCredentials> gcpCredsProvider;
 
+  @SuppressWarnings("CdiInjectionPointsInspection")
   @Inject
   public PolarisStorageIntegrationProviderImpl(
       StorageConfiguration storageConfiguration, StsClientProvider stsClientProvider) {
@@ -80,27 +84,32 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
       case S3:
         storageIntegration =
             (PolarisStorageIntegration<T>)
-                new AwsCredentialsStorageIntegration(stsClientProvider, stsCredentials);
+                new AwsCredentialsStorageIntegration(
+                    (AwsStorageConfigurationInfo) polarisStorageConfigurationInfo,
+                    stsClientProvider,
+                    stsCredentials);
         break;
       case GCS:
         storageIntegration =
             (PolarisStorageIntegration<T>)
                 new GcpCredentialsStorageIntegration(
+                    (GcpStorageConfigurationInfo) polarisStorageConfigurationInfo,
                     gcpCredsProvider.get(),
                     ServiceOptions.getFromServiceLoader(
                         HttpTransportFactory.class, NetHttpTransport::new));
         break;
       case AZURE:
         storageIntegration =
-            (PolarisStorageIntegration<T>) new AzureCredentialsStorageIntegration();
+            (PolarisStorageIntegration<T>)
+                new AzureCredentialsStorageIntegration(
+                    (AzureStorageConfigurationInfo) polarisStorageConfigurationInfo);
         break;
       case FILE:
         storageIntegration =
-            new PolarisStorageIntegration<>("file") {
+            new PolarisStorageIntegration<>((T) polarisStorageConfigurationInfo, "file") {
               @Override
               public AccessConfig getSubscopedCreds(
                   @Nonnull RealmConfig realmConfig,
-                  @Nonnull T storageConfig,
                   boolean allowListOperation,
                   @Nonnull Set<String> allowedReadLocations,
                   @Nonnull Set<String> allowedWriteLocations) {


### PR DESCRIPTION
Instances of `PolarisStorageIntegration` are created for a particular `PolarisStorageConfigurationInfo`, the same value is then passed into `PSI.getSubscopedCreds()`.

This change removes the config parameter, as it's already known when `PolarisStorageIntegration` instances are created.
