### PR TITLE
Minio testcontainer: allow setting a specific region

### DIFF
--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/Minio.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/Minio.java
@@ -39,5 +39,8 @@ public @interface Minio {
   /** Optional, use this bucket instead of a random one. */
   String bucket() default DEFAULT;
 
+  /** Optional, use this region. */
+  String region() default DEFAULT;
+
   String DEFAULT = "minio_default_value__";
 }

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
@@ -21,6 +21,7 @@ package org.apache.polaris.test.minio;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -42,6 +43,8 @@ public interface MinioAccess {
   String secretKey();
 
   String bucket();
+
+  Optional<String> region();
 
   /** HTTP protocol endpoint. */
   String s3endpoint();

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioExtension.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioExtension.java
@@ -128,8 +128,9 @@ public class MinioExtension
     String accessKey = nonDefault(minio.accessKey());
     String secretKey = nonDefault(minio.secretKey());
     String bucket = nonDefault(minio.bucket());
+    String region = nonDefault(minio.region());
     MinioContainer container =
-        new MinioContainer(null, accessKey, secretKey, bucket).withStartupAttempts(5);
+        new MinioContainer(null, accessKey, secretKey, bucket, region).withStartupAttempts(5);
     container.start();
     return container;
   }


### PR DESCRIPTION
... to remove the need to derive it via the AWS-SDK default mechanism requiring a system property or environment variable.
