### PR TITLE
Remove `CallContext.copy()`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisCallContext.java
@@ -80,17 +80,4 @@ public class PolarisCallContext implements CallContext {
   public PolarisCallContext getPolarisCallContext() {
     return this;
   }
-
-  @Override
-  public PolarisCallContext copy() {
-    // The realm context is a request scoped bean injected by CDI,
-    // which will be closed after the http request. This copy is currently
-    // only used by TaskExecutor right before the task is handled, since the
-    // task is executed outside the active request scope, we need to make a
-    // copy of the RealmContext to ensure the access during the task executor.
-    String realmId = this.realmContext.getRealmIdentifier();
-    RealmContext realmContext = () -> realmId;
-    return new PolarisCallContext(
-        realmContext, this.metaStore, this.diagServices, this.configurationStore);
-  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/context/CallContext.java
@@ -30,9 +30,6 @@ import org.apache.polaris.core.config.RealmConfig;
  * underlying nature of the persistence layer may differ between different realms.
  */
 public interface CallContext {
-  /** Copy the {@link CallContext}. */
-  CallContext copy();
-
   RealmContext getRealmContext();
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/DefaultRealmContextResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/DefaultRealmContextResolver.java
@@ -21,10 +21,7 @@ package org.apache.polaris.service.context;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import org.apache.polaris.core.context.RealmContext;
 
 @ApplicationScoped
 @Identifier("default")
@@ -38,17 +35,8 @@ public class DefaultRealmContextResolver implements RealmContextResolver {
   }
 
   @Override
-  public CompletionStage<RealmContext> resolveRealmContext(
+  public String resolveRealmId(
       String requestURL, String method, String path, Function<String, String> headers) {
-    try {
-      String realm = resolveRealmIdentifier(headers);
-      return CompletableFuture.completedFuture(() -> realm);
-    } catch (Exception e) {
-      return CompletableFuture.failedFuture(e);
-    }
-  }
-
-  private String resolveRealmIdentifier(Function<String, String> headers) {
     String realm = headers.apply(configuration.headerName());
     if (realm != null) {
       if (!configuration.realms().contains(realm)) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/TestRealmContextResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/TestRealmContextResolver.java
@@ -24,10 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import org.apache.polaris.core.context.RealmContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +49,7 @@ public class TestRealmContextResolver implements RealmContextResolver {
   }
 
   @Override
-  public CompletionStage<RealmContext> resolveRealmContext(
+  public String resolveRealmId(
       String requestURL, String method, String path, Function<String, String> headers) {
     // Since this default resolver is strictly for use in test/dev environments, we'll consider
     // it safe to log all contents. Any "real" resolver used in a prod environment should make
@@ -73,8 +70,7 @@ public class TestRealmContextResolver implements RealmContextResolver {
           configuration.defaultRealm());
       parsedProperties.put(REALM_PROPERTY_KEY, configuration.defaultRealm());
     }
-    String realmId = parsedProperties.get(REALM_PROPERTY_KEY);
-    return CompletableFuture.completedFuture(() -> realmId);
+    return parsedProperties.get(REALM_PROPERTY_KEY);
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestFixture.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/test/PolarisIntegrationTestFixture.java
@@ -102,7 +102,11 @@ public class PolarisIntegrationTestFixture {
     RealmContext realmContext =
         helper
             .realmContextResolver
-            .resolveRealmContext(baseUri.toString(), "GET", "/", Map.of(REALM_PROPERTY_KEY, realm))
+            .resolveRealmContext(
+                baseUri.toString(),
+                "GET",
+                "/",
+                k -> REALM_PROPERTY_KEY.equalsIgnoreCase(k) ? realm : null)
             .toCompletableFuture()
             .join();
 


### PR DESCRIPTION
The function is only needed to create a "safe clone" of `PolarisCallContext` in `TaskExecutorImpl`, which doesn't have references to CDI request scoped beans.

To still let `TaskExecutorImpl` making "safe clones", a functionality to get (fresh) instances of `RealmContext` is required. To enable this, the `RealmContextResolver` has been enhanced with "`RealmContext` lookups" by realm-ID. That in turn led to splitting the HTTP/REST-to-realm-context resolution into two parts: HTTP/REST-to-realm-ID and realm-ID-to-context.

This change is part of the effort to allow tasks run run in different JVMs.