### PR TITLE
Remove `PolarisCallContext` from `BasePersistence` et al

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/EclipseLinkPolarisMetaStoreManagerFactory.java
@@ -66,6 +66,7 @@ public class EclipseLinkPolarisMetaStoreManagerFactory
       @Nullable RootCredentialsSet rootCredentialsSet,
       @Nonnull PolarisDiagnostics diagnostics) {
     return new PolarisEclipseLinkMetaStoreSessionImpl(
+        diagnostics,
         store,
         storageIntegrationProvider,
         realmContext,

--- a/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
+++ b/persistence/eclipselink/src/test/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreManagerTest.java
@@ -88,7 +88,7 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     RealmContext realmContext = () -> "realm";
     PolarisEclipseLinkMetaStoreSessionImpl session =
         new PolarisEclipseLinkMetaStoreSessionImpl(
-            store, Mockito.mock(), realmContext, null, "polaris", RANDOM_SECRETS);
+            diagServices, store, Mockito.mock(), realmContext, null, "polaris", RANDOM_SECRETS);
     return new PolarisTestMetaStoreManager(
         new TransactionalMetaStoreManagerImpl(),
         new PolarisCallContext(
@@ -110,7 +110,13 @@ public class PolarisEclipseLinkMetaStoreManagerTest extends BasePolarisMetaStore
     try {
       var session =
           new PolarisEclipseLinkMetaStoreSessionImpl(
-              store, Mockito.mock(), () -> "realm", confFile, "polaris", RANDOM_SECRETS);
+              diagServices,
+              store,
+              Mockito.mock(),
+              () -> "realm",
+              confFile,
+              "polaris",
+              RANDOM_SECRETS);
       assertNotNull(session);
       assertTrue(success);
     } catch (Exception e) {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -76,6 +76,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcBasePersistenceImpl.class);
 
+  private final PolarisDiagnostics diagnostics;
   private final DatasourceOperations datasourceOperations;
   private final PrincipalSecretsGenerator secretsGenerator;
   private final PolarisStorageIntegrationProvider storageIntegrationProvider;
@@ -86,10 +87,12 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   private static final int MAX_LOCATION_COMPONENTS = 40;
 
   public JdbcBasePersistenceImpl(
+      PolarisDiagnostics diagnostics,
       DatasourceOperations databaseOperations,
       PrincipalSecretsGenerator secretsGenerator,
       PolarisStorageIntegrationProvider storageIntegrationProvider,
       String realmId) {
+    this.diagnostics = diagnostics;
     this.datasourceOperations = databaseOperations;
     this.secretsGenerator = secretsGenerator;
     this.storageIntegrationProvider = storageIntegrationProvider;
@@ -98,25 +101,21 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public long generateNewId(@Nonnull PolarisCallContext callCtx) {
+  public long generateNewId() {
     return IdGenerator.getIdGenerator().nextId();
   }
 
   @Override
   public void writeEntity(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       boolean nameOrParentChanged,
       PolarisBaseEntity originalEntity) {
     try {
       persistEntity(
-          callCtx,
           entity,
           originalEntity,
           null,
-          (connection, preparedQuery) -> {
-            return datasourceOperations.executeUpdate(preparedQuery);
-          });
+          (connection, preparedQuery) -> datasourceOperations.executeUpdate(preparedQuery));
     } catch (SQLException e) {
       throw new RuntimeException("Error persisting entity", e);
     }
@@ -124,9 +123,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void writeEntities(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull List<PolarisBaseEntity> entities,
-      List<PolarisBaseEntity> originalEntities) {
+      @Nonnull List<PolarisBaseEntity> entities, List<PolarisBaseEntity> originalEntities) {
     try {
       datasourceOperations.runWithinTransaction(
           connection -> {
@@ -137,16 +134,14 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               // first, check if the entity has already been created, in which case we will simply
               // return it.
               PolarisBaseEntity entityFound =
-                  lookupEntity(
-                      callCtx, entity.getCatalogId(), entity.getId(), entity.getTypeCode());
+                  lookupEntity(entity.getCatalogId(), entity.getId(), entity.getTypeCode());
               if (entityFound != null && originalEntity == null) {
                 // probably the client retried, simply return it
                 // TODO: Check correctness of returning entityFound vs entity here. It may have
                 // already been updated after the creation.
                 continue;
               }
-              persistEntity(
-                  callCtx, entity, originalEntity, connection, datasourceOperations::execute);
+              persistEntity(entity, originalEntity, connection, datasourceOperations::execute);
             }
             return true;
           });
@@ -159,7 +154,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   private void persistEntity(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       PolarisBaseEntity originalEntity,
       Connection connection,
@@ -178,7 +172,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         if (datasourceOperations.isConstraintViolation(e)) {
           PolarisBaseEntity existingEntity =
               lookupEntityByName(
-                  callCtx,
                   entity.getCatalogId(),
                   entity.getParentId(),
                   entity.getTypeCode(),
@@ -221,8 +214,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void writeToGrantRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec) {
+  public void writeToGrantRecords(@Nonnull PolarisGrantRecord grantRec) {
     ModelGrantRecord modelGrantRecord = ModelGrantRecord.fromGrantRecord(grantRec);
     try {
       List<Object> values =
@@ -237,7 +229,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteEntity(@Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity entity) {
+  public void deleteEntity(@Nonnull PolarisBaseEntity entity) {
     ModelEntity modelEntity = ModelEntity.fromEntity(entity);
     Map<String, Object> params =
         Map.of(
@@ -258,8 +250,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteFromGrantRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec) {
+  public void deleteFromGrantRecords(@Nonnull PolarisGrantRecord grantRec) {
     ModelGrantRecord modelGrantRecord = ModelGrantRecord.fromGrantRecord(grantRec);
     try {
       Map<String, Object> whereClause =
@@ -276,7 +267,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteAllEntityGrantRecords(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisEntityCore entity,
       @Nonnull List<PolarisGrantRecord> grantsOnGrantee,
       @Nonnull List<PolarisGrantRecord> grantsOnSecurable) {
@@ -290,7 +280,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteAll(@Nonnull PolarisCallContext callCtx) {
+  public void deleteAll() {
     try {
       Map<String, Object> params = Map.of("realm_id", realmId);
       datasourceOperations.runWithinTransaction(
@@ -324,8 +314,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public PolarisBaseEntity lookupEntity(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode) {
+  public PolarisBaseEntity lookupEntity(long catalogId, long entityId, int typeCode) {
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "type_code", typeCode, "realm_id", realmId);
     return getPolarisBaseEntity(
@@ -335,11 +324,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public PolarisBaseEntity lookupEntityByName(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      int typeCode,
-      @Nonnull String name) {
+      long catalogId, long parentId, int typeCode, @Nonnull String name) {
     Map<String, Object> params =
         Map.of(
             "catalog_id",
@@ -379,8 +364,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Nonnull
   @Override
-  public List<PolarisBaseEntity> lookupEntities(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
+  public List<PolarisBaseEntity> lookupEntities(List<PolarisEntityId> entityIds) {
     if (entityIds == null || entityIds.isEmpty()) return new ArrayList<>();
     PreparedQuery query = QueryGenerator.generateSelectQueryWithEntityIds(realmId, entityIds);
     try {
@@ -393,10 +377,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Nonnull
   @Override
-  public List<PolarisChangeTrackingVersions> lookupEntityVersions(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
+  public List<PolarisChangeTrackingVersions> lookupEntityVersions(List<PolarisEntityId> entityIds) {
     Map<PolarisEntityId, ModelEntity> idToEntityMap =
-        lookupEntities(callCtx, entityIds).stream()
+        lookupEntities(entityIds).stream()
             .collect(
                 Collectors.toMap(
                     entry -> new PolarisEntityId(entry.getCatalogId(), entry.getId()),
@@ -416,44 +399,29 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       @Nonnull PolarisEntityType entityType,
       @Nonnull PageToken pageToken) {
     return listEntities(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entity -> true,
-        EntityNameLookupRecord::new,
-        pageToken);
+        catalogId, parentId, entityType, entity -> true, EntityNameLookupRecord::new, pageToken);
   }
 
   @Nonnull
   @Override
   public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       @Nonnull PolarisEntityType entityType,
       @Nonnull Predicate<PolarisBaseEntity> entityFilter,
       @Nonnull PageToken pageToken) {
     return listEntities(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entityFilter,
-        EntityNameLookupRecord::new,
-        pageToken);
+        catalogId, parentId, entityType, entityFilter, EntityNameLookupRecord::new, pageToken);
   }
 
   @Nonnull
   @Override
   public <T> Page<T> listEntities(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       PolarisEntityType entityType,
@@ -512,8 +480,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public int lookupEntityGrantRecordsVersion(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId) {
+  public int lookupEntityGrantRecordsVersion(long catalogId, long entityId) {
 
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "realm_id", realmId);
@@ -526,7 +493,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public PolarisGrantRecord lookupGrantRecord(
-      @Nonnull PolarisCallContext callCtx,
       long securableCatalogId,
       long securableId,
       long granteeCatalogId,
@@ -569,7 +535,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisGrantRecord> loadAllGrantRecordsOnSecurable(
-      @Nonnull PolarisCallContext callCtx, long securableCatalogId, long securableId) {
+      long securableCatalogId, long securableId) {
     Map<String, Object> params =
         Map.of(
             "securable_catalog_id",
@@ -597,7 +563,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisGrantRecord> loadAllGrantRecordsOnGrantee(
-      @Nonnull PolarisCallContext callCtx, long granteeCatalogId, long granteeId) {
+      long granteeCatalogId, long granteeId) {
     Map<String, Object> params =
         Map.of(
             "grantee_catalog_id", granteeCatalogId, "grantee_id", granteeId, "realm_id", realmId);
@@ -618,11 +584,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public boolean hasChildren(
-      @Nonnull PolarisCallContext callContext,
-      PolarisEntityType optionalEntityType,
-      long catalogId,
-      long parentId) {
+  public boolean hasChildren(PolarisEntityType optionalEntityType, long catalogId, long parentId) {
     Map<String, Object> params = new HashMap<>();
     params.put("realm_id", realmId);
     params.put("catalog_id", catalogId);
@@ -663,8 +625,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   /** {@inheritDoc} */
   @Override
   public <T extends PolarisEntity & LocationBasedEntity>
-      Optional<Optional<String>> hasOverlappingSiblings(
-          @Nonnull PolarisCallContext callContext, T entity) {
+      Optional<Optional<String>> hasOverlappingSiblings(T entity) {
     if (this.version < 2) {
       return Optional.empty();
     }
@@ -705,8 +666,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Nullable
   @Override
-  public PolarisPrincipalSecrets loadPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId) {
+  public PolarisPrincipalSecrets loadPrincipalSecrets(@Nonnull String clientId) {
     Map<String, Object> params = Map.of("principal_client_id", clientId, "realm_id", realmId);
     try {
       var results =
@@ -731,7 +691,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public PolarisPrincipalSecrets generateNewPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String principalName, long principalId) {
+      @Nonnull String principalName, long principalId) {
     // ensure principal client id is unique
     PolarisPrincipalSecrets principalSecrets;
     ModelPrincipalAuthenticationData lookupPrincipalSecrets;
@@ -742,7 +702,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       // load the existing secrets
       lookupPrincipalSecrets =
           ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(
-              loadPrincipalSecrets(callCtx, principalSecrets.getPrincipalClientId()));
+              loadPrincipalSecrets(principalSecrets.getPrincipalClientId()));
     } while (lookupPrincipalSecrets != null);
 
     lookupPrincipalSecrets =
@@ -777,33 +737,25 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash) {
+      @Nonnull String clientId, long principalId, boolean reset, @Nonnull String oldSecretHash) {
     // load the existing secrets
-    PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
+    PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(clientId);
 
     // should be found
-    callCtx
-        .getDiagServices()
-        .checkNotNull(
-            principalSecrets,
-            "cannot_find_secrets",
-            "client_id={} principalId={}",
-            clientId,
-            principalId);
+    diagnostics.checkNotNull(
+        principalSecrets,
+        "cannot_find_secrets",
+        "client_id={} principalId={}",
+        clientId,
+        principalId);
 
     // ensure principal id is matching
-    callCtx
-        .getDiagServices()
-        .check(
-            principalId == principalSecrets.getPrincipalId(),
-            "principal_id_mismatch",
-            "expectedId={} id={}",
-            principalId,
-            principalSecrets.getPrincipalId());
+    diagnostics.check(
+        principalId == principalSecrets.getPrincipalId(),
+        "principal_id_mismatch",
+        "expectedId={} id={}",
+        principalId,
+        principalSecrets.getPrincipalId());
 
     // rotate the secrets
     principalSecrets.rotateSecrets(oldSecretHash);
@@ -840,8 +792,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deletePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId, long principalId) {
+  public void deletePrincipalSecrets(@Nonnull String clientId, long principalId) {
     Map<String, Object> params =
         Map.of("principal_client_id", clientId, "principal_id", principalId, "realm_id", realmId);
     try {
@@ -862,8 +813,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void writeToPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+  public void writeToPolicyMappingRecords(@Nonnull PolarisPolicyMappingRecord record) {
     try {
       datasourceOperations.runWithinTransaction(
           connection -> {
@@ -885,7 +835,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
                     values,
                     realmId);
             if (policyType.isInheritable()) {
-              return handleInheritablePolicy(callCtx, record, insertPolicyMappingQuery, connection);
+              return handleInheritablePolicy(record, insertPolicyMappingQuery, connection);
             } else {
               datasourceOperations.execute(connection, insertPolicyMappingQuery);
             }
@@ -898,14 +848,13 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   private boolean handleInheritablePolicy(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisPolicyMappingRecord record,
       @Nonnull PreparedQuery insertQuery,
       Connection connection)
       throws SQLException {
     List<PolarisPolicyMappingRecord> existingRecords =
         loadPoliciesOnTargetByType(
-            callCtx, record.getTargetCatalogId(), record.getTargetId(), record.getPolicyTypeCode());
+            record.getTargetCatalogId(), record.getTargetId(), record.getPolicyTypeCode());
     if (existingRecords.size() > 1) {
       throw new PolicyMappingAlreadyExistsException(existingRecords.getFirst());
     } else if (existingRecords.size() == 1) {
@@ -952,8 +901,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteFromPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+  public void deleteFromPolicyMappingRecords(@Nonnull PolarisPolicyMappingRecord record) {
     var modelPolicyMappingRecord = ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
     try {
       Map<String, Object> objectMap =
@@ -972,7 +920,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteAllEntityPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
@@ -1002,7 +949,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPolicyMappingRecord lookupPolicyMappingRecord(
-      @Nonnull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,
       int policyTypeCode,
@@ -1033,10 +979,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
-      @Nonnull PolarisCallContext callCtx,
-      long targetCatalogId,
-      long targetId,
-      int policyTypeCode) {
+      long targetCatalogId, long targetId, int policyTypeCode) {
     Map<String, Object> params =
         Map.of(
             "target_catalog_id",
@@ -1055,7 +998,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllPoliciesOnTarget(
-      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+      long targetCatalogId, long targetId) {
     Map<String, Object> params =
         Map.of("target_catalog_id", targetCatalogId, "target_id", targetId, "realm_id", realmId);
     return fetchPolicyMappingRecords(
@@ -1066,10 +1009,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nonnull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx,
-      long policyCatalogId,
-      long policyId,
-      int policyTypeCode) {
+      long policyCatalogId, long policyId, int policyTypeCode) {
     Map<String, Object> params =
         Map.of(
             "policy_type_code",
@@ -1100,7 +1040,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegration(
-          @Nonnull PolarisCallContext callCtx,
           long catalogId,
           long entityId,
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
@@ -1110,7 +1049,6 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public <T extends PolarisStorageConfigurationInfo> void persistStorageIntegrationIfNeeded(
-      @Nonnull PolarisCallContext callContext,
       @Nonnull PolarisBaseEntity entity,
       @Nullable PolarisStorageIntegration<T> storageIntegration) {}
 
@@ -1118,9 +1056,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegration(
-          @Nonnull PolarisCallContext callContext, @Nonnull PolarisBaseEntity entity) {
+          @Nonnull PolarisBaseEntity entity) {
     PolarisStorageConfigurationInfo storageConfig =
-        BaseMetaStoreManager.extractStorageConfiguration(callContext.getDiagServices(), entity);
+        BaseMetaStoreManager.extractStorageConfiguration(diagnostics, entity);
     return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -100,6 +100,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         realmId,
         () ->
             new JdbcBasePersistenceImpl(
+                diagServices,
                 datasourceOperations,
                 secretsGenerator(realmId, rootCredentialsSet),
                 storageIntegrationProvider,

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -65,6 +65,7 @@ public class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
     RealmContext realmContext = () -> "REALM";
     JdbcBasePersistenceImpl basePersistence =
         new JdbcBasePersistenceImpl(
+            diagServices,
             datasourceOperations,
             RANDOM_SECRETS,
             Mockito.mock(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -100,7 +100,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     try {
       // write it
-      ms.writeEntity(callCtx, entity, true, null);
+      ms.writeEntity(entity, true, null);
     } catch (EntityAlreadyExistsException e) {
       if (e.getExistingEntity().getId() == entity.getId()) {
         // Since ids are unique and reserved when generated, a matching id means a low-level retry
@@ -142,7 +142,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         prepareToPersistEntityAfterChange(callCtx, ms, entity, nameOrParentChanged, originalEntity);
 
     // persist it to the various slices
-    ms.writeEntity(callCtx, entity, nameOrParentChanged, originalEntity);
+    ms.writeEntity(entity, nameOrParentChanged, originalEntity);
 
     // return it
     return entity;
@@ -176,7 +176,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // Remove the main entity itself first-thing; once its id no longer resolves successfully
     // it will be pruned out of any grant-record lookups anyways.
-    ms.deleteEntity(callCtx, entity);
+    ms.deleteEntity(entity);
 
     // Best-effort cleanup - drop grant records, update grantRecordVersions for affected
     // other entities.
@@ -190,11 +190,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // delete ALL grant records to (if the entity is a grantee) and from that entity
     final List<PolarisGrantRecord> grantsOnGrantee =
         (entity.getType().isGrantee())
-            ? ms.loadAllGrantRecordsOnGrantee(callCtx, entity.getCatalogId(), entity.getId())
+            ? ms.loadAllGrantRecordsOnGrantee(entity.getCatalogId(), entity.getId())
             : List.of();
     final List<PolarisGrantRecord> grantsOnSecurable =
-        ms.loadAllGrantRecordsOnSecurable(callCtx, entity.getCatalogId(), entity.getId());
-    ms.deleteAllEntityGrantRecords(callCtx, entity, grantsOnGrantee, grantsOnSecurable);
+        ms.loadAllGrantRecordsOnSecurable(entity.getCatalogId(), entity.getId());
+    ms.deleteAllEntityGrantRecords(entity, grantsOnGrantee, grantsOnSecurable);
 
     if (entity.getType() == PolarisEntityType.POLICY
         || PolicyMappingUtil.isValidTargetEntityType(entity.getType(), entity.getSubType())) {
@@ -206,7 +206,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         final List<PolarisPolicyMappingRecord> mappingOnPolicy =
             (entity.getType() == PolarisEntityType.POLICY)
                 ? ms.loadAllTargetsOnPolicy(
-                    callCtx,
                     entity.getCatalogId(),
                     entity.getId(),
                     PolicyEntity.of(entity).getPolicyTypeCode())
@@ -214,8 +213,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         final List<PolarisPolicyMappingRecord> mappingOnTarget =
             (entity.getType() == PolarisEntityType.POLICY)
                 ? List.of()
-                : ms.loadAllPoliciesOnTarget(callCtx, entity.getCatalogId(), entity.getId());
-        ms.deleteAllEntityPolicyMappingRecords(callCtx, entity, mappingOnTarget, mappingOnPolicy);
+                : ms.loadAllPoliciesOnTarget(entity.getCatalogId(), entity.getId());
+        ms.deleteAllEntityPolicyMappingRecords(entity, mappingOnTarget, mappingOnPolicy);
       } catch (UnsupportedOperationException e) {
         // Policy mapping persistence not implemented, but we should not block dropping entities
       }
@@ -235,12 +234,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                 new PolarisEntityId(gr.getGranteeCatalogId(), gr.getGranteeId())));
 
     // Bump up the grant version of these entities
-    List<PolarisBaseEntity> entities =
-        ms.lookupEntities(callCtx, new ArrayList<>(entityIdsGrantChanged));
+    List<PolarisBaseEntity> entities = ms.lookupEntities(new ArrayList<>(entityIdsGrantChanged));
     for (PolarisBaseEntity originalEntity : entities) {
       PolarisBaseEntity entityGrantChanged =
           originalEntity.withGrantRecordsVersion(originalEntity.getGrantRecordsVersion() + 1);
-      ms.writeEntity(callCtx, entityGrantChanged, false, originalEntity);
+      ms.writeEntity(entityGrantChanged, false, originalEntity);
     }
 
     // if it is a principal, we also need to drop the secrets
@@ -252,7 +250,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       String clientId = properties.get(PolarisEntityConstants.getClientIdPropertyName());
 
       // delete it from the secret slice
-      ((IntegrationPersistence) ms).deletePrincipalSecrets(callCtx, clientId, entity.getId());
+      ((IntegrationPersistence) ms).deletePrincipalSecrets(clientId, entity.getId());
     }
   }
 
@@ -294,32 +292,31 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             priv.getCode());
 
     // persist the new grant
-    ms.writeToGrantRecords(callCtx, grantRecord);
+    ms.writeToGrantRecords(grantRecord);
 
     // load the grantee (either a catalog/principal role or a principal) and increment its grants
     // version
     PolarisBaseEntity granteeEntity =
-        ms.lookupEntity(callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
+        ms.lookupEntity(grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedGranteeEntity =
         granteeEntity.withGrantRecordsVersion(granteeEntity.getGrantRecordsVersion() + 1);
-    ms.writeEntity(callCtx, updatedGranteeEntity, false, granteeEntity);
+    ms.writeEntity(updatedGranteeEntity, false, granteeEntity);
 
     // we also need to invalidate the grants on that securable so that we can reload them.
     // load the securable and increment its grants version
     PolarisBaseEntity securableEntity =
-        ms.lookupEntity(
-            callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
+        ms.lookupEntity(securable.getCatalogId(), securable.getId(), securable.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(securableEntity, "securable_not_found", "securable={}", securable);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedSecurableEntity =
         securableEntity.withGrantRecordsVersion(securableEntity.getGrantRecordsVersion() + 1);
-    ms.writeEntity(callCtx, updatedSecurableEntity, false, securableEntity);
+    ms.writeEntity(updatedSecurableEntity, false, securableEntity);
 
     // TODO: Reorder and/or expose bulk update of both grantRecordsVersions and grant records. In
     // the meantime, cache can be disabled or configured with a short enough expiry time to
@@ -377,11 +374,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         .check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
 
     // remove that grant
-    ms.deleteFromGrantRecords(callCtx, grantRecord);
+    ms.deleteFromGrantRecords(grantRecord);
 
     // load the grantee and increment its grants version
     PolarisBaseEntity refreshGrantee =
-        ms.lookupEntity(callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
+        ms.lookupEntity(grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(
@@ -389,13 +386,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshGrantee =
         refreshGrantee.withGrantRecordsVersion(refreshGrantee.getGrantRecordsVersion() + 1);
-    ms.writeEntity(callCtx, updatedRefreshGrantee, false, refreshGrantee);
+    ms.writeEntity(updatedRefreshGrantee, false, refreshGrantee);
 
     // we also need to invalidate the grants on that securable so that we can reload them.
     // load the securable and increment its grants version
     PolarisBaseEntity refreshSecurable =
-        ms.lookupEntity(
-            callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
+        ms.lookupEntity(securable.getCatalogId(), securable.getId(), securable.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(
@@ -407,7 +403,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshSecurable =
         refreshSecurable.withGrantRecordsVersion(refreshSecurable.getGrantRecordsVersion() + 1);
-    ms.writeEntity(callCtx, updatedRefreshSecurable, false, refreshSecurable);
+    ms.writeEntity(updatedRefreshSecurable, false, refreshSecurable);
 
     // TODO: Reorder and/or expose bulk update of both grantRecordsVersions and grant records. In
     // the meantime, cache can be disabled or configured with a short enough expiry time to
@@ -438,7 +434,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       integration =
           ((IntegrationPersistence) ms)
               .createStorageIntegration(
-                  callCtx,
                   catalog.getCatalogId(),
                   catalog.getId(),
                   PolarisStorageConfigurationInfo.deserialize(storageConfigInfoStr));
@@ -451,7 +446,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // because same-id idempotent-retry collisions of this sort are necessarily sequential, so
     // there is no concurrency conflict for something else creating a catalog of this same id.
     PolarisBaseEntity refreshCatalog =
-        ms.lookupEntity(callCtx, catalog.getCatalogId(), catalog.getId(), catalog.getTypeCode());
+        ms.lookupEntity(catalog.getCatalogId(), catalog.getId(), catalog.getTypeCode());
 
     // if found, probably a retry, simply return the previously created catalog
     if (refreshCatalog != null) {
@@ -467,7 +462,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // lookup catalog admin role, should exist
       PolarisBaseEntity catalogAdminRole =
           ms.lookupEntityByName(
-              callCtx,
               refreshCatalog.getId(),
               refreshCatalog.getId(),
               PolarisEntityType.CATALOG_ROLE.getCode(),
@@ -482,7 +476,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // done, return the existing catalog
       return new CreateCatalogResult(refreshCatalog, catalogAdminRole);
     }
-    ((IntegrationPersistence) ms).persistStorageIntegrationIfNeeded(callCtx, catalog, integration);
+    ((IntegrationPersistence) ms).persistStorageIntegrationIfNeeded(catalog, integration);
 
     // now create and persist new catalog entity
     EntityResult lowLevelResult = this.persistNewEntity(callCtx, ms, catalog);
@@ -496,7 +490,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     }
 
     // create the catalog admin role for this new catalog
-    long adminRoleId = ms.generateNewId(callCtx);
+    long adminRoleId = ms.generateNewId();
     PolarisBaseEntity adminRole =
         new PolarisBaseEntity(
             catalog.getId(),
@@ -521,7 +515,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // lookup service admin role, should exist
       PolarisBaseEntity serviceAdminRole =
           ms.lookupEntityByName(
-              callCtx,
               PolarisEntityConstants.getNullId(),
               PolarisEntityConstants.getRootEntityId(),
               PolarisEntityType.PRINCIPAL_ROLE.getCode(),
@@ -581,7 +574,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // Now bootstrap the service by creating the root principal and the service_admin principal
     // role. The principal role will be granted to that root principal and the root catalog admin
     // of the root catalog will be granted to that principal role.
-    long rootPrincipalId = ms.generateNewId(callCtx);
+    long rootPrincipalId = ms.generateNewId();
     PolarisBaseEntity rootPrincipal =
         new PolarisBaseEntity(
             PolarisEntityConstants.getNullId(),
@@ -595,7 +588,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     this.createPrincipal(callCtx, rootPrincipal);
 
     // now create the account admin principal role
-    long serviceAdminPrincipalRoleId = ms.generateNewId(callCtx);
+    long serviceAdminPrincipalRoleId = ms.generateNewId();
     PolarisBaseEntity serviceAdminPrincipalRole =
         new PolarisBaseEntity(
             PolarisEntityConstants.getNullId(),
@@ -636,7 +629,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     LOGGER.warn("Deleting all metadata in the metastore...");
-    ms.deleteAll(callCtx);
+    ms.deleteAll();
     LOGGER.warn("Finished deleting all metadata in the metastore");
 
     // all good
@@ -662,7 +655,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             ? 0l
             : catalogPath.get(catalogPath.size() - 1).getId();
     PolarisBaseEntity entity =
-        ms.lookupEntityByName(callCtx, catalogId, parentId, entityType.getCode(), name);
+        ms.lookupEntityByName(catalogId, parentId, entityType.getCode(), name);
 
     // if found, check if subType really matches
     if (entity != null
@@ -709,7 +702,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             : entity -> true;
 
     Page<EntityNameLookupRecord> resultPage =
-        ms.listEntities(callCtx, catalogId, parentId, entityType, filter, pageToken);
+        ms.listEntities(catalogId, parentId, entityType, filter, pageToken);
 
     // TODO: Use post-validation to enforce consistent view against catalogPath. In the
     // meantime, happens-before ordering semantics aren't guaranteed during high-concurrency
@@ -733,8 +726,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // check if that catalog has already been created
     PolarisBaseEntity refreshPrincipal =
-        ms.lookupEntity(
-            callCtx, principal.getCatalogId(), principal.getId(), principal.getTypeCode());
+        ms.lookupEntity(principal.getCatalogId(), principal.getId(), principal.getTypeCode());
 
     // if found, probably a retry, simply return the previously created principal
     // This can be done safely as a separate atomic operation before trying to create the principal
@@ -776,7 +768,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
       // get the main and secondary secrets for that client
       PolarisPrincipalSecrets principalSecrets =
-          ((IntegrationPersistence) ms).loadPrincipalSecrets(callCtx, clientId);
+          ((IntegrationPersistence) ms).loadPrincipalSecrets(clientId);
 
       // should not be null
       callCtx
@@ -795,7 +787,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // generate new secrets for this principal
     PolarisPrincipalSecrets principalSecrets =
         ((IntegrationPersistence) ms)
-            .generateNewPrincipalSecrets(callCtx, principal.getName(), principal.getId());
+            .generateNewPrincipalSecrets(principal.getName(), principal.getId());
 
     // generate properties
     Map<String, String> internalProperties = getInternalPropertyMap(principal);
@@ -815,7 +807,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // before being able to do this cleanup.
       ((IntegrationPersistence) ms)
           .deletePrincipalSecrets(
-              callCtx, principalSecrets.getPrincipalClientId(), updatedPrincipal.getId());
+              principalSecrets.getPrincipalClientId(), updatedPrincipal.getId());
       return new CreatePrincipalResult(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, null);
     }
 
@@ -830,8 +822,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    PolarisPrincipalSecrets secrets =
-        ((IntegrationPersistence) ms).loadPrincipalSecrets(callCtx, clientId);
+    PolarisPrincipalSecrets secrets = ((IntegrationPersistence) ms).loadPrincipalSecrets(clientId);
 
     return (secrets == null)
         ? new PrincipalSecretsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null)
@@ -869,7 +860,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                 != null;
     PolarisPrincipalSecrets secrets =
         ((IntegrationPersistence) ms)
-            .rotatePrincipalSecrets(callCtx, clientId, principalId, doReset, oldSecretHash);
+            .rotatePrincipalSecrets(clientId, principalId, doReset, oldSecretHash);
 
     PolarisBaseEntity.Builder principalBuilder = new PolarisBaseEntity.Builder(principal);
     if (reset
@@ -880,14 +871,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       principalBuilder.internalProperties(
           PolarisObjectMapperUtil.serializeProperties(internalProps));
       principalBuilder.entityVersion(principal.getEntityVersion() + 1);
-      ms.writeEntity(callCtx, principalBuilder.build(), true, principal);
+      ms.writeEntity(principalBuilder.build(), true, principal);
     } else if (internalProps.containsKey(
         PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)) {
       internalProps.remove(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE);
       principalBuilder.internalProperties(
           PolarisObjectMapperUtil.serializeProperties(internalProps));
       principalBuilder.entityVersion(principal.getEntityVersion() + 1);
-      ms.writeEntity(callCtx, principalBuilder.build(), true, principal);
+      ms.writeEntity(principalBuilder.build(), true, principal);
     }
 
     // TODO: Rethink the atomicity of the relationship between principalSecrets and principal
@@ -935,7 +926,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     }
 
     try {
-      ms.writeEntities(callCtx, createdEntities, null);
+      ms.writeEntities(createdEntities, null);
       // TODO: Use post-validation to enforce consistent view against catalogPath. In the
       // meantime, happens-before ordering semantics aren't guaranteed during high-concurrency
       // race conditions, such as first revoking a grant on a namespace before adding sensitive
@@ -1007,7 +998,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     }
 
     try {
-      ms.writeEntities(callCtx, updatedEntities, originalEntities);
+      ms.writeEntities(updatedEntities, originalEntities);
     } catch (RetryOnConcurrencyException e) {
       return new EntitiesResult(
           BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, e.getMessage());
@@ -1048,10 +1039,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // find the entity to rename
     PolarisBaseEntity refreshEntityToRename =
         ms.lookupEntity(
-            callCtx,
-            entityToRename.getCatalogId(),
-            entityToRename.getId(),
-            entityToRename.getTypeCode());
+            entityToRename.getCatalogId(), entityToRename.getId(), entityToRename.getTypeCode());
 
     // if this entity was not found, return failure. Not expected here because it was
     // resolved successfully (see above)
@@ -1079,11 +1067,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             : newCatalogPath.get(newCatalogPath.size() - 1).getId();
     EntityNameLookupRecord entityActiveRecord =
         ms.lookupEntityIdAndSubTypeByName(
-            callCtx,
-            catalogId,
-            parentId,
-            refreshEntityToRename.getTypeCode(),
-            renamedEntity.getName());
+            catalogId, parentId, refreshEntityToRename.getTypeCode(), renamedEntity.getName());
     if (entityActiveRecord != null) {
       return new EntityResult(
           BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, entityActiveRecord.getSubTypeCode());
@@ -1139,7 +1123,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // first find the entity to drop
     PolarisBaseEntity refreshEntityToDrop =
         ms.lookupEntity(
-            callCtx, entityToDrop.getCatalogId(), entityToDrop.getId(), entityToDrop.getTypeCode());
+            entityToDrop.getCatalogId(), entityToDrop.getId(), entityToDrop.getTypeCode());
 
     // if this entity was not found, return failure
     if (refreshEntityToDrop == null) {
@@ -1165,14 +1149,13 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // where dropping a namespace or container is effectively "recursive" in deleting its
       // children as well if those child entities were created within the short window of
       // the race condition.
-      if (ms.hasChildren(callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
+      if (ms.hasChildren(PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
         return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
       }
 
       // get the list of catalog roles, at most 2
       List<PolarisBaseEntity> catalogRoles =
           ms.listEntities(
-                  callCtx,
                   catalogId,
                   catalogId,
                   PolarisEntityType.CATALOG_ROLE,
@@ -1192,8 +1175,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         this.dropEntity(callCtx, ms, catalogRoles.get(0));
       }
     } else if (refreshEntityToDrop.getType() == PolarisEntityType.NAMESPACE) {
-      if (ms.hasChildren(
-          callCtx, null, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId())) {
+      if (ms.hasChildren(null, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId())) {
         return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
       }
     } else if (refreshEntityToDrop.getType() == PolarisEntityType.POLICY && !cleanup) {
@@ -1201,7 +1183,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         //  need to check if the policy is attached to any entity
         List<PolarisPolicyMappingRecord> records =
             ms.loadAllTargetsOnPolicy(
-                callCtx,
                 refreshEntityToDrop.getCatalogId(),
                 refreshEntityToDrop.getId(),
                 PolicyEntity.of(refreshEntityToDrop).getPolicyTypeCode());
@@ -1229,7 +1210,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       PolarisBaseEntity.Builder taskEntityBuilder =
           new PolarisBaseEntity.Builder()
               .properties(PolarisObjectMapperUtil.serializeProperties(properties))
-              .id(ms.generateNewId(callCtx))
+              .id(ms.generateNewId())
               .catalogId(0L)
               .name("entityCleanup_" + entityToDrop.getId())
               .typeCode(PolarisEntityType.TASK.getCode())
@@ -1296,7 +1277,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // first, ensure that this privilege has been granted
     PolarisGrantRecord grantRecord =
         ms.lookupGrantRecord(
-            callCtx,
             role.getCatalogId(),
             role.getId(),
             grantee.getCatalogId(),
@@ -1345,7 +1325,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // lookup the grants records to find this grant
     PolarisGrantRecord grantRecord =
         ms.lookupGrantRecord(
-            callCtx,
             securable.getCatalogId(),
             securable.getId(),
             grantee.getCatalogId(),
@@ -1380,8 +1359,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // or if it's actually safe as two independent lookups.
 
     // lookup grants version for this securable entity
-    int grantsVersion =
-        ms.lookupEntityGrantRecordsVersion(callCtx, securableCatalogId, securableId);
+    int grantsVersion = ms.lookupEntityGrantRecordsVersion(securableCatalogId, securableId);
 
     // return null if securable does not exists
     if (grantsVersion == 0) {
@@ -1390,7 +1368,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // now fetch all grants for this securable
     final List<PolarisGrantRecord> returnGrantRecords =
-        ms.loadAllGrantRecordsOnSecurable(callCtx, securableCatalogId, securableId);
+        ms.loadAllGrantRecordsOnSecurable(securableCatalogId, securableId);
 
     // find all unique grantees
     List<PolarisEntityId> entityIds =
@@ -1401,7 +1379,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                         grantRecord.getGranteeCatalogId(), grantRecord.getGranteeId()))
             .distinct()
             .collect(Collectors.toList());
-    List<PolarisBaseEntity> entities = ms.lookupEntities(callCtx, entityIds);
+    List<PolarisBaseEntity> entities = ms.lookupEntities(entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
@@ -1426,7 +1404,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // or if it's actually safe as two independent lookups.
 
     // lookup grants version for this grantee entity
-    int grantsVersion = ms.lookupEntityGrantRecordsVersion(callCtx, granteeCatalogId, granteeId);
+    int grantsVersion = ms.lookupEntityGrantRecordsVersion(granteeCatalogId, granteeId);
 
     // return null if grantee does not exists
     if (grantsVersion == 0) {
@@ -1435,7 +1413,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // now fetch all grants for this grantee
     final List<PolarisGrantRecord> returnGrantRecords =
-        ms.loadAllGrantRecordsOnGrantee(callCtx, granteeCatalogId, granteeId);
+        ms.loadAllGrantRecordsOnGrantee(granteeCatalogId, granteeId);
 
     // find all unique securables
     List<PolarisEntityId> entityIds =
@@ -1446,7 +1424,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                         grantRecord.getSecurableCatalogId(), grantRecord.getSecurableId()))
             .distinct()
             .collect(Collectors.toList());
-    List<PolarisBaseEntity> entities = ms.lookupEntities(callCtx, entityIds);
+    List<PolarisBaseEntity> entities = ms.lookupEntities(entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
@@ -1462,8 +1440,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    List<PolarisChangeTrackingVersions> changeTracking =
-        ms.lookupEntityVersions(callCtx, entityIds);
+    List<PolarisChangeTrackingVersions> changeTracking = ms.lookupEntityVersions(entityIds);
     return new ChangeTrackingResult(changeTracking);
   }
 
@@ -1478,8 +1455,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // this is an easy one
-    PolarisBaseEntity entity =
-        ms.lookupEntity(callCtx, entityCatalogId, entityId, entityType.getCode());
+    PolarisBaseEntity entity = ms.lookupEntity(entityCatalogId, entityId, entityType.getCode());
     return (entity != null)
         ? new EntityResult(entity)
         : new EntityResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
@@ -1493,7 +1469,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // find all available tasks
     Page<PolarisBaseEntity> availableTasks =
         ms.listEntities(
-            callCtx,
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityType.TASK,
@@ -1594,8 +1569,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // get storage integration
     PolarisStorageIntegration<PolarisStorageConfigurationInfo> storageIntegration =
-        ((IntegrationPersistence) ms)
-            .loadPolarisStorageIntegration(callCtx, reloadedEntity.getEntity());
+        ((IntegrationPersistence) ms).loadPolarisStorageIntegration(reloadedEntity.getEntity());
 
     // cannot be null
     callCtx
@@ -1651,8 +1625,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // load that entity
-    PolarisBaseEntity entity =
-        ms.lookupEntity(callCtx, entityCatalogId, entityId, entityType.getCode());
+    PolarisBaseEntity entity = ms.lookupEntity(entityCatalogId, entityId, entityType.getCode());
 
     // if entity not found, return null
     if (entity == null) {
@@ -1665,11 +1638,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // load the grant records
     final List<PolarisGrantRecord> grantRecords;
     if (entity.getType().isGrantee()) {
-      grantRecords =
-          new ArrayList<>(ms.loadAllGrantRecordsOnGrantee(callCtx, entityCatalogId, entityId));
-      grantRecords.addAll(ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entityId));
+      grantRecords = new ArrayList<>(ms.loadAllGrantRecordsOnGrantee(entityCatalogId, entityId));
+      grantRecords.addAll(ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entityId));
     } else {
-      grantRecords = ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entityId);
+      grantRecords = ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entityId);
     }
 
     // return the result
@@ -1689,7 +1661,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // load that entity
     PolarisBaseEntity entity =
-        ms.lookupEntityByName(callCtx, entityCatalogId, parentId, entityType.getCode(), entityName);
+        ms.lookupEntityByName(entityCatalogId, parentId, entityType.getCode(), entityName);
 
     // null if entity not found
     if (entity == null) {
@@ -1703,12 +1675,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     final List<PolarisGrantRecord> grantRecords;
     if (entity.getType().isGrantee()) {
       grantRecords =
-          new ArrayList<>(
-              ms.loadAllGrantRecordsOnGrantee(callCtx, entityCatalogId, entity.getId()));
-      grantRecords.addAll(
-          ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entity.getId()));
+          new ArrayList<>(ms.loadAllGrantRecordsOnGrantee(entityCatalogId, entity.getId()));
+      grantRecords.addAll(ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entity.getId()));
     } else {
-      grantRecords = ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entity.getId());
+      grantRecords = ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entity.getId());
     }
 
     ResolvedEntityResult result =
@@ -1729,7 +1699,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       if (backfillResult.isSuccess()) {
         PolarisBaseEntity serviceAdminRole =
             ms.lookupEntityByName(
-                callCtx,
                 0L,
                 0L,
                 PolarisEntityType.PRINCIPAL_ROLE.getCode(),
@@ -1767,8 +1736,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // load version information
     PolarisChangeTrackingVersions entityVersions =
-        ms.lookupEntityVersions(callCtx, List.of(new PolarisEntityId(entityCatalogId, entityId)))
-            .get(0);
+        ms.lookupEntityVersions(List.of(new PolarisEntityId(entityCatalogId, entityId))).get(0);
 
     // if null, the entity has been purged
     if (entityVersions == null) {
@@ -1778,7 +1746,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // load the entity if something changed
     final PolarisBaseEntity entity;
     if (entityVersion != entityVersions.getEntityVersion()) {
-      entity = ms.lookupEntity(callCtx, entityCatalogId, entityId, entityType.getCode());
+      entity = ms.lookupEntity(entityCatalogId, entityId, entityType.getCode());
 
       // if not found, return null
       if (entity == null) {
@@ -1796,11 +1764,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     final List<PolarisGrantRecord> grantRecords;
     if (entityVersions.getGrantRecordsVersion() != entityGrantRecordsVersion) {
       if (entityType.isGrantee()) {
-        grantRecords =
-            new ArrayList<>(ms.loadAllGrantRecordsOnGrantee(callCtx, entityCatalogId, entityId));
-        grantRecords.addAll(ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entityId));
+        grantRecords = new ArrayList<>(ms.loadAllGrantRecordsOnGrantee(entityCatalogId, entityId));
+        grantRecords.addAll(ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entityId));
       } else {
-        grantRecords = ms.loadAllGrantRecordsOnSecurable(callCtx, entityCatalogId, entityId);
+        grantRecords = ms.loadAllGrantRecordsOnSecurable(entityCatalogId, entityId);
       }
     } else {
       grantRecords = null;
@@ -1816,7 +1783,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       Optional<Optional<String>> hasOverlappingSiblings(
           @Nonnull PolarisCallContext callContext, T entity) {
     BasePersistence ms = callContext.getMetaStore();
-    return ms.hasOverlappingSiblings(callContext, entity);
+    return ms.hasOverlappingSiblings(entity);
   }
 
   @Override
@@ -1845,7 +1812,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     PolarisPolicyMappingRecord mappingRecord =
         ms.lookupPolicyMappingRecord(
-            callCtx,
             target.getCatalogId(),
             target.getId(),
             policy.getPolicyTypeCode(),
@@ -1855,7 +1821,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       return new PolicyAttachmentResult(BaseResult.ReturnStatus.POLICY_MAPPING_NOT_FOUND, null);
     }
 
-    ms.deleteFromPolicyMappingRecords(callCtx, mappingRecord);
+    ms.deleteFromPolicyMappingRecords(mappingRecord);
 
     return new PolicyAttachmentResult(mappingRecord);
   }
@@ -1867,14 +1833,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     PolarisBaseEntity entity =
-        ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+        ms.lookupEntity(target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
       // Target entity does not exist
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
 
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
-        ms.loadAllPoliciesOnTarget(callCtx, target.getCatalogId(), target.getId());
+        ms.loadAllPoliciesOnTarget(target.getCatalogId(), target.getId());
 
     List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
@@ -1890,15 +1856,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     PolarisBaseEntity entity =
-        ms.lookupEntity(callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+        ms.lookupEntity(target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
       // Target entity does not exist
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
 
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
-        ms.loadPoliciesOnTargetByType(
-            callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
+        ms.loadPoliciesOnTargetByType(target.getCatalogId(), target.getId(), policyType.getCode());
 
     List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
@@ -1933,7 +1898,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             policy.getPolicyTypeCode(),
             parameters);
     try {
-      ms.writeToPolicyMappingRecords(callCtx, mappingRecord);
+      ms.writeToPolicyMappingRecords(mappingRecord);
     } catch (IllegalArgumentException e) {
       return new PolicyAttachmentResult(
           BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
@@ -1967,6 +1932,6 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyId()))
             .distinct()
             .collect(Collectors.toList());
-    return ms.lookupEntities(callCtx, policyEntityIds);
+    return ms.lookupEntities(policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
@@ -208,6 +208,6 @@ public abstract class BaseMetaStoreManager implements PolarisMetaStoreManager {
     // get meta store we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
-    return new GenerateEntityIdResult(ms.generateNewId(callCtx));
+    return new GenerateEntityIdResult(ms.generateNewId());
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -43,30 +42,26 @@ public interface IntegrationPersistence {
   /**
    * Allows to retrieve to the secrets of a principal given its unique client id
    *
-   * @param callCtx call context
    * @param clientId principal client id
    * @return the secrets
    */
   @Nullable
-  PolarisPrincipalSecrets loadPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId);
+  PolarisPrincipalSecrets loadPrincipalSecrets(@Nonnull String clientId);
 
   /**
    * generate and store a client id and associated secrets for a newly created principal entity
    *
-   * @param callCtx call context
    * @param principalName name of the principal
    * @param principalId principal id
    */
   @Nonnull
   PolarisPrincipalSecrets generateNewPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String principalName, long principalId);
+      @Nonnull String principalName, long principalId);
 
   /**
    * Rotate the secrets of a principal entity, i.e. make the specified main secrets the secondary
    * and generate a new main secret
    *
-   * @param callCtx call context
    * @param clientId principal client id
    * @param principalId principal id
    * @param reset true if the principal secrets should be disabled and replaced with a one-time
@@ -75,26 +70,19 @@ public interface IntegrationPersistence {
    */
   @Nullable
   PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash);
+      @Nonnull String clientId, long principalId, boolean reset, @Nonnull String oldSecretHash);
 
   /**
    * When dropping a principal, we also need to drop the secrets of that principal
    *
-   * @param callCtx the call context
    * @param clientId principal client id
    * @param principalId the id of the principal whose secrets are dropped
    */
-  void deletePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId, long principalId);
+  void deletePrincipalSecrets(@Nonnull String clientId, long principalId);
 
   /**
    * Create an in-memory storage integration
    *
-   * @param callCtx the polaris calllctx
    * @param catalogId the catalog id
    * @param entityId the entity id
    * @param polarisStorageConfigurationInfo the storage configuration information
@@ -102,7 +90,6 @@ public interface IntegrationPersistence {
    */
   @Nullable
   <T extends PolarisStorageConfigurationInfo> PolarisStorageIntegration<T> createStorageIntegration(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long entityId,
       PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
@@ -110,24 +97,19 @@ public interface IntegrationPersistence {
   /**
    * Persist a storage integration in the metastore
    *
-   * @param callContext the polaris call context
    * @param entity the entity of the object
    * @param storageIntegration the storage integration to persist
    */
   <T extends PolarisStorageConfigurationInfo> void persistStorageIntegrationIfNeeded(
-      @Nonnull PolarisCallContext callContext,
-      @Nonnull PolarisBaseEntity entity,
-      @Nullable PolarisStorageIntegration<T> storageIntegration);
+      @Nonnull PolarisBaseEntity entity, @Nullable PolarisStorageIntegration<T> storageIntegration);
 
   /**
    * Load the polaris storage integration for a polaris entity (Catalog,Namespace,Table,View)
    *
-   * @param callContext the polaris call context
    * @param entity the polaris entity
    * @return a polaris storage integration
    */
   @Nullable
   <T extends PolarisStorageConfigurationInfo>
-      PolarisStorageIntegration<T> loadPolarisStorageIntegration(
-          @Nonnull PolarisCallContext callContext, @Nonnull PolarisBaseEntity entity);
+      PolarisStorageIntegration<T> loadPolarisStorageIntegration(@Nonnull PolarisBaseEntity entity);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
@@ -283,7 +283,7 @@ public class PolarisEntityResolver {
 
     // now lookup all these entities by name
     Iterator<EntityNameLookupRecord> activeRecordIt =
-        ms.lookupEntityActiveBatchInCurrentTxn(callCtx, entityActiveKeys).iterator();
+        ms.lookupEntityActiveBatchInCurrentTxn(entityActiveKeys).iterator();
 
     // now validate if there was a change and if yes, re-resolve again
     for (PolarisEntityCore resolveEntity : toResolve) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -108,7 +108,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     entity = prepareToPersistNewEntity(callCtx, ms, entity);
 
     // write it
-    ms.writeEntityInCurrentTxn(callCtx, entity, true, null);
+    ms.writeEntityInCurrentTxn(entity, true, null);
   }
 
   /**
@@ -136,7 +136,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // Use the write method defined in TransactionalPersistence which expects an
     // existing runInTransaction to already be in-place.
-    ms.writeEntityInCurrentTxn(callCtx, entity, nameOrParentChanged, originalEntity);
+    ms.writeEntityInCurrentTxn(entity, nameOrParentChanged, originalEntity);
 
     // return it
     return entity;
@@ -172,13 +172,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // delete ALL grant records to (if the entity is a grantee) and from that entity
     final List<PolarisGrantRecord> grantsOnGrantee =
         (entity.getType().isGrantee())
-            ? ms.loadAllGrantRecordsOnGranteeInCurrentTxn(
-                callCtx, entity.getCatalogId(), entity.getId())
+            ? ms.loadAllGrantRecordsOnGranteeInCurrentTxn(entity.getCatalogId(), entity.getId())
             : List.of();
     final List<PolarisGrantRecord> grantsOnSecurable =
-        ms.loadAllGrantRecordsOnSecurableInCurrentTxn(
-            callCtx, entity.getCatalogId(), entity.getId());
-    ms.deleteAllEntityGrantRecordsInCurrentTxn(callCtx, entity, grantsOnGrantee, grantsOnSecurable);
+        ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entity.getCatalogId(), entity.getId());
+    ms.deleteAllEntityGrantRecordsInCurrentTxn(entity, grantsOnGrantee, grantsOnSecurable);
 
     // Now determine the set of entities on the other side of the grants we just removed. Grants
     // from/to these entities has been removed, hence we need to update the grant version of
@@ -195,11 +193,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // Bump up the grant version of these entities
     List<PolarisBaseEntity> entities =
-        ms.lookupEntitiesInCurrentTxn(callCtx, new ArrayList<>(entityIdsGrantChanged));
+        ms.lookupEntitiesInCurrentTxn(new ArrayList<>(entityIdsGrantChanged));
     for (PolarisBaseEntity originalEntity : entities) {
       PolarisBaseEntity entityGrantChanged =
           originalEntity.withGrantRecordsVersion(originalEntity.getGrantRecordsVersion() + 1);
-      ms.writeEntityInCurrentTxn(callCtx, entityGrantChanged, false, originalEntity);
+      ms.writeEntityInCurrentTxn(entityGrantChanged, false, originalEntity);
     }
 
     if (entity.getType() == PolarisEntityType.POLICY
@@ -210,7 +208,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         final List<PolarisPolicyMappingRecord> mappingOnPolicy =
             (entity.getType() == PolarisEntityType.POLICY)
                 ? ms.loadAllTargetsOnPolicyInCurrentTxn(
-                    callCtx,
                     entity.getCatalogId(),
                     entity.getId(),
                     PolicyEntity.of(entity).getPolicyTypeCode())
@@ -218,17 +215,16 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         final List<PolarisPolicyMappingRecord> mappingOnTarget =
             (entity.getType() == PolarisEntityType.POLICY)
                 ? List.of()
-                : ms.loadAllPoliciesOnTargetInCurrentTxn(
-                    callCtx, entity.getCatalogId(), entity.getId());
+                : ms.loadAllPoliciesOnTargetInCurrentTxn(entity.getCatalogId(), entity.getId());
         ms.deleteAllEntityPolicyMappingRecordsInCurrentTxn(
-            callCtx, entity, mappingOnTarget, mappingOnPolicy);
+            entity, mappingOnTarget, mappingOnPolicy);
       } catch (UnsupportedOperationException e) {
         // Policy mapping persistence not implemented, but we should not block dropping entities
       }
     }
 
     // remove the entity being dropped now
-    ms.deleteEntityInCurrentTxn(callCtx, entity);
+    ms.deleteEntityInCurrentTxn(entity);
 
     // if it is a principal, we also need to drop the secrets
     if (entity.getType() == PolarisEntityType.PRINCIPAL) {
@@ -239,7 +235,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       String clientId = properties.get(PolarisEntityConstants.getClientIdPropertyName());
 
       // delete it from the secret slice
-      ms.deletePrincipalSecretsInCurrentTxn(callCtx, clientId, entity.getId());
+      ms.deletePrincipalSecretsInCurrentTxn(clientId, entity.getId());
     }
     // TODO: Also, if an entity contains a storage integration, delete the storage integration
     // and other things of that nature.
@@ -283,26 +279,25 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             priv.getCode());
 
     // persist the new grant
-    ms.writeToGrantRecordsInCurrentTxn(callCtx, grantRecord);
+    ms.writeToGrantRecordsInCurrentTxn(grantRecord);
 
     // load the grantee (either a catalog/principal role or a principal) and increment its grants
     // version
     PolarisBaseEntity granteeEntity =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
+        ms.lookupEntityInCurrentTxn(grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedGranteeEntity =
         granteeEntity.withGrantRecordsVersion(granteeEntity.getGrantRecordsVersion() + 1);
-    ms.writeEntityInCurrentTxn(callCtx, updatedGranteeEntity, false, granteeEntity);
+    ms.writeEntityInCurrentTxn(updatedGranteeEntity, false, granteeEntity);
 
     // we also need to invalidate the grants on that securable so that we can reload them.
     // load the securable and increment its grants version
     PolarisBaseEntity securableEntity =
         ms.lookupEntityInCurrentTxn(
-            callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
+            securable.getCatalogId(), securable.getId(), securable.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(securableEntity, "securable_not_found", "securable={}", securable);
@@ -311,7 +306,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         new PolarisBaseEntity.Builder(securableEntity)
             .grantRecordsVersion(securableEntity.getGrantRecordsVersion() + 1)
             .build();
-    ms.writeEntityInCurrentTxn(callCtx, updatedSecurableEntity, false, securableEntity);
+    ms.writeEntityInCurrentTxn(updatedSecurableEntity, false, securableEntity);
 
     // TODO: Update this to be an atomic bulk-update of the grantee/securable, ideally along
     // with adding the grant record in the same bulk-update.
@@ -365,12 +360,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         .check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
 
     // remove that grant
-    ms.deleteFromGrantRecordsInCurrentTxn(callCtx, grantRecord);
+    ms.deleteFromGrantRecordsInCurrentTxn(grantRecord);
 
     // load the grantee and increment its grants version
     PolarisBaseEntity refreshGrantee =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
+        ms.lookupEntityInCurrentTxn(grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(
@@ -378,13 +372,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshGrantee =
         refreshGrantee.withGrantRecordsVersion(refreshGrantee.getGrantRecordsVersion() + 1);
-    ms.writeEntityInCurrentTxn(callCtx, updatedRefreshGrantee, false, refreshGrantee);
+    ms.writeEntityInCurrentTxn(updatedRefreshGrantee, false, refreshGrantee);
 
     // we also need to invalidate the grants on that securable so that we can reload them.
     // load the securable and increment its grants version
     PolarisBaseEntity refreshSecurable =
         ms.lookupEntityInCurrentTxn(
-            callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
+            securable.getCatalogId(), securable.getId(), securable.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(
@@ -396,7 +390,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshSecurable =
         refreshSecurable.withGrantRecordsVersion(refreshSecurable.getGrantRecordsVersion() + 1);
-    ms.writeEntityInCurrentTxn(callCtx, updatedRefreshSecurable, false, refreshSecurable);
+    ms.writeEntityInCurrentTxn(updatedRefreshSecurable, false, refreshSecurable);
 
     // TODO: Update this to be an atomic bulk-update of the grantee/securable, ideally along
     // with removing the grant record in the same bulk-update.
@@ -428,8 +422,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // check if that catalog has already been created
     PolarisBaseEntity refreshCatalog =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, catalog.getCatalogId(), catalog.getId(), catalog.getTypeCode());
+        ms.lookupEntityInCurrentTxn(catalog.getCatalogId(), catalog.getId(), catalog.getTypeCode());
 
     // if found, probably a retry, simply return the previously created catalog
     if (refreshCatalog != null) {
@@ -445,7 +438,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       // lookup catalog admin role, should exist
       PolarisBaseEntity catalogAdminRole =
           ms.lookupEntityByNameInCurrentTxn(
-              callCtx,
               refreshCatalog.getId(),
               refreshCatalog.getId(),
               PolarisEntityType.CATALOG_ROLE.getCode(),
@@ -464,7 +456,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // check that a catalog with the same name does not exist already
     // if it exists, this is an error, the client should retry
     if (ms.lookupEntityIdAndSubTypeByNameInCurrentTxn(
-            callCtx,
             PolarisEntityConstants.getNullId(),
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityType.CATALOG.getCode(),
@@ -473,13 +464,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       return new CreateCatalogResult(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, null);
     }
 
-    ms.persistStorageIntegrationIfNeededInCurrentTxn(callCtx, catalog, integration);
+    ms.persistStorageIntegrationIfNeededInCurrentTxn(catalog, integration);
 
     // now create and persist new catalog entity
     this.persistNewEntity(callCtx, ms, catalog);
 
     // create the catalog admin role for this new catalog
-    long adminRoleId = ms.generateNewIdInCurrentTxn(callCtx);
+    long adminRoleId = ms.generateNewIdInCurrentTxn();
     PolarisBaseEntity adminRole =
         new PolarisBaseEntity(
             catalog.getId(),
@@ -504,7 +495,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       // lookup service admin role, should exist
       PolarisBaseEntity serviceAdminRole =
           ms.lookupEntityByNameInCurrentTxn(
-              callCtx,
               PolarisEntityConstants.getNullId(),
               PolarisEntityConstants.getRootEntityId(),
               PolarisEntityType.PRINCIPAL_ROLE.getCode(),
@@ -558,7 +548,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // Now bootstrap the service by creating the root principal and the service_admin principal
     // role. The principal role will be granted to that root principal and the root catalog admin
     // of the root catalog will be granted to that principal role.
-    long rootPrincipalId = ms.generateNewIdInCurrentTxn(callCtx);
+    long rootPrincipalId = ms.generateNewIdInCurrentTxn();
     PolarisBaseEntity rootPrincipal =
         new PolarisBaseEntity(
             PolarisEntityConstants.getNullId(),
@@ -572,7 +562,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     this.createPrincipal(callCtx, ms, rootPrincipal);
 
     // now create the account admin principal role
-    long serviceAdminPrincipalRoleId = ms.generateNewIdInCurrentTxn(callCtx);
+    long serviceAdminPrincipalRoleId = ms.generateNewIdInCurrentTxn();
     PolarisBaseEntity serviceAdminPrincipalRole =
         new PolarisBaseEntity(
             PolarisEntityConstants.getNullId(),
@@ -607,7 +597,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 
     // run operation in a read/write transaction
-    ms.runActionInTransaction(callCtx, () -> this.bootstrapPolarisService(callCtx, ms));
+    ms.runActionInTransaction(() -> this.bootstrapPolarisService(callCtx, ms));
 
     // all good
     return new BaseResult(BaseResult.ReturnStatus.SUCCESS);
@@ -620,7 +610,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // run operation in a read/write transaction
     LOGGER.warn("Deleting all metadata in the metastore...");
-    ms.runActionInTransaction(callCtx, () -> ms.deleteAllInCurrentTxn(callCtx));
+    ms.runActionInTransaction(() -> ms.deleteAllInCurrentTxn());
     LOGGER.warn("Finished deleting all metadata in the metastore");
 
     // all good
@@ -649,11 +639,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // now looking the entity by name
     PolarisBaseEntity entity =
         ms.lookupEntityByNameInCurrentTxn(
-            callCtx,
-            resolver.getCatalogIdOrNull(),
-            resolver.getParentId(),
-            entityType.getCode(),
-            name);
+            resolver.getCatalogIdOrNull(), resolver.getParentId(), entityType.getCode(), name);
 
     // if found, check if subType really matches
     if (entity != null
@@ -681,7 +667,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // run operation in a read/write transaction
     return ms.runInReadTransaction(
-        callCtx, () -> readEntityByName(callCtx, ms, catalogPath, entityType, entitySubType, name));
+        () -> readEntityByName(callCtx, ms, catalogPath, entityType, entitySubType, name));
   }
 
   /**
@@ -712,12 +698,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // return list of active entities
     Page<EntityNameLookupRecord> resultPage =
         ms.listEntitiesInCurrentTxn(
-            callCtx,
-            resolver.getCatalogIdOrNull(),
-            resolver.getParentId(),
-            entityType,
-            filter,
-            pageToken);
+            resolver.getCatalogIdOrNull(), resolver.getParentId(), entityType, filter, pageToken);
 
     // done
     return ListEntitiesResult.fromPage(resultPage);
@@ -736,7 +717,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // run operation in a read transaction
     return ms.runInReadTransaction(
-        callCtx,
         () -> listEntities(callCtx, ms, catalogPath, entityType, entitySubType, pageToken));
   }
 
@@ -751,7 +731,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // check if that catalog has already been created
     PolarisBaseEntity refreshPrincipal =
         ms.lookupEntityInCurrentTxn(
-            callCtx, principal.getCatalogId(), principal.getId(), principal.getTypeCode());
+            principal.getCatalogId(), principal.getId(), principal.getTypeCode());
 
     // if found, probably a retry, simply return the previously created principal
     if (refreshPrincipal != null) {
@@ -789,8 +769,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
               refreshPrincipal.getInternalProperties());
 
       // get the main and secondary secrets for that client
-      PolarisPrincipalSecrets principalSecrets =
-          ms.loadPrincipalSecretsInCurrentTxn(callCtx, clientId);
+      PolarisPrincipalSecrets principalSecrets = ms.loadPrincipalSecretsInCurrentTxn(clientId);
 
       // should not be null
       callCtx
@@ -809,7 +788,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // check that a principal with the same name does not exist already
     // if it exists, this is an error, the client should retry
     if (ms.lookupEntityIdAndSubTypeByNameInCurrentTxn(
-            callCtx,
             PolarisEntityConstants.getNullId(),
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityType.PRINCIPAL.getCode(),
@@ -820,7 +798,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // generate new secrets for this principal
     PolarisPrincipalSecrets principalSecrets =
-        ms.generateNewPrincipalSecretsInCurrentTxn(callCtx, principal.getName(), principal.getId());
+        ms.generateNewPrincipalSecretsInCurrentTxn(principal.getName(), principal.getId());
 
     // generate properties
     Map<String, String> internalProperties = getInternalPropertyMap(principal);
@@ -848,13 +826,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 
     // need to run inside a read/write transaction
-    return ms.runInTransaction(callCtx, () -> this.createPrincipal(callCtx, ms, principal));
+    return ms.runInTransaction(() -> this.createPrincipal(callCtx, ms, principal));
   }
 
   /** See {@link #loadPrincipalSecrets(PolarisCallContext, String)} */
   private @Nullable PolarisPrincipalSecrets loadPrincipalSecrets(
       @Nonnull PolarisCallContext callCtx, TransactionalPersistence ms, @Nonnull String clientId) {
-    return ms.loadPrincipalSecretsInCurrentTxn(callCtx, clientId);
+    return ms.loadPrincipalSecretsInCurrentTxn(clientId);
   }
 
   /** {@inheritDoc} */
@@ -866,7 +844,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     PolarisPrincipalSecrets secrets =
-        ms.runInTransaction(callCtx, () -> this.loadPrincipalSecrets(callCtx, ms, clientId));
+        ms.runInTransaction(() -> this.loadPrincipalSecrets(callCtx, ms, clientId));
 
     return (secrets == null)
         ? new PrincipalSecretsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null)
@@ -875,7 +853,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
   /** See {@link #} */
   private @Nullable PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       @Nonnull String clientId,
       long principalId,
@@ -884,7 +861,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // if not found, the principal must have been dropped
     EntityResult loadEntityResult =
         loadEntity(
-            callCtx,
             ms,
             PolarisEntityConstants.getNullId(),
             principalId,
@@ -905,8 +881,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                     PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
                 != null;
     PolarisPrincipalSecrets secrets =
-        ms.rotatePrincipalSecretsInCurrentTxn(
-            callCtx, clientId, principalId, doReset, oldSecretHash);
+        ms.rotatePrincipalSecretsInCurrentTxn(clientId, principalId, doReset, oldSecretHash);
 
     if (reset
         && !internalProps.containsKey(
@@ -916,14 +891,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       principalBuilder.internalProperties(
           PolarisObjectMapperUtil.serializeProperties(internalProps));
       principalBuilder.entityVersion(principal.getEntityVersion() + 1);
-      ms.writeEntityInCurrentTxn(callCtx, principalBuilder.build(), true, principal);
+      ms.writeEntityInCurrentTxn(principalBuilder.build(), true, principal);
     } else if (internalProps.containsKey(
         PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)) {
       internalProps.remove(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE);
       principalBuilder.internalProperties(
           PolarisObjectMapperUtil.serializeProperties(internalProps));
       principalBuilder.entityVersion(principal.getEntityVersion() + 1);
-      ms.writeEntityInCurrentTxn(callCtx, principalBuilder.build(), true, principal);
+      ms.writeEntityInCurrentTxn(principalBuilder.build(), true, principal);
     }
     return secrets;
   }
@@ -942,10 +917,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // need to run inside a read/write transaction
     PolarisPrincipalSecrets secrets =
         ms.runInTransaction(
-            callCtx,
-            () ->
-                this.rotatePrincipalSecrets(
-                    callCtx, ms, clientId, principalId, reset, oldSecretHash));
+            () -> this.rotatePrincipalSecrets(ms, clientId, principalId, reset, oldSecretHash));
 
     return (secrets == null)
         ? new PrincipalSecretsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null)
@@ -972,7 +944,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     if (storageConfigInfoStr != null && integrationIdentifierOrId == null) {
       integration =
           ms.createStorageIntegrationInCurrentTxn(
-              callCtx,
               catalog.getCatalogId(),
               catalog.getId(),
               PolarisStorageConfigurationInfo.deserialize(storageConfigInfoStr));
@@ -981,7 +952,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     }
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.createCatalog(callCtx, ms, catalog, integration, principalRoles));
+        () -> this.createCatalog(callCtx, ms, catalog, integration, principalRoles));
   }
 
   /** {@link #createEntityIfNotExists(PolarisCallContext, List, PolarisBaseEntity)} */
@@ -999,8 +970,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // first, check if the entity has already been created, in which case we will simply return it
     PolarisBaseEntity entityFound =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, entity.getCatalogId(), entity.getId(), entity.getTypeCode());
+        ms.lookupEntityInCurrentTxn(entity.getCatalogId(), entity.getId(), entity.getTypeCode());
     if (entityFound != null) {
       // probably the client retried, simply return it
       // TODO: Check correctness of returning entityFound vs entity here. It may have already
@@ -1019,7 +989,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // check if an entity does not already exist with the same name. If true, this is an error
     EntityNameLookupRecord entityActiveRecord =
         ms.lookupEntityIdAndSubTypeByNameInCurrentTxn(
-            callCtx,
             entity.getCatalogId(),
             entity.getParentId(),
             entity.getType().getCode(),
@@ -1047,7 +1016,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.createEntityIfNotExists(callCtx, ms, catalogPath, entity));
+        () -> this.createEntityIfNotExists(callCtx, ms, catalogPath, entity));
   }
 
   @Override
@@ -1060,7 +1029,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx,
         () -> {
           List<PolarisBaseEntity> createdEntities = new ArrayList<>(entities.size());
           for (PolarisBaseEntity entity : entities) {
@@ -1099,8 +1067,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // lookup the entity, cannot be null
     PolarisBaseEntity entityRefreshed =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, entity.getCatalogId(), entity.getId(), entity.getTypeCode());
+        ms.lookupEntityInCurrentTxn(entity.getCatalogId(), entity.getId(), entity.getTypeCode());
     callCtx
         .getDiagServices()
         .checkNotNull(entityRefreshed, "unexpected_entity_not_found", "entity={}", entity);
@@ -1145,7 +1112,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.updateEntityPropertiesIfNotChanged(callCtx, ms, catalogPath, entity));
+        () -> this.updateEntityPropertiesIfNotChanged(callCtx, ms, catalogPath, entity));
   }
 
   /** See {@link #updateEntitiesPropertiesIfNotChanged(PolarisCallContext, List)} */
@@ -1190,7 +1157,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.updateEntitiesPropertiesIfNotChanged(callCtx, ms, entities));
+        () -> this.updateEntitiesPropertiesIfNotChanged(callCtx, ms, entities));
   }
 
   /**
@@ -1234,10 +1201,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // find the entity to rename
     PolarisBaseEntity refreshEntityToRename =
         ms.lookupEntityInCurrentTxn(
-            callCtx,
-            entityToRename.getCatalogId(),
-            entityToRename.getId(),
-            entityToRename.getTypeCode());
+            entityToRename.getCatalogId(), entityToRename.getId(), entityToRename.getTypeCode());
 
     // if this entity was not found, return failure. Not expected here because it was
     // resolved successfully (see above)
@@ -1269,7 +1233,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // if this entity already exists, this is an error
     EntityNameLookupRecord entityActiveRecord =
         ms.lookupEntityIdAndSubTypeByNameInCurrentTxn(
-            callCtx,
             resolver.getCatalogIdOrNull(),
             resolver.getParentId(),
             refreshEntityToRename.getTypeCode(),
@@ -1316,7 +1279,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.renameEntity(
                 callCtx, ms, catalogPath, entityToRename, newCatalogPath, renamedEntity));
@@ -1350,7 +1312,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // first find the entity to drop
     PolarisBaseEntity refreshEntityToDrop =
         ms.lookupEntityInCurrentTxn(
-            callCtx, entityToDrop.getCatalogId(), entityToDrop.getId(), entityToDrop.getTypeCode());
+            entityToDrop.getCatalogId(), entityToDrop.getId(), entityToDrop.getTypeCode());
 
     // if this entity was not found, return failure
     if (refreshEntityToDrop == null) {
@@ -1369,14 +1331,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       long catalogId = refreshEntityToDrop.getId();
 
       // if not all namespaces are dropped, we cannot drop this catalog
-      if (ms.hasChildrenInCurrentTxn(callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
+      if (ms.hasChildrenInCurrentTxn(PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
         return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
       }
 
       // get the list of catalog roles, at most 2
       List<PolarisBaseEntity> catalogRoles =
           ms.listEntitiesInCurrentTxn(
-                  callCtx,
                   catalogId,
                   catalogId,
                   PolarisEntityType.CATALOG_ROLE,
@@ -1397,7 +1358,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       }
     } else if (refreshEntityToDrop.getType() == PolarisEntityType.NAMESPACE) {
       if (ms.hasChildrenInCurrentTxn(
-          callCtx, null, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId())) {
+          null, refreshEntityToDrop.getCatalogId(), refreshEntityToDrop.getId())) {
         return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
       }
     } else if (refreshEntityToDrop.getType() == PolarisEntityType.POLICY && !cleanup) {
@@ -1405,7 +1366,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       try {
         List<PolarisPolicyMappingRecord> records =
             ms.loadAllTargetsOnPolicyInCurrentTxn(
-                callCtx,
                 refreshEntityToDrop.getCatalogId(),
                 refreshEntityToDrop.getId(),
                 PolicyEntity.of(refreshEntityToDrop).getPolicyTypeCode());
@@ -1432,7 +1392,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       properties.put("data", PolarisObjectMapperUtil.serialize(refreshEntityToDrop));
       PolarisBaseEntity.Builder taskEntityBuilder =
           new PolarisBaseEntity.Builder()
-              .id(ms.generateNewIdInCurrentTxn(callCtx))
+              .id(ms.generateNewIdInCurrentTxn())
               .catalogId(0L)
               .name("entityCleanup_" + entityToDrop.getId())
               .typeCode(PolarisEntityType.TASK.getCode())
@@ -1465,7 +1425,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.dropEntityIfExists(
                 callCtx, ms, catalogPath, entityToDrop, cleanupProperties, cleanup));
@@ -1603,7 +1562,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.grantUsageOnRoleToGrantee(callCtx, ms, catalog, role, grantee));
+        () -> this.grantUsageOnRoleToGrantee(callCtx, ms, catalog, role, grantee));
   }
 
   /**
@@ -1635,7 +1594,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // first, ensure that this privilege has been granted
     PolarisGrantRecord grantRecord =
         ms.lookupGrantRecordInCurrentTxn(
-            callCtx,
             role.getCatalogId(),
             role.getId(),
             grantee.getCatalogId(),
@@ -1665,7 +1623,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx, () -> this.revokeUsageOnRoleFromGrantee(callCtx, ms, catalog, role, grantee));
+        () -> this.revokeUsageOnRoleFromGrantee(callCtx, ms, catalog, role, grantee));
   }
 
   /**
@@ -1708,7 +1666,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.grantPrivilegeOnSecurableToRole(
                 callCtx, ms, grantee, catalogPath, securable, privilege));
@@ -1738,7 +1695,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // lookup the grants records to find this grant
     PolarisGrantRecord grantRecord =
         ms.lookupGrantRecordInCurrentTxn(
-            callCtx,
             securable.getCatalogId(),
             securable.getId(),
             grantee.getCatalogId(),
@@ -1770,7 +1726,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read/write transaction
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.revokePrivilegeOnSecurableFromRole(
                 callCtx, ms, grantee, catalogPath, securable, privilege));
@@ -1785,7 +1740,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // lookup grants version for this securable entity
     int grantsVersion =
-        ms.lookupEntityGrantRecordsVersionInCurrentTxn(callCtx, securableCatalogId, securableId);
+        ms.lookupEntityGrantRecordsVersionInCurrentTxn(securableCatalogId, securableId);
 
     // return null if securable does not exists
     if (grantsVersion == 0) {
@@ -1794,7 +1749,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // now fetch all grants for this securable
     final List<PolarisGrantRecord> returnGrantRecords =
-        ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, securableCatalogId, securableId);
+        ms.loadAllGrantRecordsOnSecurableInCurrentTxn(securableCatalogId, securableId);
 
     // find all unique grantees
     List<PolarisEntityId> entityIds =
@@ -1805,7 +1760,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         grantRecord.getGranteeCatalogId(), grantRecord.getGranteeId()))
             .distinct()
             .collect(Collectors.toList());
-    List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(callCtx, entityIds);
+    List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
@@ -1828,7 +1783,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read transaction
     return ms.runInReadTransaction(
-        callCtx, () -> this.loadGrantsOnSecurable(callCtx, ms, securableCatalogId, securableId));
+        () -> this.loadGrantsOnSecurable(callCtx, ms, securableCatalogId, securableId));
   }
 
   /** {@link #loadGrantsToGrantee(PolarisCallContext, long, long)} */
@@ -1839,8 +1794,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       long granteeId) {
 
     // lookup grants version for this grantee entity
-    int grantsVersion =
-        ms.lookupEntityGrantRecordsVersionInCurrentTxn(callCtx, granteeCatalogId, granteeId);
+    int grantsVersion = ms.lookupEntityGrantRecordsVersionInCurrentTxn(granteeCatalogId, granteeId);
 
     // return null if grantee does not exists
     if (grantsVersion == 0) {
@@ -1849,7 +1803,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // now fetch all grants for this grantee
     final List<PolarisGrantRecord> returnGrantRecords =
-        ms.loadAllGrantRecordsOnGranteeInCurrentTxn(callCtx, granteeCatalogId, granteeId);
+        ms.loadAllGrantRecordsOnGranteeInCurrentTxn(granteeCatalogId, granteeId);
 
     // find all unique securables
     List<PolarisEntityId> entityIds =
@@ -1860,7 +1814,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         grantRecord.getSecurableCatalogId(), grantRecord.getSecurableId()))
             .distinct()
             .collect(Collectors.toList());
-    List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(callCtx, entityIds);
+    List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
@@ -1883,16 +1837,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read transaction
     return ms.runInReadTransaction(
-        callCtx, () -> this.loadGrantsToGrantee(callCtx, ms, granteeCatalogId, granteeId));
+        () -> this.loadGrantsToGrantee(callCtx, ms, granteeCatalogId, granteeId));
   }
 
   /** {@link PolarisMetaStoreManager#loadEntitiesChangeTracking(PolarisCallContext, List)} */
   private @Nonnull ChangeTrackingResult loadEntitiesChangeTracking(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull TransactionalPersistence ms,
-      @Nonnull List<PolarisEntityId> entityIds) {
+      @Nonnull TransactionalPersistence ms, @Nonnull List<PolarisEntityId> entityIds) {
     List<PolarisChangeTrackingVersions> changeTracking =
-        ms.lookupEntityVersionsInCurrentTxn(callCtx, entityIds);
+        ms.lookupEntityVersionsInCurrentTxn(entityIds);
     return new ChangeTrackingResult(changeTracking);
   }
 
@@ -1904,20 +1856,18 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 
     // need to run inside a read transaction
-    return ms.runInReadTransaction(
-        callCtx, () -> this.loadEntitiesChangeTracking(callCtx, ms, entityIds));
+    return ms.runInReadTransaction(() -> this.loadEntitiesChangeTracking(ms, entityIds));
   }
 
   /** Refer to {@link #loadEntity(PolarisCallContext, long, long, PolarisEntityType)} */
   private @Nonnull EntityResult loadEntity(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       long entityCatalogId,
       long entityId,
       int entityTypeCode) {
     // this is an easy one
     PolarisBaseEntity entity =
-        ms.lookupEntityInCurrentTxn(callCtx, entityCatalogId, entityId, entityTypeCode);
+        ms.lookupEntityInCurrentTxn(entityCatalogId, entityId, entityTypeCode);
     return (entity != null)
         ? new EntityResult(entity)
         : new EntityResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
@@ -1935,8 +1885,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read transaction
     return ms.runInReadTransaction(
-        callCtx,
-        () -> this.loadEntity(callCtx, ms, entityCatalogId, entityId, entityType.getCode()));
+        () -> this.loadEntity(ms, entityCatalogId, entityId, entityType.getCode()));
   }
 
   /** Refer to {@link #loadTasks(PolarisCallContext, String, PageToken)} */
@@ -1949,7 +1898,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // find all available tasks
     Page<PolarisBaseEntity> availableTasks =
         ms.listEntitiesInCurrentTxn(
-            callCtx,
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityConstants.getRootEntityId(),
             PolarisEntityType.TASK,
@@ -2011,7 +1959,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   public @Nonnull EntitiesResult loadTasks(
       @Nonnull PolarisCallContext callCtx, String executorId, PageToken pageToken) {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
-    return ms.runInTransaction(callCtx, () -> this.loadTasks(callCtx, ms, executorId, pageToken));
+    return ms.runInTransaction(() -> this.loadTasks(callCtx, ms, executorId, pageToken));
   }
 
   /** {@inheritDoc} */
@@ -2042,7 +1990,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // get storage integration
     PolarisStorageIntegration<PolarisStorageConfigurationInfo> storageIntegration =
-        ms.loadPolarisStorageIntegrationInCurrentTxn(callCtx, reloadedEntity.getEntity());
+        ms.loadPolarisStorageIntegrationInCurrentTxn(reloadedEntity.getEntity());
 
     // cannot be null
     callCtx
@@ -2089,15 +2037,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
   /** {@link #loadResolvedEntityById(PolarisCallContext, long, long, PolarisEntityType)} */
   private @Nonnull ResolvedEntityResult loadResolvedEntityById(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull TransactionalPersistence ms,
-      long entityCatalogId,
-      long entityId,
-      int typeCode) {
+      @Nonnull TransactionalPersistence ms, long entityCatalogId, long entityId, int typeCode) {
 
     // load that entity
-    PolarisBaseEntity entity =
-        ms.lookupEntityInCurrentTxn(callCtx, entityCatalogId, entityId, typeCode);
+    PolarisBaseEntity entity = ms.lookupEntityInCurrentTxn(entityCatalogId, entityId, typeCode);
 
     // if entity not found, return null
     if (entity == null) {
@@ -2108,13 +2051,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     final List<PolarisGrantRecord> grantRecords;
     if (entity.getType().isGrantee()) {
       grantRecords =
-          new ArrayList<>(
-              ms.loadAllGrantRecordsOnGranteeInCurrentTxn(callCtx, entityCatalogId, entityId));
-      grantRecords.addAll(
-          ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entityId));
+          new ArrayList<>(ms.loadAllGrantRecordsOnGranteeInCurrentTxn(entityCatalogId, entityId));
+      grantRecords.addAll(ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entityId));
     } else {
-      grantRecords =
-          ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entityId);
+      grantRecords = ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entityId);
     }
 
     // return the result
@@ -2133,15 +2073,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read transaction
     return ms.runInReadTransaction(
-        callCtx,
-        () ->
-            this.loadResolvedEntityById(
-                callCtx, ms, entityCatalogId, entityId, entityType.getCode()));
+        () -> this.loadResolvedEntityById(ms, entityCatalogId, entityId, entityType.getCode()));
   }
 
   /** {@link #loadResolvedEntityById(PolarisCallContext, long, long, PolarisEntityType)} */
   private @Nonnull ResolvedEntityResult loadResolvedEntityByName(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull TransactionalPersistence ms,
       long entityCatalogId,
       long parentId,
@@ -2151,7 +2087,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // load that entity
     PolarisBaseEntity entity =
         ms.lookupEntityByNameInCurrentTxn(
-            callCtx, entityCatalogId, parentId, entityType.getCode(), entityName);
+            entityCatalogId, parentId, entityType.getCode(), entityName);
 
     // null if entity not found
     if (entity == null) {
@@ -2163,13 +2099,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     if (entity.getType().isGrantee()) {
       grantRecords =
           new ArrayList<>(
-              ms.loadAllGrantRecordsOnGranteeInCurrentTxn(
-                  callCtx, entityCatalogId, entity.getId()));
+              ms.loadAllGrantRecordsOnGranteeInCurrentTxn(entityCatalogId, entity.getId()));
       grantRecords.addAll(
-          ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entity.getId()));
+          ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entity.getId()));
     } else {
-      grantRecords =
-          ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entity.getId());
+      grantRecords = ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entity.getId());
     }
 
     // return the result
@@ -2190,16 +2124,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // need to run inside a read transaction
     ResolvedEntityResult result =
         ms.runInReadTransaction(
-            callCtx,
             () ->
                 this.loadResolvedEntityByName(
-                    callCtx, ms, entityCatalogId, parentId, entityType, entityName));
+                    ms, entityCatalogId, parentId, entityType, entityName));
     if (PolarisEntityConstants.getRootContainerName().equals(entityName)
         && entityType == PolarisEntityType.ROOT
         && !result.isSuccess()) {
       // Backfill rootContainer if needed.
       ms.runActionInTransaction(
-          callCtx,
           () -> {
             PolarisBaseEntity rootContainer =
                 new PolarisBaseEntity(
@@ -2214,7 +2146,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             if (backfillResult.isSuccess()) {
               PolarisBaseEntity serviceAdminRole =
                   ms.lookupEntityByNameInCurrentTxn(
-                      callCtx,
                       0L,
                       0L,
                       PolarisEntityType.PRINCIPAL_ROLE.getCode(),
@@ -2233,10 +2164,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       // Redo the lookup in a separate read transaction.
       result =
           ms.runInReadTransaction(
-              callCtx,
               () ->
                   this.loadResolvedEntityByName(
-                      callCtx, ms, entityCatalogId, parentId, entityType, entityName));
+                      ms, entityCatalogId, parentId, entityType, entityName));
     }
     return result;
   }
@@ -2253,8 +2183,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // load version information
     PolarisChangeTrackingVersions entityVersions =
-        ms.lookupEntityVersionsInCurrentTxn(
-                callCtx, List.of(new PolarisEntityId(entityCatalogId, entityId)))
+        ms.lookupEntityVersionsInCurrentTxn(List.of(new PolarisEntityId(entityCatalogId, entityId)))
             .get(0);
 
     // if null, the entity has been purged
@@ -2265,8 +2194,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // load the entity if something changed
     final PolarisBaseEntity entity;
     if (entityVersion != entityVersions.getEntityVersion()) {
-      entity =
-          ms.lookupEntityInCurrentTxn(callCtx, entityCatalogId, entityId, entityType.getCode());
+      entity = ms.lookupEntityInCurrentTxn(entityCatalogId, entityId, entityType.getCode());
 
       // if not found, return null
       if (entity == null) {
@@ -2282,13 +2210,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     if (entityVersions.getGrantRecordsVersion() != entityGrantRecordsVersion) {
       if (entityType.isGrantee()) {
         grantRecords =
-            new ArrayList<>(
-                ms.loadAllGrantRecordsOnGranteeInCurrentTxn(callCtx, entityCatalogId, entityId));
+            new ArrayList<>(ms.loadAllGrantRecordsOnGranteeInCurrentTxn(entityCatalogId, entityId));
         grantRecords.addAll(
-            ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entityId));
+            ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entityId));
       } else {
-        grantRecords =
-            ms.loadAllGrantRecordsOnSecurableInCurrentTxn(callCtx, entityCatalogId, entityId);
+        grantRecords = ms.loadAllGrantRecordsOnSecurableInCurrentTxn(entityCatalogId, entityId);
       }
     } else {
       grantRecords = null;
@@ -2312,7 +2238,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // need to run inside a read transaction
     return ms.runInReadTransaction(
-        callCtx,
         () ->
             this.refreshResolvedEntity(
                 callCtx,
@@ -2331,9 +2256,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
           @Nonnull PolarisCallContext callContext, T entity) {
     TransactionalPersistence ms = ((TransactionalPersistence) callContext.getMetaStore());
     return ms.runInTransaction(
-        callContext,
         () -> {
-          return callContext.getMetaStore().hasOverlappingSiblings(callContext, entity);
+          return callContext.getMetaStore().hasOverlappingSiblings(entity);
         });
   }
 
@@ -2350,7 +2274,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
 
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.doAttachPolicyToEntity(
                 callCtx, ms, targetCatalogPath, target, policyCatalogPath, policy, parameters));
@@ -2389,7 +2312,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolicyEntity policy) {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
     return ms.runInTransaction(
-        callCtx,
         () ->
             this.doDetachPolicyFromEntity(
                 callCtx, ms, targetCatalogPath, target, policyCatalogPath, policy));
@@ -2416,7 +2338,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     PolarisPolicyMappingRecord mappingRecord =
         ms.lookupPolicyMappingRecordInCurrentTxn(
-            callCtx,
             target.getCatalogId(),
             target.getId(),
             policy.getPolicyTypeCode(),
@@ -2426,7 +2347,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       return new PolicyAttachmentResult(BaseResult.ReturnStatus.POLICY_MAPPING_NOT_FOUND, null);
     }
 
-    ms.deleteFromPolicyMappingRecordsInCurrentTxn(callCtx, mappingRecord);
+    ms.deleteFromPolicyMappingRecordsInCurrentTxn(mappingRecord);
 
     return new PolicyAttachmentResult(mappingRecord);
   }
@@ -2436,7 +2357,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   public @Nonnull LoadPolicyMappingsResult loadPoliciesOnEntity(
       @Nonnull PolarisCallContext callCtx, @Nonnull PolarisEntityCore target) {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
-    return ms.runInReadTransaction(callCtx, () -> this.doLoadPoliciesOnEntity(callCtx, ms, target));
+    return ms.runInReadTransaction(() -> this.doLoadPoliciesOnEntity(callCtx, ms, target));
   }
 
   /** See {@link #loadPoliciesOnEntity(PolarisCallContext, PolarisEntityCore)} */
@@ -2445,15 +2366,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull TransactionalPersistence ms,
       @Nonnull PolarisEntityCore target) {
     PolarisBaseEntity entity =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+        ms.lookupEntityInCurrentTxn(target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
     }
 
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
-        ms.loadAllPoliciesOnTargetInCurrentTxn(callCtx, target.getCatalogId(), target.getId());
+        ms.loadAllPoliciesOnTargetInCurrentTxn(target.getCatalogId(), target.getId());
 
     List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
@@ -2468,7 +2388,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolicyType policyType) {
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
     return ms.runInReadTransaction(
-        callCtx, () -> this.doLoadPoliciesOnEntityByType(callCtx, ms, target, policyType));
+        () -> this.doLoadPoliciesOnEntityByType(callCtx, ms, target, policyType));
   }
 
   /** See {@link #loadPoliciesOnEntityByType(PolarisCallContext, PolarisEntityCore, PolicyType)} */
@@ -2478,8 +2398,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyType policyType) {
     PolarisBaseEntity entity =
-        ms.lookupEntityInCurrentTxn(
-            callCtx, target.getCatalogId(), target.getId(), target.getTypeCode());
+        ms.lookupEntityInCurrentTxn(target.getCatalogId(), target.getId(), target.getTypeCode());
     if (entity == null) {
       // Target entity does not exists
       return new LoadPolicyMappingsResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, null);
@@ -2487,7 +2406,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     final List<PolarisPolicyMappingRecord> policyMappingRecords =
         ms.loadPoliciesOnTargetByTypeInCurrentTxn(
-            callCtx, target.getCatalogId(), target.getId(), policyType.getCode());
+            target.getCatalogId(), target.getId(), policyType.getCode());
     List<PolarisBaseEntity> policyEntities =
         loadPoliciesFromMappingRecords(callCtx, ms, policyMappingRecords);
     return new LoadPolicyMappingsResult(policyMappingRecords, policyEntities);
@@ -2522,8 +2441,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             parameters);
 
     try {
-      ms.checkConditionsForWriteToPolicyMappingRecordsInCurrentTxn(callCtx, mappingRecord);
-      ms.writeToPolicyMappingRecordsInCurrentTxn(callCtx, mappingRecord);
+      ms.checkConditionsForWriteToPolicyMappingRecordsInCurrentTxn(mappingRecord);
+      ms.writeToPolicyMappingRecordsInCurrentTxn(mappingRecord);
     } catch (IllegalArgumentException e) {
       return new PolicyAttachmentResult(
           BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unknown policy type");
@@ -2557,6 +2476,6 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyId()))
             .distinct()
             .collect(Collectors.toList());
-    return ms.lookupEntitiesInCurrentTxn(callCtx, policyEntityIds);
+    return ms.lookupEntitiesInCurrentTxn(policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
@@ -57,10 +56,9 @@ public interface TransactionalPersistence
    * error. The result of the supplier lambda is returned if success, else the error will be
    * re-thrown.
    *
-   * @param callCtx call context
    * @param transactionCode code of the transaction being executed, a supplier lambda
    */
-  <T> T runInTransaction(@Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode);
+  <T> T runInTransaction(@Nonnull Supplier<T> transactionCode);
 
   /**
    * Run the specified transaction code (a runnable lambda type) in a database read/write
@@ -68,11 +66,9 @@ public interface TransactionalPersistence
    * the transaction will be committed, else the transaction will be automatically rolled-back on
    * error.
    *
-   * @param callCtx call context
    * @param transactionCode code of the transaction being executed, a runnable lambda
    */
-  void runActionInTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode);
+  void runActionInTransaction(@Nonnull Runnable transactionCode);
 
   /**
    * Run the specified transaction code (a Supplier lambda type) in a database read transaction. If
@@ -80,22 +76,18 @@ public interface TransactionalPersistence
    * will be committed, else the transaction will be automatically rolled-back on error. The result
    * of the supplier lambda is returned if success, else the error will be re-thrown.
    *
-   * @param callCtx call context
    * @param transactionCode code of the transaction being executed, a supplier lambda
    */
-  <T> T runInReadTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Supplier<T> transactionCode);
+  <T> T runInReadTransaction(@Nonnull Supplier<T> transactionCode);
 
   /**
    * Run the specified transaction code (a runnable lambda type) in a database read transaction. If
    * the code of the transaction does not throw any exception and returns normally, the transaction
    * will be committed, else the transaction will be automatically rolled-back on error.
    *
-   * @param callCtx call context
    * @param transactionCode code of the transaction being executed, a runnable lambda
    */
-  void runActionInReadTransaction(
-      @Nonnull PolarisCallContext callCtx, @Nonnull Runnable transactionCode);
+  void runActionInReadTransaction(@Nonnull Runnable transactionCode);
 
   /**
    * Lookup the specified set of entities by entityActiveKeys Return the result, a parallel list of
@@ -105,7 +97,7 @@ public interface TransactionalPersistence
    */
   @Nonnull
   List<EntityNameLookupRecord> lookupEntityActiveBatchInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntitiesActiveKey> entityActiveKeys);
+      List<PolarisEntitiesActiveKey> entityActiveKeys);
 
   /** Rollback the current transaction */
   void rollback();
@@ -120,7 +112,7 @@ public interface TransactionalPersistence
   //
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#generateNewId} */
-  long generateNewIdInCurrentTxn(@Nonnull PolarisCallContext callCtx);
+  long generateNewIdInCurrentTxn();
 
   /**
    * See {@link org.apache.polaris.core.persistence.BasePersistence#writeEntity}
@@ -133,78 +125,61 @@ public interface TransactionalPersistence
    * entity, but TransactionalPersistence::writeEntityInCurrentTxn is *not* expected to do the same.
    */
   void writeEntityInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       boolean nameOrParentChanged,
       @Nullable PolarisBaseEntity originalEntity);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#writeEntities} */
   void writeEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull List<PolarisBaseEntity> entities,
       @Nullable List<PolarisBaseEntity> originalEntities);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#writeToGrantRecords} */
-  void writeToGrantRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec);
+  void writeToGrantRecordsInCurrentTxn(@Nonnull PolarisGrantRecord grantRec);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#deleteEntity} */
-  void deleteEntityInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity entity);
+  void deleteEntityInCurrentTxn(@Nonnull PolarisBaseEntity entity);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#deleteFromGrantRecords} */
-  void deleteFromGrantRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec);
+  void deleteFromGrantRecordsInCurrentTxn(@Nonnull PolarisGrantRecord grantRec);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#deleteAllEntityGrantRecords} */
   void deleteAllEntityGrantRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisEntityCore entity,
       @Nonnull List<PolarisGrantRecord> grantsOnGrantee,
       @Nonnull List<PolarisGrantRecord> grantsOnSecurable);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#deleteAll} */
-  void deleteAllInCurrentTxn(@Nonnull PolarisCallContext callCtx);
+  void deleteAllInCurrentTxn();
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntity} */
   @Nullable
-  PolarisBaseEntity lookupEntityInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode);
+  PolarisBaseEntity lookupEntityInCurrentTxn(long catalogId, long entityId, int typeCode);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntityByName} */
   @Nullable
   PolarisBaseEntity lookupEntityByNameInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      int typeCode,
-      @Nonnull String name);
+      long catalogId, long parentId, int typeCode, @Nonnull String name);
 
   /**
    * See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntityIdAndSubTypeByName}
    */
   @Nullable
   EntityNameLookupRecord lookupEntityIdAndSubTypeByNameInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      int typeCode,
-      @Nonnull String name);
+      long catalogId, long parentId, int typeCode, @Nonnull String name);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntities} */
   @Nonnull
-  List<PolarisBaseEntity> lookupEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds);
+  List<PolarisBaseEntity> lookupEntitiesInCurrentTxn(List<PolarisEntityId> entityIds);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntityVersions} */
   @Nonnull
   List<PolarisChangeTrackingVersions> lookupEntityVersionsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds);
+      List<PolarisEntityId> entityIds);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
   @Nonnull
   Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       @Nonnull PolarisEntityType entityType,
@@ -213,7 +188,6 @@ public interface TransactionalPersistence
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
   @Nonnull
   Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       @Nonnull PolarisEntityType entityType,
@@ -223,7 +197,6 @@ public interface TransactionalPersistence
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
   @Nonnull
   <T> Page<T> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       @Nonnull PolarisEntityType entityType,
@@ -234,13 +207,11 @@ public interface TransactionalPersistence
   /**
    * See {@link org.apache.polaris.core.persistence.BasePersistence#lookupEntityGrantRecordsVersion}
    */
-  int lookupEntityGrantRecordsVersionInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId);
+  int lookupEntityGrantRecordsVersionInCurrentTxn(long catalogId, long entityId);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#lookupGrantRecord} */
   @Nullable
   PolarisGrantRecord lookupGrantRecordInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       long securableCatalogId,
       long securableId,
       long granteeCatalogId,
@@ -252,26 +223,22 @@ public interface TransactionalPersistence
    */
   @Nonnull
   List<PolarisGrantRecord> loadAllGrantRecordsOnSecurableInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long securableCatalogId, long securableId);
+      long securableCatalogId, long securableId);
 
   /**
    * See {@link org.apache.polaris.core.persistence.BasePersistence#loadAllGrantRecordsOnGrantee}
    */
   @Nonnull
   List<PolarisGrantRecord> loadAllGrantRecordsOnGranteeInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long granteeCatalogId, long granteeId);
+      long granteeCatalogId, long granteeId);
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#hasChildren} */
   boolean hasChildrenInCurrentTxn(
-      @Nonnull PolarisCallContext callContext,
-      @Nullable PolarisEntityType optionalEntityType,
-      long catalogId,
-      long parentId);
+      @Nullable PolarisEntityType optionalEntityType, long catalogId, long parentId);
 
   /** See {@link org.apache.polaris.core.persistence.IntegrationPersistence#loadPrincipalSecrets} */
   @Nullable
-  PolarisPrincipalSecrets loadPrincipalSecretsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId);
+  PolarisPrincipalSecrets loadPrincipalSecretsInCurrentTxn(@Nonnull String clientId);
 
   /**
    * See {@link
@@ -279,24 +246,19 @@ public interface TransactionalPersistence
    */
   @Nonnull
   PolarisPrincipalSecrets generateNewPrincipalSecretsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String principalName, long principalId);
+      @Nonnull String principalName, long principalId);
 
   /**
    * See {@link org.apache.polaris.core.persistence.IntegrationPersistence#rotatePrincipalSecrets}
    */
   @Nullable
   PolarisPrincipalSecrets rotatePrincipalSecretsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
-      long principalId,
-      boolean reset,
-      @Nonnull String oldSecretHash);
+      @Nonnull String clientId, long principalId, boolean reset, @Nonnull String oldSecretHash);
 
   /**
    * See {@link org.apache.polaris.core.persistence.IntegrationPersistence#deletePrincipalSecrets}
    */
-  void deletePrincipalSecretsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId, long principalId);
+  void deletePrincipalSecretsInCurrentTxn(@Nonnull String clientId, long principalId);
 
   /**
    * See {@link org.apache.polaris.core.persistence.IntegrationPersistence#createStorageIntegration}
@@ -304,7 +266,6 @@ public interface TransactionalPersistence
   @Nullable
   <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegrationInCurrentTxn(
-          @Nonnull PolarisCallContext callCtx,
           long catalogId,
           long entityId,
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
@@ -314,9 +275,7 @@ public interface TransactionalPersistence
    * org.apache.polaris.core.persistence.IntegrationPersistence#persistStorageIntegrationIfNeeded}
    */
   <T extends PolarisStorageConfigurationInfo> void persistStorageIntegrationIfNeededInCurrentTxn(
-      @Nonnull PolarisCallContext callContext,
-      @Nonnull PolarisBaseEntity entity,
-      @Nullable PolarisStorageIntegration<T> storageIntegration);
+      @Nonnull PolarisBaseEntity entity, @Nullable PolarisStorageIntegration<T> storageIntegration);
 
   /**
    * See {@link
@@ -325,5 +284,5 @@ public interface TransactionalPersistence
   @Nullable
   <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegrationInCurrentTxn(
-          @Nonnull PolarisCallContext callContext, @Nonnull PolarisBaseEntity entity);
+          @Nonnull PolarisBaseEntity entity);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyMappingPersistence.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.policy;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 
 /**
@@ -40,23 +39,19 @@ public interface PolicyMappingPersistence {
    * conflict (existing record with the same PK), all attributes of the new record will replace the
    * existing one.
    *
-   * @param callCtx call context
    * @param record policy mapping record to write, potentially replacing an existing policy mapping
    *     with the same key
    */
-  default void writeToPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+  default void writeToPolicyMappingRecords(@Nonnull PolarisPolicyMappingRecord record) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /**
    * Delete the specified policyMappingRecord to the policy_mapping_records table.
    *
-   * @param callCtx call context
    * @param record policy mapping record to delete.
    */
-  default void deleteFromPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+  default void deleteFromPolicyMappingRecords(@Nonnull PolarisPolicyMappingRecord record) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
@@ -64,7 +59,6 @@ public interface PolicyMappingPersistence {
    * Delete the all policy mapping records in the policy_mapping_records table for the specified
    * entity. This method will delete all policy mapping records on the entity
    *
-   * @param callCtx call context
    * @param entity entity whose policy mapping records should be deleted
    * @param mappingOnTarget all mappings on that target entity. Empty list if that entity is not a
    *     target
@@ -72,7 +66,6 @@ public interface PolicyMappingPersistence {
    *     policy
    */
   default void deleteAllEntityPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
@@ -83,7 +76,6 @@ public interface PolicyMappingPersistence {
    * Look up the specified policy mapping record from the policy_mapping_records table. Return NULL
    * if not found
    *
-   * @param callCtx call context
    * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
    * @param targetId id of the target entity
    * @param policyTypeCode type code of the policy entity
@@ -93,7 +85,6 @@ public interface PolicyMappingPersistence {
    */
   @Nullable
   default PolarisPolicyMappingRecord lookupPolicyMappingRecord(
-      @Nonnull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,
       int policyTypeCode,
@@ -105,7 +96,6 @@ public interface PolicyMappingPersistence {
   /**
    * Get all policies on the specified target entity with specified policy type.
    *
-   * @param callCtx call context
    * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
    * @param targetId id of the target entity
    * @param policyTypeCode type code of the policy entity
@@ -114,31 +104,26 @@ public interface PolicyMappingPersistence {
    */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
-      @Nonnull PolarisCallContext callCtx,
-      long targetCatalogId,
-      long targetId,
-      int policyTypeCode) {
+      long targetCatalogId, long targetId, int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /**
    * Get all policies on the specified target entity.
    *
-   * @param callCtx call context
    * @param targetCatalogId catalog id of the target entity, NULL_ID if the entity is top-level
    * @param targetId id of the target entity
    * @return the list of policy mapping records for the specified target entity
    */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllPoliciesOnTarget(
-      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+      long targetCatalogId, long targetId) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /**
    * Get all targets of the specified policy entity
    *
-   * @param callCtx call context
    * @param policyCatalogId catalog id of the policy entity, NULL_ID if the entity is top-level
    * @param policyId id of the policy entity
    * @param policyTypeCode type code of the policy entity
@@ -146,10 +131,7 @@ public interface PolicyMappingPersistence {
    */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx,
-      long policyCatalogId,
-      long policyId,
-      int policyTypeCode) {
+      long policyCatalogId, long policyId, int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/TransactionalPolicyMappingPersistence.java
@@ -21,13 +21,11 @@ package org.apache.polaris.core.policy;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
-import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 
 public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#writeToPolicyMappingRecords} */
-  default void writeToPolicyMappingRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+  default void writeToPolicyMappingRecordsInCurrentTxn(@Nonnull PolarisPolicyMappingRecord record) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
@@ -37,23 +35,21 @@ public interface TransactionalPolicyMappingPersistence {
    * <p>It should throw a PolicyMappingAlreadyExistsException if the new record conflicts with an
    * exising record with same policy type but different policy.
    *
-   * @param callCtx call context
    * @param record policy mapping record to write.
    */
   default void checkConditionsForWriteToPolicyMappingRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+      @Nonnull PolarisPolicyMappingRecord record) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /** See {@link PolicyMappingPersistence#deleteFromPolicyMappingRecords} */
   default void deleteFromPolicyMappingRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+      @Nonnull PolarisPolicyMappingRecord record) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /** See {@link PolicyMappingPersistence#deleteAllEntityPolicyMappingRecords} */
   default void deleteAllEntityPolicyMappingRecordsInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       @Nonnull PolarisBaseEntity entity,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
       @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
@@ -63,7 +59,6 @@ public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#lookupPolicyMappingRecord} */
   @Nullable
   default PolarisPolicyMappingRecord lookupPolicyMappingRecordInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,
       int policyTypeCode,
@@ -75,27 +70,21 @@ public interface TransactionalPolicyMappingPersistence {
   /** See {@link PolicyMappingPersistence#loadPoliciesOnTargetByType} */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByTypeInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long targetCatalogId,
-      long targetId,
-      int policyTypeCode) {
+      long targetCatalogId, long targetId, int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /** See {@link PolicyMappingPersistence#loadAllPoliciesOnTarget} */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllPoliciesOnTargetInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+      long targetCatalogId, long targetId) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 
   /** See {@link PolicyMappingPersistence#loadAllTargetsOnPolicy} */
   @Nonnull
   default List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicyInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long policyCatalogId,
-      long policyId,
-      int policyTypeCode) {
+      long policyCatalogId, long policyId, int policyTypeCode) {
     throw new UnsupportedOperationException("Not Implemented");
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
@@ -38,7 +38,8 @@ public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
     PolarisCallContext callCtx =
         new PolarisCallContext(
             () -> "testRealm",
-            new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
+            new TreeMapTransactionalPersistenceImpl(
+                diagServices, store, Mockito.mock(), RANDOM_SECRETS),
             diagServices,
             new PolarisConfigurationStore() {},
             timeSource.withZone(ZoneId.systemDefault()));

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapMetaStoreManagerTest.java
@@ -38,7 +38,8 @@ public class PolarisTreeMapMetaStoreManagerTest extends BasePolarisMetaStoreMana
     PolarisCallContext callCtx =
         new PolarisCallContext(
             () -> "testRealm",
-            new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS),
+            new TreeMapTransactionalPersistenceImpl(
+                diagServices, store, Mockito.mock(), RANDOM_SECRETS),
             diagServices,
             new PolarisConfigurationStore() {},
             timeSource.withZone(ZoneId.systemDefault()));

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -39,7 +39,8 @@ public class ResolverTest extends BaseResolverTest {
       PolarisDefaultDiagServiceImpl diagServices = new PolarisDefaultDiagServiceImpl();
       TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
       TreeMapTransactionalPersistenceImpl metaStore =
-          new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
+          new TreeMapTransactionalPersistenceImpl(
+              diagServices, store, Mockito.mock(), RANDOM_SECRETS);
       callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
     }
     return callCtx;

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
@@ -90,7 +90,9 @@ public class InMemoryEntityCacheTest {
   public InMemoryEntityCacheTest() {
     diagServices = new PolarisDefaultDiagServiceImpl();
     store = new TreeMapMetaStore(diagServices);
-    metaStore = new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
+    metaStore =
+        new TreeMapTransactionalPersistenceImpl(
+            diagServices, store, Mockito.mock(), RANDOM_SECRETS);
     callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
     metaStoreManager = new TransactionalMetaStoreManagerImpl();
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -64,7 +64,8 @@ public class StorageCredentialCacheTest {
     TreeMapMetaStore store = new TreeMapMetaStore(diagServices);
     // to interact with the metastore
     TransactionalPersistence metaStore =
-        new TreeMapTransactionalPersistenceImpl(store, Mockito.mock(), RANDOM_SECRETS);
+        new TreeMapTransactionalPersistenceImpl(
+            diagServices, store, Mockito.mock(), RANDOM_SECRETS);
     callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
     storageCredentialCacheConfig = () -> 10_000;
     metaStoreManager = Mockito.mock(PolarisMetaStoreManager.class);

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2906,7 +2906,7 @@ public class PolarisTestMetaStoreManager {
     BasePersistence ms = polarisCallContext.getMetaStore();
     Assertions.assertThat(
             ms.loadAllTargetsOnPolicy(
-                polarisCallContext, N1_P1.getCatalogId(), N1_P1.getId(), N1_P1.getPolicyTypeCode()))
+                N1_P1.getCatalogId(), N1_P1.getId(), N1_P1.getPolicyTypeCode()))
         .isEmpty();
 
     attachPolicyToTarget(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N1), N1_P2);

--- a/runtime/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/quarkus/entity/CatalogEntityTest.java
@@ -53,14 +53,13 @@ public class CatalogEntityTest {
 
   @BeforeEach
   public void setup() {
-    MetaStoreManagerFactory metaStoreManagerFactory = new InMemoryPolarisMetaStoreManagerFactory();
+    PolarisDefaultDiagServiceImpl diagnostics = new PolarisDefaultDiagServiceImpl();
+    MetaStoreManagerFactory metaStoreManagerFactory =
+        new InMemoryPolarisMetaStoreManagerFactory(null, diagnostics);
     RealmContext realmContext = () -> "realm";
-    PolarisCallContext polarisCallContext =
+    this.callContext =
         new PolarisCallContext(
-            realmContext,
-            metaStoreManagerFactory.getOrCreateSession(realmContext),
-            new PolarisDefaultDiagServiceImpl());
-    this.callContext = polarisCallContext;
+            realmContext, metaStoreManagerFactory.getOrCreateSession(realmContext), diagnostics);
   }
 
   @ParameterizedTest

--- a/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -69,7 +69,7 @@ public class InMemoryPolarisMetaStoreManagerFactory
       @Nullable RootCredentialsSet rootCredentialsSet,
       @Nonnull PolarisDiagnostics diagnostics) {
     return new TreeMapTransactionalPersistenceImpl(
-        store, storageIntegration, secretsGenerator(realmContext, rootCredentialsSet));
+        diagnostics, store, storageIntegration, secretsGenerator(realmContext, rootCredentialsSet));
   }
 
   @Override


### PR DESCRIPTION
Following up on #2251, this change removes the `PolarisCallContext` parameter from the interfaces `BasePersistence`, `IntegrationPersistence` and `PolicyMappingPersistence`. None of the implementations used the parameter for anything else than getting a `PolarisDiagnostics` instance, which is implicitly available in the containing type.