### PR TITLE
Remove PolarisCallContext.getClock

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.nio.file.Path;
+import java.time.Clock;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.LocalPolarisMetaStoreManagerFactory;
@@ -45,13 +46,14 @@ public class EclipseLinkPolarisMetaStoreManagerFactory
   @Inject EclipseLinkConfiguration eclipseLinkConfiguration;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
 
+  @SuppressWarnings("unused") // Required by CDI
   protected EclipseLinkPolarisMetaStoreManagerFactory() {
-    this(null);
+    this(null, null);
   }
 
   @Inject
-  protected EclipseLinkPolarisMetaStoreManagerFactory(PolarisDiagnostics diagnostics) {
-    super(diagnostics);
+  protected EclipseLinkPolarisMetaStoreManagerFactory(Clock clock, PolarisDiagnostics diagnostics) {
+    super(clock, diagnostics);
   }
 
   @Override

--- a/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -30,13 +30,11 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.ZoneId;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
@@ -89,14 +87,10 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     PolarisEclipseLinkMetaStoreSessionImpl session =
         new PolarisEclipseLinkMetaStoreSessionImpl(
             store, Mockito.mock(), realmContext, null, "polaris", RANDOM_SECRETS);
-    return new PolarisTestMetaStoreManager(
-        new TransactionalMetaStoreManagerImpl(),
-        new PolarisCallContext(
-            realmContext,
-            session,
-            diagServices,
-            new PolarisConfigurationStore() {},
-            timeSource.withZone(ZoneId.systemDefault())));
+    TransactionalMetaStoreManagerImpl metaStoreManager =
+        new TransactionalMetaStoreManagerImpl(clock);
+    PolarisCallContext callCtx = new PolarisCallContext(realmContext, session, diagServices);
+    return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }
 
   @ParameterizedTest

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -24,6 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +69,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   final Map<String, EntityCache> entityCacheMap = new HashMap<>();
   final Map<String, Supplier<BasePersistence>> sessionSupplierMap = new HashMap<>();
 
+  @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject Instance<DataSource> dataSource;
@@ -85,7 +87,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   protected PolarisMetaStoreManager createNewMetaStoreManager() {
-    return new AtomicOperationMetaStoreManager();
+    return new AtomicOperationMetaStoreManager(clock);
   }
 
   private void initializeForRealm(

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -22,13 +22,11 @@ import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RAND
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.ZoneId;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
@@ -71,14 +69,10 @@ public class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
             Mockito.mock(),
             realmContext.getRealmIdentifier(),
             schemaVersion);
