### PR TITLE
Deprecate ActiveRolesProvider for removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,8 @@ at locations that better optimize for object storage.
 
 ### Deprecations
 
-* The property `polaris.active-roles-provider.type` is deprecated in favor of
-  `polaris.authentication.active-roles-provider.type`. The old property is still supported, but will be removed in a
-  future release.
+- The property `polaris.active-roles-provider.type` is deprecated for removal.
+- The `ActiveRolesProvider` interface is deprecated for removal.
 
 ### Fixes
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/ActiveRolesAugmentor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/ActiveRolesAugmentor.java
@@ -35,6 +35,7 @@ import org.apache.polaris.core.auth.PolarisPrincipal;
  * authentication.
  */
 @ApplicationScoped
+@Deprecated
 public class ActiveRolesAugmentor implements SecurityIdentityAugmentor {
 
   // must run after AuthenticatingAugmentor

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/ActiveRolesProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/ActiveRolesProvider.java
@@ -25,6 +25,7 @@ import org.apache.polaris.core.auth.PolarisPrincipal;
  * Provides the active roles for a given principal. Implementations may rely on the active request
  * or SecurityContext to determine the active roles.
  */
+@Deprecated
 public interface ActiveRolesProvider {
   /**
    * Returns the active roles for the given principal.

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticationRealmConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticationRealmConfiguration.java
@@ -49,6 +49,7 @@ public interface AuthenticationRealmConfiguration {
    * The configuration for the active roles provider. The active roles provider is responsible for
    * determining the active roles for a given Polaris principal.
    */
+  @Deprecated
   ActiveRolesProviderConfiguration activeRolesProvider();
 
   interface ActiveRolesProviderConfiguration {

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 @RequestScoped
 @Identifier("default")
+@Deprecated
 public class DefaultActiveRolesProvider implements ActiveRolesProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultActiveRolesProvider.class);
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -384,6 +384,7 @@ public class ServiceProducers {
   }
 
   @Produces
+  @Deprecated
   public ActiveRolesProvider activeRolesProvider(
       AuthenticationRealmConfiguration config,
       @Any Instance<ActiveRolesProvider> activeRolesProviders) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/ActiveRolesAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/ActiveRolesAugmentorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@SuppressWarnings("deprecation")
 public class ActiveRolesAugmentorTest {
 
   private ActiveRolesAugmentor augmentor;


### PR DESCRIPTION
This change deprecates `ActiveRolesProvider` for removal. The actual removal is here: #2390.