### PR TITLE
fix(auth): let ServiceFailureException bubble up for proper HTTP status mapping during auth

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticatingAugmentor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticatingAugmentor.java
@@ -26,6 +26,7 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 
 /**
@@ -83,6 +84,10 @@ public class AuthenticatingAugmentor implements SecurityIdentityAugmentor {
       // Also include the Polaris principal properties as attributes of the identity
       polarisPrincipal.getProperties().forEach(builder::addAttribute);
       return builder.build();
+    } catch (ServiceFailureException e) {
+      // Let ServiceFailureException bubble up to be handled by IcebergExceptionMapper
+      // This will result in 503 Service Unavailable instead of 401 Unauthorized
+      throw e;
     } catch (RuntimeException e) {
       throw new AuthenticationFailedException(e);
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
@@ -29,6 +29,7 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import java.security.Principal;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,29 @@ public class AuthenticatingAugmentorTest {
             () -> augmentor.augment(identity, Uni.createFrom()::item).await().indefinitely())
         .isInstanceOf(AuthenticationFailedException.class)
         .hasCause(exception);
+  }
+
+  @Test
+  public void testServiceFailureExceptionBubblesUp() {
+    // Given
+    Principal nonPolarisPrincipal = mock(Principal.class);
+    PolarisCredential credential = mock(PolarisCredential.class);
+    SecurityIdentity identity =
+        QuarkusSecurityIdentity.builder()
+            .setPrincipal(nonPolarisPrincipal)
+            .addCredential(credential)
+            .build();
+
+    ServiceFailureException serviceException =
+        new ServiceFailureException("Unable to fetch principal entity");
+    when(authenticator.authenticate(credential)).thenThrow(serviceException);
+
+    // When/Then
+    assertThatThrownBy(
+            () -> augmentor.augment(identity, Uni.createFrom()::item).await().indefinitely())
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("Unable to fetch principal entity")
+        .isNotInstanceOf(AuthenticationFailedException.class);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
@@ -95,7 +95,6 @@ public class AuthenticatingAugmentorTest {
 
   @Test
   public void testServiceFailureExceptionBubblesUp() {
-    // Given
     Principal nonPolarisPrincipal = mock(Principal.class);
     PolarisCredential credential = mock(PolarisCredential.class);
     SecurityIdentity identity =
@@ -108,12 +107,10 @@ public class AuthenticatingAugmentorTest {
         new ServiceFailureException("Unable to fetch principal entity");
     when(authenticator.authenticate(credential)).thenThrow(serviceException);
 
-    // When/Then
     assertThatThrownBy(
             () -> augmentor.augment(identity, Uni.createFrom()::item).await().indefinitely())
         .isInstanceOf(ServiceFailureException.class)
-        .hasMessage("Unable to fetch principal entity")
-        .isNotInstanceOf(AuthenticationFailedException.class);
+        .hasMessage("Unable to fetch principal entity");
   }
 
   @Test


### PR DESCRIPTION
# Summary

Previously, ServiceFailureException from persistence layer timeouts was being
wrapped in AuthenticationFailedException, causing IOException during loadEntity
operations to return 401 Unauthorized instead of the correct 503 Service Unavailable.

This change allows ServiceFailureException to bubble up to IcebergExceptionMapper
which properly maps it to 503 Service Unavailable, while preserving the existing
behavior for other authentication exceptions.

- Modified AuthenticatingAugmentor to catch ServiceFailureException separately
- Added test case to verify ServiceFailureException bubbles up correctly
- Other RuntimeExceptions still wrapped in AuthenticationFailedException for 401

# Tests
✅  Added a unit test
✅ `./gradlew build` succeeds
