### PR TITLE
Introducing: polaris.readiness.ignore-offending-properties

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -74,7 +74,14 @@ public class ProductionReadinessChecks {
       @Observes Startup event,
       Instance<ProductionReadinessCheck> checks,
       ReadinessConfiguration config) {
-    List<Error> errors = checks.stream().flatMap(check -> check.getErrors().stream()).toList();
+    List<Error> errors =
+        checks.stream()
+            .flatMap(check -> check.getErrors().stream())
+            .filter(
+                error ->
+                    config.ignoreOffendingProperties().stream()
+                        .noneMatch(prop -> prop.equalsIgnoreCase(error.offendingProperty())))
+            .toList();
     if (!errors.isEmpty()) {
       var utf8 = Charset.defaultCharset().equals(StandardCharsets.UTF_8);
       var warning = utf8 ? WARNING_SIGN_UTF_8 : WARNING_SIGN_PLAIN;

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ReadinessConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ReadinessConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.config;
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import java.util.Set;
 
 @StaticInitSafe
 @ConfigMapping(prefix = "polaris.readiness")
@@ -33,4 +34,11 @@ public interface ReadinessConfiguration {
    */
   @WithDefault("false")
   boolean ignoreSevereIssues();
+
+  /**
+   * Set of properties that, if found to be misconfigured, will be ignored when determining the
+   * production readiness.
+   */
+  @WithDefault("{}")
+  Set<String> ignoreOffendingProperties();
 }


### PR DESCRIPTION
Fixes:  #2471 

This PR introduces a `polaris.readiness.ignore-offending-properties` config that accepts a map of properties for which readiness checks are suppressed.

It can be used, for example, as follows:
```
polaris.readiness.ignore-offending-properties=\
  polaris.metrics.user-principal-tag.enable-in-api-metrics,\
  polaris.features."ALLOW_INSECURE_STORAGE_TYPES",\
  polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES"
```

The check performed is case-insesitive.