-    return new PolarisTestMetaStoreManager(
-        new AtomicOperationMetaStoreManager(),
-        new PolarisCallContext(
-            realmContext,
-            basePersistence,
-            diagServices,
-            new PolarisConfigurationStore() {},
-            timeSource.withZone(ZoneId.systemDefault())));
+    AtomicOperationMetaStoreManager metaStoreManager = new AtomicOperationMetaStoreManager(clock);
+    PolarisCallContext callCtx =
+        new PolarisCallContext(realmContext, basePersistence, diagServices);
+    return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }
 
   private static class H2JdbcConfiguration implements RelationalJdbcConfiguration {

--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -19,8 +19,6 @@
 package org.apache.polaris.core;
 
 import jakarta.annotation.Nonnull;
-import java.time.Clock;
-import java.time.ZoneId;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.config.RealmConfigImpl;
@@ -36,29 +34,20 @@ public class PolarisCallContext implements CallContext {
 
   // meta store which is used to persist Polaris entity metadata
   private final BasePersistence metaStore;
-
-  // diag services
   private final PolarisDiagnostics diagServices;
-
   private final PolarisConfigurationStore configurationStore;
-
-  private final Clock clock;
-
   private final RealmContext realmContext;
-
   private final RealmConfig realmConfig;
 
   public PolarisCallContext(
       @Nonnull RealmContext realmContext,
       @Nonnull BasePersistence metaStore,
       @Nonnull PolarisDiagnostics diagServices,
-      @Nonnull PolarisConfigurationStore configurationStore,
-      @Nonnull Clock clock) {
+      @Nonnull PolarisConfigurationStore configurationStore) {
     this.realmContext = realmContext;
     this.metaStore = metaStore;
     this.diagServices = diagServices;
     this.configurationStore = configurationStore;
-    this.clock = clock;
     this.realmConfig = new RealmConfigImpl(this.configurationStore, this.realmContext);
   }
 
@@ -66,12 +55,7 @@ public class PolarisCallContext implements CallContext {
       @Nonnull RealmContext realmContext,
       @Nonnull BasePersistence metaStore,
       @Nonnull PolarisDiagnostics diagServices) {
-    this(
-        realmContext,
-        metaStore,
-        diagServices,
-        new PolarisConfigurationStore() {},
-        Clock.system(ZoneId.systemDefault()));
+    this(realmContext, metaStore, diagServices, new PolarisConfigurationStore() {});
   }
 
   public BasePersistence getMetaStore() {
@@ -80,10 +64,6 @@ public class PolarisCallContext implements CallContext {
 
   public PolarisDiagnostics getDiagServices() {
     return diagServices;
-  }
-
-  public Clock getClock() {
-    return clock;
   }
 
   @Override
@@ -111,6 +91,6 @@ public class PolarisCallContext implements CallContext {
     String realmId = this.realmContext.getRealmIdentifier();
     RealmContext realmContext = () -> realmId;
     return new PolarisCallContext(
-        realmContext, this.metaStore, this.diagServices, this.configurationStore, this.clock);
+        realmContext, this.metaStore, this.diagServices, this.configurationStore);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,6 +84,12 @@ import org.slf4j.LoggerFactory;
 public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AtomicOperationMetaStoreManager.class);
+
+  private final Clock clock;
+
+  public AtomicOperationMetaStoreManager(Clock clock) {
+    this.clock = clock;
+  }
 
   /**
    * Persist the specified new entity.
@@ -1234,7 +1241,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
               .name("entityCleanup_" + entityToDrop.getId())
               .typeCode(PolarisEntityType.TASK.getCode())
               .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-              .createTimestamp(callCtx.getClock().millis());
+              .createTimestamp(clock.millis());
       if (cleanupProperties != null) {
         taskEntityBuilder.internalProperties(
             PolarisObjectMapperUtil.serializeProperties(cleanupProperties));
@@ -1508,7 +1515,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                           PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
               return taskState == null
                   || taskState.executor == null
-                  || callCtx.getClock().millis() - taskState.lastAttemptStartTime > taskAgeTimeout;
+                  || clock.millis() - taskState.lastAttemptStartTime > taskAgeTimeout;
             },
             Function.identity(),
             pageToken);
@@ -1524,8 +1531,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                       PolarisObjectMapperUtil.deserializeProperties(task.getProperties());
                   properties.put(PolarisTaskConstants.LAST_ATTEMPT_EXECUTOR_ID, executorId);
                   properties.put(
-                      PolarisTaskConstants.LAST_ATTEMPT_START_TIME,
-                      String.valueOf(callCtx.getClock().millis()));
+                      PolarisTaskConstants.LAST_ATTEMPT_START_TIME, String.valueOf(clock.millis()));
                   properties.put(
                       PolarisTaskConstants.ATTEMPT_COUNT,
                       String.valueOf(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -56,9 +57,12 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
   private static final Logger LOGGER =
       LoggerFactory.getLogger(LocalPolarisMetaStoreManagerFactory.class);
 
+  private final Clock clock;
   private final PolarisDiagnostics diagnostics;
 
-  protected LocalPolarisMetaStoreManagerFactory(@Nonnull PolarisDiagnostics diagnostics) {
+  protected LocalPolarisMetaStoreManagerFactory(
+      @Nonnull Clock clock, @Nonnull PolarisDiagnostics diagnostics) {
+    this.clock = clock;
     this.diagnostics = diagnostics;
   }
 
@@ -84,8 +88,8 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
    * Subclasses can override this to inject different implementations of PolarisMetaStoreManager
    * into the existing realm-based setup flow.
    */
-  protected PolarisMetaStoreManager createNewMetaStoreManager() {
-    return new TransactionalMetaStoreManagerImpl();
+  protected PolarisMetaStoreManager createNewMetaStoreManager(Clock clock) {
+    return new TransactionalMetaStoreManagerImpl(clock);
   }
 
   private void initializeForRealm(
@@ -95,7 +99,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         realmContext.getRealmIdentifier(),
         () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics));
 
-    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager(clock);
     metaStoreManagerMap.put(realmContext.getRealmIdentifier(), metaStoreManager);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -21,6 +21,7 @@ package org.apache.polaris.core.persistence.transactional;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,6 +90,12 @@ import org.slf4j.LoggerFactory;
 public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TransactionalMetaStoreManagerImpl.class);
+
+  private final Clock clock;
+
+  public TransactionalMetaStoreManagerImpl(Clock clock) {
+    this.clock = clock;
+  }
 
   /**
    * A version of BaseMetaStoreManager::persistNewEntity but instead of calling the one-shot
@@ -1437,7 +1444,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
               .name("entityCleanup_" + entityToDrop.getId())
               .typeCode(PolarisEntityType.TASK.getCode())
               .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-              .createTimestamp(callCtx.getClock().millis())
+              .createTimestamp(clock.millis())
               .properties(PolarisObjectMapperUtil.serializeProperties(properties));
       if (cleanupProperties != null) {
         taskEntityBuilder.internalProperties(
@@ -1964,7 +1971,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                           PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
               return taskState == null
                   || taskState.executor == null
-                  || callCtx.getClock().millis() - taskState.lastAttemptStartTime > taskAgeTimeout;
+                  || clock.millis() - taskState.lastAttemptStartTime > taskAgeTimeout;
             },
             Function.identity(),
             pageToken);
@@ -1978,8 +1985,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                       PolarisObjectMapperUtil.deserializeProperties(task.getProperties());
                   properties.put(PolarisTaskConstants.LAST_ATTEMPT_EXECUTOR_ID, executorId);
                   properties.put(
-                      PolarisTaskConstants.LAST_ATTEMPT_START_TIME,
-                      String.valueOf(callCtx.getClock().millis()));
+                      PolarisTaskConstants.LAST_ATTEMPT_START_TIME, String.valueOf(clock.millis()));
                   properties.put(
                       PolarisTaskConstants.ATTEMPT_COUNT,
                       String.valueOf(

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
@@ -20,11 +20,9 @@ package org.apache.polaris.core.persistence;
 
 import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RANDOM_SECRETS;
 
-import java.time.ZoneId;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.mockito.Mockito;
@@ -35,14 +33,12 @@ public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
   public PolarisTestMetaStoreManager createPolarisTestMetaStoreManager() {
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
     TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
+    AtomicOperationMetaStoreManager metaStoreManager = new AtomicOperationMetaStoreManager(clock);
     PolarisCallContext callCtx =
         new PolarisCallContext(
             () -> "testRealm",
             new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
-            diagServices,
-            new PolarisConfigurationStore() {},
-            timeSource.withZone(ZoneId.systemDefault()));
-
-    return new PolarisTestMetaStoreManager(new AtomicOperationMetaStoreManager(), callCtx);
+            diagServices);
+    return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
@@ -20,11 +20,9 @@ package org.apache.polaris.core.persistence;
 
 import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RANDOM_SECRETS;
 
-import java.time.ZoneId;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
@@ -35,14 +33,13 @@ public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreMana
   public PolarisTestMetaStoreManager createPolarisTestMetaStoreManager() {
     PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
     TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
+    TransactionalMetaStoreManagerImpl metaStoreManager =
+        new TransactionalMetaStoreManagerImpl(clock);
     PolarisCallContext callCtx =
         new PolarisCallContext(
             () -> "testRealm",
             new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
-            diagServices,
-            new PolarisConfigurationStore() {},
-            timeSource.withZone(ZoneId.systemDefault()));
-
-    return new PolarisTestMetaStoreManager(new TransactionalMetaStoreManagerImpl(), callCtx);
+            diagServices);
+    return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.persistence;
 
 import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RANDOM_SECRETS;
 
+import java.time.Clock;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.persistence.transactional.TransactionalMetaStoreManagerImpl;
@@ -29,6 +30,7 @@ import org.mockito.Mockito;
 
 public class ResolverTest extends BaseResolverTest {
 
+  private final Clock clock = Clock.systemUTC();
   private PolarisCallContext callCtx;
   private PolarisTestMetaStoreManager tm;
   private TransactionalMetaStoreManagerImpl metaStoreManager;
@@ -48,7 +50,7 @@ public class ResolverTest extends BaseResolverTest {
   @Override
   protected PolarisMetaStoreManager metaStoreManager() {
     if (metaStoreManager == null) {
-      metaStoreManager = new TransactionalMetaStoreManagerImpl();
+      metaStoreManager = new TransactionalMetaStoreManagerImpl(clock);
     }
     return metaStoreManager;
   }
@@ -56,7 +58,7 @@ public class ResolverTest extends BaseResolverTest {
   @Override
   protected PolarisTestMetaStoreManager tm() {
     if (tm == null) {
-      // bootstrap the mata store with our test schema
+      // bootstrap the meta store with our test schema
       tm = new PolarisTestMetaStoreManager(metaStoreManager(), callCtx());
     }
     return tm;

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.persistence.cache;
 
 import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RANDOM_SECRETS;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -47,22 +48,9 @@ import org.mockito.Mockito;
 /** Unit testing of the entity cache */
 public class InMemoryEntityCacheTest {
 
-  // diag services
   private final PolarisDiagnostics diagServices;
-
-  // the entity store, use treemap implementation
-  private final TreeMapMetaStore store;
-
-  // to interact with the metastore
-  private final TransactionalPersistence metaStore;
-
-  // polaris call context
   private final PolarisCallContext callCtx;
-
-  // utility to bootstrap the mata store
   private final PolarisTestMetaStoreManager tm;
-
-  // the meta store manager
   private final PolarisMetaStoreManager metaStoreManager;
 
   /**
@@ -89,12 +77,13 @@ public class InMemoryEntityCacheTest {
    */
   public InMemoryEntityCacheTest() {
     diagServices = new PolarisDefaultDiagServiceImpl();
-    store = new TreeMapMetaStore(diagServices);
-    metaStore = new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
+    TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
+    TransactionalPersistence metaStore =
+        new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
+    metaStoreManager = new TransactionalMetaStoreManagerImpl(Clock.systemUTC());
     callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
-    metaStoreManager = new TransactionalMetaStoreManagerImpl();
 
-    // bootstrap the mata store with our test schema
+    // bootstrap the meta store with our test schema
     tm = new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
     tm.testCreateTestCatalog();
   }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -63,7 +63,7 @@ import org.threeten.extra.MutableClock;
  */
 public abstract class BasePolarisMetaStoreManagerTest {
 
-  protected final MutableClock timeSource = MutableClock.of(Instant.now(), ZoneOffset.UTC);
+  protected final MutableClock clock = MutableClock.of(Instant.now(), ZoneOffset.UTC);
 
   private PolarisTestMetaStoreManager polarisTestMetaStoreManager;
 
@@ -332,7 +332,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
 
     Assertions.assertThat(emtpyList).isNotNull().isEmpty();
 
-    timeSource.add(Duration.ofMinutes(10));
+    clock.add(Duration.ofMinutes(10));
 
     // all the tasks are unassigned. Fetch them all
     List<PolarisBaseEntity> allTasks =
@@ -348,7 +348,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
     // drop all the tasks. Skip the clock forward and fetch. empty list expected
     allTasks.forEach(
         entity -> metaStoreManager.dropEntityIfExists(callCtx, null, entity, Map.of(), false));
-    timeSource.add(Duration.ofMinutes(10));
+    clock.add(Duration.ofMinutes(10));
 
     List<PolarisBaseEntity> finalList =
         metaStoreManager.loadTasks(callCtx, executorId, PageToken.fromLimit(20)).getEntities();

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -159,11 +159,9 @@ public class ServiceProducers {
       RealmContext realmContext,
       PolarisDiagnostics diagServices,
       PolarisConfigurationStore configurationStore,
-      MetaStoreManagerFactory metaStoreManagerFactory,
-      Clock clock) {
+      MetaStoreManagerFactory metaStoreManagerFactory) {
     BasePersistence metaStoreSession = metaStoreManagerFactory.getOrCreateSession(realmContext);
-    return new PolarisCallContext(
-        realmContext, metaStoreSession, diagServices, configurationStore, clock);
+    return new PolarisCallContext(realmContext, metaStoreSession, diagServices, configurationStore);
   }
 
   @Produces

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.persistence;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Clock;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -37,17 +38,19 @@ public class InMemoryAtomicOperationMetaStoreManagerFactory
 
   @SuppressWarnings("unused") // Required by CDI
   protected InMemoryAtomicOperationMetaStoreManagerFactory() {
-    this(null, null);
+    this(null, null, null);
   }
 
   @Inject
   public InMemoryAtomicOperationMetaStoreManagerFactory(
-      PolarisStorageIntegrationProvider storageIntegration, PolarisDiagnostics diagnostics) {
-    super(storageIntegration, diagnostics);
+      Clock clock,
+      PolarisDiagnostics diagnostics,
+      PolarisStorageIntegrationProvider storageIntegration) {
+    super(clock, diagnostics, storageIntegration);
   }
 
   @Override
-  protected PolarisMetaStoreManager createNewMetaStoreManager() {
-    return new AtomicOperationMetaStoreManager();
+  protected PolarisMetaStoreManager createNewMetaStoreManager(Clock clock) {
+    return new AtomicOperationMetaStoreManager(clock);
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -23,6 +23,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Clock;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,13 +49,15 @@ public class InMemoryPolarisMetaStoreManagerFactory
 
   @SuppressWarnings("unused") // Required by CDI
   protected InMemoryPolarisMetaStoreManagerFactory() {
-    this(null, null);
+    this(null, null, null);
   }
 
   @Inject
   public InMemoryPolarisMetaStoreManagerFactory(
-      PolarisStorageIntegrationProvider storageIntegration, PolarisDiagnostics diagnostics) {
-    super(diagnostics);
+      Clock clock,
+      PolarisDiagnostics diagnostics,
+      PolarisStorageIntegrationProvider storageIntegration) {
+    super(clock, diagnostics);
     this.storageIntegration = storageIntegration;
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.task;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -52,15 +53,18 @@ import org.slf4j.LoggerFactory;
 public class TableCleanupTaskHandler implements TaskHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableCleanupTaskHandler.class);
   private final TaskExecutor taskExecutor;
+  private final Clock clock;
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final TaskFileIOSupplier fileIOSupplier;
   private static final String BATCH_SIZE_CONFIG_KEY = "TABLE_METADATA_CLEANUP_BATCH_SIZE";
 
   public TableCleanupTaskHandler(
       TaskExecutor taskExecutor,
+      Clock clock,
       MetaStoreManagerFactory metaStoreManagerFactory,
       TaskFileIOSupplier fileIOSupplier) {
     this.taskExecutor = taskExecutor;
+    this.clock = clock;
     this.metaStoreManagerFactory = metaStoreManagerFactory;
     this.fileIOSupplier = fileIOSupplier;
   }
@@ -183,7 +187,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
               return new TaskEntity.Builder()
                   .setName(taskName)
                   .setId(metaStoreManager.generateNewEntityId(polarisCallContext).getId())
-                  .setCreateTimestamp(polarisCallContext.getClock().millis())
+                  .setCreateTimestamp(clock.millis())
                   .withTaskType(AsyncTaskType.MANIFEST_FILE_CLEANUP)
                   .withData(
                       new ManifestFileCleanupTaskHandler.ManifestCleanupTask(
@@ -222,7 +226,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
               return new TaskEntity.Builder()
                   .setName(taskName)
                   .setId(metaStoreManager.generateNewEntityId(polarisCallContext).getId())
-                  .setCreateTimestamp(polarisCallContext.getClock().millis())
+                  .setCreateTimestamp(clock.millis())
                   .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
                   .withData(
                       new BatchFileCleanupTaskHandler.BatchFileCleanupTask(

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,6 +60,7 @@ public class TaskExecutorImpl implements TaskExecutor {
   private static final long TASK_RETRY_DELAY = 1000;
 
   private final Executor executor;
+  private final Clock clock;
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final TaskFileIOSupplier fileIOSupplier;
   private final List<TaskHandler> taskHandlers = new CopyOnWriteArrayList<>();
@@ -67,17 +69,19 @@ public class TaskExecutorImpl implements TaskExecutor {
 
   @SuppressWarnings("unused") // Required by CDI
   protected TaskExecutorImpl() {
-    this(null, null, null, null, null);
+    this(null, null, null, null, null, null);
   }
 
   @Inject
   public TaskExecutorImpl(
       @Identifier("task-executor") Executor executor,
+      Clock clock,
       MetaStoreManagerFactory metaStoreManagerFactory,
       TaskFileIOSupplier fileIOSupplier,
       PolarisEventListener polarisEventListener,
       @Nullable Tracer tracer) {
     this.executor = executor;
+    this.clock = clock;
     this.metaStoreManagerFactory = metaStoreManagerFactory;
     this.fileIOSupplier = fileIOSupplier;
     this.polarisEventListener = polarisEventListener;
@@ -86,7 +90,8 @@ public class TaskExecutorImpl implements TaskExecutor {
 
   @Startup
   public void init() {
-    addTaskHandler(new TableCleanupTaskHandler(this, metaStoreManagerFactory, fileIOSupplier));
+    addTaskHandler(
+        new TableCleanupTaskHandler(this, clock, metaStoreManagerFactory, fileIOSupplier));
     addTaskHandler(
         new ManifestFileCleanupTaskHandler(
             fileIOSupplier, Executors.newVirtualThreadPerTaskExecutor()));

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -30,7 +30,6 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
-import java.time.Clock;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -184,7 +183,6 @@ public abstract class PolarisAuthzTestBase {
   @Inject protected CallContextCatalogFactory callContextCatalogFactory;
   @Inject protected UserSecretsManagerFactory userSecretsManagerFactory;
   @Inject protected PolarisDiagnostics diagServices;
-  @Inject protected Clock clock;
   @Inject protected FileIOFactory fileIOFactory;
   @Inject protected PolarisEventListener polarisEventListener;
   @Inject protected CatalogHandlerUtils catalogHandlerUtils;
@@ -233,8 +231,7 @@ public abstract class PolarisAuthzTestBase {
             realmContext,
             managerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            clock);
+            configurationStore);
 
     callContext = polarisContext;
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/JWTRSAKeyPairTest.java
@@ -54,7 +54,7 @@ public class JWTRSAKeyPairTest {
     final String scope = "PRINCIPAL_ROLE:TEST";
 
     PolarisCallContext polarisCallContext =
-        new PolarisCallContext(null, null, null, configurationStore, null);
+        new PolarisCallContext(null, null, null, configurationStore);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "client-secret";
     PolarisPrincipalSecrets principalSecrets =

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/JWTSymmetricKeyGeneratorTest.java
@@ -41,7 +41,7 @@ public class JWTSymmetricKeyGeneratorTest {
   /** Sanity test to verify that we can generate a token */
   @Test
   public void testJWTSymmetricKeyGenerator() {
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null, null, null);
+    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null, null);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "test_secret";
     String clientId = "test_client_id";

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogTest.java
@@ -221,6 +221,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
           CatalogProperties.TABLE_OVERRIDE_PREFIX + "override-key4",
           "catalog-override-key4");
 
+  @Inject Clock clock;
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisConfigurationStore configurationStore;
   @Inject StorageCredentialCache storageCredentialCache;
@@ -277,8 +278,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             realmContext,
             metaStoreManagerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            Clock.systemDefaultZone());
+            configurationStore);
 
     EntityCache entityCache = createEntityCache(polarisContext.getRealmConfig(), metaStoreManager);
     resolverFactory =
@@ -2029,7 +2029,8 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             });
 
     TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(Mockito.mock(), metaStoreManagerFactory, taskFileIOSupplier);
+        new TableCleanupTaskHandler(
+            Mockito.mock(), clock, metaStoreManagerFactory, taskFileIOSupplier);
     handler.handleTask(taskEntity, polarisContext);
     Assertions.assertThat(measured.getNumDeletedFiles()).as("A table was deleted").isGreaterThan(0);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogViewTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
-import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -160,8 +159,7 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
             realmContext,
             metaStoreManagerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            Clock.systemDefaultZone());
+            configurationStore);
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolarisGenericTableCatalogTest.java
@@ -28,7 +28,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,8 +151,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            Clock.systemDefaultZone());
+            configurationStore);
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolicyCatalogTest.java
@@ -34,7 +34,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -175,8 +174,7 @@ public abstract class AbstractPolicyCatalogTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            Clock.systemDefaultZone());
+            configurationStore);
 
     callContext = polarisContext;
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Clock;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
@@ -51,6 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class CatalogEntityTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  private final Clock clock = Clock.systemUTC();
   private final PolarisDiagnostics diagnostics = new PolarisDefaultDiagServiceImpl();
   private CallContext callContext;
 
@@ -58,7 +60,7 @@ public class CatalogEntityTest {
   public void setup() {
     RealmContext realmContext = () -> "realm";
     MetaStoreManagerFactory metaStoreManagerFactory =
-        new InMemoryPolarisMetaStoreManagerFactory(null, diagnostics);
+        new InMemoryPolarisMetaStoreManagerFactory(clock, diagnostics, null);
     BasePersistence metaStore = metaStoreManagerFactory.getOrCreateSession(realmContext);
     this.callContext = new PolarisCallContext(realmContext, metaStore, diagnostics);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 
 @QuarkusTest
 class TableCleanupTaskHandlerTest {
+  @Inject Clock clock;
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisConfigurationStore configurationStore;
   @Inject PolarisDiagnostics diagServices;
@@ -68,8 +69,10 @@ class TableCleanupTaskHandlerTest {
 
   private final RealmContext realmContext = () -> "realmName";
 
-  private TaskFileIOSupplier buildTaskFileIOSupplier(FileIO fileIO) {
-    return new TaskFileIOSupplier(new TestFileIOFactory(fileIO));
+  private TableCleanupTaskHandler newTableCleanupTaskHandler(FileIO fileIO) {
+    TaskFileIOSupplier taskFileIOSupplier = new TaskFileIOSupplier(new TestFileIOFactory(fileIO));
+    return new TableCleanupTaskHandler(
+        Mockito.mock(), clock, metaStoreManagerFactory, taskFileIOSupplier);
   }
 
   @BeforeEach
@@ -81,17 +84,14 @@ class TableCleanupTaskHandlerTest {
             realmContext,
             metaStoreManagerFactory.getOrCreateSession(realmContext),
             diagServices,
-            configurationStore,
-            Clock.systemDefaultZone());
+            configurationStore);
   }
 
   @Test
   public void testTableCleanup() throws IOException {
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
-    TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(
-            Mockito.mock(), metaStoreManagerFactory, buildTaskFileIOSupplier(fileIO));
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
     long snapshotId = 100L;
     ManifestFile manifestFile =
         TaskTestUtils.manifestFile(
@@ -166,9 +166,7 @@ class TableCleanupTaskHandlerTest {
           }
         };
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
-    TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(
-            Mockito.mock(), metaStoreManagerFactory, buildTaskFileIOSupplier(fileIO));
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
     long snapshotId = 100L;
     ManifestFile manifestFile =
         TaskTestUtils.manifestFile(
@@ -226,9 +224,7 @@ class TableCleanupTaskHandlerTest {
           }
         };
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
-    TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(
-            Mockito.mock(), metaStoreManagerFactory, buildTaskFileIOSupplier(fileIO));
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
     long snapshotId = 100L;
     ManifestFile manifestFile =
         TaskTestUtils.manifestFile(
@@ -318,9 +314,7 @@ class TableCleanupTaskHandlerTest {
   public void testTableCleanupMultipleSnapshots() throws IOException {
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
-    TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(
-            Mockito.mock(), metaStoreManagerFactory, buildTaskFileIOSupplier(fileIO));
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
     long snapshotId1 = 100L;
     ManifestFile manifestFile1 =
         TaskTestUtils.manifestFile(
@@ -461,9 +455,7 @@ class TableCleanupTaskHandlerTest {
   public void testTableCleanupMultipleMetadata() throws IOException {
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
-    TableCleanupTaskHandler handler =
-        new TableCleanupTaskHandler(
-            Mockito.mock(), metaStoreManagerFactory, buildTaskFileIOSupplier(fileIO));
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
     long snapshotId1 = 100L;
     ManifestFile manifestFile1 =
         TaskTestUtils.manifestFile(

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -55,7 +55,7 @@ public class TaskExecutorImplTest {
         new TaskEntity.Builder()
             .setName("mytask")
             .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
-            .setCreateTimestamp(polarisCallCtx.getClock().millis())
+            .setCreateTimestamp(testServices.clock().millis())
             .build();
     metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
 
@@ -64,6 +64,7 @@ public class TaskExecutorImplTest {
     TaskExecutorImpl executor =
         new TaskExecutorImpl(
             Runnable::run,
+            testServices.clock(),
             testServices.metaStoreManagerFactory(),
             new TaskFileIOSupplier(testServices.fileIOFactory()),
             testServices.polarisEventListener(),

--- a/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestFixture.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestFixture.java
@@ -110,11 +110,7 @@ public class PolarisIntegrationTestFixture {
         helper.metaStoreManagerFactory.getOrCreateSession(realmContext);
     PolarisCallContext polarisContext =
         new PolarisCallContext(
-            realmContext,
-            metaStoreSession,
-            helper.diagServices,
-            helper.configurationStore,
-            helper.clock);
+            realmContext, metaStoreSession, helper.diagServices, helper.configurationStore);
     PolarisMetaStoreManager metaStoreManager =
         helper.metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     PrincipalEntity principal = metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();

--- a/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestHelper.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestHelper.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.time.Clock;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
@@ -36,7 +35,6 @@ public class PolarisIntegrationTestHelper {
   @Inject ObjectMapper objectMapper;
   @Inject PolarisDiagnostics diagServices;
   @Inject PolarisConfigurationStore configurationStore;
-  @Inject Clock clock;
 
   public PolarisIntegrationTestFixture createFixture(TestEnvironment testEnv, TestInfo testInfo) {
     return new PolarisIntegrationTestFixture(this, testEnv, testInfo);


### PR DESCRIPTION
the Clock is application scoped and thus should not be put into any
realm or call specific context class.

since there were only a handful of callers this is a good opportunity to add constructors to
the `MetaStoreManager` impls.