### PR TITLE
Remove overloads of BasePersistence.listEntities

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.extension.persistence.impl.eclipselink;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicates;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
@@ -422,44 +421,6 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
     return entityActiveKeys.stream()
         .map(entityActiveKey -> this.lookupEntityActiveInCurrentTxn(callCtx, entityActiveKey))
         .collect(Collectors.toList());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public @Nonnull Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken) {
-    return this.listEntitiesInCurrentTxn(
-        callCtx, catalogId, parentId, entityType, Predicates.alwaysTrue(), pageToken);
-  }
-
-  @Override
-  public @Nonnull Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken) {
-    // full range scan under the parent for that type
-    return this.listEntitiesInCurrentTxn(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entityFilter,
-        entity ->
-            new EntityNameLookupRecord(
-                entity.getCatalogId(),
-                entity.getId(),
-                entity.getParentId(),
-                entity.getName(),
-                entity.getTypeCode(),
-                entity.getSubTypeCode()),
-        pageToken);
   }
 
   @Override

--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkStore.java
@@ -105,7 +105,8 @@ public class PolarisEclipseLinkStore {
 
     ModelEntityActive model = lookupEntityActive(session, new PolarisEntitiesActiveKey(entity));
     if (model == null) {
-      session.persist(ModelEntityActive.fromEntityActive(new EntityNameLookupRecord(entity)));
+      session.persist(
+          ModelEntityActive.fromEntityActive(EntityNameLookupRecord.fromEntity(entity)));
     }
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
@@ -422,48 +421,11 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Nonnull
   @Override
-  public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken) {
-    return listEntities(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entity -> true,
-        EntityNameLookupRecord::new,
-        pageToken);
-  }
-
-  @Nonnull
-  @Override
-  public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken) {
-    return listEntities(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entityFilter,
-        EntityNameLookupRecord::new,
-        pageToken);
-  }
-
-  @Nonnull
-  @Override
   public <T> Page<T> listEntities(
       @Nonnull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
-      PolarisEntityType entityType,
+      @Nonnull PolarisEntityType entityType,
       @Nonnull Predicate<PolarisBaseEntity> entityFilter,
       @Nonnull Function<PolarisBaseEntity, T> transformer,
       @Nonnull PageToken pageToken) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
@@ -89,14 +89,14 @@ public class EntityNameLookupRecord {
     this.subTypeCode = subTypeCode;
   }
 
-  /** Constructor to create the object with provided entity */
-  public EntityNameLookupRecord(PolarisBaseEntity entity) {
-    this.catalogId = entity.getCatalogId();
-    this.id = entity.getId();
-    this.parentId = entity.getParentId();
-    this.typeCode = entity.getTypeCode();
-    this.name = entity.getName();
-    this.subTypeCode = entity.getSubTypeCode();
+  public static EntityNameLookupRecord fromEntity(PolarisBaseEntity entity) {
+    return new EntityNameLookupRecord(
+        entity.getCatalogId(),
+        entity.getId(),
+        entity.getParentId(),
+        entity.getName(),
+        entity.getTypeCode(),
+        entity.getSubTypeCode());
   }
 
   @Override
@@ -119,7 +119,7 @@ public class EntityNameLookupRecord {
 
   @Override
   public String toString() {
-    return "PolarisEntitiesActiveRecord{"
+    return "EntityNameLookupRecord{"
         + "catalogId="
         + catalogId
         + ", id="

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -709,7 +709,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             : entity -> true;
 
     Page<EntityNameLookupRecord> resultPage =
-        ms.listEntities(callCtx, catalogId, parentId, entityType, filter, pageToken);
+        ms.listEntities(
+            callCtx,
+            catalogId,
+            parentId,
+            entityType,
+            filter,
+            EntityNameLookupRecord::fromEntity,
+            pageToken);
 
     // TODO: Use post-validation to enforce consistent view against catalogPath. In the
     // meantime, happens-before ordering semantics aren't guaranteed during high-concurrency

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
@@ -241,7 +241,7 @@ public interface BasePersistence extends PolicyMappingPersistence {
     if (baseEntity == null) {
       return null;
     }
-    return new EntityNameLookupRecord(baseEntity);
+    return EntityNameLookupRecord.fromEntity(baseEntity);
   }
 
   /**
@@ -267,45 +267,6 @@ public interface BasePersistence extends PolicyMappingPersistence {
   @Nonnull
   List<PolarisChangeTrackingVersions> lookupEntityVersions(
       @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds);
-
-  /**
-   * List all entities of the specified type which are child entities of the specified parent
-   *
-   * @param callCtx call context
-   * @param catalogId catalog id for that entity, NULL_ID if the entity is top-level
-   * @param parentId id of the parent, can be the special 0 value representing the root entity
-   * @param entityType type of entities to list
-   * @param pageToken the token to start listing after
-   * @return the list of entities for the specified list operation
-   */
-  @Nonnull
-  Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken);
-
-  /**
-   * List entities where some predicate returns true
-   *
-   * @param callCtx call context
-   * @param catalogId catalog id for that entity, NULL_ID if the entity is top-level
-   * @param parentId id of the parent, can be the special 0 value representing the root entity
-   * @param entityType type of entities to list
-   * @param entityFilter the filter to be applied to each entity. Only entities where the predicate
-   *     returns true are returned in the list
-   * @param pageToken the token to start listing after
-   * @return the list of entities for which the predicate returns true
-   */
-  @Nonnull
-  Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken);
 
   /**
    * List entities where some predicate returns true and transform the entities with a function

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -354,37 +354,6 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   /** {@inheritDoc} */
   @Override
   @Nonnull
-  public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken) {
-    return runInReadTransaction(
-        callCtx,
-        () -> this.listEntitiesInCurrentTxn(callCtx, catalogId, parentId, entityType, pageToken));
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @Nonnull
-  public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken) {
-    return runInReadTransaction(
-        callCtx,
-        () ->
-            this.listEntitiesInCurrentTxn(
-                callCtx, catalogId, parentId, entityType, entityFilter, pageToken));
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @Nonnull
   public <T> Page<T> listEntities(
       @Nonnull PolarisCallContext callCtx,
       long catalogId,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -717,6 +717,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             resolver.getParentId(),
             entityType,
             filter,
+            EntityNameLookupRecord::fromEntity,
             pageToken);
 
     // done

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
@@ -203,25 +203,6 @@ public interface TransactionalPersistence
 
   /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
   @Nonnull
-  Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken);
-
-  /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
-  @Nonnull
-  Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken);
-
-  /** See {@link org.apache.polaris.core.persistence.BasePersistence#listEntities} */
-  @Nonnull
   <T> Page<T> listEntitiesInCurrentTxn(
       @Nonnull PolarisCallContext callCtx,
       long catalogId,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.persistence.transactional;
 
-import com.google.common.base.Predicates;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.Comparator;
@@ -288,15 +287,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
                     entityActiveKey.getName()));
 
     // return record
