### PR TITLE
Client: fix integration testing

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -72,15 +72,6 @@ jobs:
         run: |
           make client-unit-test
 
-      - name: Image build
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-        run: |
-          ./gradlew \
-            :polaris-server:assemble \
-            :polaris-server:quarkusAppPartsBuild --rerun \
-            -Dquarkus.container-image.build=true
-
       - name: Integration Tests
         run: |
           make client-integration-test

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ client-unit-test: client-setup-env ## Run client unit tests
 	@echo "--- Client unit tests complete ---"
 
 .PHONY: client-integration-test
-client-integration-test: client-setup-env ## Run client integration tests
+client-integration-test: build-server client-setup-env ## Run client integration tests
 	@echo "--- Starting client integration tests ---"
 	@echo "Ensuring Docker Compose services are stopped and removed..."
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml kill || true # `|| true` prevents make from failing if containers don't exist

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -82,6 +82,7 @@ tasks.named<QuarkusRun>("quarkusRun") {
       "-Dpolaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"=true",
       "-Dpolaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"=[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]",
       "-Dpolaris.readiness.ignore-severe-issues=true",
+      "-Dpolaris.features.\"DROP_WITH_PURGE_ENABLED\"=true",
     )
 }
 


### PR DESCRIPTION
This is side effect of https://github.com/apache/polaris/pull/1619. Current if we try to run the integration locally via `make client-integration-test`, it will try to fetch the latest image from dockerhub. It appears the latest image has some issues. Also, if we try to run locally via `./gradlew run`, we will run into issue as well. For the local one, it is due to `jvmArgs` is fixed and not allowed appended when using `./gradlew run`. Thus, with default of `false` for `DROP_WITH_PURGE_ENABLED`. the local integration test will always failed. 

To avoid this issue, I added `build-server` as pre-requisite before running the test (which is the current behavior of our github action) and remove the extra image build state as `client-integration-test` will build it automatically now.