### PR TITLE
CatalogEntity: internal endpoint not considered

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -141,6 +141,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setEndpoint(awsConfig.getEndpoint())
             .setStsEndpoint(awsConfig.getStsEndpoint())
             .setPathStyleAccess(awsConfig.getPathStyleAccess())
+            .setEndpointInternal(awsConfig.getEndpointInternal())
             .build();
       }
       if (configInfo instanceof AzureStorageConfigurationInfo) {

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -230,6 +230,15 @@ public class RestCatalogMinIOSpecialIT {
             Optional.of(endpoint),
             false,
             Optional.of(endpoint))) {
+      StorageConfigInfo storageConfig =
+          managementApi.getCatalog(catalogName).getStorageConfigInfo();
+      assertThat((AwsStorageConfigInfo) storageConfig)
+          .extracting(
+              AwsStorageConfigInfo::getEndpoint,
+              AwsStorageConfigInfo::getStsEndpoint,
+              AwsStorageConfigInfo::getEndpointInternal,
+              AwsStorageConfigInfo::getPathStyleAccess)
+          .containsExactly("http://s3.example.com", endpoint, endpoint, false);
       LoadTableResponse loadTableResponse = doTestCreateTable(restCatalog);
       assertThat(loadTableResponse.config()).containsEntry("s3.endpoint", "http://s3.example.com");
     }


### PR DESCRIPTION
Setting an S3 internal endpoint doesn't work, because the property's not carried over from the OpenAPI model type into `AwsStorageConfigInfo`.