### PR TITLE
Pass related entity to PolarisStorageIntegrationProvider

### DIFF
--- a/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -627,12 +627,8 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   @Override
   public @Nullable <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegrationInCurrentTxn(
-          @Nonnull PolarisCallContext callCtx,
-          long catalogId,
-          long entityId,
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
-    return storageIntegrationProvider.getStorageIntegrationForConfig(
-        polarisStorageConfigurationInfo);
+          @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog) {
+    return storageIntegrationProvider.getStorageIntegration(catalog);
   }
 
   /** {@inheritDoc} */
@@ -640,9 +636,8 @@ public class PolarisEclipseLinkMetaStoreSessionImpl extends AbstractTransactiona
   public @Nullable <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegrationInCurrentTxn(
           @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity entity) {
-    PolarisStorageConfigurationInfo storageConfig =
-        BaseMetaStoreManager.extractStorageConfiguration(getDiagnostics(), entity);
-    return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
+    return BaseMetaStoreManager.toStorageIntegration(
+        getDiagnostics(), entity, storageIntegrationProvider);
   }
 
   /** {@inheritDoc} */

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1099,12 +1099,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegration(
-          @Nonnull PolarisCallContext callCtx,
-          long catalogId,
-          long entityId,
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
-    return storageIntegrationProvider.getStorageIntegrationForConfig(
-        polarisStorageConfigurationInfo);
+          @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog) {
+    return storageIntegrationProvider.getStorageIntegration(catalog);
   }
 
   @Override
