### PR TITLE
Use injected PolarisDiagnostics in MetaStoreManagerFactory impls

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
@@ -68,8 +67,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   final Map<String, PolarisMetaStoreManager> metaStoreManagerMap = new HashMap<>();
   final Map<String, EntityCache> entityCacheMap = new HashMap<>();
   final Map<String, Supplier<BasePersistence>> sessionSupplierMap = new HashMap<>();
-  protected final PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
 
+  @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject Instance<DataSource> dataSource;
   @Inject RelationalJdbcConfiguration relationalJdbcConfiguration;
@@ -176,7 +175,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
       BasePersistence session = getOrCreateSession(realmContext);
 
-      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagServices);
+      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagnostics);
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
@@ -233,7 +232,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         metaStoreManagerMap.get(realmContext.getRealmIdentifier());
     BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
     PolarisCallContext polarisContext =
-        new PolarisCallContext(realmContext, metaStore, diagServices);
+        new PolarisCallContext(realmContext, metaStore, diagnostics);
 
     Optional<PrincipalEntity> preliminaryRootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext);
@@ -268,7 +267,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         metaStoreManagerMap.get(realmContext.getRealmIdentifier());
     BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
     PolarisCallContext polarisContext =
-        new PolarisCallContext(realmContext, metaStore, diagServices);
+        new PolarisCallContext(realmContext, metaStore, diagnostics);
 
     Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(polarisContext);
     if (rootPrincipal.isEmpty()) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
@@ -53,7 +52,6 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
   final Map<String, EntityCache> entityCacheMap = new HashMap<>();
   final Map<String, StoreType> backingStoreMap = new HashMap<>();
   final Map<String, Supplier<TransactionalPersistence>> sessionSupplierMap = new HashMap<>();
-  protected final PolarisDiagnostics diagServices = new PolarisDefaultDiagServiceImpl();
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(LocalPolarisMetaStoreManagerFactory.class);
@@ -128,7 +126,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
       TransactionalPersistence session = getOrCreateSession(realmContext);
 
-      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagServices);
+      PolarisCallContext callContext = new PolarisCallContext(realmContext, session, diagnostics);
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
@@ -184,7 +182,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         metaStoreManagerMap.get(realmContext.getRealmIdentifier());
     BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
     PolarisCallContext polarisContext =
-        new PolarisCallContext(realmContext, metaStore, diagServices);
+        new PolarisCallContext(realmContext, metaStore, diagnostics);
 
     Optional<PrincipalEntity> preliminaryRootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext);
@@ -219,7 +217,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         metaStoreManagerMap.get(realmContext.getRealmIdentifier());
     BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
     PolarisCallContext polarisContext =
-        new PolarisCallContext(realmContext, metaStore, diagServices);
+        new PolarisCallContext(realmContext, metaStore, diagnostics);
 
     Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(polarisContext);
     if (rootPrincipal.isEmpty()) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
@@ -35,8 +35,9 @@ import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 public class InMemoryAtomicOperationMetaStoreManagerFactory
     extends InMemoryPolarisMetaStoreManagerFactory {
 
-  public InMemoryAtomicOperationMetaStoreManagerFactory() {
-    super(null, null);
+  @SuppressWarnings("unused") // Required by CDI
+  protected InMemoryAtomicOperationMetaStoreManagerFactory() {
+    this(null, null);
   }
 
   @Inject

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -46,7 +46,8 @@ public class InMemoryPolarisMetaStoreManagerFactory
   private final PolarisStorageIntegrationProvider storageIntegration;
   private final Set<String> bootstrappedRealms = new HashSet<>();
 
-  public InMemoryPolarisMetaStoreManagerFactory() {
+  @SuppressWarnings("unused") // Required by CDI
+  protected InMemoryPolarisMetaStoreManagerFactory() {
     this(null, null);
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -66,7 +66,7 @@ public class TaskExecutorImpl implements TaskExecutor {
   @Nullable private final Tracer tracer;
 
   @SuppressWarnings("unused") // Required by CDI
-  public TaskExecutorImpl() {
+  protected TaskExecutorImpl() {
     this(null, null, null, null, null);
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -461,8 +461,9 @@ public abstract class PolarisAuthzTestBase {
   public static class TestPolarisCallContextCatalogFactory
       extends PolarisCallContextCatalogFactory {
 
-    public TestPolarisCallContextCatalogFactory() {
-      super(null, null, null, null, null, null);
+    @SuppressWarnings("unused") // Required by CDI
+    protected TestPolarisCallContextCatalogFactory() {
+      this(null, null, null, null, null, null);
     }
 
     @Inject

--- a/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -36,6 +37,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.assertj.core.api.Assertions;
@@ -49,18 +51,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class CatalogEntityTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  private final PolarisDiagnostics diagnostics = new PolarisDefaultDiagServiceImpl();
   private CallContext callContext;
 
   @BeforeEach
   public void setup() {
-    MetaStoreManagerFactory metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
     RealmContext realmContext = () -> "realm";
-    PolarisCallContext polarisCallContext =
-        new PolarisCallContext(
-            realmContext,
-            metaStoreManagerFactory.getOrCreateSession(realmContext),
-            new PolarisDefaultDiagServiceImpl());
-    this.callContext = polarisCallContext;
+    MetaStoreManagerFactory metaStoreManagerFactory =
+        new InMemoryPolarisMetaStoreManagerFactory(null, diagnostics);
+    BasePersistence metaStore = metaStoreManagerFactory.getOrCreateSession(realmContext);
+    this.callContext = new PolarisCallContext(realmContext, metaStore, diagnostics);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
`new PolarisDefaultDiagServiceImpl()` should not be used anywhere in production code outside of `QuarkusProducers`, as it turns out a `PolarisDiagnostics` instance already was getting injected.

this actually required fixing the setup in `CatalogEntityTest` so that we dont pass in `null`.

for clarity we mark ctors that only exist for CDI as protected so that they dont get used by tests accidentally.