### PR TITLE
Avoid using jackson method for parsing YAML from any URL in RootCredentialsSet

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
@@ -32,7 +32,7 @@ import com.google.common.base.Strings;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,16 +137,16 @@ public interface RootCredentialsSet {
    * }
    * </pre>
    */
-  static RootCredentialsSet fromUrl(URL url) {
-    Preconditions.checkNotNull(url);
+  static RootCredentialsSet fromUri(URI uri) {
+    Preconditions.checkNotNull(uri);
     Preconditions.checkArgument(
-        Strings.isNullOrEmpty(url.getHost()),
-        "Remote URLs are not allowed for RootCredentialsSet: %s",
-        url);
-    try (InputStream is = url.openStream()) {
+        Strings.isNullOrEmpty(uri.getHost()),
+        "Remote URIs are not allowed for RootCredentialsSet: %s",
+        uri);
+    try (InputStream is = uri.toURL().openStream()) {
       return fromInputStream(is);
     } catch (Exception e) {
-      throw new IllegalArgumentException("Failed to read credentials file: " + url, e);
+      throw new IllegalArgumentException("Failed to read credentials from " + uri, e);
     }
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSetTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSetTest.java
@@ -21,6 +21,7 @@ package org.apache.polaris.core.persistence.bootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -89,25 +90,29 @@ class RootCredentialsSetTest {
   }
 
   @Test
-  void getSecretsValidJson() {
+  void getSecretsValidJson() throws URISyntaxException {
     URL resource = getClass().getResource("credentials.json");
-    RootCredentialsSet set = RootCredentialsSet.fromUrl(resource);
+    assertThat(resource).isNotNull();
+    RootCredentialsSet set = RootCredentialsSet.fromUri(resource.toURI());
     assertCredentials(set);
   }
 
   @Test
-  void getSecretsValidYaml() {
+  void getSecretsValidYaml() throws URISyntaxException {
     URL resource = getClass().getResource("credentials.yaml");
-    RootCredentialsSet set = RootCredentialsSet.fromUrl(resource);
+    assertThat(resource).isNotNull();
+
+    RootCredentialsSet set = RootCredentialsSet.fromUri(resource.toURI());
     assertCredentials(set);
   }
 
   @Test
   void getSecretsInvalidJson() {
     URL resource = getClass().getResource("credentials-invalid.json");
-    assertThatThrownBy(() -> RootCredentialsSet.fromUrl(resource))
+    assertThat(resource).isNotNull();
+    assertThatThrownBy(() -> RootCredentialsSet.fromUri(resource.toURI()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Failed to read credentials file")
+        .hasMessageContaining("Failed to read credentials")
         .rootCause()
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(
@@ -117,9 +122,10 @@ class RootCredentialsSetTest {
   @Test
   void getSecretsInvalidYaml() {
     URL resource = getClass().getResource("credentials-invalid.yaml");
-    assertThatThrownBy(() -> RootCredentialsSet.fromUrl(resource))
+    assertThat(resource).isNotNull();
+    assertThatThrownBy(() -> RootCredentialsSet.fromUri(resource.toURI()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Failed to read credentials file")
+        .hasMessageContaining("Failed to read credentials")
         .rootCause()
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -103,8 +103,7 @@ public class BootstrapCommand extends BaseCommand {
       List<String> realms; // TODO Iterable
 
       if (inputOptions.fileOptions != null) {
-        rootCredentialsSet =
-            RootCredentialsSet.fromUrl(inputOptions.fileOptions.file.toUri().toURL());
+        rootCredentialsSet = RootCredentialsSet.fromUri(inputOptions.fileOptions.file.toUri());
         realms = rootCredentialsSet.credentials().keySet().stream().toList();
       } else {
         realms = inputOptions.stdinOptions.realms;

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
@@ -121,7 +121,7 @@ public abstract class BootstrapCommandTestBase {
     LaunchResult result = launcher.launch("bootstrap", "-f", "/non/existing/file");
     assertThat(result.exitCode()).isEqualTo(EXIT_CODE_BOOTSTRAP_ERROR);
     assertThat(result.getErrorOutput())
-        .contains("Failed to read credentials file: file:/non/existing/file")
+        .contains("Failed to read credentials from file:///non/existing/file")
         .contains("Bootstrap encountered errors during operation.");
   }
 


### PR DESCRIPTION
As discussed https://github.com/FasterXML/jackson-core/issues/803 this method can lead to hidden issues and got deprecated.

Instead, we manage URL steams locally in RootCredentialsSet and permit only those URLs that do not have the host component (such as files and java resources)... which makes sense to do from a general security perspective too.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
