### PR TITLE
Minor refactor of integration test classes

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogConfig.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.it.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.polaris.core.admin.model.Catalog;
+
+/**
+ * Annotation to configure the catalog type and properties for integration tests.
+ *
+ * <p>This is a server-side setting; it is used to specify the Polaris Catalog type (e.g., INTERNAL,
+ * EXTERNAL) and any additional properties required for the catalog configuration.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Inherited
+public @interface CatalogConfig {
+
+  /** The type of the catalog. Defaults to INTERNAL. */
+  Catalog.TypeEnum value() default Catalog.TypeEnum.INTERNAL;
+
+  /** Additional properties for the catalog configuration. */
+  String[] properties() default {};
+}

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.it.env;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 
@@ -35,12 +36,8 @@ public final class IcebergHelper {
 
     ImmutableMap.Builder<String, String> propertiesBuilder =
         ImmutableMap.<String, String>builder()
-            .put(
-                org.apache.iceberg.CatalogProperties.URI, endpoints.catalogApiEndpoint().toString())
+            .put(CatalogProperties.URI, endpoints.catalogApiEndpoint().toString())
             .put(OAuth2Properties.TOKEN, authToken)
-            .put(
-                org.apache.iceberg.CatalogProperties.FILE_IO_IMPL,
-                "org.apache.iceberg.inmemory.InMemoryFileIO")
             .put("warehouse", catalog)
             .put("header." + endpoints.realmHeaderName(), endpoints.realmId())
             .putAll(extraProperties);

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/RestCatalogConfig.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/RestCatalogConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.it.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to configure the REST catalog for integration tests.
+ *
+ * <p>This is a client-side setting; it is used to configure the client-side REST catalog that is
+ * used in test code to connect to the Polaris REST API and to the storage layer.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Inherited
+public @interface RestCatalogConfig {
+  String[] value() default {};
+}

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -22,11 +22,9 @@ import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
@@ -64,6 +62,7 @@ import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
+import org.apache.polaris.service.it.env.CatalogConfig;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.IcebergHelper;
 import org.apache.polaris.service.it.env.IntegrationTestsHelper;
@@ -71,6 +70,7 @@ import org.apache.polaris.service.it.env.ManagementApi;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.polaris.service.it.env.PolarisClient;
 import org.apache.polaris.service.it.env.PolicyApi;
+import org.apache.polaris.service.it.env.RestCatalogConfig;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.service.types.ApplicablePolicy;
 import org.apache.polaris.service.types.AttachPolicyRequest;
@@ -131,25 +131,10 @@ public class PolarisPolicyServiceIntegrationTest {
   private final String catalogBaseLocation =
       s3BucketBase + "/" + System.getenv("USER") + "/path/to/data";
 
-  private static final String[] DEFAULT_CATALOG_PROPERTIES = {
-    "polaris.config.allow.unstructured.table.location", "true",
-    "polaris.config.allow.external.table.location", "true"
-  };
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface CatalogConfig {
-    Catalog.TypeEnum value() default Catalog.TypeEnum.INTERNAL;
-
-    String[] properties() default {
-      "polaris.config.allow.unstructured.table.location", "true",
-      "polaris.config.allow.external.table.location", "true"
-    };
-  }
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface RestCatalogConfig {
-    String[] value() default {};
-  }
+  private static final Map<String, String> DEFAULT_CATALOG_PROPERTIES =
+      Map.of(
+          "polaris.config.allow.unstructured.table.location", "true",
+          "polaris.config.allow.external.table.location", "true");
 
   @BeforeAll
   public static void setup(
@@ -188,28 +173,26 @@ public class PolarisPolicyServiceIntegrationTest {
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setAllowedLocations(List.of("s3://my-old-bucket/path/to/data"))
             .build();
-    Optional<PolarisPolicyServiceIntegrationTest.CatalogConfig> catalogConfig =
-        Optional.ofNullable(
-            method.getAnnotation(PolarisPolicyServiceIntegrationTest.CatalogConfig.class));
 
     CatalogProperties.Builder catalogPropsBuilder = CatalogProperties.builder(catalogBaseLocation);
-    String[] properties =
-        catalogConfig
-            .map(PolarisPolicyServiceIntegrationTest.CatalogConfig::properties)
-            .orElse(DEFAULT_CATALOG_PROPERTIES);
-    for (int i = 0; i < properties.length; i += 2) {
-      catalogPropsBuilder.addProperty(properties[i], properties[i + 1]);
-    }
+
+    Map<String, String> catalogProperties =
+        IntegrationTestsHelper.mergeFromAnnotatedElements(
+            testInfo, CatalogConfig.class, CatalogConfig::properties, DEFAULT_CATALOG_PROPERTIES);
+    catalogPropsBuilder.putAll(catalogProperties);
+
     if (!s3BucketBase.getScheme().equals("file")) {
       catalogPropsBuilder.addProperty(
           CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:");
     }
+
+    Catalog.TypeEnum catalogType =
+        IntegrationTestsHelper.extractFromAnnotatedElements(
+            testInfo, CatalogConfig.class, CatalogConfig::value, Catalog.TypeEnum.INTERNAL);
+
     Catalog catalog =
         PolarisCatalog.builder()
-            .setType(
-                catalogConfig
-                    .map(PolarisPolicyServiceIntegrationTest.CatalogConfig::value)
-                    .orElse(Catalog.TypeEnum.INTERNAL))
+            .setType(catalogType)
             .setName(currentCatalogName)
             .setProperties(catalogPropsBuilder.build())
             .setStorageConfigInfo(
@@ -221,26 +204,14 @@ public class PolarisPolicyServiceIntegrationTest {
 
     managementApi.createCatalog(principalRoleName, catalog);
 
-    Optional<PolarisPolicyServiceIntegrationTest.RestCatalogConfig> restCatalogConfig =
-        testInfo
-            .getTestMethod()
-            .flatMap(
-                m ->
-                    Optional.ofNullable(
-                        m.getAnnotation(
-                            PolarisPolicyServiceIntegrationTest.RestCatalogConfig.class)));
-    ImmutableMap.Builder<String, String> extraPropertiesBuilder = ImmutableMap.builder();
-    restCatalogConfig.ifPresent(
-        config -> {
-          for (int i = 0; i < config.value().length; i += 2) {
-            extraPropertiesBuilder.put(config.value()[i], config.value()[i + 1]);
-          }
-        });
+    Map<String, String> restCatalogProperties =
+        IntegrationTestsHelper.mergeFromAnnotatedElements(
+            testInfo, RestCatalogConfig.class, RestCatalogConfig::value, Map.of());
 
     String principalToken = client.obtainToken(principalCredentials);
     restCatalog =
         IcebergHelper.restCatalog(
-            endpoints, currentCatalogName, extraPropertiesBuilder.build(), principalToken);
+            endpoints, currentCatalogName, restCatalogProperties, principalToken);
     CatalogGrant catalogGrant =
         new CatalogGrant(CatalogPrivilege.CATALOG_MANAGE_CONTENT, GrantResource.TypeEnum.CATALOG);
     managementApi.createCatalogRole(currentCatalogName, CATALOG_ROLE_1);
@@ -253,8 +224,14 @@ public class PolarisPolicyServiceIntegrationTest {
   }
 
   @AfterEach
-  public void cleanUp() {
-    client.cleanUp(adminToken);
+  public void cleanUp() throws IOException {
+    try {
+      if (restCatalog != null) {
+        restCatalog.close();
+      }
+    } finally {
+      client.cleanUp(adminToken);
+    }
   }
 
   @Test

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -31,8 +31,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Arrays;
@@ -93,13 +92,16 @@ import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.service.it.env.CatalogApi;
+import org.apache.polaris.service.it.env.CatalogConfig;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.ClientPrincipal;
 import org.apache.polaris.service.it.env.GenericTableApi;
 import org.apache.polaris.service.it.env.IcebergHelper;
+import org.apache.polaris.service.it.env.IntegrationTestsHelper;
 import org.apache.polaris.service.it.env.ManagementApi;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.polaris.service.it.env.PolarisClient;
+import org.apache.polaris.service.it.env.RestCatalogConfig;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.service.types.CreateGenericTableRequest;
 import org.apache.polaris.service.types.GenericTable;
@@ -149,11 +151,13 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   private RESTCatalog restCatalog;
   private String currentCatalogName;
   private Map<String, String> restCatalogConfig;
-  private URI externalCatalogBase;
+  private URI externalCatalogBaseLocation;
   private String catalogBaseLocation;
 
   private static final Map<String, String> DEFAULT_REST_CATALOG_CONFIG =
       Map.of(
+          org.apache.iceberg.CatalogProperties.FILE_IO_IMPL,
+          "org.apache.iceberg.inmemory.InMemoryFileIO",
           org.apache.iceberg.CatalogProperties.TABLE_DEFAULT_PREFIX + "default-key1",
           "catalog-default-key1",
           org.apache.iceberg.CatalogProperties.TABLE_DEFAULT_PREFIX + "default-key2",
@@ -165,26 +169,11 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
           org.apache.iceberg.CatalogProperties.TABLE_OVERRIDE_PREFIX + "override-key4",
           "catalog-override-key4");
 
-  private static final String[] DEFAULT_CATALOG_PROPERTIES = {
-    "polaris.config.allow.unstructured.table.location", "true",
-    "polaris.config.allow.external.table.location", "true",
-    "polaris.config.list-pagination-enabled", "true"
-  };
-
-  @Retention(RetentionPolicy.RUNTIME)
-  public @interface CatalogConfig {
-    Catalog.TypeEnum value() default Catalog.TypeEnum.INTERNAL;
-
-    String[] properties() default {
-      "polaris.config.allow.unstructured.table.location", "true",
-      "polaris.config.allow.external.table.location", "true"
-    };
-  }
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface RestCatalogConfig {
-    String[] value() default {};
-  }
+  private static final Map<String, String> DEFAULT_CATALOG_PROPERTIES =
+      Map.of(
+          "polaris.config.allow.unstructured.table.location", "true",
+          "polaris.config.allow.external.table.location", "true",
+          "polaris.config.list-pagination-enabled", "true");
 
   /**
    * Get the storage configuration information for the catalog.
@@ -194,11 +183,29 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   protected abstract StorageConfigInfo getStorageConfigInfo();
 
   /**
-   * A hook for test sub-classes to initialize {@link FileIO} objects used by test cases thenselves
+   * A hook for test subclasses to initialize {@link FileIO} objects used by test cases themselves
    * for accessing test storage.
+   *
+   * <p>Important: this FileIO instance is not tied to a REST Catalog; it is created by test code
+   * performing adhoc, direct access to the storage; thus, it may not be configured with the same
+   * properties as the ones used by {@link #catalog()}!
    */
-  protected void initializeClientFileIO(FileIO fileIO) {
-    fileIO.initialize(Map.of());
+  protected <T extends FileIO> T initializeClientFileIO(T fileIO) {
+    fileIO.initialize(clientFileIOProperties().build());
+    return fileIO;
+  }
+
+  /**
+   * Get the properties to be used for {@linkplain #initializeClientFileIO(FileIO) initializing} the
+   * {@link FileIO} instance used by test code for accessing test storage.
+   */
+  protected ImmutableMap.Builder<String, String> clientFileIOProperties() {
+    return ImmutableMap.builder();
+  }
+
+  /** Get the base URI for the external catalog. */
+  protected URI externalCatalogBaseLocation() {
+    return externalCatalogBaseLocation;
   }
 
   @BeforeAll
@@ -232,31 +239,36 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
 
     Method method = testInfo.getTestMethod().orElseThrow();
     currentCatalogName = client.newEntityName(method.getName());
+
     StorageConfigInfo storageConfig = getStorageConfigInfo();
     URI testRuntimeURI = URI.create(storageConfig.getAllowedLocations().getFirst());
     catalogBaseLocation = testRuntimeURI + "/" + CATALOG_LOCATION_SUBPATH;
-    externalCatalogBase =
+    externalCatalogBaseLocation =
         URI.create(
             testRuntimeURI + "/" + EXTERNAL_CATALOG_LOCATION_SUBPATH + "/" + method.getName());
 
-    Optional<CatalogConfig> catalogConfig =
-        Optional.ofNullable(method.getAnnotation(CatalogConfig.class));
-
     CatalogProperties.Builder catalogPropsBuilder = CatalogProperties.builder(catalogBaseLocation);
-    String[] properties =
-        catalogConfig.map(CatalogConfig::properties).orElse(DEFAULT_CATALOG_PROPERTIES);
-    for (int i = 0; i < properties.length; i += 2) {
-      catalogPropsBuilder.addProperty(properties[i], properties[i + 1]);
-    }
+
+    Map<String, String> catalogProperties =
+        IntegrationTestsHelper.mergeFromAnnotatedElements(
+            testInfo, CatalogConfig.class, CatalogConfig::properties, DEFAULT_CATALOG_PROPERTIES);
+    catalogPropsBuilder.putAll(catalogProperties);
+
     catalogPropsBuilder.addProperty(
         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true");
+
     if (!testRuntimeURI.getScheme().equals("file")) {
       catalogPropsBuilder.addProperty(
           CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:");
     }
+
+    Catalog.TypeEnum catalogType =
+        IntegrationTestsHelper.extractFromAnnotatedElements(
+            testInfo, CatalogConfig.class, CatalogConfig::value, Catalog.TypeEnum.INTERNAL);
+
     Catalog catalog =
         PolarisCatalog.builder()
-            .setType(catalogConfig.map(CatalogConfig::value).orElse(Catalog.TypeEnum.INTERNAL))
+            .setType(catalogType)
             .setName(currentCatalogName)
             .setProperties(catalogPropsBuilder.build())
             .setStorageConfigInfo(storageConfig)
@@ -264,30 +276,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
 
     managementApi.createCatalog(principalRoleName, catalog);
 
-    Map<String, String> dynamicConfig =
-        testInfo
-            .getTestMethod()
-            .map(m -> m.getAnnotation(RestCatalogConfig.class))
-            .map(RestCatalogConfig::value)
-            .map(
-                values -> {
-                  if (values.length % 2 != 0) {
-                    throw new IllegalArgumentException(
-                        String.format("Missing value for config '%s'", values[values.length - 1]));
-                  }
-                  Map<String, String> config = new HashMap<>();
-                  for (int i = 0; i < values.length; i += 2) {
-                    config.put(values[i], values[i + 1]);
-                  }
-                  return config;
-                })
-            .orElse(ImmutableMap.of());
-
     restCatalogConfig =
-        ImmutableMap.<String, String>builder()
-            .putAll(DEFAULT_REST_CATALOG_CONFIG)
-            .putAll(dynamicConfig)
-            .build();
+        IntegrationTestsHelper.mergeFromAnnotatedElements(
+            testInfo,
+            RestCatalogConfig.class,
+            RestCatalogConfig::value,
+            DEFAULT_REST_CATALOG_CONFIG);
 
     restCatalog = initCatalog(currentCatalogName, ImmutableMap.of());
   }
@@ -321,8 +315,14 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @AfterEach
-  public void cleanUp() {
-    cleanUp(client, adminToken);
+  public void cleanUp() throws IOException {
+    try {
+      if (restCatalog != null) {
+        restCatalog.close();
+      }
+    } finally {
+      cleanUp(client, adminToken);
+    }
   }
 
   /**
@@ -651,12 +651,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {
@@ -686,12 +686,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {
@@ -720,12 +720,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table"), fileLocation);
       try {
@@ -748,12 +748,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
       restCatalog.registerTable(TableIdentifier.of(ns1, "my_table_etagged"), fileLocation);
       Invocation invocation =
@@ -792,12 +792,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
 
       Invocation registerInvocation =
@@ -835,12 +835,12 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         TableMetadata.newTableMetadata(
             new Schema(List.of(Types.NestedField.required(1, "col1", new Types.StringType()))),
             PartitionSpec.unpartitioned(),
-            externalCatalogBase + "/ns1/my_table",
+            externalCatalogBaseLocation + "/ns1/my_table",
             Map.of());
     try (ResolvingFileIO resolvingFileIO = new ResolvingFileIO()) {
       initializeClientFileIO(resolvingFileIO);
       resolvingFileIO.setConf(new Configuration());
-      String fileLocation = externalCatalogBase + "/ns1/my_table/metadata/v1.metadata.json";
+      String fileLocation = externalCatalogBaseLocation + "/ns1/my_table/metadata/v1.metadata.json";
       TableMetadataParser.write(tableMetadata, resolvingFileIO.newOutputFile(fileLocation));
 
       Invocation createInvocation =

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
@@ -25,7 +25,6 @@ import io.quarkus.test.junit.TestProfile;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.storage.StorageAccessProperty;
@@ -70,14 +69,12 @@ public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase
   }
 
   @Override
-  protected void initializeClientFileIO(FileIO fileIO) {
-    fileIO.initialize(
-        ImmutableMap.<String, String>builder()
-            .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
-            .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
-            .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), MINIO_ACCESS_KEY)
-            .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), MINIO_SECRET_KEY)
-            .build());
+  protected ImmutableMap.Builder<String, String> clientFileIOProperties() {
+    return super.clientFileIOProperties()
+        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
+        .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
+        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), MINIO_ACCESS_KEY)
+        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), MINIO_SECRET_KEY);
   }
 
   @Override


### PR DESCRIPTION
This change promotes `CatalogConfig` and `RestCatalogConfig` to top-level, public annotations and introduces a few "hooks" in `PolarisRestCatalogIntegrationBase` that can be overridden by subclasses.

This change is a preparatory work for #2280 (S3 remote signing).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
