### PR TITLE
[Catalog Federation] Ignore JIT entities when deleting federated catalogs, add integration test for namespace/table-level RBAC

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
@@ -303,6 +303,13 @@ public class ManagementApi extends PolarisRestApi {
     }
   }
 
+  public void deletePrincipalRole(String roleName) {
+    try (Response response =
+        request("v1/principal-roles/{name}", Map.of("name", roleName)).delete()) {
+      assertThat(response.getStatus()).isEqualTo(NO_CONTENT.getStatusCode());
+    }
+  }
+
   public void dropCatalog(String catalogName) {
     listCatalogRoles(catalogName).stream()
         .filter(cr -> !cr.getName().equals(PolarisEntityConstants.getNameOfCatalogAdminRole()))

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
@@ -122,7 +122,7 @@ public class CatalogFederationIntegrationTest {
       spark.close();
     }
     catalogApi.purge(localCatalogName);
-    // managementApi.dropCatalog(federatedCatalogName);
+    managementApi.dropCatalog(federatedCatalogName);
     managementApi.dropCatalog(localCatalogName);
     managementApi.deletePrincipalRole(PRINCIPAL_ROLE_NAME);
     managementApi.deletePrincipal(PRINCIPAL_NAME);

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -407,4 +407,16 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
                       + "If set to false, Polaris will disallow setting or changing the above catalog property")
               .defaultValue(true)
               .buildFeatureConfiguration();
+
+  public static final FeatureConfiguration<Boolean>
+      ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG =
+          PolarisConfiguration.<Boolean>builder()
+              .key("ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG")
+              .description(
+                  "If enabled, allow dropping a passthrough-facade catalog even if it contains namespaces or tables. "
+                      + "passthrough-facade catalogs may contain leftover entities when syncing with source catalog."
+                      + "In the short term these entities will be ignored, in the long term there will be method/background job to clean them up.")
+              .catalogConfig("polaris.config.allow-dropping-non-empty-passthrough-facade-catalog")
+              .defaultValue(false)
+              .buildFeatureConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
@@ -1174,7 +1175,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       // passthrough entities that are not source-of-truth
       // TODO: Temporarily allow dropping a catalog with passthrough entities remaining, in the long
       // term we need to cleanup them up to avoid accumulation in the metastore
