### PR TITLE
Add user principal tag in metrics

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -44,6 +44,7 @@ import org.apache.polaris.service.context.RealmContextResolver;
 import org.apache.polaris.service.context.TestRealmContextResolver;
 import org.apache.polaris.service.events.PolarisEventListener;
 import org.apache.polaris.service.events.TestPolarisEventListener;
+import org.apache.polaris.service.metrics.MetricsConfiguration;
 import org.apache.polaris.service.persistence.InMemoryPolarisMetaStoreManagerFactory;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigValue;
@@ -111,6 +112,17 @@ public class ProductionReadinessChecks {
             severe);
       }
     }
+  }
+
+  @Produces
+  public ProductionReadinessCheck checkMetricTags(MetricsConfiguration config) {
+    if (config.userPrincipalTag().enableInApiMetrics()) {
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "Metrics configuration includes user principal name in tags.",
+              "polaris.metrics.user-principal-tag.enable-in-api-metrics"));
+    }
+    return ProductionReadinessCheck.OK;
   }
 
   @Produces

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -116,11 +116,16 @@ public class ProductionReadinessChecks {
 
   @Produces
   public ProductionReadinessCheck checkMetricTags(MetricsConfiguration config) {
-    if (config.userPrincipalTag().enableInApiMetrics()) {
+    if (config.userPrincipalTag().enableInApiMetrics()
+        && config.realmIdTag().enableInApiMetrics()) {
       return ProductionReadinessCheck.of(
           Error.of(
-              "Metrics configuration includes user principal name in tags.",
+              "Metrics configuration includes both user principal name and realm id in tags this could cause performance implications.",
               "polaris.metrics.user-principal-tag.enable-in-api-metrics"));
+    } else {
+      LOGGER.warn(
+          "Metrics configuration includes user principal name in tags. "
+              + "This could have performance implications.");
     }
     return ProductionReadinessCheck.OK;
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -115,17 +115,25 @@ public class ProductionReadinessChecks {
   }
 
   @Produces
-  public ProductionReadinessCheck checkMetricTags(MetricsConfiguration config) {
+  public ProductionReadinessCheck checkUserPrincipalMetricTag(MetricsConfiguration config) {
+    if (config.userPrincipalTag().enableInApiMetrics()) {
+      return ProductionReadinessCheck.of(
+          Error.of(
+              "Metrics configuration includes user principal name and this could have security implications.",
+              "polaris.metrics.user-principal-tag.enable-in-api-metrics"));
+    }
+    return ProductionReadinessCheck.OK;
+  }
+
+  @Produces
+  public ProductionReadinessCheck checkUserPrincipalAndRealmIdMetricTags(
+      MetricsConfiguration config) {
     if (config.userPrincipalTag().enableInApiMetrics()
         && config.realmIdTag().enableInApiMetrics()) {
       return ProductionReadinessCheck.of(
           Error.of(
-              "Metrics configuration includes both user principal name and realm id in tags this could cause performance implications.",
+              "Metrics configuration includes both user principal name and realm id in tags and this could have performance implications.",
               "polaris.metrics.user-principal-tag.enable-in-api-metrics"));
-    } else {
-      LOGGER.warn(
-          "Metrics configuration includes user principal name in tags. "
-              + "This could have performance implications.");
     }
     return ProductionReadinessCheck.OK;
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/metrics/MetricsConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/metrics/MetricsConfiguration.java
@@ -79,6 +79,5 @@ public interface MetricsConfiguration {
      */
     @WithDefault("false")
     boolean enableInApiMetrics();
-
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/metrics/MetricsConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/metrics/MetricsConfiguration.java
@@ -32,6 +32,9 @@ public interface MetricsConfiguration {
   /** Configuration for the Realm ID metric tag. */
   RealmIdTag realmIdTag();
 
+  /** Configuration for the user principal metric tag. */
+  UserPrincipalTag userPrincipalTag();
+
   interface RealmIdTag {
 
     /**
@@ -64,5 +67,18 @@ public interface MetricsConfiguration {
     @WithDefault("100")
     @Min(1)
     int httpMetricsMaxCardinality();
+  }
+
+  interface UserPrincipalTag {
+
+    /**
+     * Whether to include the User Principal tag in the API request metrics.
+     *
+     * <p>Beware that if the cardinality of this tag is too high, it can cause performance issues or
+     * even crash the server.
+     */
+    @WithDefault("false")
+    boolean enableInApiMetrics();
+
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
@@ -23,6 +23,7 @@ import io.micrometer.common.lang.Nullable;
 import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.SecurityContext;
 import org.apache.polaris.core.context.RealmContext;
 
 @ApplicationScoped
@@ -39,6 +40,13 @@ public class PolarisValueExpressionResolver implements ValueExpressionResolver {
         && expression.equals("realmIdentifier")) {
       return realmContext.getRealmIdentifier();
     }
+
+    if (metricsConfiguration.userPrincipalTag().enableInApiMetrics() &&
+            parameter instanceof SecurityContext securityContext
+            && expression.equals("userPrincipal") && securityContext.getUserPrincipal() != null) {
+      return securityContext.getUserPrincipal().getName();
+    }
     return null;
   }
+
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
@@ -41,12 +41,12 @@ public class PolarisValueExpressionResolver implements ValueExpressionResolver {
       return realmContext.getRealmIdentifier();
     }
 
-    if (metricsConfiguration.userPrincipalTag().enableInApiMetrics() &&
-            parameter instanceof SecurityContext securityContext
-            && expression.equals("userPrincipal") && securityContext.getUserPrincipal() != null) {
+    if (metricsConfiguration.userPrincipalTag().enableInApiMetrics()
+        && parameter instanceof SecurityContext securityContext
+        && expression.equals("userPrincipal")
+        && securityContext.getUserPrincipal() != null) {
       return securityContext.getUserPrincipal().getName();
     }
     return null;
   }
-
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/MetricsTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/MetricsTestBase.java
@@ -106,7 +106,7 @@ public abstract class MetricsTestBase {
                               ? fixture.realm
                               : ""),
                       Map.entry(
-                      "principal",
+                          "principal",
                           metricsConfiguration.userPrincipalTag().enableInApiMetrics()
                               ? "root"
                               : ""),
@@ -163,9 +163,9 @@ public abstract class MetricsTestBase {
                               : ""),
                       Map.entry(
                           "principal",
-                              metricsConfiguration.userPrincipalTag().enableInApiMetrics()
-                                  ? "root"
-                                  : ""),
+                          metricsConfiguration.userPrincipalTag().enableInApiMetrics()
+                              ? "root"
+                              : ""),
                       Map.entry(
                           "class", "org.apache.polaris.service.admin.api.PolarisPrincipalsApi"),
                       Map.entry("exception", "NotFoundException"),

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/MetricsTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/MetricsTestBase.java
@@ -106,6 +106,11 @@ public abstract class MetricsTestBase {
                               ? fixture.realm
                               : ""),
                       Map.entry(
+                      "principal",
+                          metricsConfiguration.userPrincipalTag().enableInApiMetrics()
+                              ? "root"
+                              : ""),
+                      Map.entry(
                           "class", "org.apache.polaris.service.admin.api.PolarisPrincipalsApi"),
                       Map.entry("exception", "none"),
                       Map.entry("method", "getPrincipal"));
@@ -156,6 +161,11 @@ public abstract class MetricsTestBase {
                           metricsConfiguration.realmIdTag().enableInApiMetrics()
                               ? fixture.realm
                               : ""),
+                      Map.entry(
+                          "principal",
+                              metricsConfiguration.userPrincipalTag().enableInApiMetrics()
+                                  ? "root"
+                                  : ""),
                       Map.entry(
                           "class", "org.apache.polaris.service.admin.api.PolarisPrincipalsApi"),
                       Map.entry("exception", "NotFoundException"),

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/RealmIdTagEnabledMetricsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/RealmIdTagEnabledMetricsTest.java
@@ -41,7 +41,7 @@ public class RealmIdTagEnabledMetricsTest extends MetricsTestBase {
           "polaris.metrics.realm-id-tag.enable-in-http-metrics",
           "true",
           "polaris.metrics.user-principal-tag.enable-in-api-metrics",
-          "true");
+          "false");
     }
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagDisabledMetricsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagDisabledMetricsTest.java
@@ -27,12 +27,12 @@ import java.util.Map;
 @TestProfile(UserPrincipalTagDisabledMetricsTest.Profile.class)
 public class UserPrincipalTagDisabledMetricsTest extends MetricsTestBase {
 
-    public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements QuarkusTestProfile {
 
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of(
-                    "polaris.metrics.tags.environment", "prod", "polaris.realm-context.type", "test");
-        }
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.metrics.tags.environment", "prod", "polaris.realm-context.type", "test");
     }
+  }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagDisabledMetricsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagDisabledMetricsTest.java
@@ -24,24 +24,15 @@ import io.quarkus.test.junit.TestProfile;
 import java.util.Map;
 
 @QuarkusTest
-@TestProfile(RealmIdTagEnabledMetricsTest.Profile.class)
-public class RealmIdTagEnabledMetricsTest extends MetricsTestBase {
+@TestProfile(UserPrincipalTagDisabledMetricsTest.Profile.class)
+public class UserPrincipalTagDisabledMetricsTest extends MetricsTestBase {
 
-  public static class Profile implements QuarkusTestProfile {
+    public static class Profile implements QuarkusTestProfile {
 
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.metrics.tags.environment",
-          "prod",
-          "polaris.realm-context.type",
-          "test",
-          "polaris.metrics.realm-id-tag.enable-in-api-metrics",
-          "true",
-          "polaris.metrics.realm-id-tag.enable-in-http-metrics",
-          "true",
-          "polaris.metrics.user-principal-tag.enable-in-api-metrics",
-          "true");
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "polaris.metrics.tags.environment", "prod", "polaris.realm-context.type", "test");
+        }
     }
-  }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagEnabledMetricsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagEnabledMetricsTest.java
@@ -24,24 +24,22 @@ import io.quarkus.test.junit.TestProfile;
 import java.util.Map;
 
 @QuarkusTest
-@TestProfile(RealmIdTagEnabledMetricsTest.Profile.class)
-public class RealmIdTagEnabledMetricsTest extends MetricsTestBase {
+@TestProfile(UserPrincipalTagEnabledMetricsTest.Profile.class)
+public class UserPrincipalTagEnabledMetricsTest extends MetricsTestBase {
 
-  public static class Profile implements QuarkusTestProfile {
+    public static class Profile implements QuarkusTestProfile {
 
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.metrics.tags.environment",
-          "prod",
-          "polaris.realm-context.type",
-          "test",
-          "polaris.metrics.realm-id-tag.enable-in-api-metrics",
-          "true",
-          "polaris.metrics.realm-id-tag.enable-in-http-metrics",
-          "true",
-          "polaris.metrics.user-principal-tag.enable-in-api-metrics",
-          "true");
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "polaris.metrics.tags.environment",
+                    "prod",
+                    "polaris.metrics.user-principal-tag.enable-in-api-metrics",
+                    "true",
+                    "polaris.metrics.realm-id-tag.enable-in-api-metrics",
+                    "false",
+                    "polaris.metrics.realm-id-tag.enable-in-http-metrics",
+                    "false");
+        }
     }
-  }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagEnabledMetricsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/metrics/UserPrincipalTagEnabledMetricsTest.java
@@ -27,19 +27,19 @@ import java.util.Map;
 @TestProfile(UserPrincipalTagEnabledMetricsTest.Profile.class)
 public class UserPrincipalTagEnabledMetricsTest extends MetricsTestBase {
 
-    public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements QuarkusTestProfile {
 
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of(
-                    "polaris.metrics.tags.environment",
-                    "prod",
-                    "polaris.metrics.user-principal-tag.enable-in-api-metrics",
-                    "true",
-                    "polaris.metrics.realm-id-tag.enable-in-api-metrics",
-                    "false",
-                    "polaris.metrics.realm-id-tag.enable-in-http-metrics",
-                    "false");
-        }
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.metrics.tags.environment",
+          "prod",
+          "polaris.metrics.user-principal-tag.enable-in-api-metrics",
+          "true",
+          "polaris.metrics.realm-id-tag.enable-in-api-metrics",
+          "false",
+          "polaris.metrics.realm-id-tag.enable-in-http-metrics",
+          "false");
     }
