### PR TITLE
Make ResolverFactory + ResolutionManifestFactory request-scoped

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -52,8 +52,8 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisResolutionManifest.class);
 
   private final ResolverFactory resolverFactory;
-  private final CallContext callContext;
   private final SecurityContext securityContext;
+  private final RealmContext realmContext;
   private final String catalogName;
   private final Resolver primaryResolver;
   private final PolarisDiagnostics diagnostics;
@@ -71,15 +71,14 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
 
   public PolarisResolutionManifest(
       PolarisDiagnostics diagnostics,
-      CallContext callContext,
+      RealmContext realmContext,
       ResolverFactory resolverFactory,
       SecurityContext securityContext,
       String catalogName) {
-    this.callContext = callContext;
+    this.realmContext = realmContext;
     this.resolverFactory = resolverFactory;
     this.catalogName = catalogName;
-    this.primaryResolver =
-        resolverFactory.createResolver(callContext, securityContext, catalogName);
+    this.primaryResolver = resolverFactory.createResolver(securityContext, catalogName);
     this.diagnostics = diagnostics;
     this.diagnostics.checkNotNull(securityContext, "null_security_context_for_resolution_manifest");
     this.securityContext = securityContext;
@@ -187,8 +186,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
     ResolverPath requestedPath = passthroughPaths.get(key);
 
     // Run a single-use Resolver for this path.
-    Resolver passthroughResolver =
-        resolverFactory.createResolver(callContext, securityContext, catalogName);
+    Resolver passthroughResolver = resolverFactory.createResolver(securityContext, catalogName);
     passthroughResolver.addPath(requestedPath);
     ResolverStatus status = passthroughResolver.resolveAll();
 
@@ -273,7 +271,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
     if (resolvedEntity == null) {
       LOGGER.warn(
           "Failed to find rootContainer for realm: {} and catalog: {}",
-          callContext.getRealmContext().getRealmIdentifier(),
+          realmContext.getRealmIdentifier(),
           catalogName);
     }
     return resolvedEntity;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactory.java
@@ -22,13 +22,10 @@ package org.apache.polaris.core.persistence.resolver;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.ws.rs.core.SecurityContext;
-import org.apache.polaris.core.context.CallContext;
 
 public interface ResolutionManifestFactory {
 
   @Nonnull
   PolarisResolutionManifest createResolutionManifest(
-      @Nonnull CallContext callContext,
-      @Nonnull SecurityContext securityContext,
-      @Nullable String referenceCatalogName);
+      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactoryImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactoryImpl.java
@@ -23,26 +23,28 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.polaris.core.PolarisDiagnostics;
-import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.context.RealmContext;
 
 public class ResolutionManifestFactoryImpl implements ResolutionManifestFactory {
 
   private final PolarisDiagnostics diagnostics;
+  private final RealmContext realmContext;
   private final ResolverFactory resolverFactory;
 
   public ResolutionManifestFactoryImpl(
-      @Nonnull PolarisDiagnostics diagnostics, @Nonnull ResolverFactory resolverFactory) {
+      @Nonnull PolarisDiagnostics diagnostics,
+      @Nonnull RealmContext realmContext,
+      @Nonnull ResolverFactory resolverFactory) {
     this.diagnostics = diagnostics;
+    this.realmContext = realmContext;
     this.resolverFactory = resolverFactory;
   }
 
   @Nonnull
   @Override
   public PolarisResolutionManifest createResolutionManifest(
-      @Nonnull CallContext callContext,
-      @Nonnull SecurityContext securityContext,
-      @Nullable String referenceCatalogName) {
+      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName) {
     return new PolarisResolutionManifest(
-        diagnostics, callContext, resolverFactory, securityContext, referenceCatalogName);
+        diagnostics, realmContext, resolverFactory, securityContext, referenceCatalogName);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverFactory.java
@@ -22,11 +22,8 @@ package org.apache.polaris.core.persistence.resolver;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.ws.rs.core.SecurityContext;
-import org.apache.polaris.core.context.CallContext;
 
 public interface ResolverFactory {
   Resolver createResolver(
-      @Nonnull CallContext callContext,
-      @Nonnull SecurityContext securityContext,
-      @Nullable String referenceCatalogName);
+      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -190,6 +190,10 @@ public class PolarisAdminService {
     return userSecretsManager;
   }
 
+  private PolarisResolutionManifest newResolutionManifest(@Nullable String catalogName) {
+    return resolutionManifestFactory.createResolutionManifest(securityContext, catalogName);
+  }
+
   private Optional<CatalogEntity> currentCatalog() {
     return Optional.ofNullable(resolutionManifest.getResolvedReferenceCatalogEntity())
         .map(path -> CatalogEntity.of(path.getRawLeafEntity()));
@@ -213,9 +217,7 @@ public class PolarisAdminService {
   }
 
   private void authorizeBasicRootOperationOrThrow(PolarisAuthorizableOperation op) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, null /* referenceCatalogName */);
+    resolutionManifest = newResolutionManifest(null);
     resolutionManifest.resolveAll();
     PolarisResolvedPathWrapper rootContainerWrapper =
         resolutionManifest.getResolvedRootContainerEntityAsPath();
@@ -240,9 +242,7 @@ public class PolarisAdminService {
       String topLevelEntityName,
       PolarisEntityType entityType,
       @Nullable String referenceCatalogName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, referenceCatalogName);
+    resolutionManifest = newResolutionManifest(referenceCatalogName);
     resolutionManifest.addTopLevelName(topLevelEntityName, entityType, false /* isOptional */);
     ResolverStatus status = resolutionManifest.resolveAll();
     if (status.getStatus() == ResolverStatus.StatusEnum.ENTITY_COULD_NOT_BE_RESOLVED) {
@@ -293,9 +293,7 @@ public class PolarisAdminService {
 
   private void authorizeBasicCatalogRoleOperationOrThrow(
       PolarisAuthorizableOperation op, String catalogName, String catalogRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addPath(
         new ResolverPath(List.of(catalogRoleName), PolarisEntityType.CATALOG_ROLE),
         catalogRoleName);
@@ -314,8 +312,7 @@ public class PolarisAdminService {
 
   private void authorizeGrantOnRootContainerToPrincipalRoleOperationOrThrow(
       PolarisAuthorizableOperation op, String principalRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(callContext, securityContext, null);
+    resolutionManifest = newResolutionManifest(null);
     resolutionManifest.addTopLevelName(
         principalRoleName, PolarisEntityType.PRINCIPAL_ROLE, false /* isOptional */);
     ResolverStatus status = resolutionManifest.resolveAll();
@@ -342,8 +339,7 @@ public class PolarisAdminService {
 
   private void authorizeGrantOnPrincipalRoleToPrincipalOperationOrThrow(
       PolarisAuthorizableOperation op, String principalRoleName, String principalName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(callContext, securityContext, null);
+    resolutionManifest = newResolutionManifest(null);
     resolutionManifest.addTopLevelName(
         principalRoleName, PolarisEntityType.PRINCIPAL_ROLE, false /* isOptional */);
     resolutionManifest.addTopLevelName(
@@ -375,9 +371,7 @@ public class PolarisAdminService {
       String catalogName,
       String catalogRoleName,
       String principalRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addPath(
         new ResolverPath(List.of(catalogRoleName), PolarisEntityType.CATALOG_ROLE),
         catalogRoleName);
@@ -411,9 +405,7 @@ public class PolarisAdminService {
 
   private void authorizeGrantOnCatalogOperationOrThrow(
       PolarisAuthorizableOperation op, String catalogName, String catalogRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addTopLevelName(
         catalogName, PolarisEntityType.CATALOG, false /* isOptional */);
     resolutionManifest.addPath(
@@ -444,9 +436,7 @@ public class PolarisAdminService {
       String catalogName,
       Namespace namespace,
       String catalogRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addPassthroughPath(
         new ResolverPath(Arrays.asList(namespace.levels()), PolarisEntityType.NAMESPACE),
         namespace);
@@ -485,9 +475,7 @@ public class PolarisAdminService {
       List<PolarisEntitySubType> subTypes,
       TableIdentifier identifier,
       String catalogRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addPassthroughPath(
         new ResolverPath(
             Arrays.asList(identifier.namespace().levels()), PolarisEntityType.NAMESPACE),
@@ -544,9 +532,7 @@ public class PolarisAdminService {
       String catalogName,
       PolicyIdentifier identifier,
       String catalogRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest(catalogName);
     resolutionManifest.addPath(
         new ResolverPath(
             PolarisCatalogHelpers.identifierToList(identifier.getNamespace(), identifier.getName()),

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
@@ -102,6 +102,10 @@ public abstract class CatalogHandler {
     return userSecretsManager;
   }
 
+  protected PolarisResolutionManifest newResolutionManifest() {
+    return resolutionManifestFactory.createResolutionManifest(securityContext, catalogName);
+  }
+
   /** Initialize the catalog once authorized. Called after all `authorize...` methods. */
   protected abstract void initializeCatalog();
 
@@ -116,9 +120,7 @@ public abstract class CatalogHandler {
       List<Namespace> extraPassthroughNamespaces,
       List<TableIdentifier> extraPassthroughTableLikes,
       List<PolicyIdentifier> extraPassThroughPolicies) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     resolutionManifest.addPath(
         new ResolverPath(Arrays.asList(namespace.levels()), PolarisEntityType.NAMESPACE),
         namespace);
@@ -170,9 +172,7 @@ public abstract class CatalogHandler {
 
   protected void authorizeCreateNamespaceUnderNamespaceOperationOrThrow(
       PolarisAuthorizableOperation op, Namespace namespace) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
 
     Namespace parentNamespace = PolarisCatalogHelpers.getParentNamespace(namespace);
     resolutionManifest.addPath(
@@ -206,9 +206,7 @@ public abstract class CatalogHandler {
       PolarisAuthorizableOperation op, TableIdentifier identifier) {
     Namespace namespace = identifier.namespace();
 
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     resolutionManifest.addPath(
         new ResolverPath(Arrays.asList(namespace.levels()), PolarisEntityType.NAMESPACE),
         namespace);
@@ -242,9 +240,7 @@ public abstract class CatalogHandler {
 
   protected void authorizeBasicTableLikeOperationOrThrow(
       PolarisAuthorizableOperation op, PolarisEntitySubType subType, TableIdentifier identifier) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
 
     // The underlying Catalog is also allowed to fetch "fresh" versions of the target entity.
     resolutionManifest.addPassthroughPath(
@@ -273,9 +269,7 @@ public abstract class CatalogHandler {
       PolarisAuthorizableOperation op,
       final PolarisEntitySubType subType,
       List<TableIdentifier> ids) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     ids.forEach(
         identifier ->
             resolutionManifest.addPassthroughPath(
@@ -325,9 +319,7 @@ public abstract class CatalogHandler {
       PolarisEntitySubType subType,
       TableIdentifier src,
       TableIdentifier dst) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     // Add src, dstParent, and dst(optional)
     resolutionManifest.addPath(
         new ResolverPath(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1231,7 +1231,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     PolarisResolutionManifest resolutionManifest =
         new PolarisResolutionManifest(
             diagnostics,
-            callContext,
+            callContext.getRealmContext(),
             resolverFactory,
             securityContext,
             parentPath.getFirst().getName());

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -800,7 +800,7 @@ public class IcebergCatalogAdapter
     if (warehouse == null) {
       throw new BadRequestException("Please specify a warehouse");
     }
-    Resolver resolver = resolverFactory.createResolver(callContext, securityContext, warehouse);
+    Resolver resolver = resolverFactory.createResolver(securityContext, warehouse);
     ResolverStatus resolverStatus = resolver.resolveAll();
     if (!resolverStatus.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
       throw new NotFoundException("Unable to find warehouse %s", warehouse);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
@@ -165,9 +165,7 @@ public class PolicyCatalogHandler extends CatalogHandler {
 
   private void authorizeBasicPolicyOperationOrThrow(
       PolarisAuthorizableOperation op, PolicyIdentifier identifier) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     resolutionManifest.addPassthroughPath(
         new ResolverPath(
             PolarisCatalogHelpers.identifierToList(identifier.getNamespace(), identifier.getName()),
@@ -215,9 +213,7 @@ public class PolicyCatalogHandler extends CatalogHandler {
   }
 
   private void authorizeBasicCatalogOperationOrThrow(PolarisAuthorizableOperation op) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     resolutionManifest.resolveAll();
 
     PolarisResolvedPathWrapper targetCatalog =
@@ -237,9 +233,7 @@ public class PolicyCatalogHandler extends CatalogHandler {
 
   private void authorizePolicyMappingOperationOrThrow(
       PolicyIdentifier identifier, PolicyAttachmentTarget target, boolean isAttach) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    resolutionManifest = newResolutionManifest();
     resolutionManifest.addPassthroughPath(
         new ResolverPath(
             PolarisCatalogHelpers.identifierToList(identifier.getNamespace(), identifier.getName()),

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -107,33 +107,6 @@ public class ServiceProducers {
   }
 
   @Produces
-  @ApplicationScoped
-  public ResolverFactory resolverFactory(
-      PolarisDiagnostics diagnostics,
-      MetaStoreManagerFactory metaStoreManagerFactory,
-      PolarisMetaStoreManager polarisMetaStoreManager) {
-    return (callContext, securityContext, referenceCatalogName) -> {
-      EntityCache entityCache =
-          metaStoreManagerFactory.getOrCreateEntityCache(
-              callContext.getRealmContext(), callContext.getRealmConfig());
-      return new Resolver(
-          diagnostics,
-          callContext.getPolarisCallContext(),
-          polarisMetaStoreManager,
-          securityContext,
-          entityCache,
-          referenceCatalogName);
-    };
-  }
-
-  @Produces
-  @ApplicationScoped
-  public ResolutionManifestFactory resolutionManifestFactory(
-      PolarisDiagnostics diagnostics, ResolverFactory resolverFactory) {
-    return new ResolutionManifestFactoryImpl(diagnostics, resolverFactory);
-  }
-
-  @Produces
   @Singleton
   public PolarisDiagnostics polarisDiagnostics() {
     return new PolarisDefaultDiagServiceImpl();
@@ -167,6 +140,34 @@ public class ServiceProducers {
   @RequestScoped
   public PolarisAuthorizer polarisAuthorizer(RealmConfig realmConfig) {
     return new PolarisAuthorizerImpl(realmConfig);
+  }
+
+  @Produces
+  @RequestScoped
+  public ResolverFactory resolverFactory(
+      PolarisDiagnostics diagnostics,
+      RealmContext realmContext,
+      RealmConfig realmConfig,
+      MetaStoreManagerFactory metaStoreManagerFactory,
+      CallContext callContext,
+      PolarisMetaStoreManager polarisMetaStoreManager) {
+    EntityCache entityCache =
+        metaStoreManagerFactory.getOrCreateEntityCache(realmContext, realmConfig);
+    return (securityContext, referenceCatalogName) ->
+        new Resolver(
+            diagnostics,
+            callContext.getPolarisCallContext(),
+            polarisMetaStoreManager,
+            securityContext,
+            entityCache,
+            referenceCatalogName);
+  }
+
+  @Produces
+  @RequestScoped
+  public ResolutionManifestFactory resolutionManifestFactory(
+      PolarisDiagnostics diagnostics, RealmContext realmContext, ResolverFactory resolverFactory) {
+    return new ResolutionManifestFactoryImpl(diagnostics, realmContext, resolverFactory);
   }
 
   // Polaris service beans - selected from @Identifier-annotated beans

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -95,7 +95,7 @@ public class PolarisAdminServiceTest {
             eq(FeatureConfiguration.ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS), Mockito.any()))
         .thenReturn(true);
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), any()))
+    when(resolutionManifestFactory.createResolutionManifest(any(), any()))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
     when(resolutionManifest.getIsPassthroughFacade()).thenReturn(false);
@@ -144,7 +144,7 @@ public class PolarisAdminServiceTest {
     Namespace namespace = Namespace.of("non-existent-ns");
     PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), eq(catalogName)))
+    when(resolutionManifestFactory.createResolutionManifest(any(), eq(catalogName)))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
 
@@ -177,7 +177,7 @@ public class PolarisAdminServiceTest {
     Namespace namespace = Namespace.of("complete-ns", "incomplete-ns");
     PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), eq(catalogName)))
+    when(resolutionManifestFactory.createResolutionManifest(any(), eq(catalogName)))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
 
@@ -237,7 +237,7 @@ public class PolarisAdminServiceTest {
     Namespace namespace = Namespace.of("non-existent-ns");
     PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), eq(catalogName)))
+    when(resolutionManifestFactory.createResolutionManifest(any(), eq(catalogName)))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
 
@@ -265,7 +265,7 @@ public class PolarisAdminServiceTest {
     Namespace namespace = Namespace.of("incomplete-ns");
     PolarisPrivilege privilege = PolarisPrivilege.NAMESPACE_FULL_METADATA;
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), eq(catalogName)))
+    when(resolutionManifestFactory.createResolutionManifest(any(), eq(catalogName)))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
 
@@ -689,7 +689,7 @@ public class PolarisAdminServiceTest {
   private void setupSuccessfulNamespaceResolution(
       String catalogName, String catalogRoleName, Namespace namespace) throws Exception {
 
-    when(resolutionManifestFactory.createResolutionManifest(any(), any(), eq(catalogName)))
+    when(resolutionManifestFactory.createResolutionManifest(any(), eq(catalogName)))
         .thenReturn(resolutionManifest);
     when(resolutionManifest.resolveAll()).thenReturn(createSuccessfulResolverStatus());
     when(resolutionManifest.getResolvedPath(eq(namespace))).thenReturn(resolvedPathWrapper);

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -520,7 +520,7 @@ public abstract class PolarisAuthzTestBase {
     Mockito.when(securityContext.isUserInRole(Mockito.anyString())).thenReturn(true);
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext, resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, securityContext, CATALOG_NAME);
     this.baseCatalog =
         new IcebergCatalog(
             diagServices,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -206,7 +206,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            polarisContext, resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, securityContext, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     this.fileIOFactory = new DefaultFileIOFactory(storageCredentialCache, metaStoreManagerFactory);
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -287,17 +287,18 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
 
     EntityCache entityCache = createEntityCache(diagServices, realmConfig, metaStoreManager);
     resolverFactory =
-        (callContext, securityContext, referenceCatalogName) ->
+        (securityContext, referenceCatalogName) ->
             new Resolver(
                 diagServices,
-                callContext.getPolarisCallContext(),
+                polarisContext,
                 metaStoreManager,
                 securityContext,
                 entityCache,
                 referenceCatalogName);
     QuarkusMock.installMockForType(resolverFactory, ResolverFactory.class);
 
-    resolutionManifestFactory = new ResolutionManifestFactoryImpl(diagServices, resolverFactory);
+    resolutionManifestFactory =
+        new ResolutionManifestFactoryImpl(diagServices, realmContext, resolverFactory);
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
@@ -440,7 +441,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
       String catalogName, PolarisMetaStoreManager metaStoreManager, FileIOFactory fileIOFactory) {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            polarisContext, resolutionManifestFactory, securityContext, catalogName);
+            resolutionManifestFactory, securityContext, catalogName);
     TaskExecutor taskExecutor = Mockito.mock(TaskExecutor.class);
     return new IcebergCatalog(
         diagServices,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
@@ -203,7 +203,7 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            polarisContext, resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, securityContext, CATALOG_NAME);
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(storageCredentialCache, metaStoreManagerFactory);
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -218,10 +218,7 @@ public class FileIOFactoryTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            callContext,
-            services.resolutionManifestFactory(),
-            services.securityContext(),
-            CATALOG_NAME);
+            services.resolutionManifestFactory(), services.securityContext(), CATALOG_NAME);
     IcebergCatalog polarisCatalog =
         new IcebergCatalog(
             services.polarisDiagnostics(),

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -225,7 +225,7 @@ public abstract class AbstractPolicyCatalogTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            polarisContext, resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, securityContext, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     this.fileIOFactory = new DefaultFileIOFactory(storageCredentialCache, metaStoreManagerFactory);
 

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -203,17 +203,18 @@ public record TestServices(
       EntityCache entityCache =
           metaStoreManagerFactory.getOrCreateEntityCache(realmContext, realmConfig);
       ResolverFactory resolverFactory =
-          (_callContext, securityContext, referenceCatalogName) ->
+          (securityContext, referenceCatalogName) ->
               new Resolver(
                   diagnostics,
-                  _callContext.getPolarisCallContext(),
+                  callContext.getPolarisCallContext(),
                   metaStoreManager,
                   securityContext,
                   entityCache,
                   referenceCatalogName);
 
       ResolutionManifestFactory resolutionManifestFactory =
-          new ResolutionManifestFactoryImpl(diagnostics, resolverFactory);
+          new ResolutionManifestFactoryImpl(diagnostics, realmContext, resolverFactory);
+
       UserSecretsManager userSecretsManager =
           userSecretsManagerFactory.getOrCreateUserSecretsManager(realmContext);
 

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/PolarisPassthroughResolutionView.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/PolarisPassthroughResolutionView.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -42,35 +41,32 @@ import org.apache.polaris.service.types.PolicyIdentifier;
  */
 public class PolarisPassthroughResolutionView implements PolarisResolutionManifestCatalogView {
   private final ResolutionManifestFactory resolutionManifestFactory;
-  private final CallContext callContext;
   private final SecurityContext securityContext;
   private final String catalogName;
 
   public PolarisPassthroughResolutionView(
-      CallContext callContext,
       ResolutionManifestFactory resolutionManifestFactory,
       SecurityContext securityContext,
       String catalogName) {
     this.resolutionManifestFactory = resolutionManifestFactory;
-    this.callContext = callContext;
     this.securityContext = securityContext;
     this.catalogName = catalogName;
   }
 
+  private PolarisResolutionManifest newResolutionManifest() {
+    return resolutionManifestFactory.createResolutionManifest(securityContext, catalogName);
+  }
+
   @Override
   public PolarisResolvedPathWrapper getResolvedReferenceCatalogEntity() {
-    PolarisResolutionManifest manifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    PolarisResolutionManifest manifest = newResolutionManifest();
     manifest.resolveAll();
     return manifest.getResolvedReferenceCatalogEntity();
   }
 
   @Override
   public PolarisResolvedPathWrapper getResolvedPath(Object key) {
-    PolarisResolutionManifest manifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    PolarisResolutionManifest manifest = newResolutionManifest();
 
     if (key instanceof Namespace namespace) {
       manifest.addPath(
@@ -88,9 +84,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   @Override
   public PolarisResolvedPathWrapper getResolvedPath(
       Object key, PolarisEntityType entityType, PolarisEntitySubType subType) {
-    PolarisResolutionManifest manifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    PolarisResolutionManifest manifest = newResolutionManifest();
 
     if (key instanceof TableIdentifier identifier) {
       manifest.addPath(
@@ -117,9 +111,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
 
   @Override
   public PolarisResolvedPathWrapper getPassthroughResolvedPath(Object key) {
-    PolarisResolutionManifest manifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    PolarisResolutionManifest manifest = newResolutionManifest();
 
     if (key instanceof Namespace namespace) {
       manifest.addPassthroughPath(
@@ -136,9 +128,7 @@ public class PolarisPassthroughResolutionView implements PolarisResolutionManife
   @Override
   public PolarisResolvedPathWrapper getPassthroughResolvedPath(
       Object key, PolarisEntityType entityType, PolarisEntitySubType subType) {
-    PolarisResolutionManifest manifest =
-        resolutionManifestFactory.createResolutionManifest(
-            callContext, securityContext, catalogName);
+    PolarisResolutionManifest manifest = newResolutionManifest();
 
     if (key instanceof TableIdentifier identifier) {
       manifest.addPassthroughPath(


### PR DESCRIPTION
this avoids passing around the `CallContext` parameter

note that ideally the `SecurityContext` would also be injected from the request however our tests around `PolarisAuthzTestBase` are written in a way that does not easily support this currently.