@@ -1118,9 +1114,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegration(
           @Nonnull PolarisCallContext callContext, @Nonnull PolarisBaseEntity entity) {
-    PolarisStorageConfigurationInfo storageConfig =
-        BaseMetaStoreManager.extractStorageConfiguration(callContext.getDiagServices(), entity);
-    return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
+    return BaseMetaStoreManager.toStorageIntegration(
+        callContext.getDiagServices(), entity, storageIntegrationProvider);
   }
 
   @FunctionalInterface

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -441,13 +441,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // storageConfigInfo's presence is needed to create a storage integration
     // and the catalog should not have an internal property of storage identifier or id yet
     if (storageConfigInfoStr != null && integrationIdentifierOrId == null) {
-      integration =
-          ((IntegrationPersistence) ms)
-              .createStorageIntegration(
-                  callCtx,
-                  catalog.getCatalogId(),
-                  catalog.getId(),
-                  PolarisStorageConfigurationInfo.deserialize(storageConfigInfoStr));
+      integration = ((IntegrationPersistence) ms).createStorageIntegration(callCtx, catalog);
     } else {
       integration = null;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/IntegrationPersistence.java
@@ -94,18 +94,13 @@ public interface IntegrationPersistence {
   /**
    * Create an in-memory storage integration
    *
-   * @param callCtx the polaris calllctx
-   * @param catalogId the catalog id
-   * @param entityId the entity id
-   * @param polarisStorageConfigurationInfo the storage configuration information
+   * @param callCtx the polaris call context
+   * @param catalog the catalog entity, for which a storage integration object needs to be created
    * @return a storage integration object
    */
   @Nullable
   <T extends PolarisStorageConfigurationInfo> PolarisStorageIntegration<T> createStorageIntegration(
-      @Nonnull PolarisCallContext callCtx,
-      long catalogId,
-      long entityId,
-      PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
+      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog);
 
   /**
    * Persist a storage integration in the metastore

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -524,15 +524,9 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   @Nullable
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegration(
-          @Nonnull PolarisCallContext callCtx,
-          long catalogId,
-          long entityId,
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
+          @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog) {
     return runInTransaction(
-        callCtx,
-        () ->
-            this.createStorageIntegrationInCurrentTxn(
-                callCtx, catalogId, entityId, polarisStorageConfigurationInfo));
+        callCtx, () -> this.createStorageIntegrationInCurrentTxn(callCtx, catalog));
   }
 
   /** {@inheritDoc} */

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -981,12 +981,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // storageConfigInfo's presence is needed to create a storage integration
     // and the catalog should not have an internal property of storage identifier or id yet
     if (storageConfigInfoStr != null && integrationIdentifierOrId == null) {
-      integration =
-          ms.createStorageIntegrationInCurrentTxn(
-              callCtx,
-              catalog.getCatalogId(),
-              catalog.getId(),
-              PolarisStorageConfigurationInfo.deserialize(storageConfigInfoStr));
+      integration = ms.createStorageIntegrationInCurrentTxn(callCtx, catalog);
     } else {
       integration = null;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalPersistence.java
@@ -310,10 +310,7 @@ public interface TransactionalPersistence
   @Nullable
   <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegrationInCurrentTxn(
-          @Nonnull PolarisCallContext callCtx,
-          long catalogId,
-          long entityId,
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
+          @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog);
 
   /**
    * See {@link

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -518,12 +518,8 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
   @Override
   public @Nullable <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegrationInCurrentTxn(
-          @Nonnull PolarisCallContext callCtx,
-          long catalogId,
-          long entityId,
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
-    return storageIntegrationProvider.getStorageIntegrationForConfig(
-        polarisStorageConfigurationInfo);
+          @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity catalog) {
+    return storageIntegrationProvider.getStorageIntegration(catalog);
   }
 
   /** {@inheritDoc} */
@@ -531,9 +527,8 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
   public @Nullable <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegrationInCurrentTxn(
           @Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity entity) {
-    PolarisStorageConfigurationInfo storageConfig =
-        BaseMetaStoreManager.extractStorageConfiguration(getDiagnostics(), entity);
-    return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
+    return BaseMetaStoreManager.toStorageIntegration(
+        getDiagnostics(), entity, storageIntegrationProvider);
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegrationProvider.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.storage;
 
 import jakarta.annotation.Nullable;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 
 /**
  * Factory interface that knows how to construct a {@link PolarisStorageIntegration} given a {@link
@@ -26,6 +27,5 @@ import jakarta.annotation.Nullable;
  */
 public interface PolarisStorageIntegrationProvider {
   <T extends PolarisStorageConfigurationInfo>
-      @Nullable PolarisStorageIntegration<T> getStorageIntegrationForConfig(
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo);
+      @Nullable PolarisStorageIntegration<T> getStorageIntegration(PolarisBaseEntity entity);
 }

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
@@ -28,6 +28,7 @@ import java.time.Clock;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
@@ -64,8 +65,7 @@ public class AdminToolProducers {
       @Override
       @Nullable
       public <T extends PolarisStorageConfigurationInfo>
-          PolarisStorageIntegration<T> getStorageIntegrationForConfig(
-              PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
+          PolarisStorageIntegration<T> getStorageIntegration(PolarisBaseEntity entity) {
         return null;
       }
     };

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.storage.AccessConfig;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -72,14 +74,21 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
     this.gcpCredsProvider = gcpCredsProvider;
   }
 
-  @Override
   @SuppressWarnings("unchecked")
+  @Override
+  @Nullable
   public <T extends PolarisStorageConfigurationInfo>
-      @Nullable PolarisStorageIntegration<T> getStorageIntegrationForConfig(
-          PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
-    if (polarisStorageConfigurationInfo == null) {
+      PolarisStorageIntegration<T> getStorageIntegration(PolarisBaseEntity entity) {
+    Map<String, String> propMap = entity.getInternalPropertiesAsMap();
+    String storageConfigInfoStr =
+        propMap.get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
+    if (storageConfigInfoStr == null) {
       return null;
     }
+
+    PolarisStorageConfigurationInfo polarisStorageConfigurationInfo =
+        PolarisStorageConfigurationInfo.deserialize(storageConfigInfoStr);
+
     PolarisStorageIntegration<T> storageIntegration;
     switch (polarisStorageConfigurationInfo.getStorageType()) {
       case S3:

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractIcebergCatalogTest.java
@@ -362,8 +362,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             (AwsStorageConfigurationInfo)
                 CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
             stsClient);
-    when(storageIntegrationProvider.getStorageIntegrationForConfig(
-            isA(AwsStorageConfigurationInfo.class)))
+    when(storageIntegrationProvider.getStorageIntegration(any()))
         .thenReturn((PolarisStorageIntegration) storageIntegration);
 
     this.catalog = initCatalog("my-catalog", ImmutableMap.of());

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolarisGenericTableCatalogTest.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.catalog;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
@@ -226,8 +227,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
             (AwsStorageConfigurationInfo)
                 CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
             stsClient);
-    when(storageIntegrationProvider.getStorageIntegrationForConfig(
-            isA(AwsStorageConfigurationInfo.class)))
+    when(storageIntegrationProvider.getStorageIntegration(any()))
         .thenReturn((PolarisStorageIntegration) storageIntegration);
 
     this.genericTableCatalog =

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/AbstractPolicyCatalogTest.java
@@ -25,6 +25,7 @@ import static org.apache.polaris.core.policy.PredefinedPolicyTypes.ORPHAN_FILE_R
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
@@ -245,8 +246,7 @@ public abstract class AbstractPolicyCatalogTest {
             (AwsStorageConfigurationInfo)
                 CatalogEntity.of(catalogEntity).getStorageConfigurationInfo(),
             stsClient);
-    when(storageIntegrationProvider.getStorageIntegrationForConfig(
-            isA(AwsStorageConfigurationInfo.class)))
+    when(storageIntegrationProvider.getStorageIntegration(any()))
         .thenReturn((PolarisStorageIntegration) storageIntegration);
 
     this.policyCatalog = new PolicyCatalog(metaStoreManager, polarisContext, passthroughView);


### PR DESCRIPTION
PolarisStorageIntegrationProvider used to operate on a `PolarisStorageConfigurationInfo` instance extracted from the related entity by the caller.

This change delegated this config extraction to the implementations of the `PolarisStorageIntegrationProvider` interface.

The main purpose of this change is to allow implementations to have more flexibility by being able to inspect the whole entity that contains storage info.

The default `PolarisStorageIntegrationProvider` implementation works as before. There is no behaviour change in Polaris from the clients' perspective.

As a side effect, `IntegrationPersistence` and `TransactionalPersistence` interfaces also had to be changed to propagate related entities to `PolarisStorageIntegrationProvider`.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
