### PR TITLE
Let CI archive html test reports

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -73,6 +73,7 @@ jobs:
           name: upload-unit-test-artifacts
           path: |
             **/build/test-results/**
+            **/build/reports/tests/**
 
   quarkus-tests:
     name: Quarkus Tests
@@ -110,6 +111,7 @@ jobs:
           name: upload-quarkus-test-artifacts
           path: |
             **/build/test-results/**
+            **/build/reports/tests/**
 
   integration-tests:
     name: Integration Tests
@@ -143,6 +145,7 @@ jobs:
           name: upload-integration-test-artifacts
           path: |
             **/build/test-results/**
+            **/build/reports/tests/**
 
   store-gradle-cache:
     name: Store Gradle Cache


### PR DESCRIPTION
when having to debug CI test failures its much more convenient to be able to download the html report compared to the XML reports (as the latter requires to you find the right file/failure manually).