### PR TITLE
Remove numeric identifier from PolarisPrincipal

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -39,26 +39,19 @@ public interface PolarisPrincipal extends Principal {
    * @param roles the set of roles associated with the principal
    */
   static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
-    return of(
-        principalEntity.getId(),
-        principalEntity.getName(),
-        principalEntity.getInternalPropertiesAsMap(),
-        roles);
+    return of(principalEntity.getName(), principalEntity.getInternalPropertiesAsMap(), roles);
   }
 
   /**
    * Creates a new instance of {@link PolarisPrincipal} with the specified ID, name, roles, and
    * properties.
    *
-   * @param id the unique identifier of the principal
    * @param name the name of the principal
    * @param properties additional properties associated with the principal
    * @param roles the set of roles associated with the principal
    */
-  static PolarisPrincipal of(
-      long id, String name, Map<String, String> properties, Set<String> roles) {
+  static PolarisPrincipal of(String name, Map<String, String> properties, Set<String> roles) {
     return ImmutablePolarisPrincipal.builder()
-        .id(id)
         .name(name)
         .properties(properties)
         .roles(roles)
@@ -66,16 +59,11 @@ public interface PolarisPrincipal extends Principal {
   }
 
   /**
-   * Returns the unique identifier of the principal.
+   * Returns the set of activated principal role names.
    *
-   * <p>This identifier is used to uniquely identify the principal within a Polaris realm.
-   */
-  long getId();
-
-  /**
-   * Returns the set of activated principal role names. Activated role names are the roles that were
-   * explicitly requested by the client when authenticating, through JWT claims or other means. It
-   * may be a subset of the roles that the principal has in the system.
+   * <p>Activated role names are the roles that were explicitly requested by the client when
+   * authenticating, through JWT claims or other means. It may be a subset of the roles that the
+   * principal has in the system.
    */
   Set<String> getRoles();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -755,11 +755,7 @@ public class Resolver {
 
     // resolve the principal, by name or id
     this.resolvedCallerPrincipal =
-        this.resolveById(
-            toValidate,
-            PolarisEntityType.PRINCIPAL,
-            PolarisEntityConstants.getNullId(),
-            polarisPrincipal.getId());
+        this.resolveByName(toValidate, PolarisEntityType.PRINCIPAL, polarisPrincipal.getName());
 
     // if the principal was not found, we can end right there
     if (this.resolvedCallerPrincipal == null

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/PersistedPolarisPrincipal.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/PersistedPolarisPrincipal.java
@@ -52,12 +52,6 @@ abstract class PersistedPolarisPrincipal implements PolarisPrincipal {
     return getEntity().getName();
   }
 
-  @Value.Derived
-  @Override
-  public long getId() {
-    return getEntity().getId();
-  }
-
   @Value.Lazy
   @Override
   public Map<String, String> getProperties() {

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -399,9 +399,8 @@ public abstract class PolarisAuthzTestBase {
   protected @Nonnull Set<String> loadPrincipalRolesNames(PolarisPrincipal p) {
     PolarisBaseEntity principal =
         metaStoreManager
-            .loadEntity(
-                callContext.getPolarisCallContext(), 0L, p.getId(), PolarisEntityType.PRINCIPAL)
-            .getEntity();
+            .findPrincipalByName(callContext.getPolarisCallContext(), p.getName())
+            .orElseThrow();
     return metaStoreManager
         .loadGrantsToGrantee(callContext.getPolarisCallContext(), principal)
         .getGrantRecords()


### PR DESCRIPTION
This change removes the requirement for Polaris principals to have a numeric identifier, by removing the only sites where such an identifier was required: 

- In the `Resolver`. Instead of lookups by id, the `Resolver` now performs lookups by principal name.
- In  `PolarisAdminService`. Instead of comparing entity ids, the code now compares the principal name against the entity name and type.

Note: the lookup in the `Resolver` is still necessary, because the `Resolver` also needs to fetch the grant records.