### PR TITLE
KeyCloak integration tests failing on some OSX Dev machines

### DIFF
--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakProfile.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakProfile.java
@@ -27,6 +27,8 @@ public class KeycloakProfile implements QuarkusTestProfile {
   @Override
   public Map<String, String> getConfigOverrides() {
     return Map.of(
+        "quarkus.http.test-port",
+        "0",
         "quarkus.oidc.tenant-enabled",
         "true",
         "quarkus.oidc.client-id",


### PR DESCRIPTION
Added missing port property in Keycloack profile for integration testing
#2501 

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
