### PR TITLE
Add support for poetry build with wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ client-integration-test: client-setup-env ## Run client integration tests
 	@echo "Tearing down Docker Compose services..."
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml down || true # Ensure teardown even if tests fail
 
+.PHONY: client-build
+client-build: client-setup-env ## Build client distribution
+	@echo "--- Building client distribution ---"
+	@$(ACTIVATE_AND_CD) && poetry build -f wheel
+	@echo "--- Client distribution build complete ---"
+
 .PHONY: client-cleanup
 client-cleanup: ## Cleanup virtual environment and Python cache files
 	@echo "--- Cleaning up virtual environment and Python cache files ---"

--- a/client/python/generate_clients.py
+++ b/client/python/generate_clients.py
@@ -80,6 +80,7 @@ EXCLUDE_PATHS = [
     Path("README.md"),
     Path("generate_clients.py"),
     Path(".venv"),
+    Path("dist/"),
 ]
 EXCLUDE_EXTENSIONS = [
     "json",

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -46,12 +46,9 @@ polaris = "cli.polaris_cli:main"
 
 [tool.poetry]
 requires-poetry = "==2.1.4"
-packages = [
-    { include = "polaris" },
-    { include = "cli" }
-]
 include = [
-  "polaris/**"
+    { path = "polaris/**", format = "wheel" },
+    { path = "cli/**", format = "wheel" },
 ]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Earlier I created https://github.com/apache/polaris/pull/2049 to show how we can now use `poetry build` to create sdist in python:
```
(venv) ➜  python git:(polaris_cli_package) poetry build
Building polaris (1.0.0)
Building sdist
  - Building sdist
  - Built polaris-1.0.0.tar.gz
Building wheel
  - Building wheel
  - Built polaris-1.0.0-py3-none-any.whl
...
(venv_dist) ➜  Desktop pip install GitHome/polaris/client/python/dist/polaris-1.0.0.tar.gz
...
Building wheels for collected packages: polaris
  Building wheel for polaris (pyproject.toml) ... done
  Created wheel for polaris: filename=polaris-1.0.0-py3-none-any.whl size=520413 sha256=9c9a25c6edb2a0b642666ab07abf5bc52f0a51f939095b18f12404bb118ec2e5
  Stored in directory: /Users/yong/Library/Caches/pip/wheels/b8/f1/20/1dd4b05f93820742954b32d0d44f211007e0d06e5742927628
Successfully built polaris
Installing collected packages: urllib3, typing-extensions, six, jmespath, annotated-types, typing-inspection, python-dateutil, pydantic-core, pydantic, botocore, s3transfer, boto3, polaris
Successfully installed annotated-types-0.7.0 boto3-1.38.36 botocore-1.38.46 jmespath-1.0.1 polaris-1.0.0 pydantic-2.11.7 pydantic-core-2.33.2 python-dateutil-2.9.0.post0 s3transfer-0.13.0 six-1.17.0 typing-extensions-4.14.1 typing-inspection-0.4.1 urllib3-2.5.0

[notice] A new release of pip is available: 24.2 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
(venv_dist) ➜  Desktop which polaris
/Users/yong/Desktop/venv_dist/bin/polaris
```

With recent merge of https://github.com/apache/polaris/pull/2192, we move the openapi code generation into python. The problem with this is, now it is depends on openapi template file which is outside python directory and `generate_clients.py` is referring the the template one directory above. Thus, we are no longer able to provide sdist (we never provided as well...often time sdist is less preferred).

Now another issue I noticed is the wheel files generated by current main doesn't include the actual code files generated by `poetry build` but the sdist has it. Upon debugging, this seems to be due to the project layout we are using is not matching to what poetry suggests:
"If your project structure differs from the standard one supported by poetry, you can specify the packages you want to include in the final distribution." (ref: https://python-poetry.org/docs/pyproject/#packages). Here is the sample content if we try to generate one:
```
(.venv) ➜  python git:(main) unzip -l dist/polaris-1.0.0-cp313-cp313-macosx_15_0_arm64.whl
Archive:  dist/polaris-1.0.0-cp313-cp313-macosx_15_0_arm64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      789  01-01-2016 00:00   cli/__init__.py
     9979  01-01-2016 00:00   cli/command/__init__.py
     5362  01-01-2016 00:00   cli/command/catalog_roles.py
    19082  01-01-2016 00:00   cli/command/catalogs.py
     4239  01-01-2016 00:00   cli/command/namespaces.py
     5328  01-01-2016 00:00   cli/command/principal_roles.py
     6954  01-01-2016 00:00   cli/command/principals.py
     6138  01-01-2016 00:00   cli/command/privileges.py
     5750  01-01-2016 00:00   cli/command/profiles.py
    14076  01-01-2016 00:00   cli/constants.py
      789  01-01-2016 00:00   cli/options/__init__.py
    16669  01-01-2016 00:00   cli/options/option_tree.py
     9355  01-01-2016 00:00   cli/options/parser.py
     8964  01-01-2016 00:00   cli/polaris_cli.py
        0  01-01-2016 00:00   polaris/.keep
        0  01-01-2016 00:00   polaris/catalog/.keep
        0  01-01-2016 00:00   polaris/catalog/api/.keep
        0  01-01-2016 00:00   polaris/catalog/models/.keep
        0  01-01-2016 00:00   polaris/management/.keep
        0  01-01-2016 00:00   polaris/management/api/.keep
        0  01-01-2016 00:00   polaris/management/models/.keep
     2510  01-01-2016 00:00   polaris-1.0.0.dist-info/METADATA
      106  01-01-2016 00:00   polaris-1.0.0.dist-info/WHEEL
       48  01-01-2016 00:00   polaris-1.0.0.dist-info/entry_points.txt
     1970  01-01-2016 00:00   polaris-1.0.0.dist-info/RECORD
---------                     -------
   118108                     25 files
```

Thus, I purpose the change in this PR to implicitly add those files. Here is the new sample output:
```
➜  1 unzip dist/polaris-1.0.0-cp313-cp313-macosx_15_0_arm64.whl
Archive:  dist/polaris-1.0.0-cp313-cp313-macosx_15_0_arm64.whl
  inflating: cli/__init__.py
  inflating: cli/command/__init__.py
  inflating: cli/command/catalog_roles.py
  inflating: cli/command/catalogs.py
  inflating: cli/command/namespaces.py
  inflating: cli/command/principal_roles.py
  inflating: cli/command/principals.py
  inflating: cli/command/privileges.py
  inflating: cli/command/profiles.py
  inflating: cli/constants.py
  inflating: cli/options/__init__.py
  inflating: cli/options/option_tree.py
  inflating: cli/options/parser.py
  inflating: cli/polaris_cli.py
  inflating: polaris/.keep
  inflating: polaris/__init__.py
  inflating: polaris/catalog/.keep
  inflating: polaris/catalog/__init__.py
  inflating: polaris/catalog/api/.keep
  inflating: polaris/catalog/api/__init__.py
  inflating: polaris/catalog/api/catalog_api.py
  inflating: polaris/catalog/api/configuration_api.py
  inflating: polaris/catalog/api/generic_table_api.py
  inflating: polaris/catalog/api/iceberg_catalog_api.py
  inflating: polaris/catalog/api/iceberg_configuration_api.py
  inflating: polaris/catalog/api/iceberg_o_auth2_api.py
  inflating: polaris/catalog/api/o_auth2_api.py
  inflating: polaris/catalog/api/policy_api.py
  inflating: polaris/catalog/api_client.py
  inflating: polaris/catalog/api_response.py
  inflating: polaris/catalog/configuration.py
  inflating: polaris/catalog/docs/AddPartitionSpecUpdate.md
  inflating: polaris/catalog/docs/AddSchemaUpdate.md
  inflating: polaris/catalog/docs/AddSnapshotUpdate.md
  inflating: polaris/catalog/docs/AddSortOrderUpdate.md
  inflating: polaris/catalog/docs/AddViewVersionUpdate.md
  inflating: polaris/catalog/docs/AndOrExpression.md
  inflating: polaris/catalog/docs/ApplicablePolicy.md
  inflating: polaris/catalog/docs/AssertCreate.md
  inflating: polaris/catalog/docs/AssertCurrentSchemaId.md
  inflating: polaris/catalog/docs/AssertDefaultSortOrderId.md
  inflating: polaris/catalog/docs/AssertDefaultSpecId.md
  inflating: polaris/catalog/docs/AssertLastAssignedFieldId.md
  inflating: polaris/catalog/docs/AssertLastAssignedPartitionId.md
  inflating: polaris/catalog/docs/AssertRefSnapshotId.md
  inflating: polaris/catalog/docs/AssertTableUUID.md
  inflating: polaris/catalog/docs/AssertViewUUID.md
  inflating: polaris/catalog/docs/AssignUUIDUpdate.md
  inflating: polaris/catalog/docs/AsyncPlanningResult.md
  inflating: polaris/catalog/docs/AttachPolicyRequest.md
  inflating: polaris/catalog/docs/BaseUpdate.md
  inflating: polaris/catalog/docs/BlobMetadata.md
  inflating: polaris/catalog/docs/CatalogAPI.md
  inflating: polaris/catalog/docs/CatalogConfig.md
  inflating: polaris/catalog/docs/CommitReport.md
  inflating: polaris/catalog/docs/CommitTableRequest.md
  inflating: polaris/catalog/docs/CommitTableResponse.md
  inflating: polaris/catalog/docs/CommitTransactionRequest.md
  inflating: polaris/catalog/docs/CommitViewRequest.md
  inflating: polaris/catalog/docs/CompletedPlanningResult.md
  inflating: polaris/catalog/docs/CompletedPlanningWithIDResult.md
  inflating: polaris/catalog/docs/ConfigurationAPI.md
  inflating: polaris/catalog/docs/ContentFile.md
  inflating: polaris/catalog/docs/CountMap.md
  inflating: polaris/catalog/docs/CounterResult.md
  inflating: polaris/catalog/docs/CreateGenericTableRequest.md
  inflating: polaris/catalog/docs/CreateNamespaceRequest.md
  inflating: polaris/catalog/docs/CreateNamespaceResponse.md
  inflating: polaris/catalog/docs/CreatePolicyRequest.md
  inflating: polaris/catalog/docs/CreateTableRequest.md
  inflating: polaris/catalog/docs/CreateViewRequest.md
  inflating: polaris/catalog/docs/DataFile.md
  inflating: polaris/catalog/docs/DeleteFile.md
  inflating: polaris/catalog/docs/DetachPolicyRequest.md
  inflating: polaris/catalog/docs/EmptyPlanningResult.md
  inflating: polaris/catalog/docs/EnableRowLineageUpdate.md
  inflating: polaris/catalog/docs/EqualityDeleteFile.md
  inflating: polaris/catalog/docs/ErrorModel.md
  inflating: polaris/catalog/docs/Expression.md
  inflating: polaris/catalog/docs/FailedPlanningResult.md
  inflating: polaris/catalog/docs/FalseExpression.md
  inflating: polaris/catalog/docs/FetchPlanningResult.md
  inflating: polaris/catalog/docs/FetchScanTasksRequest.md
  inflating: polaris/catalog/docs/FetchScanTasksResult.md
  inflating: polaris/catalog/docs/FileFormat.md
  inflating: polaris/catalog/docs/FileScanTask.md
  inflating: polaris/catalog/docs/GenericTable.md
  inflating: polaris/catalog/docs/GenericTableAPI.md
  inflating: polaris/catalog/docs/GetApplicablePoliciesResponse.md
  inflating: polaris/catalog/docs/GetNamespaceResponse.md
  inflating: polaris/catalog/docs/IcebergCatalogAPI.md
  inflating: polaris/catalog/docs/IcebergConfigurationAPI.md
  inflating: polaris/catalog/docs/IcebergErrorResponse.md
  inflating: polaris/catalog/docs/IcebergErrorResponse1.md
  inflating: polaris/catalog/docs/IcebergOAuth2API.md
  inflating: polaris/catalog/docs/ListGenericTablesResponse.md
  inflating: polaris/catalog/docs/ListNamespacesResponse.md
  inflating: polaris/catalog/docs/ListPoliciesResponse.md
  inflating: polaris/catalog/docs/ListTablesResponse.md
  inflating: polaris/catalog/docs/ListType.md
  inflating: polaris/catalog/docs/LiteralExpression.md
  inflating: polaris/catalog/docs/LoadCredentialsResponse.md
  inflating: polaris/catalog/docs/LoadGenericTableResponse.md
  inflating: polaris/catalog/docs/LoadPolicyResponse.md
  inflating: polaris/catalog/docs/LoadTableResult.md
  inflating: polaris/catalog/docs/LoadViewResult.md
  inflating: polaris/catalog/docs/MapType.md
  inflating: polaris/catalog/docs/MetadataLogInner.md
  inflating: polaris/catalog/docs/MetricResult.md
  inflating: polaris/catalog/docs/ModelSchema.md
  inflating: polaris/catalog/docs/NotExpression.md
  inflating: polaris/catalog/docs/NotificationRequest.md
  inflating: polaris/catalog/docs/NotificationType.md
  inflating: polaris/catalog/docs/NullOrder.md
  inflating: polaris/catalog/docs/OAuth2API.md
  inflating: polaris/catalog/docs/OAuthError.md
  inflating: polaris/catalog/docs/OAuthTokenResponse.md
  inflating: polaris/catalog/docs/PartitionField.md
  inflating: polaris/catalog/docs/PartitionSpec.md
  inflating: polaris/catalog/docs/PartitionStatisticsFile.md
  inflating: polaris/catalog/docs/PlanStatus.md
  inflating: polaris/catalog/docs/PlanTableScanRequest.md
  inflating: polaris/catalog/docs/PlanTableScanResult.md
  inflating: polaris/catalog/docs/Policy.md
  inflating: polaris/catalog/docs/PolicyAPI.md
  inflating: polaris/catalog/docs/PolicyAttachmentTarget.md
  inflating: polaris/catalog/docs/PolicyIdentifier.md
  inflating: polaris/catalog/docs/PositionDeleteFile.md
  inflating: polaris/catalog/docs/PrimitiveTypeValue.md
  inflating: polaris/catalog/docs/RegisterTableRequest.md
  inflating: polaris/catalog/docs/RemovePartitionSpecsUpdate.md
  inflating: polaris/catalog/docs/RemovePartitionStatisticsUpdate.md
  inflating: polaris/catalog/docs/RemovePropertiesUpdate.md
  inflating: polaris/catalog/docs/RemoveSnapshotRefUpdate.md
  inflating: polaris/catalog/docs/RemoveSnapshotsUpdate.md
  inflating: polaris/catalog/docs/RemoveStatisticsUpdate.md
  inflating: polaris/catalog/docs/RenameTableRequest.md
  inflating: polaris/catalog/docs/ReportMetricsRequest.md
  inflating: polaris/catalog/docs/SQLViewRepresentation.md
  inflating: polaris/catalog/docs/ScanReport.md
  inflating: polaris/catalog/docs/ScanTasks.md
  inflating: polaris/catalog/docs/SetCurrentSchemaUpdate.md
  inflating: polaris/catalog/docs/SetCurrentViewVersionUpdate.md
  inflating: polaris/catalog/docs/SetDefaultSortOrderUpdate.md
  inflating: polaris/catalog/docs/SetDefaultSpecUpdate.md
  inflating: polaris/catalog/docs/SetExpression.md
  inflating: polaris/catalog/docs/SetLocationUpdate.md
  inflating: polaris/catalog/docs/SetPartitionStatisticsUpdate.md
  inflating: polaris/catalog/docs/SetPropertiesUpdate.md
  inflating: polaris/catalog/docs/SetSnapshotRefUpdate.md
  inflating: polaris/catalog/docs/SetStatisticsUpdate.md
  inflating: polaris/catalog/docs/Snapshot.md
  inflating: polaris/catalog/docs/SnapshotLogInner.md
  inflating: polaris/catalog/docs/SnapshotReference.md
  inflating: polaris/catalog/docs/SnapshotSummary.md
  inflating: polaris/catalog/docs/SortDirection.md
  inflating: polaris/catalog/docs/SortField.md
  inflating: polaris/catalog/docs/SortOrder.md
  inflating: polaris/catalog/docs/StatisticsFile.md
  inflating: polaris/catalog/docs/StorageCredential.md
  inflating: polaris/catalog/docs/StructField.md
  inflating: polaris/catalog/docs/StructType.md
  inflating: polaris/catalog/docs/TableIdentifier.md
  inflating: polaris/catalog/docs/TableMetadata.md
  inflating: polaris/catalog/docs/TableRequirement.md
  inflating: polaris/catalog/docs/TableUpdate.md
  inflating: polaris/catalog/docs/TableUpdateNotification.md
  inflating: polaris/catalog/docs/Term.md
  inflating: polaris/catalog/docs/TimerResult.md
  inflating: polaris/catalog/docs/TokenType.md
  inflating: polaris/catalog/docs/TransformTerm.md
  inflating: polaris/catalog/docs/TrueExpression.md
  inflating: polaris/catalog/docs/Type.md
  inflating: polaris/catalog/docs/UnaryExpression.md
  inflating: polaris/catalog/docs/UpdateNamespacePropertiesRequest.md
  inflating: polaris/catalog/docs/UpdateNamespacePropertiesResponse.md
  inflating: polaris/catalog/docs/UpdatePolicyRequest.md
  inflating: polaris/catalog/docs/UpgradeFormatVersionUpdate.md
  inflating: polaris/catalog/docs/ValueMap.md
  inflating: polaris/catalog/docs/ViewHistoryEntry.md
  inflating: polaris/catalog/docs/ViewMetadata.md
  inflating: polaris/catalog/docs/ViewRepresentation.md
  inflating: polaris/catalog/docs/ViewRequirement.md
  inflating: polaris/catalog/docs/ViewUpdate.md
  inflating: polaris/catalog/docs/ViewVersion.md
  inflating: polaris/catalog/exceptions.py
  inflating: polaris/catalog/models/.keep
  inflating: polaris/catalog/models/__init__.py
  inflating: polaris/catalog/models/add_partition_spec_update.py
  inflating: polaris/catalog/models/add_schema_update.py
  inflating: polaris/catalog/models/add_snapshot_update.py
  inflating: polaris/catalog/models/add_sort_order_update.py
  inflating: polaris/catalog/models/add_view_version_update.py
  inflating: polaris/catalog/models/and_or_expression.py
  inflating: polaris/catalog/models/applicable_policy.py
  inflating: polaris/catalog/models/assert_create.py
  inflating: polaris/catalog/models/assert_current_schema_id.py
  inflating: polaris/catalog/models/assert_default_sort_order_id.py
  inflating: polaris/catalog/models/assert_default_spec_id.py
  inflating: polaris/catalog/models/assert_last_assigned_field_id.py
  inflating: polaris/catalog/models/assert_last_assigned_partition_id.py
  inflating: polaris/catalog/models/assert_ref_snapshot_id.py
  inflating: polaris/catalog/models/assert_table_uuid.py
  inflating: polaris/catalog/models/assert_view_uuid.py
  inflating: polaris/catalog/models/assign_uuid_update.py
  inflating: polaris/catalog/models/async_planning_result.py
  inflating: polaris/catalog/models/attach_policy_request.py
  inflating: polaris/catalog/models/base_update.py
  inflating: polaris/catalog/models/blob_metadata.py
  inflating: polaris/catalog/models/catalog_config.py
  inflating: polaris/catalog/models/commit_report.py
  inflating: polaris/catalog/models/commit_table_request.py
  inflating: polaris/catalog/models/commit_table_response.py
  inflating: polaris/catalog/models/commit_transaction_request.py
  inflating: polaris/catalog/models/commit_view_request.py
  inflating: polaris/catalog/models/completed_planning_result.py
  inflating: polaris/catalog/models/completed_planning_with_id_result.py
  inflating: polaris/catalog/models/content_file.py
  inflating: polaris/catalog/models/count_map.py
  inflating: polaris/catalog/models/counter_result.py
  inflating: polaris/catalog/models/create_generic_table_request.py
  inflating: polaris/catalog/models/create_namespace_request.py
  inflating: polaris/catalog/models/create_namespace_response.py
  inflating: polaris/catalog/models/create_policy_request.py
  inflating: polaris/catalog/models/create_table_request.py
  inflating: polaris/catalog/models/create_view_request.py
  inflating: polaris/catalog/models/data_file.py
  inflating: polaris/catalog/models/delete_file.py
  inflating: polaris/catalog/models/detach_policy_request.py
  inflating: polaris/catalog/models/empty_planning_result.py
  inflating: polaris/catalog/models/enable_row_lineage_update.py
  inflating: polaris/catalog/models/equality_delete_file.py
  inflating: polaris/catalog/models/error_model.py
  inflating: polaris/catalog/models/expression.py
  inflating: polaris/catalog/models/failed_planning_result.py
  inflating: polaris/catalog/models/false_expression.py
  inflating: polaris/catalog/models/fetch_planning_result.py
  inflating: polaris/catalog/models/fetch_scan_tasks_request.py
  inflating: polaris/catalog/models/fetch_scan_tasks_result.py
  inflating: polaris/catalog/models/file_format.py
  inflating: polaris/catalog/models/file_scan_task.py
  inflating: polaris/catalog/models/generic_table.py
  inflating: polaris/catalog/models/get_applicable_policies_response.py
  inflating: polaris/catalog/models/get_namespace_response.py
  inflating: polaris/catalog/models/iceberg_error_response.py
  inflating: polaris/catalog/models/iceberg_error_response1.py
  inflating: polaris/catalog/models/list_generic_tables_response.py
  inflating: polaris/catalog/models/list_namespaces_response.py
  inflating: polaris/catalog/models/list_policies_response.py
  inflating: polaris/catalog/models/list_tables_response.py
  inflating: polaris/catalog/models/list_type.py
  inflating: polaris/catalog/models/literal_expression.py
  inflating: polaris/catalog/models/load_credentials_response.py
  inflating: polaris/catalog/models/load_generic_table_response.py
  inflating: polaris/catalog/models/load_policy_response.py
  inflating: polaris/catalog/models/load_table_result.py
  inflating: polaris/catalog/models/load_view_result.py
  inflating: polaris/catalog/models/map_type.py
  inflating: polaris/catalog/models/metadata_log_inner.py
  inflating: polaris/catalog/models/metric_result.py
  inflating: polaris/catalog/models/model_schema.py
  inflating: polaris/catalog/models/not_expression.py
  inflating: polaris/catalog/models/notification_request.py
  inflating: polaris/catalog/models/notification_type.py
  inflating: polaris/catalog/models/null_order.py
  inflating: polaris/catalog/models/o_auth_error.py
  inflating: polaris/catalog/models/o_auth_token_response.py
  inflating: polaris/catalog/models/partition_field.py
  inflating: polaris/catalog/models/partition_spec.py
  inflating: polaris/catalog/models/partition_statistics_file.py
  inflating: polaris/catalog/models/plan_status.py
  inflating: polaris/catalog/models/plan_table_scan_request.py
  inflating: polaris/catalog/models/plan_table_scan_result.py
  inflating: polaris/catalog/models/policy.py
  inflating: polaris/catalog/models/policy_attachment_target.py
  inflating: polaris/catalog/models/policy_identifier.py
  inflating: polaris/catalog/models/position_delete_file.py
  inflating: polaris/catalog/models/primitive_type_value.py
  inflating: polaris/catalog/models/register_table_request.py
  inflating: polaris/catalog/models/remove_partition_specs_update.py
  inflating: polaris/catalog/models/remove_partition_statistics_update.py
  inflating: polaris/catalog/models/remove_properties_update.py
  inflating: polaris/catalog/models/remove_snapshot_ref_update.py
  inflating: polaris/catalog/models/remove_snapshots_update.py
  inflating: polaris/catalog/models/remove_statistics_update.py
  inflating: polaris/catalog/models/rename_table_request.py
  inflating: polaris/catalog/models/report_metrics_request.py
  inflating: polaris/catalog/models/scan_report.py
  inflating: polaris/catalog/models/scan_tasks.py
  inflating: polaris/catalog/models/set_current_schema_update.py
  inflating: polaris/catalog/models/set_current_view_version_update.py
  inflating: polaris/catalog/models/set_default_sort_order_update.py
  inflating: polaris/catalog/models/set_default_spec_update.py
  inflating: polaris/catalog/models/set_expression.py
  inflating: polaris/catalog/models/set_location_update.py
  inflating: polaris/catalog/models/set_partition_statistics_update.py
  inflating: polaris/catalog/models/set_properties_update.py
  inflating: polaris/catalog/models/set_snapshot_ref_update.py
  inflating: polaris/catalog/models/set_statistics_update.py
  inflating: polaris/catalog/models/snapshot.py
  inflating: polaris/catalog/models/snapshot_log_inner.py
  inflating: polaris/catalog/models/snapshot_reference.py
  inflating: polaris/catalog/models/snapshot_summary.py
  inflating: polaris/catalog/models/sort_direction.py
  inflating: polaris/catalog/models/sort_field.py
  inflating: polaris/catalog/models/sort_order.py
  inflating: polaris/catalog/models/sql_view_representation.py
  inflating: polaris/catalog/models/statistics_file.py
  inflating: polaris/catalog/models/storage_credential.py
  inflating: polaris/catalog/models/struct_field.py
  inflating: polaris/catalog/models/struct_type.py
  inflating: polaris/catalog/models/table_identifier.py
  inflating: polaris/catalog/models/table_metadata.py
  inflating: polaris/catalog/models/table_requirement.py
  inflating: polaris/catalog/models/table_update.py
  inflating: polaris/catalog/models/table_update_notification.py
  inflating: polaris/catalog/models/term.py
  inflating: polaris/catalog/models/timer_result.py
  inflating: polaris/catalog/models/token_type.py
  inflating: polaris/catalog/models/transform_term.py
  inflating: polaris/catalog/models/true_expression.py
  inflating: polaris/catalog/models/type.py
  inflating: polaris/catalog/models/unary_expression.py
  inflating: polaris/catalog/models/update_namespace_properties_request.py
  inflating: polaris/catalog/models/update_namespace_properties_response.py
  inflating: polaris/catalog/models/update_policy_request.py
  inflating: polaris/catalog/models/upgrade_format_version_update.py
  inflating: polaris/catalog/models/value_map.py
  inflating: polaris/catalog/models/view_history_entry.py
  inflating: polaris/catalog/models/view_metadata.py
  inflating: polaris/catalog/models/view_representation.py
  inflating: polaris/catalog/models/view_requirement.py
  inflating: polaris/catalog/models/view_update.py
  inflating: polaris/catalog/models/view_version.py
  inflating: polaris/catalog/py.typed
  inflating: polaris/catalog/rest.py
  inflating: polaris/catalog/test/__init__.py
  inflating: polaris/catalog/test/test_add_partition_spec_update.py
  inflating: polaris/catalog/test/test_add_schema_update.py
  inflating: polaris/catalog/test/test_add_snapshot_update.py
  inflating: polaris/catalog/test/test_add_sort_order_update.py
  inflating: polaris/catalog/test/test_add_view_version_update.py
  inflating: polaris/catalog/test/test_and_or_expression.py
  inflating: polaris/catalog/test/test_applicable_policy.py
  inflating: polaris/catalog/test/test_assert_create.py
  inflating: polaris/catalog/test/test_assert_current_schema_id.py
  inflating: polaris/catalog/test/test_assert_default_sort_order_id.py
  inflating: polaris/catalog/test/test_assert_default_spec_id.py
  inflating: polaris/catalog/test/test_assert_last_assigned_field_id.py
  inflating: polaris/catalog/test/test_assert_last_assigned_partition_id.py
  inflating: polaris/catalog/test/test_assert_ref_snapshot_id.py
  inflating: polaris/catalog/test/test_assert_table_uuid.py
  inflating: polaris/catalog/test/test_assert_view_uuid.py
  inflating: polaris/catalog/test/test_assign_uuid_update.py
  inflating: polaris/catalog/test/test_async_planning_result.py
  inflating: polaris/catalog/test/test_attach_policy_request.py
  inflating: polaris/catalog/test/test_base_update.py
  inflating: polaris/catalog/test/test_blob_metadata.py
  inflating: polaris/catalog/test/test_catalog_api.py
  inflating: polaris/catalog/test/test_catalog_config.py
  inflating: polaris/catalog/test/test_commit_report.py
  inflating: polaris/catalog/test/test_commit_table_request.py
  inflating: polaris/catalog/test/test_commit_table_response.py
  inflating: polaris/catalog/test/test_commit_transaction_request.py
  inflating: polaris/catalog/test/test_commit_view_request.py
  inflating: polaris/catalog/test/test_completed_planning_result.py
  inflating: polaris/catalog/test/test_completed_planning_with_id_result.py
  inflating: polaris/catalog/test/test_configuration_api.py
  inflating: polaris/catalog/test/test_content_file.py
  inflating: polaris/catalog/test/test_count_map.py
  inflating: polaris/catalog/test/test_counter_result.py
  inflating: polaris/catalog/test/test_create_generic_table_request.py
  inflating: polaris/catalog/test/test_create_namespace_request.py
  inflating: polaris/catalog/test/test_create_namespace_response.py
  inflating: polaris/catalog/test/test_create_policy_request.py
  inflating: polaris/catalog/test/test_create_table_request.py
  inflating: polaris/catalog/test/test_create_view_request.py
  inflating: polaris/catalog/test/test_data_file.py
  inflating: polaris/catalog/test/test_delete_file.py
  inflating: polaris/catalog/test/test_detach_policy_request.py
  inflating: polaris/catalog/test/test_empty_planning_result.py
  inflating: polaris/catalog/test/test_enable_row_lineage_update.py
  inflating: polaris/catalog/test/test_equality_delete_file.py
  inflating: polaris/catalog/test/test_error_model.py
  inflating: polaris/catalog/test/test_expression.py
  inflating: polaris/catalog/test/test_failed_planning_result.py
  inflating: polaris/catalog/test/test_false_expression.py
  inflating: polaris/catalog/test/test_fetch_planning_result.py
  inflating: polaris/catalog/test/test_fetch_scan_tasks_request.py
  inflating: polaris/catalog/test/test_fetch_scan_tasks_result.py
  inflating: polaris/catalog/test/test_file_format.py
  inflating: polaris/catalog/test/test_file_scan_task.py
  inflating: polaris/catalog/test/test_generic_table.py
  inflating: polaris/catalog/test/test_generic_table_api.py
  inflating: polaris/catalog/test/test_get_applicable_policies_response.py
  inflating: polaris/catalog/test/test_get_namespace_response.py
  inflating: polaris/catalog/test/test_iceberg_catalog_api.py
  inflating: polaris/catalog/test/test_iceberg_configuration_api.py
  inflating: polaris/catalog/test/test_iceberg_error_response.py
  inflating: polaris/catalog/test/test_iceberg_error_response1.py
  inflating: polaris/catalog/test/test_iceberg_o_auth2_api.py
  inflating: polaris/catalog/test/test_list_generic_tables_response.py
  inflating: polaris/catalog/test/test_list_namespaces_response.py
  inflating: polaris/catalog/test/test_list_policies_response.py
  inflating: polaris/catalog/test/test_list_tables_response.py
  inflating: polaris/catalog/test/test_list_type.py
  inflating: polaris/catalog/test/test_literal_expression.py
  inflating: polaris/catalog/test/test_load_credentials_response.py
  inflating: polaris/catalog/test/test_load_generic_table_response.py
  inflating: polaris/catalog/test/test_load_policy_response.py
  inflating: polaris/catalog/test/test_load_table_result.py
  inflating: polaris/catalog/test/test_load_view_result.py
  inflating: polaris/catalog/test/test_map_type.py
  inflating: polaris/catalog/test/test_metadata_log_inner.py
  inflating: polaris/catalog/test/test_metric_result.py
  inflating: polaris/catalog/test/test_model_schema.py
  inflating: polaris/catalog/test/test_not_expression.py
  inflating: polaris/catalog/test/test_notification_request.py
  inflating: polaris/catalog/test/test_notification_type.py
  inflating: polaris/catalog/test/test_null_order.py
  inflating: polaris/catalog/test/test_o_auth2_api.py
  inflating: polaris/catalog/test/test_o_auth_error.py
  inflating: polaris/catalog/test/test_o_auth_token_response.py
  inflating: polaris/catalog/test/test_partition_field.py
  inflating: polaris/catalog/test/test_partition_spec.py
  inflating: polaris/catalog/test/test_partition_statistics_file.py
  inflating: polaris/catalog/test/test_plan_status.py
  inflating: polaris/catalog/test/test_plan_table_scan_request.py
  inflating: polaris/catalog/test/test_plan_table_scan_result.py
  inflating: polaris/catalog/test/test_policy.py
  inflating: polaris/catalog/test/test_policy_api.py
  inflating: polaris/catalog/test/test_policy_attachment_target.py
  inflating: polaris/catalog/test/test_policy_identifier.py
  inflating: polaris/catalog/test/test_position_delete_file.py
  inflating: polaris/catalog/test/test_primitive_type_value.py
  inflating: polaris/catalog/test/test_register_table_request.py
  inflating: polaris/catalog/test/test_remove_partition_specs_update.py
  inflating: polaris/catalog/test/test_remove_partition_statistics_update.py
  inflating: polaris/catalog/test/test_remove_properties_update.py
  inflating: polaris/catalog/test/test_remove_snapshot_ref_update.py
  inflating: polaris/catalog/test/test_remove_snapshots_update.py
  inflating: polaris/catalog/test/test_remove_statistics_update.py
  inflating: polaris/catalog/test/test_rename_table_request.py
  inflating: polaris/catalog/test/test_report_metrics_request.py
  inflating: polaris/catalog/test/test_scan_report.py
  inflating: polaris/catalog/test/test_scan_tasks.py
  inflating: polaris/catalog/test/test_set_current_schema_update.py
  inflating: polaris/catalog/test/test_set_current_view_version_update.py
  inflating: polaris/catalog/test/test_set_default_sort_order_update.py
  inflating: polaris/catalog/test/test_set_default_spec_update.py
  inflating: polaris/catalog/test/test_set_expression.py
  inflating: polaris/catalog/test/test_set_location_update.py
  inflating: polaris/catalog/test/test_set_partition_statistics_update.py
  inflating: polaris/catalog/test/test_set_properties_update.py
  inflating: polaris/catalog/test/test_set_snapshot_ref_update.py
  inflating: polaris/catalog/test/test_set_statistics_update.py
  inflating: polaris/catalog/test/test_snapshot.py
  inflating: polaris/catalog/test/test_snapshot_log_inner.py
  inflating: polaris/catalog/test/test_snapshot_reference.py
  inflating: polaris/catalog/test/test_snapshot_summary.py
  inflating: polaris/catalog/test/test_sort_direction.py
  inflating: polaris/catalog/test/test_sort_field.py
  inflating: polaris/catalog/test/test_sort_order.py
  inflating: polaris/catalog/test/test_sql_view_representation.py
  inflating: polaris/catalog/test/test_statistics_file.py
  inflating: polaris/catalog/test/test_storage_credential.py
  inflating: polaris/catalog/test/test_struct_field.py
  inflating: polaris/catalog/test/test_struct_type.py
  inflating: polaris/catalog/test/test_table_identifier.py
  inflating: polaris/catalog/test/test_table_metadata.py
  inflating: polaris/catalog/test/test_table_requirement.py
  inflating: polaris/catalog/test/test_table_update.py
  inflating: polaris/catalog/test/test_table_update_notification.py
  inflating: polaris/catalog/test/test_term.py
  inflating: polaris/catalog/test/test_timer_result.py
  inflating: polaris/catalog/test/test_token_type.py
  inflating: polaris/catalog/test/test_transform_term.py
  inflating: polaris/catalog/test/test_true_expression.py
  inflating: polaris/catalog/test/test_type.py
  inflating: polaris/catalog/test/test_unary_expression.py
  inflating: polaris/catalog/test/test_update_namespace_properties_request.py
  inflating: polaris/catalog/test/test_update_namespace_properties_response.py
  inflating: polaris/catalog/test/test_update_policy_request.py
  inflating: polaris/catalog/test/test_upgrade_format_version_update.py
  inflating: polaris/catalog/test/test_value_map.py
  inflating: polaris/catalog/test/test_view_history_entry.py
  inflating: polaris/catalog/test/test_view_metadata.py
  inflating: polaris/catalog/test/test_view_representation.py
  inflating: polaris/catalog/test/test_view_requirement.py
  inflating: polaris/catalog/test/test_view_update.py
  inflating: polaris/catalog/test/test_view_version.py
  inflating: polaris/catalog_README.md
  inflating: polaris/management/.keep
  inflating: polaris/management/__init__.py
  inflating: polaris/management/api/.keep
  inflating: polaris/management/api/__init__.py
  inflating: polaris/management/api/polaris_default_api.py
  inflating: polaris/management/api_client.py
  inflating: polaris/management/api_response.py
  inflating: polaris/management/configuration.py
  inflating: polaris/management/docs/AddGrantRequest.md
  inflating: polaris/management/docs/AuthenticationParameters.md
  inflating: polaris/management/docs/AwsIamServiceIdentityInfo.md
  inflating: polaris/management/docs/AwsStorageConfigInfo.md
  inflating: polaris/management/docs/AzureStorageConfigInfo.md
  inflating: polaris/management/docs/BearerAuthenticationParameters.md
  inflating: polaris/management/docs/Catalog.md
  inflating: polaris/management/docs/CatalogGrant.md
  inflating: polaris/management/docs/CatalogPrivilege.md
  inflating: polaris/management/docs/CatalogProperties.md
  inflating: polaris/management/docs/CatalogRole.md
  inflating: polaris/management/docs/CatalogRoles.md
  inflating: polaris/management/docs/Catalogs.md
  inflating: polaris/management/docs/ConnectionConfigInfo.md
  inflating: polaris/management/docs/CreateCatalogRequest.md
  inflating: polaris/management/docs/CreateCatalogRoleRequest.md
  inflating: polaris/management/docs/CreatePrincipalRequest.md
  inflating: polaris/management/docs/CreatePrincipalRoleRequest.md
  inflating: polaris/management/docs/ExternalCatalog.md
  inflating: polaris/management/docs/FileStorageConfigInfo.md
  inflating: polaris/management/docs/GcpStorageConfigInfo.md
  inflating: polaris/management/docs/GrantCatalogRoleRequest.md
  inflating: polaris/management/docs/GrantPrincipalRoleRequest.md
  inflating: polaris/management/docs/GrantResource.md
  inflating: polaris/management/docs/GrantResources.md
  inflating: polaris/management/docs/HadoopConnectionConfigInfo.md
  inflating: polaris/management/docs/HiveConnectionConfigInfo.md
  inflating: polaris/management/docs/IcebergRestConnectionConfigInfo.md
  inflating: polaris/management/docs/ImplicitAuthenticationParameters.md
  inflating: polaris/management/docs/NamespaceGrant.md
  inflating: polaris/management/docs/NamespacePrivilege.md
  inflating: polaris/management/docs/OAuthClientCredentialsParameters.md
  inflating: polaris/management/docs/PolarisCatalog.md
  inflating: polaris/management/docs/PolarisDefaultApi.md
  inflating: polaris/management/docs/PolicyGrant.md
  inflating: polaris/management/docs/PolicyPrivilege.md
  inflating: polaris/management/docs/Principal.md
  inflating: polaris/management/docs/PrincipalRole.md
  inflating: polaris/management/docs/PrincipalRoles.md
  inflating: polaris/management/docs/PrincipalWithCredentials.md
  inflating: polaris/management/docs/PrincipalWithCredentialsCredentials.md
  inflating: polaris/management/docs/Principals.md
  inflating: polaris/management/docs/RevokeGrantRequest.md
  inflating: polaris/management/docs/ServiceIdentityInfo.md
  inflating: polaris/management/docs/SigV4AuthenticationParameters.md
  inflating: polaris/management/docs/StorageConfigInfo.md
  inflating: polaris/management/docs/TableGrant.md
  inflating: polaris/management/docs/TablePrivilege.md
  inflating: polaris/management/docs/UpdateCatalogRequest.md
  inflating: polaris/management/docs/UpdateCatalogRoleRequest.md
  inflating: polaris/management/docs/UpdatePrincipalRequest.md
  inflating: polaris/management/docs/UpdatePrincipalRoleRequest.md
  inflating: polaris/management/docs/ViewGrant.md
  inflating: polaris/management/docs/ViewPrivilege.md
  inflating: polaris/management/exceptions.py
  inflating: polaris/management/models/.keep
  inflating: polaris/management/models/__init__.py
  inflating: polaris/management/models/add_grant_request.py
  inflating: polaris/management/models/authentication_parameters.py
  inflating: polaris/management/models/aws_iam_service_identity_info.py
  inflating: polaris/management/models/aws_storage_config_info.py
  inflating: polaris/management/models/azure_storage_config_info.py
  inflating: polaris/management/models/bearer_authentication_parameters.py
  inflating: polaris/management/models/catalog.py
  inflating: polaris/management/models/catalog_grant.py
  inflating: polaris/management/models/catalog_privilege.py
  inflating: polaris/management/models/catalog_properties.py
  inflating: polaris/management/models/catalog_role.py
  inflating: polaris/management/models/catalog_roles.py
  inflating: polaris/management/models/catalogs.py
  inflating: polaris/management/models/connection_config_info.py
  inflating: polaris/management/models/create_catalog_request.py
  inflating: polaris/management/models/create_catalog_role_request.py
  inflating: polaris/management/models/create_principal_request.py
  inflating: polaris/management/models/create_principal_role_request.py
  inflating: polaris/management/models/external_catalog.py
  inflating: polaris/management/models/file_storage_config_info.py
  inflating: polaris/management/models/gcp_storage_config_info.py
  inflating: polaris/management/models/grant_catalog_role_request.py
  inflating: polaris/management/models/grant_principal_role_request.py
  inflating: polaris/management/models/grant_resource.py
  inflating: polaris/management/models/grant_resources.py
  inflating: polaris/management/models/hadoop_connection_config_info.py
  inflating: polaris/management/models/hive_connection_config_info.py
  inflating: polaris/management/models/iceberg_rest_connection_config_info.py
  inflating: polaris/management/models/implicit_authentication_parameters.py
  inflating: polaris/management/models/namespace_grant.py
  inflating: polaris/management/models/namespace_privilege.py
  inflating: polaris/management/models/o_auth_client_credentials_parameters.py
  inflating: polaris/management/models/polaris_catalog.py
  inflating: polaris/management/models/policy_grant.py
  inflating: polaris/management/models/policy_privilege.py
  inflating: polaris/management/models/principal.py
  inflating: polaris/management/models/principal_role.py
  inflating: polaris/management/models/principal_roles.py
  inflating: polaris/management/models/principal_with_credentials.py
  inflating: polaris/management/models/principal_with_credentials_credentials.py
  inflating: polaris/management/models/principals.py
  inflating: polaris/management/models/revoke_grant_request.py
  inflating: polaris/management/models/service_identity_info.py
  inflating: polaris/management/models/sig_v4_authentication_parameters.py
  inflating: polaris/management/models/storage_config_info.py
  inflating: polaris/management/models/table_grant.py
  inflating: polaris/management/models/table_privilege.py
  inflating: polaris/management/models/update_catalog_request.py
  inflating: polaris/management/models/update_catalog_role_request.py
  inflating: polaris/management/models/update_principal_request.py
  inflating: polaris/management/models/update_principal_role_request.py
  inflating: polaris/management/models/view_grant.py
  inflating: polaris/management/models/view_privilege.py
  inflating: polaris/management/py.typed
  inflating: polaris/management/rest.py
  inflating: polaris/management/test/__init__.py
  inflating: polaris/management/test/test_add_grant_request.py
  inflating: polaris/management/test/test_authentication_parameters.py
  inflating: polaris/management/test/test_aws_iam_service_identity_info.py
  inflating: polaris/management/test/test_aws_storage_config_info.py
  inflating: polaris/management/test/test_azure_storage_config_info.py
  inflating: polaris/management/test/test_bearer_authentication_parameters.py
  inflating: polaris/management/test/test_catalog.py
  inflating: polaris/management/test/test_catalog_grant.py
  inflating: polaris/management/test/test_catalog_privilege.py
  inflating: polaris/management/test/test_catalog_properties.py
  inflating: polaris/management/test/test_catalog_role.py
  inflating: polaris/management/test/test_catalog_roles.py
  inflating: polaris/management/test/test_catalogs.py
  inflating: polaris/management/test/test_connection_config_info.py
  inflating: polaris/management/test/test_create_catalog_request.py
  inflating: polaris/management/test/test_create_catalog_role_request.py
  inflating: polaris/management/test/test_create_principal_request.py
  inflating: polaris/management/test/test_create_principal_role_request.py
  inflating: polaris/management/test/test_external_catalog.py
  inflating: polaris/management/test/test_file_storage_config_info.py
  inflating: polaris/management/test/test_gcp_storage_config_info.py
  inflating: polaris/management/test/test_grant_catalog_role_request.py
  inflating: polaris/management/test/test_grant_principal_role_request.py
  inflating: polaris/management/test/test_grant_resource.py
  inflating: polaris/management/test/test_grant_resources.py
  inflating: polaris/management/test/test_hadoop_connection_config_info.py
  inflating: polaris/management/test/test_hive_connection_config_info.py
  inflating: polaris/management/test/test_iceberg_rest_connection_config_info.py
  inflating: polaris/management/test/test_implicit_authentication_parameters.py
  inflating: polaris/management/test/test_namespace_grant.py
  inflating: polaris/management/test/test_namespace_privilege.py
  inflating: polaris/management/test/test_o_auth_client_credentials_parameters.py
  inflating: polaris/management/test/test_polaris_catalog.py
  inflating: polaris/management/test/test_polaris_default_api.py
  inflating: polaris/management/test/test_policy_grant.py
  inflating: polaris/management/test/test_policy_privilege.py
  inflating: polaris/management/test/test_principal.py
  inflating: polaris/management/test/test_principal_role.py
  inflating: polaris/management/test/test_principal_roles.py
  inflating: polaris/management/test/test_principal_with_credentials.py
  inflating: polaris/management/test/test_principal_with_credentials_credentials.py
  inflating: polaris/management/test/test_principals.py
  inflating: polaris/management/test/test_revoke_grant_request.py
  inflating: polaris/management/test/test_service_identity_info.py
  inflating: polaris/management/test/test_sig_v4_authentication_parameters.py
  inflating: polaris/management/test/test_storage_config_info.py
  inflating: polaris/management/test/test_table_grant.py
  inflating: polaris/management/test/test_table_privilege.py
  inflating: polaris/management/test/test_update_catalog_request.py
  inflating: polaris/management/test/test_update_catalog_role_request.py
  inflating: polaris/management/test/test_update_principal_request.py
  inflating: polaris/management/test/test_update_principal_role_request.py
  inflating: polaris/management/test/test_view_grant.py
  inflating: polaris/management/test/test_view_privilege.py
  inflating: polaris/management_README.md
  inflating: polaris-1.0.0.dist-info/METADATA
  inflating: polaris-1.0.0.dist-info/WHEEL
  inflating: polaris-1.0.0.dist-info/entry_points.txt
  inflating: polaris-1.0.0.dist-info/RECORD
```

Also, this PR add support with Makefile so now we can use `make client-build` to create the new wheel file.