### PR TITLE
Built: improve reproducible archive files

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -32,6 +32,7 @@ plugins {
   `jvm-test-suite`
   checkstyle
   id("polaris-spotless")
+  id("polaris-reproducible")
   id("jacoco-report-aggregation")
   id("net.ltgt.errorprone")
 }
@@ -237,9 +238,20 @@ configurations.all {
     }
 }
 
-// ensure jars conform to reproducible builds
-// (https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
-tasks.withType<AbstractArchiveTask>().configureEach {
-  isPreserveFileTimestamps = false
-  isReproducibleFileOrder = true
+if (plugins.hasPlugin("io.quarkus")) {
+  tasks.named("quarkusBuild") {
+    actions.addLast {
+      listOf(
+          "quarkus-app/quarkus-run.jar",
+          "quarkus-app/quarkus/generated-bytecode.jar",
+          "quarkus-app/quarkus/transformed-bytecode.jar",
+        )
+        .forEach { name ->
+          val file = project.layout.buildDirectory.get().file(name).asFile
+          if (file.exists()) {
+            makeZipReproducible(file)
+          }
+        }
+    }
+  }
 }

--- a/build-logic/src/main/kotlin/polaris-reproducible.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-reproducible.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ensure jars conform to reproducible builds
+// (https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
+tasks.withType<AbstractArchiveTask>().configureEach {
+  isPreserveFileTimestamps = false
+  isReproducibleFileOrder = true
+}

--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -23,6 +23,7 @@ import publishing.PublishingHelperPlugin
 plugins {
     id("distribution")
     id("signing")
+    id("polaris-reproducible")
 }
 
 description = "Apache Polaris Binary Distribution"

--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
   `java-library`
+  id("polaris-reproducible")
 }
 
 description = "Polaris site - reference docs"


### PR DESCRIPTION
As part of the effort for #2204, this change fixes a few aspects around reproducible builds:

Some Gradle projects produce archive files, but don't get the necessary Gradle archive-tasks settings applied: one not-published project but also the tarball&zip of the distribution. This change moves the logic to the new build-plugin `polaris-reproducible`.

Another change is to have some Quarkus generated jar files adhere to the same conventions, which are constant timestamps for the zip entries and a deterministic order of the entries. That's sadly not a full fix, as the classes that are generated or instumented by Quarkus differ in each build.

Contributes to #2204
