### PR TITLE
Allow `PolarisServerManager` implementations to define custom client headers

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergHelper.java
@@ -39,7 +39,7 @@ public final class IcebergHelper {
             .put(CatalogProperties.URI, endpoints.catalogApiEndpoint().toString())
             .put(OAuth2Properties.TOKEN, authToken)
             .put("warehouse", catalog)
-            .put("header." + endpoints.realmHeaderName(), endpoints.realmId())
+            .putAll(endpoints.extraHeaders("header."))
             .putAll(extraProperties);
 
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisApiEndpoints.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisApiEndpoints.java
@@ -20,6 +20,8 @@ package org.apache.polaris.service.it.env;
 
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class contains the most fundamental information for accessing Polaris APIs, such as the base
@@ -30,12 +32,16 @@ public final class PolarisApiEndpoints implements Serializable {
 
   private final URI baseUri;
   private final String realmId;
-  private final String realmHeaderName;
+  private final Map<String, String> headers;
 
   public PolarisApiEndpoints(URI baseUri, String realmId, String realmHeaderName) {
+    this(baseUri, realmId, Map.of(realmHeaderName, realmId));
+  }
+
+  public PolarisApiEndpoints(URI baseUri, String realmId, Map<String, String> headers) {
     this.baseUri = baseUri;
     this.realmId = realmId;
-    this.realmHeaderName = realmHeaderName;
+    this.headers = headers;
   }
 
   public URI catalogApiEndpoint() {
@@ -50,7 +56,13 @@ public final class PolarisApiEndpoints implements Serializable {
     return realmId;
   }
 
-  public String realmHeaderName() {
-    return realmHeaderName;
+  public Map<String, String> extraHeaders() {
+    return headers;
+  }
+
+  public Map<String, String> extraHeaders(String keyPrefix) {
+    return headers.entrySet().stream()
+        .map(e -> Map.entry(keyPrefix + e.getKey(), e.getValue()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisRestApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisRestApi.java
@@ -39,8 +39,7 @@ public class PolarisRestApi extends RestApi {
   }
 
   protected Map<String, String> defaultHeaders() {
-    Map<String, String> headers = new HashMap<>();
-    headers.put(endpoints.realmHeaderName(), endpoints.realmId());
+    Map<String, String> headers = new HashMap<>(endpoints.extraHeaders());
     if (authToken != null) {
       headers.put("Authorization", "Bearer " + authToken);
     }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/Server.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/Server.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.it.env;
 
 import java.net.URI;
+import java.util.Map;
 
 /**
  * This is a holder for access information to a particular Polaris Server. Test cases may use only
@@ -35,6 +36,10 @@ public interface Server extends AutoCloseable {
 
   default String realmHeaderName() {
     return DEFAULT_REALM_HEADER;
+  }
+
+  default Map<String, String> headers() {
+    return Map.of(realmHeaderName(), realmId());
   }
 
   /**

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisIntegrationTestExtension.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/PolarisIntegrationTestExtension.java
@@ -92,7 +92,7 @@ public class PolarisIntegrationTestExtension implements ParameterResolver {
     private Env(Server server) {
       this.server = server;
       this.endpoints =
-          new PolarisApiEndpoints(server.baseUri(), server.realmId(), server.realmHeaderName());
+          new PolarisApiEndpoints(server.baseUri(), server.realmId(), server.headers());
     }
 
     PolarisApiEndpoints endpoints() {

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -259,15 +259,12 @@ public class PolarisApplicationIntegrationTest {
     RESTSessionCatalog sessionCatalog = new RESTSessionCatalog();
     sessionCatalog.initialize(
         "polaris_catalog_test",
-        Map.of(
-            "uri",
-            endpoints.catalogApiEndpoint().toString(),
-            OAuth2Properties.TOKEN,
-            authToken,
-            "warehouse",
-            catalog,
-            "header." + endpoints.realmHeaderName(),
-            realm));
+        ImmutableMap.<String, String>builder()
+            .put("uri", endpoints.catalogApiEndpoint().toString())
+            .put(OAuth2Properties.TOKEN, authToken)
+            .put("warehouse", catalog)
+            .putAll(endpoints.extraHeaders("header."))
+            .build());
     return sessionCatalog;
   }
 
@@ -590,15 +587,12 @@ public class PolarisApplicationIntegrationTest {
               () ->
                   sessionCatalog.initialize(
                       "polaris_catalog_test",
-                      Map.of(
-                          "uri",
-                          endpoints.catalogApiEndpoint().toString(),
-                          OAuth2Properties.TOKEN,
-                          authToken,
-                          "warehouse",
-                          emptyEnvironmentVariable,
-                          "header." + endpoints.realmHeaderName(),
-                          realm)))
+                      ImmutableMap.<String, String>builder()
+                          .put("uri", endpoints.catalogApiEndpoint().toString())
+                          .put(OAuth2Properties.TOKEN, authToken)
+                          .put("warehouse", emptyEnvironmentVariable)
+                          .putAll(endpoints.extraHeaders("header."))
+                          .build()))
           .isInstanceOf(BadRequestException.class)
           .hasMessage("Malformed request: Please specify a warehouse");
     }

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -198,7 +198,7 @@ public class RestCatalogMinIOSpecialIT {
                 org.apache.iceberg.CatalogProperties.URI, endpoints.catalogApiEndpoint().toString())
             .put(OAuth2Properties.TOKEN, authToken)
             .put("warehouse", catalogName)
-            .put("header." + endpoints.realmHeaderName(), endpoints.realmId())
+            .putAll(endpoints.extraHeaders("header."))
             .put("header.X-Iceberg-Access-Delegation", "vended-credentials");
 
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
@@ -75,7 +75,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
     String path = endpoints.catalogApiEndpoint() + "/v1/oauth/tokens";
     try (RESTClient client =
         HTTPClient.builder(Map.of())
-            .withHeader(endpoints.realmHeaderName(), endpoints.realmId())
+            .withHeaders(endpoints.extraHeaders())
             .uri(path)
             .withAuthSession(AuthSession.EMPTY)
             .build()) {
@@ -106,7 +106,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
     String path = endpoints.catalogApiEndpoint() + "/v1/oauth/tokens";
     try (RESTClient client =
         HTTPClient.builder(Map.of())
-            .withHeader(endpoints.realmHeaderName(), endpoints.realmId())
+            .withHeaders(endpoints.extraHeaders())
             .uri(path)
             .withAuthSession(AuthSession.EMPTY)
             .build()) {
@@ -147,7 +147,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
     String path = endpoints.catalogApiEndpoint() + "/v1/oauth/tokens";
     try (RESTClient client =
         HTTPClient.builder(Map.of())
-            .withHeader(endpoints.realmHeaderName(), endpoints.realmId())
+            .withHeaders(endpoints.extraHeaders())
             .uri(path)
             .withAuthSession(AuthSession.EMPTY)
             .build()) {


### PR DESCRIPTION
`PolarisServerManager` is a plugin point for downstream builds to define runtime env. for tests under `integration-tests`.

This change allows more flexibility for test runtime environments by allowing injecting extra headers into test clients.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
