### PR TITLE
Remove CallContext from IcebergPropertiesValidation

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/rest/PolarisEndpoints.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/rest/PolarisEndpoints.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.polaris.core.config.FeatureConfiguration;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.config.RealmConfig;
 
 public class PolarisEndpoints {
   // Generic table endpoints
@@ -77,10 +77,9 @@ public class PolarisEndpoints {
    * Get the generic table endpoints. Returns GENERIC_TABLE_ENDPOINTS if ENABLE_GENERIC_TABLES is
    * set to true, otherwise, returns an empty set.
    */
-  public static Set<Endpoint> getSupportedGenericTableEndpoints(CallContext callContext) {
+  public static Set<Endpoint> getSupportedGenericTableEndpoints(RealmConfig realmConfig) {
     // add the generic table endpoints as supported endpoints if generic table feature is enabled.
-    boolean genericTableEnabled =
-        callContext.getRealmConfig().getConfig(FeatureConfiguration.ENABLE_GENERIC_TABLES);
+    boolean genericTableEnabled = realmConfig.getConfig(FeatureConfiguration.ENABLE_GENERIC_TABLES);
 
     return genericTableEnabled ? GENERIC_TABLE_ENDPOINTS : ImmutableSet.of();
   }
@@ -89,9 +88,8 @@ public class PolarisEndpoints {
    * Get the policy store endpoints. Returns POLICY_ENDPOINTS if ENABLE_POLICY_STORE is set to true,
    * otherwise, returns an empty set
    */
-  public static Set<Endpoint> getSupportedPolicyEndpoints(CallContext callContext) {
-    boolean policyStoreEnabled =
-        callContext.getRealmConfig().getConfig(FeatureConfiguration.ENABLE_POLICY_STORE);
+  public static Set<Endpoint> getSupportedPolicyEndpoints(RealmConfig realmConfig) {
+    boolean policyStoreEnabled = realmConfig.getConfig(FeatureConfiguration.ENABLE_POLICY_STORE);
     return policyStoreEnabled ? POLICY_STORE_ENDPOINTS : ImmutableSet.of();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -256,7 +256,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     var storageConfigurationInfo = catalogEntity.getStorageConfigurationInfo();
     ioImplClassName =
         IcebergPropertiesValidation.determineFileIOClassName(
-            callContext, properties, storageConfigurationInfo);
+            callContext.getRealmConfig(), properties, storageConfigurationInfo);
 
     if (ioImplClassName == null) {
       LOGGER.warn(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
@@ -27,7 +27,7 @@ import jakarta.annotation.Nullable;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,15 +36,14 @@ public class IcebergPropertiesValidation {
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergPropertiesValidation.class);
 
   public static void validateIcebergProperties(
-      @Nonnull CallContext callContext, @Nonnull Map<String, String> properties) {
-    determineFileIOClassName(callContext, properties, null);
+      @Nonnull RealmConfig realmConfig, @Nonnull Map<String, String> properties) {
+    determineFileIOClassName(realmConfig, properties, null);
   }
 
   public static String determineFileIOClassName(
-      @Nonnull CallContext callContext,
+      @Nonnull RealmConfig realmConfig,
       @Nonnull Map<String, String> properties,
       @Nullable PolarisStorageConfigurationInfo storageConfigurationInfo) {
-    var realmConfig = callContext.getPolarisCallContext().getRealmConfig();
     var ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
 
     if (ioImpl != null) {


### PR DESCRIPTION
it is sufficient to pass the `RealmConfig`.
same applies to helpers in `PolarisEndpoints`.