### PR TITLE
Python client: remove tox

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -54,7 +54,6 @@ include = [
 [tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
-tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"
 types-python-dateutil = ">= 2.8.19.14"
 mypy = ">=1.18, <=1.18.1"


### PR DESCRIPTION
`tox` was removed via https://github.com/apache/polaris/pull/867/files due to LGPL licensing concerns from https://github.com/apache/polaris/issues/821 from its dependency on `chardet`. Seem likes it got added back by mistake via https://github.com/apache/polaris/pull/1675. 