### PR TITLE
Bump: iceberg 1.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@
 checkstyle = "10.25.0"
 hadoop = "3.4.2"
 hive = "3.1.3"
-iceberg = "1.9.2" # Ensure to update the iceberg version in regtests to keep regtests up-to-date
+iceberg = "1.10.0" # Ensure to update the iceberg version in regtests to keep regtests up-to-date
 quarkus = "3.26.3"
 immutables = "2.11.3"
 jmh = "1.37"

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -471,9 +471,9 @@ public class PolarisApplicationIntegrationTest {
           TableMetadata.buildFromEmpty()
               .setLocation(location)
               .assignUUID()
+              .addSchema(new Schema(Types.NestedField.required(1, "col1", Types.StringType.get())))
               .addPartitionSpec(PartitionSpec.unpartitioned())
               .addSortOrder(SortOrder.unsorted())
-              .addSchema(new Schema(Types.NestedField.required(1, "col1", Types.StringType.get())))
               .build();
       TableMetadataParser.write(tableMetadata, fileIo.newOutputFile(metadataLocation));
 
@@ -514,9 +514,9 @@ public class PolarisApplicationIntegrationTest {
           TableMetadata.buildFromEmpty()
               .setLocation(location)
               .assignUUID()
-              .addPartitionSpec(PartitionSpec.unpartitioned())
               .addSortOrder(SortOrder.unsorted())
               .addSchema(new Schema(col1))
+              .addPartitionSpec(PartitionSpec.unpartitioned())
               .build();
       TableMetadataParser.write(tableMetadata, fileIo.newOutputFile(metadataLocation));
 
@@ -562,9 +562,9 @@ public class PolarisApplicationIntegrationTest {
           TableMetadata.buildFromEmpty()
               .setLocation(location)
               .assignUUID()
+              .addSchema(new Schema(Types.NestedField.required(1, "col1", Types.StringType.get())))
               .addPartitionSpec(PartitionSpec.unpartitioned())
               .addSortOrder(SortOrder.unsorted())
-              .addSchema(new Schema(Types.NestedField.required(1, "col1", Types.StringType.get())))
               .build();
       TableMetadataParser.write(tableMetadata, fileIo.newOutputFile(metadataLocation));
 

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
   implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:iam-policy-builder")
   implementation("software.amazon.awssdk:s3")
+  implementation("software.amazon.awssdk:kms")
 
   implementation("org.apache.iceberg:iceberg-azure")
   implementation(platform(libs.azuresdk.bom))

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
   implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:iam-policy-builder")
   implementation("software.amazon.awssdk:s3")
+  implementation("software.amazon.awssdk:kms")
   implementation("software.amazon.awssdk:cloudwatchlogs")
   implementation("software.amazon.awssdk:apache-client") {
     exclude("commons-logging", "commons-logging")
@@ -170,6 +171,7 @@ dependencies {
   testFixturesImplementation("software.amazon.awssdk:sts")
   testFixturesImplementation("software.amazon.awssdk:iam-policy-builder")
   testFixturesImplementation("software.amazon.awssdk:s3")
+  testFixturesImplementation("software.amazon.awssdk:kms")
 
   testFixturesImplementation(platform(libs.azuresdk.bom))
   testFixturesImplementation("com.azure:azure-core")

--- a/tools/minio-testcontainer/build.gradle.kts
+++ b/tools/minio-testcontainer/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
   api(platform(libs.awssdk.bom))
   api("software.amazon.awssdk:s3")
+  api("software.amazon.awssdk:kms")
 
   implementation(project(":polaris-container-spec-helper"))
   implementation("software.amazon.awssdk:url-connection-client")


### PR DESCRIPTION
### About the change 

Manual intervention required for the bump due to the new changes https://github.com/apache/polaris/pull/2586#issue-3423430216 
1. MINIO / S3FileIO tests fails post due to 
- https://github.com/apache/iceberg/pull/13136 
now we required kms too when creating the client factor otherwise we get server RT failure 

2. The metadata construction assertion requires schema to be set before partition spec 