### PR TITLE
Make database column events.request_id nullable

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -19,6 +19,7 @@
 
 package org.apache.polaris.persistence.relational.jdbc.models;
 
+import jakarta.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -51,6 +52,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   String getEventId();
 
   // id of the request that generated this event
+  @Nullable
   String getRequestId();
 
   // event type that was created
@@ -60,6 +62,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   long getTimestampMs();
 
   // polaris principal who took this action
+  @Nullable
   String getPrincipalName();
 
   // Enum that states the type of resource was being operated on

--- a/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS events (
     realm_id TEXT NOT NULL,
     catalog_id TEXT NOT NULL,
     event_id TEXT NOT NULL,
-    request_id TEXT NOT NULL,
+    request_id TEXT,
     event_type TEXT NOT NULL,
     timestamp_ms BIGINT NOT NULL,
     principal_name TEXT,

--- a/persistence/relational-jdbc/src/main/resources/postgres/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/postgres/schema-v3.sql
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS events (
     realm_id TEXT NOT NULL,
     catalog_id TEXT NOT NULL,
     event_id TEXT NOT NULL,
-    request_id TEXT NOT NULL,
+    request_id TEXT,
     event_type TEXT NOT NULL,
     timestamp_ms BIGINT NOT NULL,
     principal_name TEXT,

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEvent.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEvent.java
@@ -22,6 +22,7 @@ package org.apache.polaris.core.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import java.util.Map;
 
 public class PolarisEvent {
@@ -32,28 +33,28 @@ public class PolarisEvent {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   // catalog id
-  private String catalogId;
+  private final String catalogId;
 
   // event id
-  private String id;
+  private final String id;
 
-  // id of the request that generated this event
-  private String requestId;
+  // id of the request that generated this event, if any
+  @Nullable private final String requestId;
 
   // event type that was fired
-  private String eventType;
+  private final String eventType;
 
   // timestamp in epoch milliseconds of when this event was emitted
-  private long timestampMs;
+  private final long timestampMs;
 
-  // polaris principal who took this action
-  private String principalName;
+  // polaris principal who took this action, or null if unknown
+  @Nullable private final String principalName;
 
   // Enum that states the type of resource was being operated on
-  private ResourceType resourceType;
+  private final ResourceType resourceType;
 
   // Which resource was operated on
-  private String resourceIdentifier;
+  private final String resourceIdentifier;
 
   // Additional parameters that were not earlier recorded
   private String additionalProperties;
@@ -66,6 +67,7 @@ public class PolarisEvent {
     return id;
   }
 
+  @Nullable
   public String getRequestId() {
     return requestId;
   }
@@ -78,6 +80,7 @@ public class PolarisEvent {
     return timestampMs;
   }
 
+  @Nullable
   public String getPrincipalName() {
     return principalName;
   }
@@ -97,10 +100,10 @@ public class PolarisEvent {
   public PolarisEvent(
       String catalogId,
       String id,
-      String requestId,
+      @Nullable String requestId,
       String eventType,
       long timestampMs,
-      String actor,
+      @Nullable String principalName,
       ResourceType resourceType,
       String resourceIdentifier) {
     this.catalogId = catalogId;
@@ -108,7 +111,7 @@ public class PolarisEvent {
     this.requestId = requestId;
     this.eventType = eventType;
     this.timestampMs = timestampMs;
-    this.principalName = actor;
+    this.principalName = principalName;
     this.resourceType = resourceType;
     this.resourceIdentifier = resourceIdentifier;
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/InMemoryBufferPolarisPersistenceEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/InMemoryBufferPolarisPersistenceEventListener.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.events.listeners;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.smallrye.common.annotation.Identifier;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -124,6 +125,7 @@ public class InMemoryBufferPolarisPersistenceEventListener extends PolarisPersis
     }
   }
 
+  @Nullable
   @Override
   String getRequestId() {
     if (containerRequestContext != null && containerRequestContext.hasProperty(REQUEST_ID_KEY)) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
@@ -19,6 +19,7 @@
 
 package org.apache.polaris.service.events.listeners;
 
+import jakarta.annotation.Nullable;
 import java.util.Map;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.polaris.core.entity.PolarisEvent;
@@ -111,10 +112,11 @@ public abstract class PolarisPersistenceEventListener extends PolarisEventListen
     processEvent(polarisEvent);
   }
 
-  protected record ContextSpecificInformation(long timestamp, String principalName) {}
+  protected record ContextSpecificInformation(long timestamp, @Nullable String principalName) {}
 
   abstract ContextSpecificInformation getContextSpecificInformation();
 
+  @Nullable
   abstract String getRequestId();
 
   abstract void processEvent(PolarisEvent event);


### PR DESCRIPTION
The request ID is an optional information coming from the REST request. This PR makes it nullable in the database schema.

This PR also annotates the `ModelEvent.principalName` and `PolarisEvent.principalName` fields as nullable in code (the corresponding column was already nullable in the database schema).