### PR TITLE
Fix license check for cryptography

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -77,6 +77,7 @@ ignore-packages = [
     "CacheControl",          # Apache-2.0
     "cffi",                  # MIT License (MIT)
     "click",                 # BSD-3-Clause
+    "cryptography",          # Apache-2.0 or BSD-3-Clause
     "fsspec",                # BSD-3-Clause
     "jaraco.functools",      # MIT License (MIT)
     "jeepney",               # MIT License (MIT)


### PR DESCRIPTION
This got added in python3.11 and python3.12:
```
Collecting cryptography>=2.0 (from SecretStorage>=3.2->keyring<26.0.0,>=25.1.0->poetry==2.1.4)
  Downloading cryptography-46.0.1-cp311-abi3-manylinux_2_34_x86_64.whl.metadata (5.7 kB)
```