### PR TITLE
Nit: simplify runtime-service dependencies

### DIFF
--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
   implementation(project(":polaris-api-iceberg-service"))
   implementation(project(":polaris-api-catalog-service"))
 
+  runtimeOnly(project(":polaris-relational-jdbc"))
+
   implementation(project(":polaris-runtime-defaults"))
   implementation(project(":polaris-runtime-common"))
 
@@ -54,6 +56,7 @@ dependencies {
   implementation("io.quarkus:quarkus-security")
   implementation("io.quarkus:quarkus-smallrye-context-propagation")
   implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
+  runtimeOnly("io.quarkus:quarkus-jdbc-postgresql")
 
   implementation(libs.jakarta.enterprise.cdi.api)
   implementation(libs.jakarta.inject.api)
@@ -135,12 +138,6 @@ dependencies {
   testImplementation("software.amazon.awssdk:kms")
   testImplementation("software.amazon.awssdk:dynamodb")
 
-  runtimeOnly(project(":polaris-relational-jdbc"))
-  runtimeOnly("io.quarkus:quarkus-jdbc-postgresql") {
-    exclude(group = "org.antlr", module = "antlr4-runtime")
-    exclude(group = "org.scala-lang", module = "scala-library")
-    exclude(group = "org.scala-lang", module = "scala-reflect")
-  }
   testImplementation(platform(libs.quarkus.bom))
   testImplementation("io.quarkus:quarkus-junit5")
   testImplementation("io.quarkus:quarkus-junit5-mockito")


### PR DESCRIPTION
Project ":polaris-relational-jdbc" should be included like all other Polaris modules.

Dependency "io.quarkus:quarkus-jdbc-postgresql" doesn't need any excludes (these excludes were for `SparkIT` which is now isolated in a separate module).
