### PR TITLE
Reduce getOrCreateMetaStoreManager callers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultActiveRolesProvider.java
@@ -35,7 +35,6 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
-import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
@@ -55,7 +54,7 @@ public class DefaultActiveRolesProvider implements ActiveRolesProvider {
 
   @Inject PolarisDiagnostics diagnostics;
   @Inject CallContext callContext;
-  @Inject MetaStoreManagerFactory metaStoreManagerFactory;
+  @Inject PolarisMetaStoreManager metaStoreManager;
 
   @Override
   public Set<String> getActiveRoles(PolarisPrincipal principal) {
@@ -68,9 +67,7 @@ public class DefaultActiveRolesProvider implements ActiveRolesProvider {
     }
     List<PrincipalRoleEntity> activeRoles =
         loadActivePrincipalRoles(
-            principal.getRoles(),
-            persistedPolarisPrincipal.getEntity(),
-            metaStoreManagerFactory.getOrCreateMetaStoreManager(callContext.getRealmContext()));
+            principal.getRoles(), persistedPolarisPrincipal.getEntity(), metaStoreManager);
     return activeRoles.stream().map(PrincipalRoleEntity::getName).collect(Collectors.toSet());
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -31,7 +31,6 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
-import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,14 +49,12 @@ public class DefaultAuthenticator implements Authenticator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticator.class);
 
