### PR TITLE
Testing: Let runtime-service tests use Quarkus via `enforcedPlatform()`

### DIFF
--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -123,7 +123,7 @@ dependencies {
   testImplementation("software.amazon.awssdk:kms")
   testImplementation("software.amazon.awssdk:dynamodb")
 
-  testImplementation(platform(libs.quarkus.bom))
+  testImplementation(enforcedPlatform(libs.quarkus.bom))
   testImplementation("io.quarkus:quarkus-junit5")
   testImplementation("io.quarkus:quarkus-junit5-mockito")
   testImplementation("io.quarkus:quarkus-rest-client")


### PR DESCRIPTION
This change ensures that the tests in runtime-service use the same Quarkus platform dependency versions as Polaris server does.