### PR TITLE
Fix Keycloak getting-started example

### DIFF
--- a/getting-started/keycloak/docker-compose.yml
+++ b/getting-started/keycloak/docker-compose.yml
@@ -67,13 +67,16 @@ services:
       - CLIENT_SECRET=s3cr3t
     volumes:
       - ../assets/polaris/:/polaris
-    entrypoint: |
-      /bin/sh -c "apk add --no-cache jq && \
-        chmod +x /polaris/create-catalog.sh && \
-        token=$$(curl http://keycloak:8080/realms/iceberg/protocol/openid-connect/token --user client1:s3cr3t -d 'grant_type=client_credentials' -d 'scope=catalog' | jq -r .access_token) && \
-        /polaris/create-catalog.sh realm-internal && \
-        /polaris/create-catalog.sh realm-external $$token && \
-        /polaris/create-catalog.sh realm-mixed $$token"
+    entrypoint: "/bin/sh"
+    command:
+      - "-c"
+      - >-
+        apk add --no-cache jq && 
+        chmod +x /polaris/create-catalog.sh && 
+        token=$$(curl http://keycloak:8080/realms/iceberg/protocol/openid-connect/token --user client1:s3cr3t -d 'grant_type=client_credentials' | jq -r .access_token) && 
+        /polaris/create-catalog.sh realm-internal && 
+        /polaris/create-catalog.sh realm-external $$token && 
+        /polaris/create-catalog.sh realm-mixed $$token
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.2


### PR DESCRIPTION
The `polaris-setup` container was erroneously including a non-existent scope when fetching a token from Keycloak.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