-      if (!catalogEntityToDrop.isPassthroughFacade()) {
+      if (!catalogEntityToDrop.isPassthroughFacade()
+          || !callCtx
+              .getRealmConfig()
+              .getConfig(
+                  FeatureConfiguration.ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG,
+                  catalogEntityToDrop)) {
         // if not all namespaces are dropped, we cannot drop this catalog
         // TODO: Come up with atomic solution to blocking dropping of container entities that
         // have children; one option is reference-counting if all child creation/drop operations
@@ -1184,7 +1190,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         // children as well if those child entities were created within the short window of
         // the race condition.
         if (ms.hasChildren(callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
-          return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
+          return new DropEntityResult(
+              BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY,
+              catalogEntityToDrop.isPassthroughFacade()
+                  ? String.format(
+                      "Set %s to true to drop non-empty passthrough facade catalogs",
+                      FeatureConfiguration.ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG
+                          .key())
+                  : null);
         }
       }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.AsyncTaskType;
+import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -1416,10 +1417,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     if (refreshEntityToDrop.getType() == PolarisEntityType.CATALOG) {
       // the id of the catalog
       long catalogId = refreshEntityToDrop.getId();
+      CatalogEntity catalogEntityToDrop = CatalogEntity.of(refreshEntityToDrop);
 
-      // if not all namespaces are dropped, we cannot drop this catalog
-      if (ms.hasChildrenInCurrentTxn(callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
-        return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
+      if (!catalogEntityToDrop.isPassthroughFacade()) {
+        // if not all namespaces are dropped, we cannot drop this catalog
+        if (ms.hasChildrenInCurrentTxn(
+            callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
+          return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
+        }
       }
 
       // get the list of catalog roles, at most 2

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
@@ -1419,11 +1420,27 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       long catalogId = refreshEntityToDrop.getId();
       CatalogEntity catalogEntityToDrop = CatalogEntity.of(refreshEntityToDrop);
 
-      if (!catalogEntityToDrop.isPassthroughFacade()) {
+      // For passthrough facade catalogs, all catalog level entities, except catalog roles, are
+      // passthrough entities that are not source-of-truth
+      // TODO: Temporarily allow dropping a catalog with passthrough entities remaining, in the long
+      // term we need to cleanup them up to avoid accumulation in the metastore
+      if (!catalogEntityToDrop.isPassthroughFacade()
+          || !callCtx
+              .getRealmConfig()
+              .getConfig(
+                  FeatureConfiguration.ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG,
+                  catalogEntityToDrop)) {
         // if not all namespaces are dropped, we cannot drop this catalog
         if (ms.hasChildrenInCurrentTxn(
             callCtx, PolarisEntityType.NAMESPACE, catalogId, catalogId)) {
-          return new DropEntityResult(BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY, null);
+          return new DropEntityResult(
+              BaseResult.ReturnStatus.NAMESPACE_NOT_EMPTY,
+              catalogEntityToDrop.isPassthroughFacade()
+                  ? String.format(
+                      "Set %s to true to drop non-empty passthrough facade catalogs",
+                      FeatureConfiguration.ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG
+                          .key())
+                  : null);
         }
       }
 

--- a/runtime/spark-tests/src/intTest/java/org/apache/polaris/service/spark/it/CatalogFederationIT.java
+++ b/runtime/spark-tests/src/intTest/java/org/apache/polaris/service/spark/it/CatalogFederationIT.java
@@ -34,7 +34,8 @@ public class CatalogFederationIT extends CatalogFederationIntegrationTest {
       return Map.of(
           "polaris.features.\"ENABLE_CATALOG_FEDERATION\"", "true",
           "polaris.features.\"SUPPORTED_CATALOG_CONNECTION_TYPES\"", "[\"ICEBERG_REST\"]",
-          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"", "true");
+          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"", "true",
+          "polaris.features.\"ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS\"", "true");
     }
   }
 }

--- a/runtime/spark-tests/src/intTest/java/org/apache/polaris/service/spark/it/CatalogFederationIT.java
+++ b/runtime/spark-tests/src/intTest/java/org/apache/polaris/service/spark/it/CatalogFederationIT.java
@@ -32,10 +32,16 @@ public class CatalogFederationIT extends CatalogFederationIntegrationTest {
     @Override
     public Map<String, String> getConfigOverrides() {
       return Map.of(
-          "polaris.features.\"ENABLE_CATALOG_FEDERATION\"", "true",
-          "polaris.features.\"SUPPORTED_CATALOG_CONNECTION_TYPES\"", "[\"ICEBERG_REST\"]",
-          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"", "true",
-          "polaris.features.\"ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS\"", "true");
+          "polaris.features.\"ENABLE_CATALOG_FEDERATION\"",
+          "true",
+          "polaris.features.\"SUPPORTED_CATALOG_CONNECTION_TYPES\"",
+          "[\"ICEBERG_REST\"]",
+          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"",
+          "true",
+          "polaris.features.\"ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS\"",
+          "true",
+          "polaris.features.\"ALLOW_DROPPING_NON_EMPTY_PASSTHROUGH_FACADE_CATALOG\"",
+          "true");
     }
   }
 }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
When enabling table/namespace level RBAC in federated catalog, JIT entities will be created during privilege grant. In the short term, we should ignore them when dropping the catalog. In the long term, we will clean-up those entities when deleting the catalog.

This will be the first step towards JIT entity clean-up:
1. Ignore JIT entities when dropping federated catalog (orphan entities)
2. Register tasks/in-place cleanup JIT entities during catalog drop
3. Add new functionality to PolarisMetastoreManager to support atomic delete non-used JIT entities during revoke.
4. Global Garbage Collector to clean-up unreachable entities (entities with non-existing catalog path/parent)
