### PR TITLE
Add client build to Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,13 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("**/*.png")
 }
 
+tasks.register<Exec>("buildPythonClient") {
+  description = "Build the python client"
+
+  workingDir = project.projectDir
+  commandLine("make", "client-build")
+}
+
 // Pass environment variables:
 //    ORG_GRADLE_PROJECT_apacheUsername
 //    ORG_GRADLE_PROJECT_apachePassword


### PR DESCRIPTION
This is for adding a client build task to Gradle as requested via https://github.com/apache/polaris/pull/2530/files:

```
➜  polaris git:(gradle_client_build) ./gradlew buildPythonClient
Starting a Gradle Daemon (subsequent builds will be faster)
Configuration on demand is an incubating feature.

> Task :buildPythonClient
Installing Poetry and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (25.2)
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: polaris (1.1.0)
Preparing build environment with build-system requirements poetry-core>=2.0.0,<3.0.0, openapi-generator-cli==7.11.0.post0
Preparing spec directory...
Copying spec directory from /Users/yong/Desktop/GitHome/polaris/spec to /Users/yong/Desktop/GitHome/polaris/client/python/spec
Spec directory copied to ensure it is up-to-date.
Deleting old tests...
Old test deletion complete.
Re-applying license headers...
License fix complete.
Poetry and dependencies installed.
--- Building client distribution ---
Building polaris (1.1.0)
Building sdist
Building wheel
--- Client distribution build complete ---

[Incubating] Problems report is available at: file:///Users/yong/Desktop/GitHome/polaris/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 47s
10 actionable tasks: 1 executed, 9 up-to-date
```
