### PR TITLE
Fix "polaris" CLI script package not found issue

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -79,3 +79,7 @@ jobs:
         working-directory: client/python
         run: |
           make test-integration
+
+      - name: CLI Script Sanity Check
+        run: |
+          ./polaris --help

--- a/polaris
+++ b/polaris
@@ -73,4 +73,4 @@ if [ -z "$VIRTUAL_ENV" ] || [ "$(realpath "$VIRTUAL_ENV")" != "$(realpath "${dir
 fi
 
 export SCRIPT_DIR="${dir}"
-exec polaris "$@"
+exec poetry -C "${dir}/client/python" run polaris "$@"


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Fixes: #2293 
Currently, running the CLI using the `polaris` script will get `./polaris: line 76: exec: polaris: not found`. This PR fix the script to execute the package installed in the poetry environment

Also included a sanity check running `./polaris --help` in the CI