### PR TITLE
Build: remove code to post-process generated Quarkus jars

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import java.io.File
-import java.io.FileOutputStream
-import java.nio.file.attribute.FileTime
-import java.util.zip.ZipFile
-import java.util.zip.ZipOutputStream
 import org.gradle.api.Project
 import org.gradle.process.JavaForkOptions
 
@@ -65,42 +60,4 @@ fun JavaForkOptions.addSparkJvmOptions() {
         // Spark 3.4+
         "-Djdk.reflect.useDirectMethodHandle=false",
       )
-}
-
-/**
- * Rewrites the given ZIP file.
- *
- * The timestamps of all entries are set to `1980-02-01 00:00`, zip entries appear in a
- * deterministic order.
- */
-fun makeZipReproducible(source: File) {
-  val t = FileTime.fromMillis(318211200_000) // 1980-02-01 00:00 GMT
-
-  val outFile = File(source.absolutePath + ".tmp.out")
-
-  val names = mutableListOf<String>()
-  ZipFile(source).use { zip -> zip.stream().forEach { e -> names.add(e.name) } }
-  names.sort()
-
-  ZipOutputStream(FileOutputStream(outFile)).use { dst ->
-    ZipFile(source).use { zip ->
-      names.forEach { n ->
-        val e = zip.getEntry(n)
-        zip.getInputStream(e).use { src ->
-          e.setCreationTime(t)
-          e.setLastAccessTime(t)
-          e.setLastModifiedTime(t)
-          dst.putNextEntry(e)
-          src.copyTo(dst)
-          dst.closeEntry()
-          src.close()
-        }
-      }
-    }
-  }
-
-  val origFile = File(source.absolutePath + ".tmp.orig")
-  source.renameTo(origFile)
-  outFile.renameTo(source)
-  origFile.delete()
 }

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -256,24 +256,6 @@ configurations.all {
     }
 }
 
-if (plugins.hasPlugin("io.quarkus")) {
-  tasks.named("quarkusBuild") {
-    actions.addLast {
-      listOf(
-          "quarkus-app/quarkus-run.jar",
-          "quarkus-app/quarkus/generated-bytecode.jar",
-          "quarkus-app/quarkus/transformed-bytecode.jar",
-        )
-        .forEach { name ->
-          val file = project.layout.buildDirectory.get().file(name).asFile
-          if (file.exists()) {
-            makeZipReproducible(file)
-          }
-        }
-    }
-  }
-}
-
 gradle.sharedServices.registerIfAbsent(
   "intTestParallelismConstraint",
   TestingParallelismHelper::class.java,


### PR DESCRIPTION
Before Quarkus 3.28, the Quarkus generated jars used the "current" timestamp for all ZIP entries, which made the jars not-reproducible. Since Quarkus 3.28, the generated jars use a fixed timestamp for all ZIP entries, so the custom code is no longer necessary.

This PR depends on Quarkus 3.28.