### PR TITLE
Docs: Add more details about v1 schema user to upgrade from 1.0 to 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,10 @@ Apache Polaris 1.1.0-incubating was released on September 19th, 2025.
       ON CONFLICT (version_key) DO UPDATE
                               SET version_value = EXCLUDED.version_value;
       COMMENT ON TABLE version IS 'the version of the JDBC schema in use';
+    
+    ALTER TABLE polaris_schema.entities ADD COLUMN IF NOT EXISTS location_without_scheme TEXT;
     ```
+    - Please don't enable [OPTIMIZED_SIBLING_CHECK](https://github.com/apache/polaris/blob/740993963cb41c2c1b4638be5e04dd00f1263c98/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java#L346) feature configuration, once the above SQL statements are run. As it may lead to incorrect behavior.
 - **Deprecations**
   - The property `polaris.active-roles-provider.type` is deprecated for removal.
   - The `ActiveRolesProvider` interface is deprecated for removal.

--- a/site/content/downloads/_index.md
+++ b/site/content/downloads/_index.md
@@ -69,7 +69,10 @@ Apache Polaris 1.1.0-incubating was released on September 19th, 2025.
     ON CONFLICT (version_key) DO UPDATE
                             SET version_value = EXCLUDED.version_value;
     COMMENT ON TABLE version IS 'the version of the JDBC schema in use';
+    
+    ALTER TABLE polaris_schema.entities ADD COLUMN IF NOT EXISTS location_without_scheme TEXT;
     ```
+    - Please don't enable [OPTIMIZED_SIBLING_CHECK](https://github.com/apache/polaris/blob/740993963cb41c2c1b4638be5e04dd00f1263c98/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java#L346) feature configuration, once the above SQL statements are run. As it may lead to incorrect behavior.
 
 ## 1.0.1
 | Artifact                                                                                                                                                                                         | PGP Sig                                                                                                                                                  | SHA-512 |


### PR DESCRIPTION
### About this change 
 
Seems like just adding schema is not sufficient 

https://apache-polaris.slack.com/archives/C084XDM50CB/p1758754322883619?thread_ts=1758368000.877189&cid=C084XDM50CB

Also add a note that not enable Optimized sibling check in this to warn with the potential incorrect answer because of backfill 

