### PR TITLE
Fix merge conflict in CatalogFederationIntegrationTest

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
@@ -63,7 +63,6 @@ public class CatalogFederationIntegrationTest {
   private static PolarisClient client;
   private static ManagementApi managementApi;
   private static PolarisApiEndpoints endpoints;
-  private static ClientCredentials adminCredentials;
   private static SparkSession spark;
   private static String sparkToken;
   private static String adminToken;
@@ -85,7 +84,6 @@ public class CatalogFederationIntegrationTest {
     client = polarisClient(endpoints);
     adminToken = client.obtainToken(credentials);
     managementApi = client.managementApi(adminToken);
-    adminCredentials = credentials;
     sparkToken = client.obtainToken(credentials);
   }
 


### PR DESCRIPTION
#2344 added a new test for catalog federation, but it looks like an undetected conflict with concurrent changes related to authentication have broken the test in main.