+  }
 }

--- a/server-templates/api.mustache
+++ b/server-templates/api.mustache
@@ -93,7 +93,7 @@ public class {{classname}}  {
   {{#authMethods}}{{#isOAuth}}@RolesAllowed("**"){{/isOAuth}}{{/authMethods}}{{/hasAuthMethods}}
   @Timed("{{metricsPrefix}}.{{baseName}}.{{nickname}}")
   @Timeout
-  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realmIdentifier") RealmContext realmContext,@Context SecurityContext securityContext) {
+  public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context @MeterTag(key="realm_id",expression="realmIdentifier") RealmContext realmContext,@Context @MeterTag(key="principal",expression="userPrincipal") SecurityContext securityContext) {
 {{! Don't log form or header params in case there are secrets, e.g., OAuth tokens }}
     LOGGER.atDebug().setMessage("Invoking {{baseName}} with params")
       .addKeyValue("operation", "{{nickname}}"){{#allParams}}{{^isHeaderParam}}{{^isFormParam}}


### PR DESCRIPTION
Fixes #2444.

This PR adds a user principal tag in metrics and an associated configuration option that turns it on. 
This is the following: `polaris.metrics.user-principal-tag.enable-in-api-metrics`, and **by default this is set to `false`.**

To retrieve the user principal ID it uses the SecurityContext and annotates it with a `MeterTag` annotation under the key `principal`. 
