### PR TITLE
Perform force repair when polaris not found

### DIFF
--- a/polaris
+++ b/polaris
@@ -72,5 +72,12 @@ if [ -z "$VIRTUAL_ENV" ] || [ "$(realpath "$VIRTUAL_ENV")" != "$(realpath "${dir
   source "${dir}/polaris-venv/bin/activate"
 fi
 
+# If polaris is not found after activating the venv, it's likely the venv is old and needs a repair
+if ! command -v polaris &> /dev/null; then
+  echo "Polaris executable not found. Forcing a repair..." >&2
+  "${dir}/polaris" --repair
+  source "${dir}/polaris-venv/bin/activate"
+fi
+
 export SCRIPT_DIR="${dir}"
 exec polaris "$@"


### PR DESCRIPTION
With change in https://github.com/apache/polaris/pull/2049, we are not making polaris as a package and remove dependency on the the top level `polaris` bash script (still useful ATM until we start publishing python CLI which is being asked in https://github.com/apache/polaris/issues/2042). However, this does bring one non-backward compatible change where if the venv used by polaris was created long before, it can be a breaking change https://github.com/apache/polaris/issues/2293. To fix this problem, this PR added a check if `polaris` command existed. If missing (which indicated older venv), it will then use a sub-process to perform a force repair then loaded the new venv and continue the workflow.

Here is how to reproduce this issue and how this PR fix this issue:

To reproduce this issue, I will setup an venv with older branch:
```
➜  polaris git:(main) git checkout apache-polaris-0.9.0-incubating
➜  polaris git:(apache-polaris-0.9.0-incubating) ./polaris
...
First time setup complete.
Traceback (most recent call last):
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 144, in <module>
    PolarisCli.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 50, in execute
    client_builder = PolarisCli._get_client_builder(options)
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 105, in _get_client_builder
    raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
    ...<3 lines>...
                    f' {CLIENT_SECRET_ENV}.')
Exception: Please provide credentials via either --client-id & --client-secret or --access-token. Alternatively, you may set the environment variables CLIENT_ID & CLIENT_SECRET.
(polaris-venv) ➜  polaris git:(apache-polaris-0.9.0-incubating) which polaris
polaris not found
(polaris-venv) ➜  polaris git:(apache-polaris-0.9.0-incubating) ./polaris
Traceback (most recent call last):
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 144, in <module>
    PolarisCli.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 50, in execute
    client_builder = PolarisCli._get_client_builder(options)
  File "/Users/yong/Desktop/1/polaris/regtests/client/python/cli/polaris_cli.py", line 105, in _get_client_builder
    raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
    ...<3 lines>...
                    f' {CLIENT_SECRET_ENV}.')
Exception: Please provide credentials via either --client-id & --client-secret or --access-token. Alternatively, you may set the environment variables CLIENT_ID & CLIENT_SECRET.
```
Now to reproduce the issue, i will switch to the main branch:
```
(polaris-venv) ➜  polaris git:(apache-polaris-0.9.0-incubating) git switch main
(polaris-venv) ➜  polaris git:(main) ✗ export DOCKER=docker
(polaris-venv) ➜  polaris git:(main) ✗ ./polaris
Configuration on demand is an incubating feature.
...
License fix complete
Deletion complete
Regeneration complete

BUILD SUCCESSFUL in 15s
14 actionable tasks: 1 executed, 13 up-to-date
./polaris: line 76: exec: polaris: not found
(polaris-venv) ➜  polaris git:(main) ✗ which polaris
polaris not found
```

Now the issue is easily reproducible. With the current PR, user will then see the following:
```
➜  polaris git:(main) ✗ ./polaris
Polaris executable not found. Forcing a repair...
Configuration on demand is an incubating feature.
...
Installing the current project: polaris (1.0.0)
Dependencies repaired.
Traceback (most recent call last):
  File "/Users/yong/Desktop/1/polaris/polaris-venv/bin/polaris", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/yong/Desktop/1/polaris/client/python/cli/polaris_cli.py", line 219, in main
    PolarisCli.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/yong/Desktop/1/polaris/client/python/cli/polaris_cli.py", line 70, in execute
    client_builder = PolarisCli._get_client_builder(options)
  File "/Users/yong/Desktop/1/polaris/client/python/cli/polaris_cli.py", line 175, in _get_client_builder
    raise Exception(
    ...<5 lines>...
    )
Exception: Please provide credentials via either --client-id & --client-secret or --access-token. Alternatively, you may set the environment variables CLIENT_ID & CLIENT_SECRET.
➜  polaris git:(main) ✗ source polaris-venv/bin/activate
(polaris-venv) ➜  polaris git:(main) ✗ which polaris
/Users/yong/Desktop/1/polaris/polaris-venv/bin/polaris
```
