### PR TITLE
fix: Filter null entities in listPrincipals and listPrincipalRoles to prevent NPE

### DIFF
--- a/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/service/common/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1141,10 +1141,18 @@ public class PolarisAdminService {
     return rotateOrResetCredentialsHelper(principalName, true);
   }
 
+  /**
+   * List all principals after checking for permission. Nulls due to non-atomic list-then-get are
+   * filtered out.
+   */
   public List<PolarisEntity> listPrincipals() {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LIST_PRINCIPALS;
     authorizeBasicRootOperationOrThrow(op);
 
+    // loadEntity may return null due to multiple non-atomic
+    // API calls to the persistence layer. Specifically, this can happen when a PolarisEntity is
+    // returned by listEntities, but cannot be loaded afterward because it was purged by another
+    // process before it could be loaded.
     return metaStoreManager
         .listEntities(
             getCurrentPolarisContext(),
@@ -1159,6 +1167,7 @@ public class PolarisAdminService {
                 PolarisEntity.of(
                     metaStoreManager.loadEntity(
                         getCurrentPolarisContext(), 0, nameAndId.getId(), nameAndId.getType())))
+        .filter(Objects::nonNull)
         .toList();
   }
 
@@ -1254,10 +1263,18 @@ public class PolarisAdminService {
     return returnedEntity;
   }
 
+  /**
+   * List all principal roles after checking for permission. Nulls due to non-atomic list-then-get
+   * are filtered out.
+   */
   public List<PolarisEntity> listPrincipalRoles() {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LIST_PRINCIPAL_ROLES;
     authorizeBasicRootOperationOrThrow(op);
 
+    // loadEntity may return null due to multiple non-atomic
+    // API calls to the persistence layer. Specifically, this can happen when a PolarisEntity is
+    // returned by listEntities, but cannot be loaded afterward because it was purged by another
+    // process before it could be loaded.
     return metaStoreManager
         .listEntities(
             getCurrentPolarisContext(),
@@ -1272,6 +1289,7 @@ public class PolarisAdminService {
                 PolarisEntity.of(
                     metaStoreManager.loadEntity(
                         getCurrentPolarisContext(), 0, nameAndId.getId(), nameAndId.getType())))
+        .filter(Objects::nonNull)
         .toList();
   }
 


### PR DESCRIPTION
## Summary
Similar to listCatalogs fix, these methods are non-atomic and can cause NPE when entities are deleted between listEntities and loadEntity calls. Added  .filter(Objects::nonNull) to safely handle race conditions.

Similar to:  https://github.com/apache/polaris/pull/1949

Tagging reviewers from previous pr:
@eric-maynard 
@dimas-b 
@andrew4699 

## Tests
Added tests to verify null filtering behavior when entities are deleted  after being listed but before being loaded.
✅ `./gradlew build` succeeds
✅ Added unit tests

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
