### PR TITLE
Clean exit when running repair mode for client

### DIFF
--- a/polaris
+++ b/polaris
@@ -39,14 +39,15 @@ if [ ! -d "${dir}"/polaris-venv ] || [ "$repair" == true ]; then
   rm -f "${dir}"/poetry.lock
   rm -f "${dir}/client/python/poetry.lock"
 
+  is_first_time=false
   if [ ! -d "${dir}/polaris-venv" ]; then
+    is_first_time=true
     echo "Performing first-time setup for the Python client..."
     python3 -m venv "${dir}"/polaris-venv
   else
     echo "Repair dependencies for the Python client..."
   fi
 
-  rm -f "${dir}"/poetry.lock
   . "${dir}"/polaris-venv/bin/activate
   pip install --upgrade pip
   pip install --upgrade -r regtests/requirements.txt
@@ -55,10 +56,13 @@ if [ ! -d "${dir}"/polaris-venv ] || [ "$repair" == true ]; then
 
   deactivate
 
-  if [ ! -d ${dir}/polaris-venv ]; then
+  if [ "$is_first_time" == true ]; then
     echo "First time setup complete."
   else
     echo "Dependencies repaired."
+  fi
+
+  if [ "$repair" == true ]; then
     exit 0
   fi
 fi

--- a/polaris
+++ b/polaris
@@ -59,6 +59,7 @@ if [ ! -d "${dir}"/polaris-venv ] || [ "$repair" == true ]; then
     echo "First time setup complete."
   else
     echo "Dependencies repaired."
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
Currently when running `--repair` with client, it will produce following message
```
➜  polaris git:(client_repair_mode) ./polaris --repair
Configuration on demand is an incubating feature.

> Task :regeneratePythonClient
...
Writing lock file

Installing the current project: polaris (1.0.0)
Dependencies repaired.
Traceback (most recent call last):
  File "/Users/yong/Desktop/GitHome/polaris/polaris-venv/bin/polaris", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/polaris_cli.py", line 219, in main
    PolarisCli.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/polaris_cli.py", line 70, in execute
    client_builder = PolarisCli._get_client_builder(options)
  File "/Users/yong/Desktop/GitHome/polaris/client/python/cli/polaris_cli.py", line 175, in _get_client_builder
    raise Exception(
    ...<5 lines>...
    )
Exception: Please provide credentials via either --client-id & --client-secret or --access-token. Alternatively, you may set the environment variables CLIENT_ID & CLIENT_SECRET.
```

This is bad user experience as we are not expecting user to run the main CLI during repair mode. Thus. it is better to clean exit if repair mode is invoked to avoid confusion. 

With this PR, we will know have following instead:
```
...
No dependencies to install or update

Writing lock file

Installing the current project: polaris (1.0.0)
Dependencies repaired.
➜  polaris git:(client_repair_mode) ✗
```

This PR also fixed a logic flaw in the first time setup complete message that will never happened with original code path. 

Personally. I think using `polaris` bash script is very confusing for new comers as the python client is also called `polaris`. With the recent changes, we no longer depends on this script to invoke the client CLI. We can still use this script but maybe a diff name to setup the client as well running this repair mode.