### PR TITLE
Remove unused `name` arg from findCatalogByName in PolarisAdminService

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -190,7 +190,7 @@ public class PolarisAdminService {
     return userSecretsManager;
   }
 
-  private Optional<CatalogEntity> findCatalogByName(String name) {
+  private Optional<CatalogEntity> findCatalog() {
     return Optional.ofNullable(resolutionManifest.getResolvedReferenceCatalogEntity())
         .map(path -> CatalogEntity.of(path.getRawLeafEntity()));
   }
@@ -513,7 +513,7 @@ public class PolarisAdminService {
 
     CatalogEntity catalogEntity =
         CatalogEntity.of(
-            findCatalogByName(catalogName)
+            findCatalog()
                 .orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName)));
     PolarisResolvedPathWrapper tableLikeWrapper =
         resolutionManifest.getResolvedPath(
@@ -797,8 +797,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
     PolarisEntity entity =
-        findCatalogByName(name)
-            .orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
     // TODO: Handle return value in case of concurrent modification
     boolean cleanup = realmConfig.getConfig(FeatureConfiguration.CLEANUP_ON_CATALOG_DROP);
     DropEntityResult dropEntityResult =
@@ -823,8 +822,7 @@ public class PolarisAdminService {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_CATALOG;
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
-    return findCatalogByName(name)
-        .orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+    return findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
   }
 
   /**
@@ -883,8 +881,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
     CatalogEntity currentCatalogEntity =
-        findCatalogByName(name)
-            .orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
 
     if (currentCatalogEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
       throw new CommitConflictException(
@@ -1321,7 +1318,7 @@ public class PolarisAdminService {
     checkArgument(entity.getId() == -1, "Entity to be created must have no ID assigned");
 
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
 
     PolarisEntity returnedEntity =
@@ -1386,8 +1383,7 @@ public class PolarisAdminService {
     authorizeBasicCatalogRoleOperationOrThrow(op, catalogName, name);
 
     CatalogEntity catalogEntity =
-        findCatalogByName(catalogName)
-            .orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName));
+        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName));
     CatalogRoleEntity currentCatalogRoleEntity =
         findCatalogRoleByName(catalogName, name)
             .orElseThrow(() -> new NotFoundException("CatalogRole %s not found", name));
@@ -1427,7 +1423,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, catalogName, PolarisEntityType.CATALOG);
 
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     List<PolarisEntityCore> catalogPath = PolarisEntity.toCoreList(List.of(catalogEntity));
     return metaStoreManager
@@ -1509,7 +1505,7 @@ public class PolarisAdminService {
             .orElseThrow(
                 () -> new NotFoundException("PrincipalRole %s not found", principalRoleName));
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1531,7 +1527,7 @@ public class PolarisAdminService {
             .orElseThrow(
                 () -> new NotFoundException("PrincipalRole %s not found", principalRoleName));
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1597,7 +1593,7 @@ public class PolarisAdminService {
         op, principalRoleName, PolarisEntityType.PRINCIPAL_ROLE, catalogName);
 
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity principalRoleEntity =
         findPrincipalRoleByName(principalRoleName)
@@ -1659,7 +1655,7 @@ public class PolarisAdminService {
     authorizeGrantOnCatalogOperationOrThrow(op, catalogName, catalogRoleName);
 
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1681,7 +1677,7 @@ public class PolarisAdminService {
     authorizeGrantOnCatalogOperationOrThrow(op, catalogName, catalogRoleName);
 
     PolarisEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1703,7 +1699,7 @@ public class PolarisAdminService {
     authorizeGrantOnNamespaceOperationOrThrow(op, catalogName, namespace, catalogRoleName);
 
     CatalogEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1965,7 +1961,7 @@ public class PolarisAdminService {
         PolarisAuthorizableOperation.LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE;
     authorizeBasicCatalogRoleOperationOrThrow(op, catalogName, catalogRoleName);
 
-    if (findCatalogByName(catalogName).isEmpty()) {
+    if (findCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2129,7 +2125,7 @@ public class PolarisAdminService {
       List<PolarisEntitySubType> subTypes,
       PolarisPrivilege privilege) {
     CatalogEntity catalogEntity =
-        findCatalogByName(catalogName)
+        findCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -2253,7 +2249,7 @@ public class PolarisAdminService {
       TableIdentifier identifier,
       List<PolarisEntitySubType> subTypes,
       PolarisPrivilege privilege) {
-    if (findCatalogByName(catalogName).isEmpty()) {
+    if (findCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2283,7 +2279,7 @@ public class PolarisAdminService {
       String catalogRoleName,
       PolicyIdentifier identifier,
       PolarisPrivilege privilege) {
-    if (findCatalogByName(catalogName).isEmpty()) {
+    if (findCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2311,7 +2307,7 @@ public class PolarisAdminService {
       String catalogRoleName,
       PolicyIdentifier identifier,
       PolarisPrivilege privilege) {
-    if (findCatalogByName(catalogName).isEmpty()) {
+    if (findCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -190,7 +190,7 @@ public class PolarisAdminService {
     return userSecretsManager;
   }
 
-  private Optional<CatalogEntity> findCatalog() {
+  private Optional<CatalogEntity> currentCatalog() {
     return Optional.ofNullable(resolutionManifest.getResolvedReferenceCatalogEntity())
         .map(path -> CatalogEntity.of(path.getRawLeafEntity()));
   }
@@ -513,7 +513,7 @@ public class PolarisAdminService {
 
     CatalogEntity catalogEntity =
         CatalogEntity.of(
-            findCatalog()
+            currentCatalog()
                 .orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName)));
     PolarisResolvedPathWrapper tableLikeWrapper =
         resolutionManifest.getResolvedPath(
@@ -797,7 +797,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
     PolarisEntity entity =
-        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+        currentCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
     // TODO: Handle return value in case of concurrent modification
     boolean cleanup = realmConfig.getConfig(FeatureConfiguration.CLEANUP_ON_CATALOG_DROP);
     DropEntityResult dropEntityResult =
@@ -822,7 +822,7 @@ public class PolarisAdminService {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_CATALOG;
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
-    return findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+    return currentCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
   }
 
   /**
@@ -881,7 +881,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
 
     CatalogEntity currentCatalogEntity =
-        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
+        currentCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", name));
 
     if (currentCatalogEntity.getEntityVersion() != updateRequest.getCurrentEntityVersion()) {
       throw new CommitConflictException(
@@ -1318,7 +1318,7 @@ public class PolarisAdminService {
     checkArgument(entity.getId() == -1, "Entity to be created must have no ID assigned");
 
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
 
     PolarisEntity returnedEntity =
@@ -1383,7 +1383,8 @@ public class PolarisAdminService {
     authorizeBasicCatalogRoleOperationOrThrow(op, catalogName, name);
 
     CatalogEntity catalogEntity =
-        findCatalog().orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName));
+        currentCatalog()
+            .orElseThrow(() -> new NotFoundException("Catalog %s not found", catalogName));
     CatalogRoleEntity currentCatalogRoleEntity =
         findCatalogRoleByName(catalogName, name)
             .orElseThrow(() -> new NotFoundException("CatalogRole %s not found", name));
@@ -1423,7 +1424,7 @@ public class PolarisAdminService {
     authorizeBasicTopLevelEntityOperationOrThrow(op, catalogName, PolarisEntityType.CATALOG);
 
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     List<PolarisEntityCore> catalogPath = PolarisEntity.toCoreList(List.of(catalogEntity));
     return metaStoreManager
@@ -1505,7 +1506,7 @@ public class PolarisAdminService {
             .orElseThrow(
                 () -> new NotFoundException("PrincipalRole %s not found", principalRoleName));
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1527,7 +1528,7 @@ public class PolarisAdminService {
             .orElseThrow(
                 () -> new NotFoundException("PrincipalRole %s not found", principalRoleName));
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1593,7 +1594,7 @@ public class PolarisAdminService {
         op, principalRoleName, PolarisEntityType.PRINCIPAL_ROLE, catalogName);
 
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity principalRoleEntity =
         findPrincipalRoleByName(principalRoleName)
@@ -1655,7 +1656,7 @@ public class PolarisAdminService {
     authorizeGrantOnCatalogOperationOrThrow(op, catalogName, catalogRoleName);
 
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1677,7 +1678,7 @@ public class PolarisAdminService {
     authorizeGrantOnCatalogOperationOrThrow(op, catalogName, catalogRoleName);
 
     PolarisEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1699,7 +1700,7 @@ public class PolarisAdminService {
     authorizeGrantOnNamespaceOperationOrThrow(op, catalogName, namespace, catalogRoleName);
 
     CatalogEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -1961,7 +1962,7 @@ public class PolarisAdminService {
         PolarisAuthorizableOperation.LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE;
     authorizeBasicCatalogRoleOperationOrThrow(op, catalogName, catalogRoleName);
 
-    if (findCatalog().isEmpty()) {
+    if (currentCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2125,7 +2126,7 @@ public class PolarisAdminService {
       List<PolarisEntitySubType> subTypes,
       PolarisPrivilege privilege) {
     CatalogEntity catalogEntity =
-        findCatalog()
+        currentCatalog()
             .orElseThrow(() -> new NotFoundException("Parent catalog %s not found", catalogName));
     PolarisEntity catalogRoleEntity =
         findCatalogRoleByName(catalogName, catalogRoleName)
@@ -2249,7 +2250,7 @@ public class PolarisAdminService {
       TableIdentifier identifier,
       List<PolarisEntitySubType> subTypes,
       PolarisPrivilege privilege) {
-    if (findCatalog().isEmpty()) {
+    if (currentCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2279,7 +2280,7 @@ public class PolarisAdminService {
       String catalogRoleName,
       PolicyIdentifier identifier,
       PolarisPrivilege privilege) {
-    if (findCatalog().isEmpty()) {
+    if (currentCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =
@@ -2307,7 +2308,7 @@ public class PolarisAdminService {
       String catalogRoleName,
       PolicyIdentifier identifier,
       PolarisPrivilege privilege) {
-    if (findCatalog().isEmpty()) {
+    if (currentCatalog().isEmpty()) {
       throw new NotFoundException("Parent catalog %s not found", catalogName);
     }
     PolarisEntity catalogRoleEntity =


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
`findCatalogByName` in `PolarisAdminService` does not actually require a name, it will fetch the catalog resolved in the resolutionManifest

This PR remove the unused arg and change the name to avoid confusion
