### PR TITLE
Stop mocking PolarisDiagnostics

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -58,6 +58,7 @@ public class TaskExecutorImplTest {
         new TaskEntity.Builder()
             .setName("mytask")
             .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
+            .setCreateTimestamp(polarisCallCtx.getClock().millis())
             .build();
     metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
 

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
@@ -118,6 +119,7 @@ public record TestServices(
   }
 
   public static class Builder {
+    private PolarisDiagnostics polarisDiagnostics = new PolarisDefaultDiagServiceImpl();
     private RealmContext realmContext = TEST_REALM;
     private Map<String, Object> config = Map.of();
     private StsClient stsClient = Mockito.mock(StsClient.class);
@@ -147,7 +149,6 @@ public record TestServices(
 
     public TestServices build() {
       PolarisConfigurationStore configurationStore = new MockedConfigurationStore(config);
-      PolarisDiagnostics polarisDiagnostics = Mockito.mock(PolarisDiagnostics.class);
       PolarisAuthorizer authorizer = Mockito.mock(PolarisAuthorizer.class);
 
       // Application level


### PR DESCRIPTION
if diagnostics checks are failing in our tests we want to know about it as input validation and object invariants of production code should never be bypassed