### PR TITLE
Build: Make META-INF/MANIFEST.MF content reproducible

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -18,7 +18,8 @@ package publishing
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import javax.inject.Inject
-import org.gradle.api.*
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
@@ -27,7 +28,14 @@ import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registering
+import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
 
@@ -35,8 +43,8 @@ import org.gradle.plugins.signing.SigningPlugin
  * Release-publishing helper plugin to generate publications that pass Sonatype validations,
  * generate Apache release source tarball.
  *
- * The `release` Gradle project property triggers: signed artifacts + jars with Git information. The
- * current Git HEAD must point to a Git tag.
+ * The `release` Gradle project property triggers: signed artifacts and jars with Git information.
+ * The current Git HEAD must point to a Git tag.
  *
  * The `jarWithGitInfo` Gradle project property triggers: jars with Git information (not necessary
  * with `release`).

--- a/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
+++ b/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
@@ -21,10 +21,8 @@ package org.apache.polaris.version;
 import static java.lang.String.format;
 import static org.apache.polaris.version.PolarisVersion.getBuildGitHead;
 import static org.apache.polaris.version.PolarisVersion.getBuildGitTag;
-import static org.apache.polaris.version.PolarisVersion.getBuildJavaVersion;
+import static org.apache.polaris.version.PolarisVersion.getBuildJavaSpecificationVersion;
 import static org.apache.polaris.version.PolarisVersion.getBuildReleasedVersion;
-import static org.apache.polaris.version.PolarisVersion.getBuildSystem;
-import static org.apache.polaris.version.PolarisVersion.getBuildTimestamp;
 import static org.apache.polaris.version.PolarisVersion.isReleaseBuild;
 import static org.apache.polaris.version.PolarisVersion.polarisVersionString;
 
