### PR TITLE
Fix failing tests in IcebergAllowedLocationTest

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -199,7 +199,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
           .putAll(super.getConfigOverrides())
           .put("polaris.features.\"ALLOW_TABLE_LOCATION_OVERLAP\"", "true")
           .put("polaris.features.\"LIST_PAGINATION_ENABLED\"", "true")
-          .put("polaris.features.\"ALLOW_NAMESPACE_CUSTOM_LOCATION\"", "true")
+          .put("polaris.behavior-changes.\"ALLOW_NAMESPACE_CUSTOM_LOCATION\"", "true")
           .build();
     }
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -147,6 +147,8 @@ public class IcebergAllowedLocationTest {
             "SUPPORTED_CATALOG_STORAGE_TYPES",
             List.of("FILE"),
             OPTIMIZED_SIBLING_CHECK.key(),
+            "true",
+            "ALLOW_NAMESPACE_CUSTOM_LOCATION",
             "true");
     TestServices services =
         TestServices.builder().config(strictServicesWithOptimizedOverlapCheck).build();


### PR DESCRIPTION
This test, added in #2473, fails after #2422. This fixes the config override.