### PR TITLE
Remove DROP statements from SQL init scripts

### DIFF
--- a/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
@@ -35,7 +35,6 @@ MERGE INTO version (version_key, version_value)
 -- H2 supports COMMENT, but some modes may ignore it
 COMMENT ON TABLE version IS 'the version of the JDBC schema in use';
 
-DROP TABLE IF EXISTS entities;
 CREATE TABLE IF NOT EXISTS entities (
     realm_id TEXT NOT NULL,
     catalog_id BIGINT NOT NULL,
@@ -80,7 +79,6 @@ COMMENT ON COLUMN entities.properties IS 'entities properties json';
 COMMENT ON COLUMN entities.internal_properties IS 'entities internal properties json';
 COMMENT ON COLUMN entities.grant_records_version IS 'the version of grant records change on the entity';
 
-DROP TABLE IF EXISTS grant_records;
 CREATE TABLE IF NOT EXISTS grant_records (
     realm_id TEXT NOT NULL,
     securable_catalog_id BIGINT NOT NULL,
@@ -98,7 +96,6 @@ COMMENT ON COLUMN grant_records.grantee_catalog_id IS 'catalog id of the grantee
 COMMENT ON COLUMN grant_records.grantee_id IS 'id of the grantee';
 COMMENT ON COLUMN grant_records.privilege_code IS 'privilege code';
 
-DROP TABLE IF EXISTS principal_authentication_data;
 CREATE TABLE IF NOT EXISTS principal_authentication_data (
     realm_id TEXT NOT NULL,
     principal_id BIGINT NOT NULL,
@@ -111,7 +108,6 @@ CREATE TABLE IF NOT EXISTS principal_authentication_data (
 
 COMMENT ON TABLE principal_authentication_data IS 'authentication data for client';
 
-DROP TABLE IF EXISTS policy_mapping_record;
 CREATE TABLE IF NOT EXISTS policy_mapping_record (
     realm_id TEXT NOT NULL,
     target_catalog_id BIGINT NOT NULL,

--- a/persistence/relational-jdbc/src/main/resources/postgres/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/postgres/schema-v3.sql
@@ -108,7 +108,6 @@ CREATE TABLE IF NOT EXISTS principal_authentication_data (
 
 COMMENT ON TABLE principal_authentication_data IS 'authentication data for client';
 
-DROP TABLE IF EXISTS policy_mapping_record;
 CREATE TABLE IF NOT EXISTS policy_mapping_record (
     realm_id TEXT NOT NULL,
     target_catalog_id BIGINT NOT NULL,


### PR DESCRIPTION
SQL init scripts must be idempotent, because they may be invoked several times by a Polaris server during realm bootstrapping (the script is invoked once per realm to bootstrap).

It is therefore not possible to put any DROP statements in the scripts as this would result in immediate data loss of all previously-bootstrapped realms.