### PR TITLE
Suppress deprecation warnings in `PolarisSparkCatalog.createTable()`

### DIFF
--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisSparkCatalog.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/PolarisSparkCatalog.java
@@ -78,6 +78,7 @@ public class PolarisSparkCatalog implements TableCatalog {
   }
 
   @Override
+  @SuppressWarnings({"deprecation", "RedundantSuppression"})
   public Table createTable(
       Identifier identifier,
       StructType schema,


### PR DESCRIPTION
Background: #2394

Since we have to override the deprecated `createTable` method, we suppress deprecation warnings produced by `javac`.

Suppressing `RedundantSuppression` is needed for IntelliJ, which appears to consider this a normal situation and does not issue a deprecation warning.

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
