### PR TITLE
feat: Add Pod Disruption Budget support to Helm chart

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -314,8 +314,8 @@ ct install --namespace polaris --charts ./helm/polaris
 | podDisruptionBudget | object | `{"annotations":{},"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Pod disruption budget settings. |
 | podDisruptionBudget.annotations | object | `{}` | Annotations to add to the pod disruption budget. |
 | podDisruptionBudget.enabled | bool | `false` | Specifies whether a pod disruption budget should be created. |
-| podDisruptionBudget.maxUnavailable | string | `nil` | The maximum number of pods that can be unavailable during disruptions. Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%). IMPORTANT: Cannot be used simultaneously with minAvailable. If both are set, minAvailable takes precedence. |
-| podDisruptionBudget.minAvailable | string | `nil` | The minimum number of pods that should remain available during disruptions. Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%). IMPORTANT: Cannot be used simultaneously with maxUnavailable. If both are set, minAvailable takes precedence. |
+| podDisruptionBudget.maxUnavailable | string | `nil` | The maximum number of pods that can be unavailable during disruptions. Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%). IMPORTANT: Cannot be used simultaneously with minAvailable. |
+| podDisruptionBudget.minAvailable | string | `nil` | The minimum number of pods that should remain available during disruptions. Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%). IMPORTANT: Cannot be used simultaneously with maxUnavailable. |
 | podLabels | object | `{}` | Additional Labels to apply to polaris pods. |
 | podSecurityContext | object | `{"fsGroup":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
 | podSecurityContext.fsGroup | int | `10001` | GID 10001 is compatible with Polaris OSS default images; change this if you are using a different image. |

--- a/helm/polaris/templates/poddisruptionbudget.yaml
+++ b/helm/polaris/templates/poddisruptionbudget.yaml
@@ -30,9 +30,13 @@ metadata:
     {{- tpl (toYaml .Values.podDisruptionBudget.annotations) . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+  {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot be both set." -}}
+  {{- end }}
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/helm/polaris/tests/poddisruptionbudget_test.yaml
+++ b/helm/polaris/tests/poddisruptionbudget_test.yaml
@@ -200,14 +200,11 @@ tests:
             app.kubernetes.io/instance: polaris-release
 
   # validation tests
-  - it: should not allow both minAvailable and maxUnavailable (minAvailable takes precedence)
+  - it: should fail when both minAvailable and maxUnavailable are set
     set:
       podDisruptionBudget.enabled: true
       podDisruptionBudget.minAvailable: 1
       podDisruptionBudget.maxUnavailable: 1
     asserts:
-      - equal:
-          path: spec.minAvailable
-          value: 1
-      - isNull:
-          path: spec.maxUnavailable
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot be both set."

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -68,11 +68,11 @@ podDisruptionBudget:
   enabled: false
   # -- The minimum number of pods that should remain available during disruptions.
   # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%).
-  # IMPORTANT: Cannot be used simultaneously with maxUnavailable. If both are set, minAvailable takes precedence.
+  # IMPORTANT: Cannot be used simultaneously with maxUnavailable.
   minAvailable: ~
   # -- The maximum number of pods that can be unavailable during disruptions.
   # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 50%).
-  # IMPORTANT: Cannot be used simultaneously with minAvailable. If both are set, minAvailable takes precedence.
+  # IMPORTANT: Cannot be used simultaneously with minAvailable.
   maxUnavailable: ~
   # -- Annotations to add to the pod disruption budget.
   annotations: {}


### PR DESCRIPTION
Add PodDisruptionBudget support to Helm chart (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
This PR should resolve #2345 