@@ -50,7 +48,7 @@ public class TestPolarisVersion {
   @InjectSoftAssertions private SoftAssertions soft;
 
   /**
-   * Test runs using a "non release" build, so the MANIFEST.MF file has no release version
+   * Test runs using a "non-release" build, so the MANIFEST.MF file has no release version
    * information.
    */
   @Test
@@ -59,18 +57,14 @@ public class TestPolarisVersion {
     soft.assertThat(polarisVersionString()).isEqualTo(System.getProperty("polarisVersion"));
     if (isReleaseBuild()) {
       soft.assertThat(getBuildReleasedVersion()).isNotEmpty();
-      soft.assertThat(getBuildTimestamp()).isNotEmpty();
       soft.assertThat(getBuildGitHead()).isNotEmpty();
       soft.assertThat(getBuildGitTag()).isNotEmpty();
-      soft.assertThat(getBuildSystem()).isNotEmpty();
-      soft.assertThat(getBuildJavaVersion()).isNotEmpty();
+      soft.assertThat(getBuildJavaSpecificationVersion()).isNotEmpty();
     } else {
       soft.assertThat(getBuildReleasedVersion()).isEmpty();
-      soft.assertThat(getBuildTimestamp()).isEmpty();
       soft.assertThat(getBuildGitHead()).isEmpty();
       soft.assertThat(getBuildGitTag()).isEmpty();
-      soft.assertThat(getBuildSystem()).isEmpty();
-      soft.assertThat(getBuildJavaVersion()).isEmpty();
+      soft.assertThat(getBuildJavaSpecificationVersion()).isEmpty();
     }
   }
 
@@ -88,13 +82,9 @@ public class TestPolarisVersion {
     soft.assertThat(polarisVersionString()).isEqualTo(System.getProperty("polarisVersion"));
     soft.assertThat(isReleaseBuild()).isTrue();
     soft.assertThat(getBuildReleasedVersion()).contains("0.1.2-incubating-SNAPSHOT");
-    soft.assertThat(getBuildTimestamp()).contains("2024-12-26-10:31:19+01:00");
     soft.assertThat(getBuildGitHead()).contains("27cf81929cbb08e545c8fcb1ed27a53d7ef1af79");
     soft.assertThat(getBuildGitTag()).contains("foo-tag-bar");
-    soft.assertThat(getBuildSystem())
-        .contains(
-            "Linux myawesomehost 6.12.6 #81 SMP PREEMPT_DYNAMIC Fri Dec 20 09:22:38 CET 2024 x86_64 x86_64 x86_64 GNU/Linux");
-    soft.assertThat(getBuildJavaVersion()).contains("21.0.5");
+    soft.assertThat(getBuildJavaSpecificationVersion()).contains("21");
   }
 
   @Test

--- a/tools/version/src/jarTest/resources/META-INF/FAKE_MANIFEST.MF
+++ b/tools/version/src/jarTest/resources/META-INF/FAKE_MANIFEST.MF
@@ -3,7 +3,4 @@ Apache-Polaris-Version: 0.1.2-incubating-SNAPSHOT
 Apache-Polaris-Is-Release: true
 Apache-Polaris-Build-Git-Head: 27cf81929cbb08e545c8fcb1ed27a53d7ef1af79
 Apache-Polaris-Build-Git-Describe: foo-tag-bar
-Apache-Polaris-Build-Timestamp: 2024-12-26-10:31:19+01:00
-Apache-Polaris-Build-System: Linux myawesomehost 6.12.6 #81 SMP PREEMPT_DY
- NAMIC Fri Dec 20 09:22:38 CET 2024 x86_64 x86_64 x86_64 GNU/Linux
-Apache-Polaris-Build-Java-Version: 21.0.5
+Apache-Polaris-Build-Java-Specification-Version: 21

--- a/tools/version/src/main/java/org/apache/polaris/version/PolarisVersion.java
+++ b/tools/version/src/main/java/org/apache/polaris/version/PolarisVersion.java
@@ -98,43 +98,16 @@ public final class PolarisVersion {
   }
 
   /**
-   * Returns the Java version used during the build as in the jar manifest, if {@linkplain
-   * #isReleaseBuild() build-time Git information} is available, when Polaris has been built with
-   * the Gradle {@code -Prelease} project property.
+   * Returns the Java <em>specification</em> version used during the build as in the jar manifest,
+   * if {@linkplain #isReleaseBuild() build-time Git information} is available, when Polaris has
+   * been built with the Gradle {@code -Prelease} project property.
    *
-   * <p>Example value: {@code 21.0.5}
-   *
-   * @see #isReleaseBuild()
-   */
-  public static Optional<String> getBuildJavaVersion() {
-    return PolarisVersionJarInfo.buildInfo(MF_BUILD_JAVA_VERSION);
-  }
-
-  /**
-   * Returns information about the system that performed the build, if {@linkplain #isReleaseBuild()
-   * build-time Git information} is available, when Polaris has been built with the Gradle {@code
-   * -Prelease} project property.
-   *
-   * <p>Example value: {@code Linux myawesomehost 6.12.6 #81 SMP PREEMPT_DYNAMIC Fri Dec 20 09:22:38
-   * CET 2024 x86_64 x86_64 x86_64 GNU/Linux}
+   * <p>Example value: {@code 21}
    *
    * @see #isReleaseBuild()
    */
-  public static Optional<String> getBuildSystem() {
-    return PolarisVersionJarInfo.buildInfo(MF_BUILD_SYSTEM);
-  }
-
-  /**
-   * Returns the build timestamp as in the jar manifest, if {@linkplain #isReleaseBuild() build-time
-   * Git information} is available, when Polaris has been built with the Gradle {@code -Prelease}
-   * project property.
-   *
-   * <p>Example value: {@code 2024-12-16-11:54:05+01:00}
-   *
-   * @see #isReleaseBuild()
-   */
-  public static Optional<String> getBuildTimestamp() {
-    return PolarisVersionJarInfo.buildInfo(MF_BUILD_TIMESTAMP);
+  public static Optional<String> getBuildJavaSpecificationVersion() {
+    return PolarisVersionJarInfo.buildInfo(MF_BUILD_JAVA_SPECIFICATION_VERSION);
   }
 
   public static String readNoticeFile() {
@@ -155,18 +128,15 @@ public final class PolarisVersion {
   private static final String MF_IS_RELEASE = "Apache-Polaris-Is-Release";
   private static final String MF_BUILD_GIT_HEAD = "Apache-Polaris-Build-Git-Head";
   private static final String MF_BUILD_GIT_DESCRIBE = "Apache-Polaris-Build-Git-Describe";
-  private static final String MF_BUILD_TIMESTAMP = "Apache-Polaris-Build-Timestamp";
-  private static final String MF_BUILD_SYSTEM = "Apache-Polaris-Build-System";
-  private static final String MF_BUILD_JAVA_VERSION = "Apache-Polaris-Build-Java-Version";
+  private static final String MF_BUILD_JAVA_SPECIFICATION_VERSION =
+      "Apache-Polaris-Build-Java-Specification-Version";
   private static final List<String> MF_ALL =
       List.of(
           MF_VERSION,
           MF_IS_RELEASE,
           MF_BUILD_GIT_HEAD,
           MF_BUILD_GIT_DESCRIBE,
-          MF_BUILD_TIMESTAMP,
-          MF_BUILD_SYSTEM,
-          MF_BUILD_JAVA_VERSION);
+          MF_BUILD_JAVA_SPECIFICATION_VERSION);
 
   static String readResource(String resource) {
     var fullResource = format("/META-INF/resources/apache-polaris/%s.txt", resource);


### PR DESCRIPTION
As described in #2204, some jar manifest attributes prevent having a reproducible build, to eventually be able to generate the _exact_ same artifacts on different systems at different times. Committers shall then be able to re-run the build and compare proposed release artifacts bit-by-bit.

This change changes the jar manifest attributes:
* `Apache-Polaris-Is-Release` is now also set to `true`, if `-PjarWithGitInfo` is specified
* `Apache-Polaris-Build-Git-Describe` is now also generated, if `-PjarWithGitInfo` is specified
* `Apache-Polaris-Build-Java-Version` has been removed
* `Apache-Polaris-Build-Java-Specification-Version` has been added (it's only the Java major version)
* `Apache-Polaris-Build-Timestamp` has been removed
* `Apache-Polaris-Build-System` has been removed

Contributes to: #2204
