### PR TITLE
fix(downloads): Fix Small Downloads Page Issues

### DIFF
--- a/site/content/downloads/_index.md
+++ b/site/content/downloads/_index.md
@@ -17,14 +17,17 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+linkTitle: 'Downloads'
+title: 'Downloads'
+type: docs
 weight: 200
-toc_hide: true
-hide_summary: true
-exclude_search: true
+params:
+  top_hidden: true
+  show_page_toc: true 
 cascade:
   type: docs
-params:
-  show_page_toc: true 
+  params:
+    show_page_toc: true
 ---
 
 ## Helm Chart


### PR DESCRIPTION
# Context 
This change should finish up Issue #2024 . It does a small update to add a page title and a Table of Contents to the downloads section of the site.

# Screenshot
The before is below and the after is above.

<img width="1224" height="923" alt="image" src="https://github.com/user-attachments/assets/f168b63a-1b56-4893-8c21-58e428c101c1" />

