### PR TITLE
Docs: Add analytics for polaris.apache.org

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -26,6 +26,25 @@
 {{ template "_internal/twitter_cards.html" . -}}
 {{ partialCached "head-css.html" . "asdf" -}}
 
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  /* We explicitly disable cookie tracking to avoid privacy issues */
+  _paq.push(['disableCookies']);
+  /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics.apache.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '<YourSiteId>']); <!-- Apache Polaris Matomo Site ID -->
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 <!--
 Customization to host jQuery + Lunr JS files on ASF site
 -->


### PR DESCRIPTION
### About the change 

Add some analytics for polaris.apache.org to help collect some telemetry 
details - https://privacy.apache.org/matomo/

this will make a really nice dashboards like 
https://analytics.apache.org/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=40#?period=day&date=yesterday&category=Dashboard_Dashboard&subcategory=1&idSite=40

TODO: Get siteId for polaris which requires mailing privacy@ email, marking this in draft to see how folks feel about it if we are good i just cc PPMC folks and start mail thread
