### PR TITLE
Revert "Update plugin com.gradle.develocity to v4.2 (#2583)"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,7 +110,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.2"
+  id("com.gradle.develocity") version "4.1.1"
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 


### PR DESCRIPTION
This reverts commit 8cc0fad7b77e47c437e25c198be6924fa63e4d59, build scans are not published to the ASF Develocity instance.
