### PR TITLE
chore(errorprone): Enabling EqualsGetClass, PatternMatchingInstanceof, and UnusedMethod in ErrorProne

### DIFF
--- a/api/iceberg-service/src/main/java/org/apache/polaris/service/types/NotificationRequest.java
+++ b/api/iceberg-service/src/main/java/org/apache/polaris/service/types/NotificationRequest.java
@@ -54,7 +54,7 @@ public class NotificationRequest {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof NotificationRequest)) {
       return false;
     }
     NotificationRequest notificationRequest = (NotificationRequest) o;

--- a/api/iceberg-service/src/main/java/org/apache/polaris/service/types/TableUpdateNotification.java
+++ b/api/iceberg-service/src/main/java/org/apache/polaris/service/types/TableUpdateNotification.java
@@ -106,7 +106,7 @@ public class TableUpdateNotification {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof TableUpdateNotification)) {
       return false;
     }
     TableUpdateNotification tableUpdateNotification = (TableUpdateNotification) o;

--- a/api/polaris-catalog-service/src/main/java/org/apache/polaris/service/types/PolicyIdentifier.java
+++ b/api/polaris-catalog-service/src/main/java/org/apache/polaris/service/types/PolicyIdentifier.java
@@ -104,7 +104,7 @@ public class PolicyIdentifier {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof PolicyIdentifier)) {
       return false;
     }
     PolicyIdentifier policyIdentifier = (PolicyIdentifier) o;

--- a/codestyle/errorprone-rules.properties
+++ b/codestyle/errorprone-rules.properties
@@ -87,7 +87,7 @@ DistinctVarargsChecker=ERROR
 DoubleCheckedLocking=ERROR
 # Double-checked locking on non-volatile fields is unsafe
 
-# TODO enable: EqualsGetClass=ERROR
+EqualsGetClass=ERROR
 # Prefer instanceof to getClass when implementing Object#equals.
 
 EqualsIncompatibleType=ERROR
@@ -184,7 +184,7 @@ OrphanedFormatString=ERROR
 Overrides=ERROR
 # Varargs doesn't agree for overridden method
 
-# TODO PatternMatchingInstanceof=ERROR
+PatternMatchingInstanceof=ERROR
 # This code can be simplified to use a pattern-matching instanceof.
 
 StreamToIterable=ERROR
@@ -202,7 +202,7 @@ URLEqualsHashCode=ERROR
 UnnecessaryLambda=ERROR
 # Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer to implement the functional interface method directly and use a method reference instead.
 
-# TODO enable: UnusedMethod=ERROR
+UnusedMethod=ERROR
 # Unused.
 
 UnusedNestedClass=ERROR

--- a/plugins/spark/v3.5/integration/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkIntegrationBase.java
+++ b/plugins/spark/v3.5/integration/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkIntegrationBase.java
@@ -181,8 +181,8 @@ public abstract class SparkIntegrationBase {
               }
 
               Object value = row.get(pos);