-    return (entity == null)
-        ? null
-        : new EntityNameLookupRecord(
-            entity.getCatalogId(),
-            entity.getId(),
-            entity.getParentId(),
-            entity.getName(),
-            entity.getTypeCode(),
-            entity.getSubTypeCode());
+    return (entity == null) ? null : EntityNameLookupRecord.fromEntity(entity);
   }
 
   /** {@inheritDoc} */
@@ -309,44 +300,6 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
     return entityActiveKeys.stream()
         .map(entityActiveKey -> this.lookupEntityActiveInCurrentTxn(callCtx, entityActiveKey))
         .collect(Collectors.toList());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public @Nonnull Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PageToken pageToken) {
-    return this.listEntitiesInCurrentTxn(
-        callCtx, catalogId, parentId, entityType, Predicates.alwaysTrue(), pageToken);
-  }
-
-  @Override
-  public @Nonnull Page<EntityNameLookupRecord> listEntitiesInCurrentTxn(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull PageToken pageToken) {
-    // full range scan under the parent for that type
-    return this.listEntitiesInCurrentTxn(
-        callCtx,
-        catalogId,
-        parentId,
-        entityType,
-        entityFilter,
-        entity ->
-            new EntityNameLookupRecord(
-                entity.getCatalogId(),
-                entity.getId(),
-                entity.getParentId(),
-                entity.getName(),
-                entity.getTypeCode(),
-                entity.getSubTypeCode()),
-        pageToken);
   }
 
   @Override

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -130,20 +130,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
         .isNotNull()
         .hasSize(2)
         .containsExactly(
-            new EntityNameLookupRecord(
-                task1.getCatalogId(),
-                task1.getId(),
-                task1.getParentId(),
-                task1.getName(),
-                task1.getTypeCode(),
-                task1.getSubTypeCode()),
-            new EntityNameLookupRecord(
-                task2.getCatalogId(),
-                task2.getId(),
-                task2.getParentId(),
-                task2.getName(),
-                task2.getTypeCode(),
-                task2.getSubTypeCode()));
+            EntityNameLookupRecord.fromEntity(task1), EntityNameLookupRecord.fromEntity(task2));
   }
 
   @Test


### PR DESCRIPTION
`BasePersistence.listEntities` and `TransactionalPersistence.listEntitiesInCurrentTxn`
are afaict only overloaded to make the `entityFilter` and `transformer`
parameters "optional" for some callers.
the most central method still has to have support for both of them.

using default methods in the interface would enable this more clearly
but as it turns out, hardly any callers are utilizing those overloads
and thus if we simply remove the overloads we have less code and things
become clearer across the board.

we also add a `EntityNameLookupRecord.fromEntity` factory method to
replace the overloaded constructor.