### PR TITLE
Azure: Fix azure expires at prefix for the credentials refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+* Fixed incorrect Azure expires at field for the credentials refresh response, leading to client failure via #2633
+
 ### Commits
 
 ## [1.1.0-incubating]

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.storage;
 
 import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 
 /**
@@ -69,7 +70,7 @@ public enum StorageAccessProperty {
   AZURE_SAS_TOKEN(String.class, "adls.sas-token.", "an azure shared access signature token"),
   AZURE_REFRESH_CREDENTIALS_ENDPOINT(
       String.class,
-      "adls.refresh-credentials-endpoint",
+      AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
       "the endpoint to load vended credentials for a table from the catalog",
       false,
       false),
@@ -77,6 +78,12 @@ public enum StorageAccessProperty {
       Long.class,
       "expiration-time",
       "the expiration time for the access token, in milliseconds",
+      true,
+      true),
+  AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX(
+      Long.class,
+      AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX,
+      "The expiration time for the access token, in milliseconds",
       true,
       true);
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -182,7 +182,7 @@ public class AzureCredentialsStorageIntegration
       Instant expiresAt,
       Optional<String> refreshCredentialsEndpoint) {
     AccessConfig.Builder accessConfig = AccessConfig.builder();
-    handleAzureCredential(accessConfig, sasToken, storageDnsName);
+    handleAzureCredential(accessConfig, sasToken, storageDnsName, expiresAt);
     accessConfig.put(
         StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt.toEpochMilli()));
     refreshCredentialsEndpoint.ifPresent(
@@ -193,8 +193,11 @@ public class AzureCredentialsStorageIntegration
   }
 
   private static void handleAzureCredential(
-      AccessConfig.Builder config, String sasToken, String host) {
+      AccessConfig.Builder config, String sasToken, String host, Instant expiresAt) {
     config.putCredential(StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + host, sasToken);
+    config.putCredential(
+        StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX.getPropertyName() + host,
+        String.valueOf(expiresAt.toEpochMilli()));
 
     // Iceberg 1.7.x may expect the credential key to _not_ be suffixed with endpoint
     if (host.endsWith(AzureLocation.ADLS_ENDPOINT)) {

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -36,8 +36,10 @@ public class AzureCredentialsStorageIntegrationTest {
 
     AccessConfig noSuffixResult =
         toAccessConfig("sasToken", "some_account", expiresAt, Optional.empty());
-    Assertions.assertThat(noSuffixResult.credentials()).hasSize(2);
+    Assertions.assertThat(noSuffixResult.credentials()).hasSize(3);
     Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsKey("adls.sas-token-expires-at-ms.some_account");
     Assertions.assertThat(noSuffixResult.credentials())
         .doesNotContainKey(
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName());
@@ -48,9 +50,11 @@ public class AzureCredentialsStorageIntegrationTest {
             "some_account." + AzureLocation.ADLS_ENDPOINT,
             expiresAt,
             Optional.of("endpoint/credentials"));
-    Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(3);
+    Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(4);
     Assertions.assertThat(adlsSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account");
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsKey("adls.sas-token-expires-at-ms.some_account");
     Assertions.assertThat(adlsSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
 
@@ -62,10 +66,12 @@ public class AzureCredentialsStorageIntegrationTest {
     AccessConfig blobSuffixResult =
         toAccessConfig(
             "sasToken", "some_account." + AzureLocation.BLOB_ENDPOINT, expiresAt, Optional.empty());
-    Assertions.assertThat(blobSuffixResult.credentials()).hasSize(3);
+    Assertions.assertThat(blobSuffixResult.credentials()).hasSize(4);
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account");
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
+    Assertions.assertThat(blobSuffixResult.credentials())
+        .containsKey("adls.sas-token-expires-at-ms.some_account.blob.core.windows.net");
   }
 }


### PR DESCRIPTION
### About the change 

For the credential refresh endpoint for the ADLS its expected the expiration time should be sent with the prefix of `AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX` which presently Polaris doesn't sends as the course of that the CredentialProvider responsible for the refresh fails the assertion here https://github.com/apache/iceberg/blob/main/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java#L123
and hence not making it usable.


P.S I think we should also use constants for iceberg SDK in the StorageAccessProperty, but this is an orthogonal discussion for now. 

### Testing 
Add a small UT