### PR TITLE
Fix deprecation warnings in GcpCredentialsStorageIntegrationTest

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -37,6 +37,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -178,9 +179,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   }
 
   private JsonNode readResource(ObjectMapper mapper, String name) throws IOException {
-    // readTree from a test resource is not affected by the issues that prompted its deprecation
-    //noinspection deprecation
-    return mapper.readTree(GcpCredentialsStorageIntegrationTest.class.getResource(name));
+    try (InputStream in = GcpCredentialsStorageIntegrationTest.class.getResourceAsStream(name)) {
+      return mapper.readTree(in);
+    }
   }
 
   @Test


### PR DESCRIPTION
Refactor the code and suppress the warning about readTree(URL). The rationale for its deprecation does not apply to java resources.

Cf. https://github.com/FasterXML/jackson-core/issues/803

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