-              if (value instanceof Row) {
-                return toJava((Row) value);
+              if (value instanceof Row valueRow) {
+                return toJava(valueRow);
               } else if (value instanceof scala.collection.Seq) {
                 return row.getList(pos);
               } else if (value instanceof scala.collection.Map) {

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRequest.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRequest.java
@@ -145,7 +145,7 @@ public class CreateGenericTableRequest {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CreateGenericTableRequest)) {
       return false;
     }
     CreateGenericTableRequest createGenericTableRequest = (CreateGenericTableRequest) o;

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
@@ -144,7 +144,7 @@ public class GenericTable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof GenericTable)) {
       return false;
     }
     GenericTable genericTable = (GenericTable) o;

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/ListGenericTablesResponse.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/ListGenericTablesResponse.java
@@ -98,7 +98,7 @@ public class ListGenericTablesResponse {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ListGenericTablesResponse)) {
       return false;
     }
     ListGenericTablesResponse listGenericTablesResponse = (ListGenericTablesResponse) o;

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/LoadGenericTableResponse.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/LoadGenericTableResponse.java
@@ -74,7 +74,7 @@ public class LoadGenericTableResponse {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof LoadGenericTableResponse)) {
       return false;
     }
     LoadGenericTableResponse loadGenericTableResponse = (LoadGenericTableResponse) o;

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityId.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityId.java
@@ -49,7 +49,7 @@ public class PolarisEntityId {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof PolarisEntityId)) return false;
     PolarisEntityId that = (PolarisEntityId) o;
     return catalogId == that.catalogId && id == that.id;
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisGrantRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisGrantRecord.java
@@ -139,7 +139,7 @@ public class PolarisGrantRecord {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof PolarisGrantRecord)) return false;
     PolarisGrantRecord that = (PolarisGrantRecord) o;
     return securableCatalogId == that.securableCatalogId
         && securableId == that.securableId

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/cache/EntityCacheByNameKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/cache/EntityCacheByNameKey.java
@@ -101,7 +101,7 @@ public class EntityCacheByNameKey {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof EntityCacheByNameKey)) return false;
     EntityCacheByNameKey that = (EntityCacheByNameKey) o;
     return parentId == that.parentId
         && typeCode == that.typeCode

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverEntityName.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverEntityName.java
@@ -54,7 +54,7 @@ public class ResolverEntityName {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ResolverEntityName)) return false;
     ResolverEntityName that = (ResolverEntityName) o;
     return getEntityType() == that.getEntityType()
         && Objects.equals(getEntityName(), that.getEntityName());

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
@@ -198,7 +198,7 @@ public class PolarisPolicyMappingRecord {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof PolarisPolicyMappingRecord)) return false;
     PolarisPolicyMappingRecord that = (PolarisPolicyMappingRecord) o;
     return targetCatalogId == that.targetCatalogId
         && targetId == that.targetId

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
@@ -404,55 +404,6 @@ public abstract class BaseResolverTest {
   }
 
   /**
-   * Create a simple resolver without a reference catalog, any principal roles sub-scope and using
-   * P1 as the caller principal
-   *
-   * @return new resolver to test with
-   */
-  @Nonnull
-  private Resolver allocateResolver() {
-    return this.allocateResolver(null, null);
-  }
-
-  /**
-   * Create a simple resolver without any principal roles sub-scope and using P1 as the caller
-   * principal
-   *
-   * @param referenceCatalogName the reference e catalog name, can be null
-   * @return new resolver to test with
-   */
-  @Nonnull
-  private Resolver allocateResolver(@Nullable String referenceCatalogName) {
-    return this.allocateResolver(null, referenceCatalogName);
-  }
-
-  /**
-   * Create a simple resolver without any principal roles sub-scope and using P1 as the caller
-   * principal
-   *
-   * @param cache if not null, cache to use, else one will be created
-   * @return new resolver to test with
-   */
-  @Nonnull
-  private Resolver allocateResolver(@Nullable InMemoryEntityCache cache) {
-    return this.allocateResolver(cache, null);
-  }
-
-  /**
-   * Create a simple resolver without any principal roles sub-scope and using P1 as the caller
-   * principal
-   *
-   * @param cache if not null, cache to use, else one will be created
-   * @param referenceCatalogName the reference e catalog name, can be null
-   * @return new resolver to test with
-   */
-  @Nonnull
-  private Resolver allocateResolver(
-      @Nullable InMemoryEntityCache cache, @Nullable String referenceCatalogName) {
-    return this.allocateResolver(cache, null, referenceCatalogName);
-  }
-
-  /**
    * Create a simple resolver without any principal roles sub-scope and using P1 as the caller
    * principal
    *
@@ -516,72 +467,6 @@ public abstract class BaseResolverTest {
         },
         this.shouldUseCache ? this.cache : null,
         referenceCatalogName);
-  }
-
-  /**
-   * Resolve a principal and optionally a principal role
-   *
-   * @param cache if not null, cache to use
-   * @param principalName name of the principal name being created
-   * @param exists true if this principal already exists
-   * @param principalRoleName name of the principal role, should exist
-   */
-  private void resolvePrincipalAndPrincipalRole(
-      InMemoryEntityCache cache, String principalName, boolean exists, String principalRoleName) {
-    Resolver resolver = allocateResolver(cache);
-
-    // for a principal creation, we simply want to test if the principal we are creating exists
-    // or not
-    resolver.addOptionalEntityByName(PolarisEntityType.PRINCIPAL, principalName);
-
-    // add principal role if one passed-in
-    if (principalRoleName != null) {
-      resolver.addOptionalEntityByName(PolarisEntityType.PRINCIPAL_ROLE, principalRoleName);
-    }
-
-    // done, run resolve
-    ResolverStatus status = resolver.resolveAll();
-
-    // we expect success
-    Assertions.assertThat(status.getStatus()).isEqualTo(ResolverStatus.StatusEnum.SUCCESS);
-
-    // the principal does not exist, check that this is the case
-    if (exists) {
-      // the principal exist, check that this is the case
-      this.ensureResolved(
-          resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName),
-          PolarisEntityType.PRINCIPAL,
-          principalName);
-    } else {
-      // not found
-      Assertions.assertThat(resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName))
-          .isNull();
-    }
-
-    // validate that we were able to resolve the principal and the two principal roles
-    this.ensureResolved(resolver.getResolvedCallerPrincipal(), PolarisEntityType.PRINCIPAL, "P1");
-
-    // validate that the two principal roles have been activated
-    List<ResolvedPolarisEntity> principalRolesResolved = resolver.getResolvedCallerPrincipalRoles();
-
-    // expect two principal roles
-    Assertions.assertThat(principalRolesResolved).hasSize(2);
-    principalRolesResolved.sort(Comparator.comparing(p -> p.getEntity().getName()));
-
-    // ensure they are PR1 and PR2
-    this.ensureResolved(principalRolesResolved.get(0), PolarisEntityType.PRINCIPAL_ROLE, "PR1");
-    this.ensureResolved(
-        principalRolesResolved.get(principalRolesResolved.size() - 1),
-        PolarisEntityType.PRINCIPAL_ROLE,
-        "PR2");
-
-    // if a principal role was passed-in, ensure it exists
-    if (principalRoleName != null) {
-      this.ensureResolved(
-          resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL_ROLE, principalRoleName),
-          PolarisEntityType.PRINCIPAL_ROLE,
-          principalRoleName);
-    }
   }
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -305,8 +305,6 @@ public class PolarisAdminService {
           status.getFailedToResolvedEntityName(), principalRoleName);
     }
 
