### PR TITLE
Fix client license check

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -62,40 +62,15 @@ mypy = ">=1.18, <=1.18.2"
 pyiceberg = "==0.10.0"
 pre-commit = "==4.3.0"
 openapi-generator-cli = "==7.11.0.post0"
-pip-licenses = "==5.0.0"
+pip-licenses-cli = "==v2.0.0"
 # pin virtualenv version to prevent poetry from upgrading to an incompatible version
 # see https://github.com/python-poetry/poetry/issues/10504#issuecomment-3176923981
 # 20.33.0 is the oldest version supported by poetry 2.2.0
 virtualenv = ">=20.33.0,<20.35.0"
 
 [tool.pip-licenses]
-from-classifier = true
-# Packages with "UNKNOWN" licenses in pip-licenses metadata.
-# These have been manually verified and are known to be compatible with ASF.
-ignore-packages = [
-    "anyio",                 # MIT License (MIT)
-    "build",                 # MIT License (MIT)
-    "CacheControl",          # Apache-2.0
-    "cffi",                  # MIT License (MIT)
-    "click",                 # BSD-3-Clause
-    "cryptography",          # Apache-2.0 or BSD-3-Clause
-    "fsspec",                # BSD-3-Clause
-    "jaraco.functools",      # MIT License (MIT)
-    "jeepney",               # MIT License (MIT)
-    "more-itertools",        # MIT License (MIT)
-    "mypy_extensions",       # MIT License (MIT)
-    "pyparsing",             # MIT License (MIT)
-    "RapidFuzz",             # MIT License (MIT)
-    "SecretStorage",         # BSD-3-Clause
-    "types-python-dateutil", # Apache-2.0
-    "typing-inspection",     # MIT License (MIT)
-    "typing_extensions",     # PSF-2.0
-    "urllib3",               # MIT License (MIT)
-    "zipp",                  # MIT License (MIT)
-    "zstandard",             # BSD-3-Clause
-]
 partial-match = true
-allow-only = "MIT;Apache;BSD License;PSF-2.0;ISC;The Unlicense;Python Software Foundation License;Mozilla Public License"
+allow-only = "Apache;BSD License;BSD-3-Clause;ISC;MIT;Mozilla Public License;PSF-2.0;Python Software Foundation License;The Unlicense"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0", "openapi-generator-cli==7.11.0.post0"]


### PR DESCRIPTION
There has been a long-standing request for pip-licenses to support [PEP 639 – Improving License Clarity with Better Package Metadata](https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/127). However, pip-licenses has shown limited progress or support for this enhancement (see [PR #213](https://github.com/raimon49/pip-licenses/pull/213)).

To address this gap, we are switching to [pip-licenses-cli](https://pypi.org/project/pip-licenses-cli/), which provides PEP 639–compliant license metadata handling and is being actively maintained in this area.