### PR TITLE
Add PolarisAdminService.loadEntities helper

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -239,11 +239,7 @@ public class PolarisServiceImpl
   @Override
   public Response listCatalogs(RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
-    List<Catalog> catalogList =
-        adminService.listCatalogs().stream()
-            .map(CatalogEntity::new)
-            .map(CatalogEntity::asCatalog)
-            .toList();
+    List<Catalog> catalogList = adminService.listCatalogs();
     Catalogs catalogs = new Catalogs(catalogList);
     LOGGER.debug("listCatalogs returning: {}", catalogs);
     return Response.ok(catalogs).build();
@@ -311,11 +307,7 @@ public class PolarisServiceImpl
   @Override
   public Response listPrincipals(RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
-    List<Principal> principalList =
-        adminService.listPrincipals().stream()
-            .map(PrincipalEntity::new)
-            .map(PrincipalEntity::asPrincipal)
-            .toList();
+    List<Principal> principalList = adminService.listPrincipals();
     Principals principals = new Principals(principalList);
     LOGGER.debug("listPrincipals returning: {}", principals);
     return Response.ok(principals).build();
@@ -375,11 +367,7 @@ public class PolarisServiceImpl
   @Override
   public Response listPrincipalRoles(RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
-    List<PrincipalRole> principalRoleList =
-        adminService.listPrincipalRoles().stream()
-            .map(PrincipalRoleEntity::new)
-            .map(PrincipalRoleEntity::asPrincipalRole)
-            .toList();
+    List<PrincipalRole> principalRoleList = adminService.listPrincipalRoles();
     PrincipalRoles principalRoles = new PrincipalRoles(principalRoleList);
     LOGGER.debug("listPrincipalRoles returning: {}", principalRoles);
     return Response.ok(principalRoles).build();
@@ -451,11 +439,7 @@ public class PolarisServiceImpl
   public Response listCatalogRoles(
       String catalogName, RealmContext realmContext, SecurityContext securityContext) {
     PolarisAdminService adminService = newAdminService(realmContext, securityContext);
-    List<CatalogRole> catalogRoleList =
-        adminService.listCatalogRoles(catalogName).stream()
-            .map(CatalogRoleEntity::new)
-            .map(CatalogRoleEntity::asCatalogRole)
-            .toList();
+    List<CatalogRole> catalogRoleList = adminService.listCatalogRoles(catalogName);
     CatalogRoles catalogRoles = new CatalogRoles(catalogRoleList);
     LOGGER.debug("listCatalogRoles returning: {}", catalogRoles);
     return Response.ok(catalogRoles).build();

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -42,7 +42,6 @@ import org.apache.polaris.core.auth.AuthenticatedPolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -310,8 +309,8 @@ public class ManagementServiceTest {
         .when(metaStoreManager)
         .loadEntity(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any());
 
-    List<PolarisEntity> catalogs = polarisAdminService.listCatalogs();
+    List<Catalog> catalogs = polarisAdminService.listCatalogs();
     assertThat(catalogs.size()).isEqualTo(1);
-    assertThat(catalogs.getFirst().getId()).isEqualTo(catalog2.getCatalog().getId());
+    assertThat(catalogs.getFirst().getName()).isEqualTo(catalog2.getCatalog().getName());
   }
 }


### PR DESCRIPTION
`PolarisAdminService` has multiple spots where it is working around the sub-optimal `PolarisMetaStoreManager` APIs.

This results in multiple fixes like:
https://github.com/apache/polaris/pull/1949
https://github.com/apache/polaris/pull/2258

While eventually the underlying APIs should be improved, for now we can make a single central workaround and clean up some redundant code. Also we can improve the return types as callers are not interested in details of the entity layer.