### PR TITLE
Publish Develocity builds scans for PRs and local use

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
 
   unit-tests:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -30,6 +30,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
 
   helm-tests:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,11 @@ permissions:
   security-events: read
   statuses: read
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
   nightly_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -32,6 +32,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
   build:
 

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -24,6 +24,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
   regtest:
 

--- a/.github/workflows/spark_client_regtests.yml
+++ b/.github/workflows/spark_client_regtests.yml
@@ -24,6 +24,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}
+  DEVELOCITY_SERVER: ${{ vars.DEVELOCITY_SERVER }}
+  DEVELOCITY_PROJECT_ID: ${{ vars.DEVELOCITY_PROJECT_ID }}
+
 jobs:
   spark-plugin-regtest:
 

--- a/README.md
+++ b/README.md
@@ -138,16 +138,33 @@ Default configuration values can be found in `runtime/defaults/src/main/resource
 
 #### Publishing Build Scans to develocity.apache.org
 
-All authenticated builds of Apache Polaris will automatically publish build scans to the ASF Develocity instance at 
-[develocity.apache.org](https://develocity.apache.org/scans?search.rootProjectNames=polaris). 
+Build scans of CI builds from a branch or tag in the `apache/polaris` repository on GitHub publish build scans
+to the ASF Develocity instance at
+[develocity.apache.org](https://develocity.apache.org/scans?search.rootProjectNames=polaris), if the workflow runs have access to the Apache organization-level secret 
+`DEVELOCITY_ACCESS_KEY`.
 
-CI builds originating from the `apache/polaris` repository will have access to the Apache organization-level secret 
-`DEVELOCITY_ACCESS_KEY` and publish build scans using the secret. CI builds originating from pull requests from forks 
-will not have access to the secret and will silently skip build scan publication.
+Build scans of local developer builds publish build scans only if the Gradle command line option `--scan` is used.
+Those build scans are published to Gradle's public Develocity instance (see advanced configuration options below).
+Note that build scans on Gradle's public Develocity instance are publicly accessible to anyone.
+You have to accept Gradle's terms of service to publish to the Gradle's public Develocity instance.
 
-Apache committers can publish build scans from their local machine by 
-[provisioning an access key](https://docs.gradle.com/develocity/gradle-plugin/current/#automated_access_key_provisioning) 
-using ASF LDAP credentials. Builds by anonymous, unauthenticated contributors will silently skip build scan publication.
+CI builds originating from pull requests against the `apache/polaris` GitHub repository are published to Gradle's
+_public_ Develocity instance. 
+
+Other CI build scans do only publish build scans to the Gradle's _public_ Develocity instance, if the environment
+variable `GRADLE_TOS_ACCEPTED` is set to `true`.
+By setting this variable you agree to the [Gradle's terms of service](https://gradle.com/terms-of-service), because
+accepting these ToS is your personal decision. 
+You can configure this environment variable for your GitHub repository in the GitHub repository settings under
+`Secrets` > `Secrets and variables` > `Actions` > choose the `Variables` tab > `New repository variable`. 
+
+Advanced configuration options for publishing build scans (only local and non-`apache/polaris` repository CI):
+* The project ID published with the build scan can be specified using the environment variable `DEVELOCITY_PROJECT_ID`.
+  The project ID defaults to the GitHub repository owner/name, for example `octocat/polaris`.
+* The Develocity server can be specified using the environment variable `DEVELOCITY_SERVER` if build scans should be
+  published to another than Gradle's public Develocity instance.
+* If you have to publish build scans to your own Develocity instance, you can configure the access key using a
+  GitHub secret named `DEVELOCITY_ACCESS_KEY`.
 
 ## License
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -135,11 +135,49 @@ gradle.beforeProject {
 val isCI = System.getenv("CI") != null
 
 develocity {
-  server = "https://develocity.apache.org"
-  projectId = "polaris"
-  buildScan {
-    uploadInBackground = !isCI
-    publishing.onlyIf { it.isAuthenticated }
-    obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+  val isApachePolarisGitHub = "apache/polaris" == System.getenv("GITHUB_REPOSITORY")
+  val gitHubRef: String? = System.getenv("GITHUB_REF")
+  val isGitHubBranchOrTag =
+    gitHubRef != null && (gitHubRef.startsWith("refs/heads/") || gitHubRef.startsWith("refs/tags/"))
+  if (isApachePolarisGitHub && isGitHubBranchOrTag) {
+    // Use the ASF's Develocity instance when running against the Apache Polaris repository against
+    // a branch or tag.
+    // This is for CI runs that have access to the secret for the ASF's Develocity instance.
+    server = "https://develocity.apache.org"
+    projectId = "polaris"
+    buildScan {
+      uploadInBackground = !isCI
+      publishing.onlyIf { it.isAuthenticated }
+      obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+    }
+  } else {
+    // In all other cases, especially PR CI runs, use Gradle's public Develocity instance.
+    var cfgPrjId: String? = System.getenv("DEVELOCITY_PROJECT_ID")
+    projectId = if (cfgPrjId == null || cfgPrjId.isEmpty()) "polaris" else cfgPrjId
+    buildScan {
+      val isGradleTosAccepted = "true" == System.getenv("GRADLE_TOS_ACCEPTED")
+      val isGitHubPullRequest = gitHubRef?.startsWith("refs/pull/") ?: false
+      if (isGradleTosAccepted || (isCI && isGitHubPullRequest && isApachePolarisGitHub)) {
+        // Leave TOS agreement to the user, if not running in CI.
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+      }
+      System.getenv("DEVELOCITY_SERVER")?.run {
+        if (isNotEmpty()) {
+          server = this
+        }
+      }
+      if (isGitHubPullRequest) {
+        System.getenv("GITHUB_SERVER_URL")?.run {
+          val ghUrl = this
+          val ghRepo = System.getenv("GITHUB_REPOSITORY")
+          val prNumber = gitHubRef!!.substringAfter("refs/pull/").substringBefore("/merge")
+          link("GitHub pull request", "$ghUrl/$ghRepo/pull/$prNumber")
+        }
+      }
+      uploadInBackground = !isCI
+      publishing.onlyIf { isCI || gradle.startParameter.isBuildScan }
+      obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+    }
   }
 }


### PR DESCRIPTION
This PR enables Develocity build scans for all PRs and contributors w/o an Apache account.

CI build scans in the `apache/polaris` repo against branches and tags and having access to the ASF's Develocity secret continue to publish to the ASF's Develocity instance (no behavioral change).

All other build scans are published to Gradle's public Develocity instance:
- Build scans from local developer (non-CI) runs are only published, if Gradle is invoked with the `--scan` option.
- Build scans from or targeting another repository than `apache/polaris` do need be enabled explicity by accepting Gradle's terms of service, via a repository variable, because this is a decision of the owner of a repository.

Advanced options to configure another Develocity server or project-ID are available (for non-`apache/polaris` repositories).

Detailed instructions in the `README.md`.
