### PR TITLE
Remove hadoop-common from polaris-runtime-service

### DIFF
--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -75,22 +75,6 @@ dependencies {
 
   implementation(libs.auth0.jwt)
 
-  implementation(libs.hadoop.common) {
-    exclude("org.slf4j", "slf4j-reload4j")
-    exclude("org.slf4j", "slf4j-log4j12")
-    exclude("ch.qos.reload4j", "reload4j")
-    exclude("log4j", "log4j")
-    exclude("org.apache.zookeeper", "zookeeper")
-    exclude("org.apache.hadoop.thirdparty", "hadoop-shaded-protobuf_3_25")
-    exclude("com.github.pjfanning", "jersey-json")
-    exclude("com.sun.jersey", "jersey-core")
-    exclude("com.sun.jersey", "jersey-server")
-    exclude("com.sun.jersey", "jersey-servlet")
-    exclude("com.sun.jersey", "jersey-servlet")
-    exclude("io.dropwizard.metrics", "metrics-core")
-  }
-  implementation(libs.hadoop.hdfs.client)
-
   implementation(libs.smallrye.common.annotation)
   implementation(libs.swagger.jaxrs)
   implementation(libs.microprofile.fault.tolerance.api)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
@@ -110,7 +109,6 @@ public class DefaultFileIOFactory implements FileIOFactory {
   @VisibleForTesting
   FileIO loadFileIOInternal(
       @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
-    return new ExceptionMappingFileIO(
-        CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration()));
+    return new ExceptionMappingFileIO(CatalogUtil.loadFileIO(ioImplClassName, properties, null));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/RealmContextResolver.java
@@ -18,10 +18,11 @@
  */
 package org.apache.polaris.service.context;
 
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.polaris.core.context.RealmContext;
 
 /**
@@ -59,8 +60,11 @@ public interface RealmContextResolver {
    */
   default CompletionStage<RealmContext> resolveRealmContext(
       String requestURL, String method, String path, Map<String, String> headers) {
-    CaseInsensitiveMap caseInsensitiveMap = new CaseInsensitiveMap(headers);
+    Map<String, String> caseInsensitiveMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      caseInsensitiveMap.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+    }
     return resolveRealmContext(
-        requestURL, method, path, (key) -> (String) caseInsensitiveMap.get(key));
+        requestURL, method, path, (key) -> caseInsensitiveMap.get(key.toLowerCase(Locale.ROOT)));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
@@ -1785,7 +1784,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             catalog.initialize(
                 externalCatalog, ImmutableMap.of(CatalogProperties.FILE_IO_IMPL, fileIoImpl));
 
-            FileIO fileIO = CatalogUtil.loadFileIO(fileIoImpl, Map.of(), new Configuration());
+            FileIO fileIO = CatalogUtil.loadFileIO(fileIoImpl, Map.of(), null);
             TableMetadata tableMetadata =
                 TableMetadata.buildFromEmpty()
                     .addSchema(SCHEMA)


### PR DESCRIPTION
since https://github.com/apache/iceberg/commit/9bc6853938533c9c1dfac497229c8f4c30672458 passing a hadoop Configuration to `CatalogUtil.loadCatalog` is optional.

since `hadoop-common` brings in a lot of dependencies (and thus potential vulnerabilities) we should avoid depending on it in our core modules if not strictly required.

note that we were using the transitive `commons-collections` dependency in a spot that we have to adjust.