### PR TITLE
CI: Fix Gradle cache usages

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,10 +46,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Run unit tests
@@ -88,10 +84,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Run Quarkus tests
@@ -128,10 +120,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Run integration tests
@@ -168,10 +156,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
       - name: Collect partial Gradle build caches
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,10 +52,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Publish SNAPSHOTs to Apache Nexus Repository
         run: ./gradlew publishToApache
         env:

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -40,11 +40,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
-
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
 

--- a/.github/workflows/spark_client_regtests.yml
+++ b/.github/workflows/spark_client_regtests.yml
@@ -40,11 +40,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-        with:
-          validate-wrappers: false
-
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
 


### PR DESCRIPTION
The GH action `ci-incr-build-cache-prepare` calls the `setup-gradle` action with the "right" parameters, so the call of `setup-gradle` in jobs that use `ci-incr-build-cache-prepare` is superfluous. But this also renders the caching ineffective as `setup-gradle` is called w/o `cache-read-only: true` in "child jobs", which then attempt to store their Gradle cache contents. This leads to attempty storing the Gradle cache in `Post Setup Gradle` steps of the "child" jobs, conflicting with other child jobs and also conflicting with `Store Gradle Cache` purpose.

"Which cache" is then restored, is rather non-deterministic, but almost always at least "partial" leading to unnecessary (re)builds.