### PR TITLE
CHANGELOG: Freeze change log for 1.1 and clear out unreleased version for 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,18 +29,6 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Highlights
 
-- **HMS Federation Support**: Added support for Hive Metastore (HMS) federation, enabling integration with existing Hive metastores.
-
-- **Modularized Federation**: Introduced modularized federation architecture to support multiple catalog types and improve extensibility.
-
-- **External Authentication**: Added comprehensive support for external identity providers including Keycloak integration and Helm chart configuration options.
-
-- **Python Client Distribution**: The Python client is now packaged and distributed as a proper Python package for easier installation and usage.
-
-- **Catalog Federation CLI**: Extended the CLI with support for managing federated catalogs, making it easier to configure and operate catalog federation.
-
-- **MinIO**: Added MinIO integration support with comprehensive getting started documentation.
-
 ### Upgrade Notes
 
 - The EclipseLink Persistence implementation has been deprecated since 1.0.0 and will be completely removed
@@ -48,56 +36,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Breaking Changes
 
-- Helm chart: the default value of the `authentication.tokenBroker.secret.symmetricKey.secretKey` property has changed
-  from `symmetric.pem` to `symmetric.key`.
-
 ### New Features
 
-- Added Catalog configuration for S3 and STS endpoints. This also allows using non-AWS S3 implementations.
-  The realm-level feature flag `ALLOW_SETTING_S3_ENDPOINTS` (default: true) may be used to disable this
-  functionality.
-
-- The `IMPLICIT` authentication type enables users to create federated catalogs without explicitly
-providing authentication parameters to Polaris. When the authentication type is set to `IMPLICIT`,
-the authentication parameters are picked from the environment or configuration files.
-
-- The `DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED` feature was added to support placing tables
-at locations that better optimize for object storage.
-
-- The `LIST_PAGINATION_ENABLED` (default: false) feature flag can be used to enable pagination
-  in the Iceberg REST Catalog API.
-
-- The Helm chart now supports Pod Disruption Budgets (PDBs) for Polaris components. This allows users to define
-  the minimum number of pods that must be available during voluntary disruptions, such as node maintenance.
-
-- Feature configuration `PURGE_VIEW_METADATA_ON_DROP` was added to allow dropping views without purging their metadata files.
-
-- Introduced S3 path-style access support for improved compatibility with S3-compatible storage systems.
-
-- Enhanced Python client with integration tests and improved error handling.
-
-- Introduced extensible pagination token implementation for better API performance.
-
-- Added support for `s3a` scheme in addition to existing S3 schemes.
-
-- Enhanced Helm chart with support for external authentication configuration and relational JDBC backend options.
-
-- Added comprehensive diagnostics and monitoring capabilities throughout the system.
-
-- Introduced bootstrap command options to specify custom schema files for database initialization.
-
-- Added refresh credentials endpoint configuration to LoadTableResponse for AWS, Azure, and GCP. Enabling
-automatic storage credential refresh per table on the client side. Java client version >= 1.8.0 is required.
-The endpoint path is always returned when using vended credentials, but clients must enable the 
-refresh-credentials flag for the desired storage provider.
-
-- Added a Management API endpoint to reset principal credentials, controlled by the `ENABLE_CREDENTIAL_RESET` (default: true) feature flag.
-
 ### Changes
-
-- Polaris Management API clients must be prepared to deal with new attributes in `AwsStorageConfigInfo` objects.
-
-- S3 configuration property role-ARN is no longer mandatory.
 
 ### Deprecations
 
@@ -106,6 +47,51 @@ refresh-credentials flag for the desired storage provider.
 ### Fixes
 
 ### Commits
+
+## [1.1.0-incubating]
+Apache Polaris 1.1.0-incubating was released on September 19th, 2025.
+- **Highlights**
+  - **HMS Federation Support**: Added support for Hive Metastore (HMS) federation, enabling integration with existing Hive metastores.
+  - **Modularized Federation**: Introduced modularized federation architecture to support multiple catalog types and improve extensibility.
+  - **External Authentication**: Added comprehensive support for external identity providers including Keycloak integration and Helm chart configuration options.
+  - **Python Client Distribution**: The Python client is now packaged and distributed as a proper Python package for easier installation and usage.
+  - **Catalog Federation CLI**: Extended the CLI with support for managing federated catalogs, making it easier to configure and operate catalog federation.
+  - **MinIO**: Added MinIO integration support with comprehensive getting started documentation.
+- **New features**
+  - Added Catalog configuration for S3 and STS endpoints. This also allows using non-AWS S3 implementations.
+  - The realm-level feature flag `ALLOW_SETTING_S3_ENDPOINTS` (default: true) may be used to disable this
+    functionality.
+  - The `IMPLICIT` authentication type enables users to create federated catalogs without explicitly
+    providing authentication parameters to Polaris. When the authentication type is set to `IMPLICIT`,
+    the authentication parameters are picked from the environment or configuration files.
+  - The `DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED` feature was added to support placing tables
+    at locations that better optimize for object storage.
+  - The `LIST_PAGINATION_ENABLED` (default: false) feature flag can be used to enable pagination
+    in the Iceberg REST Catalog API.
+  - The Helm chart now supports Pod Disruption Budgets (PDBs) for Polaris components. This allows users to define
+    the minimum number of pods that must be available during voluntary disruptions, such as node maintenance.
+  - Feature configuration `PURGE_VIEW_METADATA_ON_DROP` was added to allow dropping views without purging their metadata files.
+  - Introduced S3 path-style access support for improved compatibility with S3-compatible storage systems.
+  - Enhanced Python client with integration tests and improved error handling.
+  - Introduced extensible pagination token implementation for better API performance.
+  - Added support for `s3a` scheme in addition to existing S3 schemes.
+  - Enhanced Helm chart with support for external authentication configuration and relational JDBC backend options.
+  - Added comprehensive diagnostics and monitoring capabilities throughout the system.
+  - Introduced bootstrap command options to specify custom schema files for database initialization.
+  - Added refresh credentials endpoint configuration to LoadTableResponse for AWS, Azure, and GCP. Enabling
+    automatic storage credential refresh per table on the client side. Java client version >= 1.8.0 is required.
+    The endpoint path is always returned when using vended credentials, but clients must enable the
+    refresh-credentials flag for the desired storage provider.
+  - Added a Management API endpoint to reset principal credentials, controlled by the `ENABLE_CREDENTIAL_RESET` (default: true) feature flag.
+- **Changes**
+  - Polaris Management API clients must be prepared to deal with new attributes in `AwsStorageConfigInfo` objects.
+  - S3 configuration property role-ARN is no longer mandatory.
+- **Breaking changes**
+  - Helm chart: the default value of the `authentication.tokenBroker.secret.symmetricKey.secretKey` property has changed
+      from `symmetric.pem` to `symmetric.key`.
+- **Deprecations**
+  - The property `polaris.active-roles-provider.type` is deprecated for removal.
+  - The `ActiveRolesProvider` interface is deprecated for removal.
 
 ## [1.0.1-incubating]
 Apache Polaris 1.0.1-incubating was released on August 16th, 2025. It’s a maintenance release on the 1.0.0 release fixing a couple of issues on the Helm Chart:


### PR DESCRIPTION
### About the change 

Clear out the unreleased version of the CHANGELOG and move the parts release in 1.1 to its dedicated section 
1.1 release logs are taken from here - https://github.com/apache/polaris/commit/9c635e14fb7497cd4d40b79075048af49350d622

Need to put bug fixes which will be part of 1.2 in the unreleased section 
