### PR TITLE
Use application-scoped clock when generating GCP credentials

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -52,11 +53,11 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
 
   @Inject
   public PolarisStorageIntegrationProviderImpl(
-      StorageConfiguration storageConfiguration, StsClientProvider stsClientProvider) {
+      StorageConfiguration storageConfiguration, StsClientProvider stsClientProvider, Clock clock) {
     this(
         stsClientProvider,
         Optional.ofNullable(storageConfiguration.stsCredentials()),
-        storageConfiguration.gcpCredentialsSupplier());
+        storageConfiguration.gcpCredentialsSupplier(clock));
   }
 
   public PolarisStorageIntegrationProviderImpl(

--- a/service/common/src/main/java/org/apache/polaris/service/storage/StorageConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/storage/StorageConfiguration.java
@@ -22,8 +22,8 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Suppliers;
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -89,7 +89,7 @@ public interface StorageConfiguration {
     }
   }
 
-  default Supplier<GoogleCredentials> gcpCredentialsSupplier() {
+  default Supplier<GoogleCredentials> gcpCredentialsSupplier(Clock clock) {
     return Suppliers.memoize(
         () -> {
           if (gcpAccessToken().isEmpty()) {
@@ -103,7 +103,8 @@ public interface StorageConfiguration {
                 new AccessToken(
                     gcpAccessToken().get(),
                     new Date(
-                        Instant.now()
+                        clock
+                            .instant()
                             .plus(gcpAccessTokenLifespan().orElse(DEFAULT_TOKEN_LIFESPAN))
                             .toEpochMilli()));
             return GoogleCredentials.create(accessToken);


### PR DESCRIPTION
This change also fixes a flaky test: `StorageConfigurationTest.testCreateGcpCredentialsFromStaticToken`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