-    // TODO: Merge this method into authorizeGrantOnTopLevelEntityToPrincipalRoleOperationOrThrow
-    // once we remove any special handling logic for the rootContainer.
     PolarisResolvedPathWrapper rootContainerWrapper =
         resolutionManifest.getResolvedRootContainerEntityAsPath();
     PolarisResolvedPathWrapper principalRoleWrapper =
@@ -318,42 +316,6 @@ public class PolarisAdminService {
         resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
         op,
         rootContainerWrapper,
-        principalRoleWrapper);
-  }
-
-  private void authorizeGrantOnTopLevelEntityToPrincipalRoleOperationOrThrow(
-      PolarisAuthorizableOperation op,
-      String topLevelEntityName,
-      PolarisEntityType topLevelEntityType,
-      String principalRoleName) {
-    resolutionManifest =
-        resolutionManifestFactory.createResolutionManifest(callContext, securityContext, null);
-    resolutionManifest.addTopLevelName(
-        topLevelEntityName, topLevelEntityType, false /* isOptional */);
-    resolutionManifest.addTopLevelName(
-        principalRoleName, PolarisEntityType.PRINCIPAL_ROLE, false /* isOptional */);
-    ResolverStatus status = resolutionManifest.resolveAll();
-
-    if (status.getStatus() == ResolverStatus.StatusEnum.ENTITY_COULD_NOT_BE_RESOLVED) {
-      throw new NotFoundException(
-          "Entity %s not found when trying to assign %s of type %s to %s",
-          status.getFailedToResolvedEntityName(),
-          topLevelEntityName,
-          topLevelEntityType,
-          principalRoleName);
-    }
-
-    PolarisResolvedPathWrapper topLevelEntityWrapper =
-        resolutionManifest.getResolvedTopLevelEntity(topLevelEntityName, topLevelEntityType);
-    PolarisResolvedPathWrapper principalRoleWrapper =
-        resolutionManifest.getResolvedTopLevelEntity(
-            principalRoleName, PolarisEntityType.PRINCIPAL_ROLE);
-
-    authorizer.authorizeOrThrow(
-        polarisPrincipal,
-        resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
-        op,
-        topLevelEntityWrapper,
         principalRoleWrapper);
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/external/mapping/DefaultPrincipalMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/external/mapping/DefaultPrincipalMapper.java
@@ -51,7 +51,7 @@ class DefaultPrincipalMapper implements PrincipalMapper {
     return principalMapper
         .idClaimPath()
         .map(claimPath -> claimsLocator.locateClaim(claimPath, jwt))
-        .map(id -> id instanceof Number ? ((Number) id).longValue() : Long.parseLong(id.toString()))
+        .map(id -> id instanceof Number number ? number.longValue() : Long.parseLong(id.toString()))
         .map(OptionalLong::of)
         .orElse(OptionalLong.empty());
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -334,9 +334,9 @@ public class CatalogHandlerUtils {
             .withProperties(request.properties())
             .create();
 
-    if (table instanceof BaseTable) {
+    if (table instanceof BaseTable baseTable) {
       return LoadTableResponse.builder()
-          .withTableMetadata(((BaseTable) table).operations().current())
+          .withTableMetadata(baseTable.operations().current())
           .build();
     }
 
@@ -349,9 +349,9 @@ public class CatalogHandlerUtils {
 
     TableIdentifier identifier = TableIdentifier.of(namespace, request.name());
     Table table = catalog.registerTable(identifier, request.metadataLocation());
-    if (table instanceof BaseTable) {
+    if (table instanceof BaseTable baseTable) {
       return LoadTableResponse.builder()
-          .withTableMetadata(((BaseTable) table).operations().current())
+          .withTableMetadata(baseTable.operations().current())
           .build();
     }
 
@@ -382,9 +382,9 @@ public class CatalogHandlerUtils {
   public LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
     Table table = catalog.loadTable(ident);
 
-    if (table instanceof BaseTable) {
+    if (table instanceof BaseTable baseTable) {
       return LoadTableResponse.builder()
-          .withTableMetadata(((BaseTable) table).operations().current())
+          .withTableMetadata(baseTable.operations().current())
           .build();
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
@@ -401,8 +401,7 @@ public class CatalogHandlerUtils {
       // this is a hacky way to get TableOperations for an uncommitted table
       Transaction transaction =
           catalog.buildTable(ident, EMPTY_SCHEMA).createOrReplaceTransaction();
-      if (transaction instanceof BaseTransaction) {
-        BaseTransaction baseTransaction = (BaseTransaction) transaction;
+      if (transaction instanceof BaseTransaction baseTransaction) {
         finalMetadata = create(baseTransaction.underlyingOps(), request);
       } else {
         throw new IllegalStateException(
@@ -411,8 +410,8 @@ public class CatalogHandlerUtils {
 
     } else {
       Table table = catalog.loadTable(ident);
-      if (table instanceof BaseTable) {
-        TableOperations ops = ((BaseTable) table).operations();
+      if (table instanceof BaseTable baseTable) {
+        TableOperations ops = baseTable.operations();
         finalMetadata = commit(ops, request);
       } else {
         throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
@@ -588,9 +587,9 @@ public class CatalogHandlerUtils {
     UpdateRequirement.AssertRefSnapshotID assertRefSnapshotID = null;
     int total = 0;
     for (UpdateRequirement requirement : request.requirements()) {
-      if (requirement instanceof UpdateRequirement.AssertRefSnapshotID) {
+      if (requirement instanceof UpdateRequirement.AssertRefSnapshotID assertRefSnapshotIDReq) {
         ++total;
-        assertRefSnapshotID = (UpdateRequirement.AssertRefSnapshotID) requirement;
+        assertRefSnapshotID = assertRefSnapshotIDReq;
       }
     }
 
@@ -666,9 +665,9 @@ public class CatalogHandlerUtils {
     MetadataUpdate.SetSnapshotRef setSnapshotRefUpdate = null;
     // find the SetRefName snapshot update
     for (MetadataUpdate update : request.updates()) {
-      if (update instanceof MetadataUpdate.SetSnapshotRef) {
+      if (update instanceof MetadataUpdate.SetSnapshotRef setSnapshotRefUpd) {
         total++;
-        setSnapshotRefUpdate = (MetadataUpdate.SetSnapshotRef) update;
+        setSnapshotRefUpdate = setSnapshotRefUpd;
       }
     }
 
@@ -681,9 +680,9 @@ public class CatalogHandlerUtils {
     MetadataUpdate.AddSnapshot addSnapshot = null;
     // find the SetRefName snapshot update
     for (MetadataUpdate update : request.updates()) {
-      if (update instanceof MetadataUpdate.AddSnapshot) {
+      if (update instanceof MetadataUpdate.AddSnapshot addSnapshotUpd) {
         total++;
-        addSnapshot = (MetadataUpdate.AddSnapshot) update;
+        addSnapshot = addSnapshotUpd;
       }
     }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -796,8 +796,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
             .map(
                 update -> {
                   if (baseCatalog instanceof IcebergCatalog
-                      && update instanceof MetadataUpdate.SetLocation) {
-                    String requestedLocation = ((MetadataUpdate.SetLocation) update).location();
+                      && update instanceof MetadataUpdate.SetLocation setLocation) {
+                    String requestedLocation = setLocation.location();
                     String filteredLocation =
                         ((IcebergCatalog) baseCatalog)
                             .transformTableLikeLocation(identifier, requestedLocation);
@@ -912,7 +912,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
         .forEach(
             change -> {
               Table table = baseCatalog.loadTable(change.identifier());
-              if (!(table instanceof BaseTable)) {
+              if (!(table instanceof BaseTable baseTable)) {
                 throw new IllegalStateException(
                     "Cannot wrap catalog that does not produce BaseTable");
               }
@@ -922,7 +922,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
                     change);
               }
 
-              TableOperations tableOps = ((BaseTable) table).operations();
+              TableOperations tableOps = baseTable.operations();
               TableMetadata currentMetadata = tableOps.current();
 
               // Validate requirements; any CommitFailedExceptions will fail the overall request
@@ -937,10 +937,8 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
                         // support validation within a single multi-table transaction as well, but
                         // will need to update the TransactionWorkspaceMetaStoreManager to better
                         // expose the concept of being able to read uncommitted updates.
-                        if (singleUpdate instanceof MetadataUpdate.SetLocation) {
-                          if (!currentMetadata
-                                  .location()
-                                  .equals(((MetadataUpdate.SetLocation) singleUpdate).location())
+                        if (singleUpdate instanceof MetadataUpdate.SetLocation setLocation) {
+                          if (!currentMetadata.location().equals(setLocation.location())
                               && !realmConfig.getConfig(
                                   FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
                             throw new BadRequestException(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTExternalCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTExternalCatalogFactory.java
@@ -39,14 +39,11 @@ public class IcebergRESTExternalCatalogFactory implements ExternalCatalogFactory
   @Override
   public Catalog createCatalog(
       ConnectionConfigInfoDpo connectionConfig, UserSecretsManager userSecretsManager) {
-    if (!(connectionConfig instanceof IcebergRestConnectionConfigInfoDpo)) {
+    if (!(connectionConfig instanceof IcebergRestConnectionConfigInfoDpo icebergConfig)) {
       throw new IllegalArgumentException(
           "Expected IcebergRestConnectionConfigInfoDpo but got: "
               + connectionConfig.getClass().getSimpleName());
     }
-
-    IcebergRestConnectionConfigInfoDpo icebergConfig =
-        (IcebergRestConnectionConfigInfoDpo) connectionConfig;
 
     SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
     RESTCatalog federatedCatalog =

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplTest.java
@@ -236,8 +236,8 @@ public class PolarisServiceImplTest {
       method.invoke(service, catalog);
     } catch (java.lang.reflect.InvocationTargetException e) {
       Throwable cause = e.getCause();
-      if (cause instanceof Exception) {
-        throw (Exception) cause;
+      if (cause instanceof Exception exception) {
+        throw exception;
       } else {
         throw e;
       }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultOAuth2ApiServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultOAuth2ApiServiceTest.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.auth;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
 import java.nio.charset.Charset;
 import java.util.Base64;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
@@ -270,12 +269,7 @@ class DefaultOAuth2ApiServiceTest {
     private String clientId;
     private String clientSecret;
     private TokenType requestedTokenType;
-    private String subjectToken;
-    private TokenType subjectTokenType;
-    private String actorToken;
-    private TokenType actorTokenType;
     private RealmContext realmContext;
-    private SecurityContext securityContext;
 
     public InvocationBuilder authHeader(String authHeader) {
       this.authHeader = authHeader;
@@ -307,33 +301,8 @@ class DefaultOAuth2ApiServiceTest {
       return this;
     }
 
-    public InvocationBuilder subjectToken(String subjectToken) {
-      this.subjectToken = subjectToken;
-      return this;
-    }
-
-    public InvocationBuilder subjectTokenType(TokenType subjectTokenType) {
-      this.subjectTokenType = subjectTokenType;
-      return this;
-    }
-
-    public InvocationBuilder actorToken(String actorToken) {
-      this.actorToken = actorToken;
-      return this;
-    }
-
-    public InvocationBuilder actorTokenType(TokenType actorTokenType) {
-      this.actorTokenType = actorTokenType;
-      return this;
-    }
-
     public InvocationBuilder realmContext(RealmContext realmContext) {
       this.realmContext = realmContext;
-      return this;
-    }
-
-    public InvocationBuilder securityContext(SecurityContext securityContext) {
-      this.securityContext = securityContext;
       return this;
     }
 
@@ -345,12 +314,12 @@ class DefaultOAuth2ApiServiceTest {
           clientId,
           clientSecret,
           requestedTokenType,
-          subjectToken,
-          subjectTokenType,
-          actorToken,
-          actorTokenType,
+          null, // subjectToken
+          null, // subjectTokenType
+          null, // actorToken
+          null, // actorTokenType
           realmContext,
-          securityContext);
+          null); // securityContext
     }
   }
 }


### PR DESCRIPTION
# Context
I was going through all of the open TODOs in the codebase and found some that were on ErrorProne that were easy to enable.

Personally, I think that EqualsGetClass and PatternMatchingInstanceof are reasonable, but I'm on the fence on whether to enable UnusedMethod.