### PR TITLE
chore(test): Restore PolarisAccessManager

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergTokenAccessManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergTokenAccessManager.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.it.env;
+
+import jakarta.ws.rs.client.Client;
+import org.apache.polaris.service.it.ext.PolarisAccessManager;
+
+/**
+ * This class obtains access tokens from the {@code v1/oauth/tokens} endpoint defined by the Iceberg
+ * REST Catalog spec.
+ *
+ * <p>Note: even though this endpoint is still part of the Iceberg REST Catalog spec it has been
+ * deprecated per <a href="https://github.com/apache/iceberg/pull/10603">Iceberg PR#10603</a>.
+ */
+public class IcebergTokenAccessManager implements PolarisAccessManager {
+  private final Client client;
+
+  public IcebergTokenAccessManager(Client client) {
+    this.client = client;
+  }
+
+  @Override
+  public String obtainAccessToken(PolarisApiEndpoints endpoints, ClientCredentials credentials) {
+    OAuth2Api api = new OAuth2Api(client, endpoints.catalogApiEndpoint(), "v1/oauth/tokens");
+    return api.obtainAccessToken(credentials, "PRINCIPAL_ROLE:ALL");
+  }
+}

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
@@ -114,8 +114,7 @@ public final class PolarisClient implements AutoCloseable {
 
   /** Requests an access token from the Polaris server for the given credentials. */
   public String obtainToken(ClientCredentials credentials) {
-    OAuth2Api api = new OAuth2Api(client, endpoints.catalogApiEndpoint(), "v1/oauth/tokens");
-    return api.obtainAccessToken(credentials, "PRINCIPAL_ROLE:ALL");
+    return polarisServerManager().accessManager(client).obtainAccessToken(endpoints, credentials);
   }
 
   /**

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisAccessManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisAccessManager.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.it.ext;
+
+import org.apache.polaris.service.it.env.ClientCredentials;
+import org.apache.polaris.service.it.env.PolarisApiEndpoints;
+
+public interface PolarisAccessManager {
+
+  String obtainAccessToken(PolarisApiEndpoints endpoints, ClientCredentials credentials);
+}

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisServerManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisServerManager.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import java.util.ServiceLoader;
+import org.apache.polaris.service.it.env.IcebergTokenAccessManager;
 import org.apache.polaris.service.it.env.Server;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -49,6 +50,10 @@ public interface PolarisServerManager {
    * this is not guaranteed.
    */
   Server serverForContext(ExtensionContext context);
+
+  default PolarisAccessManager accessManager(Client client) {
+    return new IcebergTokenAccessManager(client);
+  }
 
   /** Create a new HTTP client for accessing the server targeted by tests. */
   default Client createClient() {


### PR DESCRIPTION
Restore `PolarisAccessManager` (with default implementation of `IcebergTokenAccessManager`) which was added as an extension point for running Polaris tests in downstream build environments under #789, but was mistakenly removed in #2343

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
