### PR TITLE
Fix H2 JDBC schema init script

### DIFF
--- a/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
@@ -135,6 +135,6 @@ CREATE TABLE IF NOT EXISTS events (
     principal_name TEXT,
     resource_type TEXT NOT NULL,
     resource_identifier TEXT NOT NULL,
-    additional_properties JSONB NOT NULL DEFAULT '{}'::JSONB,
+    additional_properties TEXT NOT NULL,
     PRIMARY KEY (event_id)
 );


### PR DESCRIPTION
Changed `additional_properties` column type from `JSONB` to `TEXT` in `schema-v3.sql`, since `JSONB` is not a valid H2 type.