-  @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject CallContext callContext;
+  @Inject PolarisMetaStoreManager metaStoreManager;
 
   @Override
   public PolarisPrincipal authenticate(PolarisCredential credentials) {
     LOGGER.debug("Resolving principal for credentials={}", credentials);
-    PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(callContext.getRealmContext());
     PolarisEntity principal = null;
     try {
       // If the principal id is present, prefer to use it to load the principal entity,

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -41,14 +41,12 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
 import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
-import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
@@ -228,12 +226,6 @@ public class ManagementServiceTest {
         .hasMessage("Explicitly setting S3 endpoints is not allowed.");
   }
 
-  private PolarisMetaStoreManager setupMetaStoreManager() {
-    MetaStoreManagerFactory metaStoreManagerFactory = services.metaStoreManagerFactory();
-    RealmContext realmContext = services.realmContext();
-    return metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
-  }
-
   private PolarisAdminService setupPolarisAdminService(
       PolarisMetaStoreManager metaStoreManager, PolarisCallContext callContext) {
     return new PolarisAdminService(
@@ -297,7 +289,7 @@ public class ManagementServiceTest {
 
   @Test
   public void testCannotAssignFederatedEntities() {
-    PolarisMetaStoreManager metaStoreManager = setupMetaStoreManager();
+    PolarisMetaStoreManager metaStoreManager = services.metaStoreManager();
     PolarisCallContext callContext = services.newCallContext();
     PolarisAdminService polarisAdminService =
         setupPolarisAdminService(metaStoreManager, callContext);
@@ -316,7 +308,7 @@ public class ManagementServiceTest {
 
   @Test
   public void testCanListCatalogs() {
-    PolarisMetaStoreManager metaStoreManager = setupMetaStoreManager();
+    PolarisMetaStoreManager metaStoreManager = services.metaStoreManager();
     PolarisCallContext callContext = services.newCallContext();
     PolarisAdminService polarisAdminService =
         setupPolarisAdminService(metaStoreManager, callContext);
@@ -356,7 +348,7 @@ public class ManagementServiceTest {
 
   @Test
   public void testCreateCatalogReturnErrorOnFailure() {
-    PolarisMetaStoreManager metaStoreManager = Mockito.spy(setupMetaStoreManager());
+    PolarisMetaStoreManager metaStoreManager = Mockito.spy(services.metaStoreManager());
     PolarisCallContext callContext = services.newCallContext();
     PolarisAdminService polarisAdminService =
         setupPolarisAdminService(metaStoreManager, callContext);

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
@@ -46,11 +45,8 @@ public class DefaultAuthenticatorTest {
     polarisCallContext = Mockito.mock(PolarisCallContext.class);
     when(polarisCallContext.getRealmContext()).thenReturn(realmContext);
     metaStoreManager = Mockito.mock(PolarisMetaStoreManager.class);
-    MetaStoreManagerFactory metaStoreManagerFactory = Mockito.mock(MetaStoreManagerFactory.class);
-    when(metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext))
-        .thenReturn(metaStoreManager);
     authenticator = new DefaultAuthenticator();
-    authenticator.metaStoreManagerFactory = metaStoreManagerFactory;
+    authenticator.metaStoreManager = metaStoreManager;
     authenticator.callContext = polarisCallContext;
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -169,8 +169,7 @@ public class FileIOFactoryTest {
 
     List<PolarisBaseEntity> tasks =
         testServices
-            .metaStoreManagerFactory()
-            .getOrCreateMetaStoreManager(realmContext)
+            .metaStoreManager()
             .loadTasks(callContext.getPolarisCallContext(), "testExecutor", PageToken.fromLimit(1))
             .getEntities();
     Assertions.assertThat(tasks).hasSize(1);
@@ -228,7 +227,7 @@ public class FileIOFactoryTest {
             services.polarisDiagnostics(),
             services.storageCredentialCache(),
             services.resolverFactory(),
-            services.metaStoreManagerFactory().getOrCreateMetaStoreManager(realmContext),
+            services.metaStoreManager(),
             callContext,
             passthroughView,
             services.securityContext(),

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -48,6 +48,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.service.TestFileIOFactory;
 import org.assertj.core.api.Assertions;
@@ -62,6 +63,7 @@ class TableCleanupTaskHandlerTest {
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject PolarisConfigurationStore configurationStore;
 
+  private PolarisMetaStoreManager metaStoreManager;
   private CallContext callContext;
 
   private final RealmContext realmContext = () -> "realmName";
@@ -76,6 +78,7 @@ class TableCleanupTaskHandlerTest {
   void setup() {
     QuarkusMock.installMockForType(realmContext, RealmContext.class);
 
+    metaStoreManager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     callContext =
         new PolarisCallContext(
             realmContext,
@@ -121,8 +124,7 @@ class TableCleanupTaskHandlerTest {
     handler.handleTask(task, callContext);
 
     assertThat(
-            metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+            metaStoreManager
                 .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(2))
                 .getEntities())
         .hasSize(2)
@@ -196,8 +198,7 @@ class TableCleanupTaskHandlerTest {
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(
-            metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+            metaStoreManager
                 .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(5))
                 .getEntities())
         .hasSize(2);
@@ -254,8 +255,7 @@ class TableCleanupTaskHandlerTest {
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(
-            metaStoreManagerFactory
-                .getOrCreateMetaStoreManager(realmContext)
+            metaStoreManager
                 .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(5))
                 .getEntities())
         .hasSize(4)
@@ -367,8 +367,7 @@ class TableCleanupTaskHandlerTest {
     handler.handleTask(task, callContext);
 
     List<PolarisBaseEntity> entities =
-        metaStoreManagerFactory
-            .getOrCreateMetaStoreManager(realmContext)
+        metaStoreManager
             .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(5))
             .getEntities();
 
@@ -535,8 +534,7 @@ class TableCleanupTaskHandlerTest {
     handler.handleTask(task, callContext);
 
     List<PolarisBaseEntity> entities =
-        metaStoreManagerFactory
-            .getOrCreateMetaStoreManager(callContext.getRealmContext())
+        metaStoreManager
             .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(6))
             .getEntities();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -22,7 +22,6 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.TaskEntity;
-import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.service.TestServices;
 import org.apache.polaris.service.events.AfterTaskAttemptedEvent;
@@ -43,9 +42,7 @@ public class TaskExecutorImplTest {
     TestPolarisEventListener testPolarisEventListener =
         (TestPolarisEventListener) testServices.polarisEventListener();
 
-    MetaStoreManagerFactory metaStoreManagerFactory = testServices.metaStoreManagerFactory();
-    PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+    PolarisMetaStoreManager metaStoreManager = testServices.metaStoreManager();
 
     PolarisCallContext polarisCallCtx = testServices.newCallContext();
 

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -92,6 +92,7 @@ public record TestServices(
     RealmContext realmContext,
     RealmConfig realmConfig,
     SecurityContext securityContext,
+    PolarisMetaStoreManager metaStoreManager,
     FileIOFactory fileIOFactory,
     TaskExecutor taskExecutor,
     PolarisEventListener polarisEventListener) {
@@ -305,6 +306,7 @@ public record TestServices(
           realmContext,
           realmConfig,
           securityContext,
+          metaStoreManager,
           fileIOFactory,
           taskExecutor,
           polarisEventListener);


### PR DESCRIPTION
we can inject `PolarisMetaStoreManager` directly into request-scoped beans or build it only once in tests that operate in a single realm.