### PR TITLE
Prepare upgrade to Gradle 9

### DIFF
--- a/api/iceberg-service/build.gradle.kts
+++ b/api/iceberg-service/build.gradle.kts
@@ -63,13 +63,13 @@ val generatedOpenApiSrcDir = project.layout.buildDirectory.dir("generated-openap
 openApiGenerate {
   // The OpenAPI generator does NOT resolve relative paths correctly against the Gradle project
   // directory
-  inputSpec = specsDir.file("polaris-catalog-service.yaml").asFile.absolutePath
+  inputSpec = provider { specsDir.file("polaris-catalog-service.yaml").asFile.absolutePath }
   generatorName = "jaxrs-resteasy"
-  outputDir = generatedDir.get().asFile.absolutePath
+  outputDir = provider { generatedDir.get().asFile.absolutePath }
   apiPackage = "org.apache.polaris.service.catalog.api"
-  ignoreFileOverride = rootDir.file(".openapi-generator-ignore").asFile.absolutePath
-  removeOperationIdPrefix = true
-  templateDir = templatesDir.asFile.absolutePath
+  ignoreFileOverride.set(provider { rootDir.file(".openapi-generator-ignore").asFile.absolutePath })
+  templateDir.set(provider { templatesDir.asFile.absolutePath })
+  removeOperationIdPrefix.set(true)
   globalProperties.put("apis", "CatalogApi,ConfigurationApi,OAuth2Api")
   globalProperties.put("models", "false")
   globalProperties.put("apiDocs", "false")

--- a/api/management-model/build.gradle.kts
+++ b/api/management-model/build.gradle.kts
@@ -50,13 +50,13 @@ val generatedOpenApiSrcDir = project.layout.buildDirectory.dir("generated-openap
 openApiGenerate {
   // The OpenAPI generator does NOT resolve relative paths correctly against the Gradle project
   // directory
-  inputSpec = specsDir.file("polaris-management-service.yml").asFile.absolutePath
+  inputSpec = provider { specsDir.file("polaris-management-service.yml").asFile.absolutePath }
   generatorName = "jaxrs-resteasy"
-  outputDir = generatedDir.get().asFile.absolutePath
+  outputDir = provider { generatedDir.get().asFile.absolutePath }
   modelPackage = "org.apache.polaris.core.admin.model"
-  ignoreFileOverride = rootDir.file(".openapi-generator-ignore").asFile.absolutePath
-  removeOperationIdPrefix = true
-  templateDir = templatesDir.asFile.absolutePath
+  ignoreFileOverride.set(provider { rootDir.file(".openapi-generator-ignore").asFile.absolutePath })
+  removeOperationIdPrefix.set(true)
+  templateDir.set(provider { templatesDir.asFile.absolutePath })
   globalProperties.put("apis", "false")
   globalProperties.put("models", "")
   globalProperties.put("apiDocs", "false")

--- a/api/management-service/build.gradle.kts
+++ b/api/management-service/build.gradle.kts
@@ -59,14 +59,14 @@ val generatedOpenApiSrcDir = project.layout.buildDirectory.dir("generated-openap
 openApiGenerate {
   // The OpenAPI generator does NOT resolve relative paths correctly against the Gradle project
   // directory
-  inputSpec = specsDir.file("polaris-management-service.yml").asFile.absolutePath
+  inputSpec = provider { specsDir.file("polaris-management-service.yml").asFile.absolutePath }
   generatorName = "jaxrs-resteasy"
-  outputDir = generatedDir.get().asFile.absolutePath
+  outputDir = provider { generatedDir.get().asFile.absolutePath }
   apiPackage = "org.apache.polaris.service.admin.api"
   modelPackage = "org.apache.polaris.core.admin.model"
-  ignoreFileOverride = rootDir.file(".openapi-generator-ignore").asFile.absolutePath
-  removeOperationIdPrefix = true
-  templateDir = templatesDir.asFile.absolutePath
+  ignoreFileOverride.set(provider { rootDir.file(".openapi-generator-ignore").asFile.absolutePath })
+  removeOperationIdPrefix.set(true)
+  templateDir.set(provider { templatesDir.asFile.absolutePath })
   globalProperties.put("apis", "")
   globalProperties.put("models", "false")
   globalProperties.put("apiDocs", "false")

--- a/api/polaris-catalog-service/build.gradle.kts
+++ b/api/polaris-catalog-service/build.gradle.kts
@@ -89,14 +89,14 @@ val generatedOpenApiSrcDir = project.layout.buildDirectory.dir("generated-openap
 openApiGenerate {
   // The OpenAPI generator does NOT resolve relative paths correctly against the Gradle project
   // directory
-  inputSpec = specsDir.file("polaris-catalog-service.yaml").asFile.absolutePath
+  inputSpec = provider { specsDir.file("polaris-catalog-service.yaml").asFile.absolutePath }
   generatorName = "jaxrs-resteasy"
-  outputDir = generatedDir.get().asFile.absolutePath
+  outputDir = provider { generatedDir.get().asFile.absolutePath }
   apiPackage = "org.apache.polaris.service.catalog.api"
   modelPackage = "org.apache.polaris.service.types"
-  ignoreFileOverride = rootDir.file(".openapi-generator-ignore").asFile.absolutePath
-  removeOperationIdPrefix = true
-  templateDir = templatesDir.asFile.absolutePath
+  ignoreFileOverride.set(provider { rootDir.file(".openapi-generator-ignore").asFile.absolutePath })
+  removeOperationIdPrefix.set(true)
+  templateDir.set(provider { templatesDir.asFile.absolutePath })
   globalProperties.put("apis", "GenericTableApi,PolicyApi")
   globalProperties.put("models", models)
   globalProperties.put("apiDocs", "false")

--- a/build-logic/src/main/kotlin/publishing/shadowPub.kt
+++ b/build-logic/src/main/kotlin/publishing/shadowPub.kt
@@ -113,10 +113,7 @@ internal fun configureShadowPublishing(
           if ((depNode as NodeList).isNotEmpty()) depNode[0] as Node
           else node.appendNode("dependencies")
         project.configurations.getByName("shadow").allDependencies.forEach {
-          @Suppress("DEPRECATION")
-          if (
-            (it is ProjectDependency) || it !is org.gradle.api.artifacts.SelfResolvingDependency
-          ) {
+          if (it is ProjectDependency) {
             val dependencyNode = dependenciesNode.appendNode("dependency")
             dependencyNode.appendNode("groupId", it.group)
             dependencyNode.appendNode("artifactId", it.name)


### PR DESCRIPTION
* `shadowPub.kt` the change removes a special case that doesn't apply to Polaris
* `api/...` build scripts - changes due to nullable type handling (`Property<String>` vs `Property<String?>` - latter is ... weird)
