### PR TITLE
Pin virtualenv version to fix python client installation issue

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout Polaris project
@@ -74,6 +74,6 @@ jobs:
         run: |
           make client-integration-test
 
-      - name: Run Polaris Client help maual
+      - name: Run Polaris Client help manual
         run: |
           ./polaris --help

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -62,6 +62,9 @@ mypy = ">=1.18, <=1.18.1"
 pyiceberg = "==0.10.0"
 pre-commit = "==4.3.0"
 openapi-generator-cli = "==7.11.0.post0"
+# pin virtualenv version to prevent poetry from upgrading to an incompatible version
+# see https://github.com/python-poetry/poetry/issues/10504#issuecomment-3176923981
+virtualenv = ">=20.26.6,<20.33.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0", "openapi-generator-cli==7.11.0.post0"]


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
```
Package operations: 1 install, 1 update, 0 removals

  - Updating virtualenv (20.32.0 -> 20.34.0)
  - Installing pyiceberg (0.10.0): Failed

  AttributeError

  'PythonInfo' object has no attribute 'tcl_lib'

  at ~/tmp/3/polaris/polaris-venv/lib/python3.13/site-packages/virtualenv/activation/via_template.py:50 in replacements
       46│             "__VIRTUAL_ENV__": str(creator.dest),
       47│             "__VIRTUAL_NAME__": creator.env_name,
       48│             "__BIN_NAME__": str(creator.bin_dir.relative_to(creator.dest)),
       49│             "__PATH_SEP__": os.pathsep,
    →  50│             "__TCL_LIBRARY__": creator.interpreter.tcl_lib or "",
       51│             "__TK_LIBRARY__": creator.interpreter.tk_lib or "",
       52│         }
       53│
       54│     def _generate(self, replacements, templates, to_folder, creator):
```
Currently user may get the above error when running `./polaris` for the first time. This is caused by an upstream bug in `virtualenv>=20.33.0` and a bug in poetry that mistakenly upgrade the package version even if it is not compatible: https://github.com/python-poetry/poetry/issues/10504#issuecomment-3176923981.

This PR fix the issue by pinning the `virtualenv` version to match what's in upstream poetry: https://github.com/python-poetry/poetry/blob/a8f0889a54a545ec4f7ceed7bf41f8c2a7677bbb/pyproject.toml#L31
