### PR TITLE
Add PolarisDiagnostics field to BaseMetaStoreManager

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -87,7 +87,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   protected PolarisMetaStoreManager createNewMetaStoreManager() {
-    return new AtomicOperationMetaStoreManager(clock);
+    return new AtomicOperationMetaStoreManager(clock, diagnostics);
   }
 
   private void initializeForRealm(

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -69,7 +69,8 @@ public class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
             Mockito.mock(),
             realmContext.getRealmIdentifier(),
             schemaVersion);
-    AtomicOperationMetaStoreManager metaStoreManager = new AtomicOperationMetaStoreManager(clock);
+    AtomicOperationMetaStoreManager metaStoreManager =
+        new AtomicOperationMetaStoreManager(clock, diagServices);
     PolarisCallContext callCtx =
         new PolarisCallContext(realmContext, basePersistence, diagServices);
     return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.LocationBasedEntity;
@@ -86,7 +87,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
   private final Clock clock;
 
-  public AtomicOperationMetaStoreManager(Clock clock) {
+  public AtomicOperationMetaStoreManager(Clock clock, PolarisDiagnostics diagnostics) {
+    super(diagnostics);
     this.clock = clock;
   }
 
@@ -174,11 +176,11 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @Nonnull PolarisBaseEntity entity) {
 
     // validate the entity type and subtype
-    callCtx.getDiagServices().checkNotNull(entity, "unexpected_null_dpo");
-    callCtx.getDiagServices().checkNotNull(entity.getName(), "unexpected_null_name");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_dpo");
+    getDiagnostics().checkNotNull(entity.getName(), "unexpected_null_name");
 
     // creation timestamp must be filled
-    callCtx.getDiagServices().check(entity.getDropTimestamp() == 0, "already_dropped");
+    getDiagnostics().check(entity.getDropTimestamp() == 0, "already_dropped");
 
     // Remove the main entity itself first-thing; once its id no longer resolves successfully
     // it will be pruned out of any grant-record lookups anyways.
@@ -281,13 +283,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @Nonnull PolarisPrivilege priv) {
 
     // validate non null arguments
-    callCtx.getDiagServices().checkNotNull(securable, "unexpected_null_securable");
-    callCtx.getDiagServices().checkNotNull(grantee, "unexpected_null_grantee");
-    callCtx.getDiagServices().checkNotNull(priv, "unexpected_null_priv");
+    getDiagnostics().checkNotNull(securable, "unexpected_null_securable");
+    getDiagnostics().checkNotNull(grantee, "unexpected_null_grantee");
+    getDiagnostics().checkNotNull(priv, "unexpected_null_priv");
 
     // ensure that this entity is indeed a grantee like entity
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .check(grantee.getType().isGrantee(), "entity_must_be_grantee", "entity={}", grantee);
 
     // create new grant record
@@ -306,9 +307,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // version
     PolarisBaseEntity granteeEntity =
         ms.lookupEntity(callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
-    callCtx
-        .getDiagServices()
-        .checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
+    getDiagnostics().checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedGranteeEntity =
         granteeEntity.withGrantRecordsVersion(granteeEntity.getGrantRecordsVersion() + 1);
@@ -319,8 +318,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     PolarisBaseEntity securableEntity =
         ms.lookupEntity(
             callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .checkNotNull(securableEntity, "securable_not_found", "securable={}", securable);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedSecurableEntity =
@@ -356,8 +354,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @Nonnull PolarisGrantRecord grantRecord) {
 
     // validate securable
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .check(
             securable.getCatalogId() == grantRecord.getSecurableCatalogId()
                 && securable.getId() == grantRecord.getSecurableId(),
@@ -367,8 +364,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             grantRecord);
 
     // validate grantee
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .check(
             grantee.getCatalogId() == grantRecord.getGranteeCatalogId()
                 && grantee.getId() == grantRecord.getGranteeId(),
@@ -378,9 +374,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             grantRecord);
 
     // ensure the grantee is really a grantee
-    callCtx
-        .getDiagServices()
-        .check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
+    getDiagnostics().check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
 
     // remove that grant
     ms.deleteFromGrantRecords(callCtx, grantRecord);
@@ -388,8 +382,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // load the grantee and increment its grants version
     PolarisBaseEntity refreshGrantee =
         ms.lookupEntity(callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .checkNotNull(
             refreshGrantee, "missing_grantee", "grantRecord={} grantee={}", grantRecord, grantee);
     // grants have changed, we need to bump-up the grants version
@@ -402,8 +395,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     PolarisBaseEntity refreshSecurable =
         ms.lookupEntity(
             callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .checkNotNull(
             refreshSecurable,
             "missing_securable",
@@ -430,7 +422,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // validate input
-    callCtx.getDiagServices().checkNotNull(catalog, "unexpected_null_catalog");
+    getDiagnostics().checkNotNull(catalog, "unexpected_null_catalog");
 
     Map<String, String> internalProp = catalog.getInternalPropertiesAsMap();
     String integrationIdentifierOrId =
@@ -462,8 +454,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // if found, probably a retry, simply return the previously created catalog
     if (refreshCatalog != null) {
       // if found, ensure it is indeed a catalog
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .check(
               refreshCatalog.getTypeCode() == PolarisEntityType.CATALOG.getCode(),
               "not_a_catalog",
@@ -480,8 +471,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
               PolarisEntityConstants.getNameOfCatalogAdminRole());
 
       // if found, ensure not null
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .checkNotNull(
               catalogAdminRole, "catalog_admin_role_not_found", "catalog={}", refreshCatalog);
 
@@ -532,16 +522,15 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
               PolarisEntityConstants.getRootEntityId(),
               PolarisEntityType.PRINCIPAL_ROLE.getCode(),
               PolarisEntityConstants.getNameOfPrincipalServiceAdminRole());
-      callCtx.getDiagServices().checkNotNull(serviceAdminRole, "missing_service_admin_role");
+      getDiagnostics().checkNotNull(serviceAdminRole, "missing_service_admin_role");
       this.persistNewGrantRecord(
           callCtx, ms, adminRole, serviceAdminRole, PolarisPrivilege.CATALOG_ROLE_USAGE);
     } else {
       // grant to each principal role usage on its catalog_admin role
       for (PolarisEntityCore principalRole : principalRoles) {
         // validate not null and really a principal role
-        callCtx.getDiagServices().checkNotNull(principalRole, "null principal role");
-        callCtx
-            .getDiagServices()
+        getDiagnostics().checkNotNull(principalRole, "null principal role");
+        getDiagnostics()
             .check(
                 principalRole.getTypeCode() == PolarisEntityType.PRINCIPAL_ROLE.getCode(),
                 "not_principal_role",
@@ -764,7 +753,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // validate input
-    callCtx.getDiagServices().checkNotNull(principal, "unexpected_null_principal");
+    getDiagnostics().checkNotNull(principal, "unexpected_null_principal");
 
     // check if that catalog has already been created
     PolarisBaseEntity refreshPrincipal =
@@ -777,8 +766,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // there is no concurrency conflict for something else creating a principal of this same id.
     if (refreshPrincipal != null) {
       // if found, ensure it is indeed a principal
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .check(
               principal.getTypeCode() == PolarisEntityType.PRINCIPAL.getCode(),
               "not_a_principal",
@@ -792,16 +780,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       String clientId = properties.get(PolarisEntityConstants.getClientIdPropertyName());
 
       // should not be null
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .checkNotNull(
               clientId,
               "null_client_id",
               "properties={}",
               refreshPrincipal.getInternalProperties());
       // ensure non null and non empty
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .check(
               !clientId.isEmpty(),
               "empty_client_id",
@@ -813,8 +799,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
           ((IntegrationPersistence) ms).loadPrincipalSecrets(callCtx, clientId);
 
       // should not be null
-      callCtx
-          .getDiagServices()
+      getDiagnostics()
           .checkNotNull(
               principalSecrets,
               "missing_principal_secrets",
@@ -937,10 +922,10 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // entity cannot be null
-    callCtx.getDiagServices().checkNotNull(entity, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_entity");
 
     // entity name must be specified
-    callCtx.getDiagServices().checkNotNull(entity.getName(), "unexpected_null_entity_name");
+    getDiagnostics().checkNotNull(entity.getName(), "unexpected_null_entity_name");
 
     // TODO: Use post-validation to enforce consistent view against catalogPath. In the
     // meantime, happens-before ordering semantics aren't guaranteed during high-concurrency
@@ -994,7 +979,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // entity cannot be null
-    callCtx.getDiagServices().checkNotNull(entity, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_entity");
     // persist this entity after changing it. This will update the version and update the last
     // updated time. Because the entity version is changed, we will update the change tracking table
     try {
@@ -1018,7 +1003,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // ensure that the entities list is not null
-    callCtx.getDiagServices().checkNotNull(entities, "unexpected_null_entities");
+    getDiagnostics().checkNotNull(entities, "unexpected_null_entities");
 
     List<PolarisBaseEntity> updatedEntities = new ArrayList<>(entities.size());
     List<PolarisBaseEntity> originalEntities = new ArrayList<>(entities.size());
@@ -1059,13 +1044,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // entity and new name cannot be null
-    callCtx.getDiagServices().checkNotNull(entityToRename, "unexpected_null_entityToRename");
-    callCtx.getDiagServices().checkNotNull(renamedEntity, "unexpected_null_renamedEntity");
+    getDiagnostics().checkNotNull(entityToRename, "unexpected_null_entityToRename");
+    getDiagnostics().checkNotNull(renamedEntity, "unexpected_null_renamedEntity");
 
     // if a new catalog path is specified (i.e. re-parent operation), a catalog path should be
     // specified too
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .check(
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
@@ -1159,7 +1143,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     // entity cannot be null
-    callCtx.getDiagServices().checkNotNull(entityToDrop, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entityToDrop, "unexpected_null_entity");
 
     // TODO: Either document allowance of dropping entity concurrently with potentially-impacting
     // changes in the parent path (e.g. race-condition revocation of grants on parent) or
@@ -1300,9 +1284,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             : PolarisPrivilege.PRINCIPAL_ROLE_USAGE;
 
     // grant usage on this role to this principal
-    callCtx
-        .getDiagServices()
-        .check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
+    getDiagnostics().check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
     PolarisGrantRecord grantRecord =
         this.persistNewGrantRecord(callCtx, ms, role, grantee, usagePriv);
     return new PrivilegeResult(grantRecord);
@@ -1604,8 +1586,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
     // get meta store session we should be using
     BasePersistence ms = callCtx.getMetaStore();
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .check(
             !allowedReadLocations.isEmpty() || !allowedWriteLocations.isEmpty(),
             "allowed_locations_to_subscope_is_required");
@@ -1627,8 +1608,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             .loadPolarisStorageIntegration(callCtx, reloadedEntity.getEntity());
 
     // cannot be null
-    callCtx
-        .getDiagServices()
+    getDiagnostics()
         .checkNotNull(
             storageIntegration,
             "storage_integration_not_exists",
@@ -1931,8 +1911,8 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyEntity policy,
       Map<String, String> parameters) {
-    callCtx.getDiagServices().checkNotNull(target, "unexpected_null_target");
-    callCtx.getDiagServices().checkNotNull(policy, "unexpected_null_policy");
+    getDiagnostics().checkNotNull(target, "unexpected_null_target");
+    getDiagnostics().checkNotNull(policy, "unexpected_null_policy");
 
     PolarisPolicyMappingRecord mappingRecord =
         new PolarisPolicyMappingRecord(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -88,7 +88,8 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
    * Subclasses can override this to inject different implementations of PolarisMetaStoreManager
    * into the existing realm-based setup flow.
    */
-  protected PolarisMetaStoreManager createNewMetaStoreManager(Clock clock) {
+  protected PolarisMetaStoreManager createNewMetaStoreManager(
+      Clock clock, PolarisDiagnostics diagnostics) {
     return new TransactionalMetaStoreManagerImpl(clock, diagnostics);
   }
 
@@ -99,7 +100,7 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
         realmContext.getRealmIdentifier(),
         () -> createMetaStoreSession(backingStore, realmContext, rootCredentialsSet, diagnostics));
 
-    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager(clock);
+    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager(clock, diagnostics);
     metaStoreManagerMap.put(realmContext.getRealmIdentifier(), metaStoreManager);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -93,6 +93,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   private final PolarisDiagnostics diagnostics;
 
   public TransactionalMetaStoreManagerImpl(Clock clock, PolarisDiagnostics diagnostics) {
+    super(diagnostics);
     this.clock = clock;
     this.diagnostics = diagnostics;
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -90,12 +90,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       LoggerFactory.getLogger(TransactionalMetaStoreManagerImpl.class);
 
   private final Clock clock;
-  private final PolarisDiagnostics diagnostics;
 
   public TransactionalMetaStoreManagerImpl(Clock clock, PolarisDiagnostics diagnostics) {
     super(diagnostics);
     this.clock = clock;
-    this.diagnostics = diagnostics;
   }
 
   /**
@@ -170,11 +168,11 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisBaseEntity entity) {
 
     // validate the entity type and subtype
-    diagnostics.checkNotNull(entity, "unexpected_null_dpo");
-    diagnostics.checkNotNull(entity.getName(), "unexpected_null_name");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_dpo");
+    getDiagnostics().checkNotNull(entity.getName(), "unexpected_null_name");
 
     // creation timestamp must be filled
-    diagnostics.check(entity.getDropTimestamp() == 0, "already_dropped");
+    getDiagnostics().check(entity.getDropTimestamp() == 0, "already_dropped");
 
     // for now drop all associated grants, etc. synchronously
     // delete ALL grant records to (if the entity is a grantee) and from that entity
@@ -272,13 +270,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisPrivilege priv) {
 
     // validate non null arguments
-    diagnostics.checkNotNull(securable, "unexpected_null_securable");
-    diagnostics.checkNotNull(grantee, "unexpected_null_grantee");
-    diagnostics.checkNotNull(priv, "unexpected_null_priv");
+    getDiagnostics().checkNotNull(securable, "unexpected_null_securable");
+    getDiagnostics().checkNotNull(grantee, "unexpected_null_grantee");
+    getDiagnostics().checkNotNull(priv, "unexpected_null_priv");
 
     // ensure that this entity is indeed a grantee like entity
-    diagnostics.check(
-        grantee.getType().isGrantee(), "entity_must_be_grantee", "entity={}", grantee);
+    getDiagnostics()
+        .check(grantee.getType().isGrantee(), "entity_must_be_grantee", "entity={}", grantee);
 
     // create new grant record
     PolarisGrantRecord grantRecord =
@@ -297,7 +295,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     PolarisBaseEntity granteeEntity =
         ms.lookupEntityInCurrentTxn(
             callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
-    diagnostics.checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
+    getDiagnostics().checkNotNull(granteeEntity, "grantee_not_found", "grantee={}", grantee);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedGranteeEntity =
         granteeEntity.withGrantRecordsVersion(granteeEntity.getGrantRecordsVersion() + 1);
@@ -308,7 +306,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     PolarisBaseEntity securableEntity =
         ms.lookupEntityInCurrentTxn(
             callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
-    diagnostics.checkNotNull(securableEntity, "securable_not_found", "securable={}", securable);
+    getDiagnostics()
+        .checkNotNull(securableEntity, "securable_not_found", "securable={}", securable);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedSecurableEntity =
         new PolarisBaseEntity.Builder(securableEntity)
@@ -341,25 +340,27 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisGrantRecord grantRecord) {
 
     // validate securable
-    diagnostics.check(
-        securable.getCatalogId() == grantRecord.getSecurableCatalogId()
-            && securable.getId() == grantRecord.getSecurableId(),
-        "securable_mismatch",
-        "securable={} grantRec={}",
-        securable,
-        grantRecord);
+    getDiagnostics()
+        .check(
+            securable.getCatalogId() == grantRecord.getSecurableCatalogId()
+                && securable.getId() == grantRecord.getSecurableId(),
+            "securable_mismatch",
+            "securable={} grantRec={}",
+            securable,
+            grantRecord);
 
     // validate grantee
-    diagnostics.check(
-        grantee.getCatalogId() == grantRecord.getGranteeCatalogId()
-            && grantee.getId() == grantRecord.getGranteeId(),
-        "grantee_mismatch",
-        "grantee={} grantRec={}",
-        grantee,
-        grantRecord);
+    getDiagnostics()
+        .check(
+            grantee.getCatalogId() == grantRecord.getGranteeCatalogId()
+                && grantee.getId() == grantRecord.getGranteeId(),
+            "grantee_mismatch",
+            "grantee={} grantRec={}",
+            grantee,
+            grantRecord);
 
     // ensure the grantee is really a grantee
-    diagnostics.check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
+    getDiagnostics().check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
 
     // remove that grant
     ms.deleteFromGrantRecordsInCurrentTxn(callCtx, grantRecord);
@@ -368,8 +369,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     PolarisBaseEntity refreshGrantee =
         ms.lookupEntityInCurrentTxn(
             callCtx, grantee.getCatalogId(), grantee.getId(), grantee.getTypeCode());
-    diagnostics.checkNotNull(
-        refreshGrantee, "missing_grantee", "grantRecord={} grantee={}", grantRecord, grantee);
+    getDiagnostics()
+        .checkNotNull(
+            refreshGrantee, "missing_grantee", "grantRecord={} grantee={}", grantRecord, grantee);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshGrantee =
         refreshGrantee.withGrantRecordsVersion(refreshGrantee.getGrantRecordsVersion() + 1);
@@ -380,12 +382,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     PolarisBaseEntity refreshSecurable =
         ms.lookupEntityInCurrentTxn(
             callCtx, securable.getCatalogId(), securable.getId(), securable.getTypeCode());
-    diagnostics.checkNotNull(
-        refreshSecurable,
-        "missing_securable",
-        "grantRecord={} securable={}",
-        grantRecord,
-        securable);
+    getDiagnostics()
+        .checkNotNull(
+            refreshSecurable,
+            "missing_securable",
+            "grantRecord={} securable={}",
+            grantRecord,
+            securable);
     // grants have changed, we need to bump-up the grants version
     PolarisBaseEntity updatedRefreshSecurable =
         refreshSecurable.withGrantRecordsVersion(refreshSecurable.getGrantRecordsVersion() + 1);
@@ -417,7 +420,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nullable PolarisStorageIntegration<?> integration,
       @Nonnull List<PolarisEntityCore> principalRoles) {
     // validate input
-    diagnostics.checkNotNull(catalog, "unexpected_null_catalog");
+    getDiagnostics().checkNotNull(catalog, "unexpected_null_catalog");
 
     // check if that catalog has already been created
     PolarisBaseEntity refreshCatalog =
@@ -427,11 +430,12 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // if found, probably a retry, simply return the previously created catalog
     if (refreshCatalog != null) {
       // if found, ensure it is indeed a catalog
-      diagnostics.check(
-          refreshCatalog.getTypeCode() == PolarisEntityType.CATALOG.getCode(),
-          "not_a_catalog",
-          "catalog={}",
-          catalog);
+      getDiagnostics()
+          .check(
+              refreshCatalog.getTypeCode() == PolarisEntityType.CATALOG.getCode(),
+              "not_a_catalog",
+              "catalog={}",
+              catalog);
 
       // lookup catalog admin role, should exist
       PolarisBaseEntity catalogAdminRole =
@@ -443,8 +447,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
               PolarisEntityConstants.getNameOfCatalogAdminRole());
 
       // if found, ensure not null
-      diagnostics.checkNotNull(
-          catalogAdminRole, "catalog_admin_role_not_found", "catalog={}", refreshCatalog);
+      getDiagnostics()
+          .checkNotNull(
+              catalogAdminRole, "catalog_admin_role_not_found", "catalog={}", refreshCatalog);
 
       // done, return the existing catalog
       return new CreateCatalogResult(refreshCatalog, catalogAdminRole);
@@ -498,19 +503,20 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
               PolarisEntityConstants.getRootEntityId(),
               PolarisEntityType.PRINCIPAL_ROLE.getCode(),
               PolarisEntityConstants.getNameOfPrincipalServiceAdminRole());
-      diagnostics.checkNotNull(serviceAdminRole, "missing_service_admin_role");
+      getDiagnostics().checkNotNull(serviceAdminRole, "missing_service_admin_role");
       this.persistNewGrantRecord(
           callCtx, ms, adminRole, serviceAdminRole, PolarisPrivilege.CATALOG_ROLE_USAGE);
     } else {
       // grant to each principal role usage on its catalog_admin role
       for (PolarisEntityCore principalRole : principalRoles) {
         // validate not null and really a principal role
-        diagnostics.checkNotNull(principalRole, "null principal role");
-        diagnostics.check(
-            principalRole.getTypeCode() == PolarisEntityType.PRINCIPAL_ROLE.getCode(),
-            "not_principal_role",
-            "type={}",
-            principalRole.getType());
+        getDiagnostics().checkNotNull(principalRole, "null principal role");
+        getDiagnostics()
+            .check(
+                principalRole.getTypeCode() == PolarisEntityType.PRINCIPAL_ROLE.getCode(),
+                "not_principal_role",
+                "type={}",
+                principalRole.getType());
 
         // grant usage on that catalog admin role to this principal
         this.persistNewGrantRecord(
@@ -774,7 +780,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull TransactionalPersistence ms,
       @Nonnull PolarisBaseEntity principal) {
     // validate input
-    diagnostics.checkNotNull(principal, "unexpected_null_principal");
+    getDiagnostics().checkNotNull(principal, "unexpected_null_principal");
 
     // check if that catalog has already been created
     PolarisBaseEntity refreshPrincipal =
@@ -784,11 +790,12 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // if found, probably a retry, simply return the previously created principal
     if (refreshPrincipal != null) {
       // if found, ensure it is indeed a principal
-      diagnostics.check(
-          principal.getTypeCode() == PolarisEntityType.PRINCIPAL.getCode(),
-          "not_a_principal",
-          "principal={}",
-          principal);
+      getDiagnostics()
+          .check(
+              principal.getTypeCode() == PolarisEntityType.PRINCIPAL.getCode(),
+              "not_a_principal",
+              "principal={}",
+              principal);
 
       // get internal properties
       Map<String, String> properties = refreshPrincipal.getInternalPropertiesAsMap();
@@ -797,26 +804,32 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       String clientId = properties.get(PolarisEntityConstants.getClientIdPropertyName());
 
       // should not be null
-      diagnostics.checkNotNull(
-          clientId, "null_client_id", "properties={}", refreshPrincipal.getInternalProperties());
+      getDiagnostics()
+          .checkNotNull(
+              clientId,
+              "null_client_id",
+              "properties={}",
+              refreshPrincipal.getInternalProperties());
       // ensure non null and non empty
-      diagnostics.check(
-          !clientId.isEmpty(),
-          "empty_client_id",
-          "properties={}",
-          refreshPrincipal.getInternalProperties());
+      getDiagnostics()
+          .check(
+              !clientId.isEmpty(),
+              "empty_client_id",
+              "properties={}",
+              refreshPrincipal.getInternalProperties());
 
       // get the main and secondary secrets for that client
       PolarisPrincipalSecrets principalSecrets =
           ms.loadPrincipalSecretsInCurrentTxn(callCtx, clientId);
 
       // should not be null
-      diagnostics.checkNotNull(
-          principalSecrets,
-          "missing_principal_secrets",
-          "clientId={} principal={}",
-          clientId,
-          refreshPrincipal);
+      getDiagnostics()
+          .checkNotNull(
+              principalSecrets,
+              "missing_principal_secrets",
+              "clientId={} principal={}",
+              clientId,
+              refreshPrincipal);
 
       // done, return the newly created principal
       return new CreatePrincipalResult(refreshPrincipal, principalSecrets);
@@ -1004,10 +1017,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisBaseEntity entity) {
 
     // entity cannot be null
-    diagnostics.checkNotNull(entity, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_entity");
 
     // entity name must be specified
-    diagnostics.checkNotNull(entity.getName(), "unexpected_null_entity_name");
+    getDiagnostics().checkNotNull(entity.getName(), "unexpected_null_entity_name");
 
     // first, check if the entity has already been created, in which case we will simply return it
     PolarisBaseEntity entityFound =
@@ -1099,7 +1112,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nullable List<PolarisEntityCore> catalogPath,
       @Nonnull PolarisBaseEntity entity) {
     // entity cannot be null
-    diagnostics.checkNotNull(entity, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entity, "unexpected_null_entity");
 
     // re-resolve everything including that entity
     PolarisEntityResolver resolver = new PolarisEntityResolver(callCtx, ms, catalogPath, entity);
@@ -1113,7 +1126,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     PolarisBaseEntity entityRefreshed =
         ms.lookupEntityInCurrentTxn(
             callCtx, entity.getCatalogId(), entity.getId(), entity.getTypeCode());
-    diagnostics.checkNotNull(entityRefreshed, "unexpected_entity_not_found", "entity={}", entity);
+    getDiagnostics()
+        .checkNotNull(entityRefreshed, "unexpected_entity_not_found", "entity={}", entity);
 
     // check that the version of the entity has not changed at all to avoid concurrent updates
     if (entityRefreshed.getEntityVersion() != entity.getEntityVersion()) {
@@ -1164,7 +1178,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull TransactionalPersistence ms,
       @Nonnull List<EntityWithPath> entities) {
     // ensure that the entities list is not null
-    diagnostics.checkNotNull(entities, "unexpected_null_entities");
+    getDiagnostics().checkNotNull(entities, "unexpected_null_entities");
 
     // list of all updated entities
     List<PolarisBaseEntity> updatedEntities = new ArrayList<>(entities.size());
@@ -1216,14 +1230,15 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisBaseEntity renamedEntity) {
 
     // entity and new name cannot be null
-    diagnostics.checkNotNull(entityToRename, "unexpected_null_entityToRename");
-    diagnostics.checkNotNull(renamedEntity, "unexpected_null_renamedEntity");
+    getDiagnostics().checkNotNull(entityToRename, "unexpected_null_entityToRename");
+    getDiagnostics().checkNotNull(renamedEntity, "unexpected_null_renamedEntity");
 
     // if a new catalog path is specified (i.e. re-parent operation), a catalog path should be
     // specified too
-    diagnostics.check(
-        (newCatalogPath == null) || (catalogPath != null),
-        "newCatalogPath_specified_without_catalogPath");
+    getDiagnostics()
+        .check(
+            (newCatalogPath == null) || (catalogPath != null),
+            "newCatalogPath_specified_without_catalogPath");
 
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {
@@ -1344,7 +1359,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nullable Map<String, String> cleanupProperties,
       boolean cleanup) {
     // entity cannot be null
-    diagnostics.checkNotNull(entityToDrop, "unexpected_null_entity");
+    getDiagnostics().checkNotNull(entityToDrop, "unexpected_null_entity");
 
     // re-resolve everything including that entity
     PolarisEntityResolver resolver =
@@ -1500,25 +1515,26 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisEntityCore grantee) {
 
     // validate the grantee input
-    diagnostics.checkNotNull(grantee, "unexpected_null_grantee");
-    diagnostics.check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
+    getDiagnostics().checkNotNull(grantee, "unexpected_null_grantee");
+    getDiagnostics().check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
 
     // validate role
-    diagnostics.checkNotNull(role, "unexpected_null_role");
+    getDiagnostics().checkNotNull(role, "unexpected_null_role");
 
     // role should be a catalog or a principal role
     boolean isCatalogRole = role.getTypeCode() == PolarisEntityType.CATALOG_ROLE.getCode();
     boolean isPrincipalRole = role.getTypeCode() == PolarisEntityType.PRINCIPAL_ROLE.getCode();
-    diagnostics.check(isCatalogRole || isPrincipalRole, "not_a_role");
+    getDiagnostics().check(isCatalogRole || isPrincipalRole, "not_a_role");
 
     // if the role is a catalog role, ensure a catalog is specified and
     // vice-versa, catalog should be null if the role is a principal role
-    diagnostics.check(
-        (catalog == null && isPrincipalRole) || (catalog != null && isCatalogRole),
-        "catalog_mismatch",
-        "catalog={} role={}",
-        catalog,
-        role);
+    getDiagnostics()
+        .check(
+            (catalog == null && isPrincipalRole) || (catalog != null && isCatalogRole),
+            "catalog_mismatch",
+            "catalog={} role={}",
+            catalog,
+            role);
 
     // re-resolve now all these entities
     List<PolarisEntityCore> otherTopLevelEntities = new ArrayList<>(2);
@@ -1545,14 +1561,15 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nullable List<PolarisEntityCore> catalogPath,
       @Nonnull PolarisEntityCore securable) {
     // validate role input
-    diagnostics.checkNotNull(grantee, "unexpected_null_grantee");
-    diagnostics.check(grantee.getType().isGrantee(), "not_grantee_type", "grantee={}", grantee);
+    getDiagnostics().checkNotNull(grantee, "unexpected_null_grantee");
+    getDiagnostics()
+        .check(grantee.getType().isGrantee(), "not_grantee_type", "grantee={}", grantee);
 
     // securable must be supplied
-    diagnostics.checkNotNull(securable, "unexpected_null_securable");
+    getDiagnostics().checkNotNull(securable, "unexpected_null_securable");
     if (securable.getCatalogId() > 0) {
       // catalogPath must be supplied if the securable has a catalogId
-      diagnostics.checkNotNull(catalogPath, "unexpected_null_catalogPath");
+      getDiagnostics().checkNotNull(catalogPath, "unexpected_null_catalogPath");
     }
 
     // re-resolve now all these entities
@@ -1586,7 +1603,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             : PolarisPrivilege.PRINCIPAL_ROLE_USAGE;
 
     // grant usage on this role to this principal
-    diagnostics.check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
+    getDiagnostics().check(grantee.getType().isGrantee(), "not_a_grantee", "grantee={}", grantee);
     PolarisGrantRecord grantRecord =
         this.persistNewGrantRecord(callCtx, ms, role, grantee, usagePriv);
     return new PrivilegeResult(grantRecord);
@@ -2027,9 +2044,10 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
 
     // get meta store session we should be using
     TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
-    diagnostics.check(
-        !allowedReadLocations.isEmpty() || !allowedWriteLocations.isEmpty(),
-        "allowed_locations_to_subscope_is_required");
+    getDiagnostics()
+        .check(
+            !allowedReadLocations.isEmpty() || !allowedWriteLocations.isEmpty(),
+            "allowed_locations_to_subscope_is_required");
 
     // reload the entity, error out if not found
     EntityResult reloadedEntity = loadEntity(callCtx, catalogId, entityId, entityType);
@@ -2043,12 +2061,13 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         ms.loadPolarisStorageIntegrationInCurrentTxn(callCtx, reloadedEntity.getEntity());
 
     // cannot be null
-    diagnostics.checkNotNull(
-        storageIntegration,
-        "storage_integration_not_exists",
-        "catalogId={}, entityId={}",
-        catalogId,
-        entityId);
+    getDiagnostics()
+        .checkNotNull(
+            storageIntegration,
+            "storage_integration_not_exists",
+            "catalogId={}, entityId={}",
+            catalogId,
+            entityId);
 
     try {
       AccessConfig accessConfig =
@@ -2486,8 +2505,8 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       @Nonnull PolarisEntityCore target,
       @Nonnull PolicyEntity policy,
       Map<String, String> parameters) {
-    diagnostics.checkNotNull(target, "unexpected_null_target");
-    diagnostics.checkNotNull(policy, "unexpected_null_policy");
+    getDiagnostics().checkNotNull(target, "unexpected_null_target");
+    getDiagnostics().checkNotNull(policy, "unexpected_null_policy");
 
     PolarisPolicyMappingRecord mappingRecord =
         new PolarisPolicyMappingRecord(

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
@@ -36,7 +36,8 @@ public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
     TreeMapTransactionalPersistenceImpl metaStore =
         new TreeMapTransactionalPersistenceImpl(
             diagServices, store, Mockito.mock(), RANDOM_SECRETS);
-    AtomicOperationMetaStoreManager metaStoreManager = new AtomicOperationMetaStoreManager(clock);
+    AtomicOperationMetaStoreManager metaStoreManager =
+        new AtomicOperationMetaStoreManager(clock, diagServices);
     PolarisCallContext callCtx = new PolarisCallContext(() -> "testRealm", metaStore, diagServices);
     return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryAtomicOperationMetaStoreManagerFactory.java
@@ -50,7 +50,8 @@ public class InMemoryAtomicOperationMetaStoreManagerFactory
   }
 
   @Override
-  protected PolarisMetaStoreManager createNewMetaStoreManager(Clock clock) {
-    return new AtomicOperationMetaStoreManager(clock);
+  protected PolarisMetaStoreManager createNewMetaStoreManager(
+      Clock clock, PolarisDiagnostics diagnostics) {
+    return new AtomicOperationMetaStoreManager(clock, diagnostics);
   }
 }


### PR DESCRIPTION
the ultimate goal is removing the `PolarisCallContext` parameter from every `PolarisMetaStoreManager` interface method, so we make steps towards reducing its usage first.