### PR TITLE
Add support for MySQL Metastore

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "
 opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version = "1.37.0" }
 picocli = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
+mysql-connector-j = { module = "com.mysql:mysql-connector-j", version = "8.0.33" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.8" }
 prometheus-metrics-exporter-servlet-jakarta = { module = "io.prometheus:prometheus-metrics-exporter-servlet-jakarta", version = "1.4.1" }
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }

--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
   implementation(libs.smallrye.common.annotation) // @Identifier
   implementation(libs.postgresql)
-  implementation("com.mysql:mysql-connector-j:8.0.33") 
+  implementation(libs.mysql.connector.j) 
 
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))

--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
   implementation(libs.smallrye.common.annotation) // @Identifier
   implementation(libs.postgresql)
+  implementation("com.mysql:mysql-connector-j:8.0.33") 
 
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -27,7 +27,8 @@ import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 
 public enum DatabaseType {
   POSTGRES("postgres"),
-  H2("h2");
+  H2("h2"),
+  MYSQL("mysql");
 
   private final String displayName; // Store the user-friendly name
 
@@ -44,6 +45,7 @@ public enum DatabaseType {
     return switch (displayName.toLowerCase(Locale.ROOT)) {
       case "h2" -> DatabaseType.H2;
       case "postgresql" -> DatabaseType.POSTGRES;
+      case "mysql" -> DatabaseType.MYSQL;
       default -> throw new IllegalStateException("Unsupported DatabaseType: '" + displayName + "'");
     };
   }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -250,7 +250,8 @@ public class QueryGenerator {
 
   @VisibleForTesting
   static PreparedQuery generateVersionQuery() {
-    return new PreparedQuery("SELECT version_value FROM POLARIS_SCHEMA.VERSION", List.of());
+    String tableName = getFullyQualifiedTableName("VERSION");
+    return new PreparedQuery("SELECT version_value FROM " + tableName, List.of());
   }
 
   /**

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/Converter.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/Converter.java
@@ -50,4 +50,18 @@ public interface Converter<T> {
       throw new RuntimeException(e);
     }
   }
+
+  /**
+   * Creates a JSON object based on the database type.
+   */
+  default Object toJsonObject(String props, DatabaseType databaseType) {
+    switch (databaseType) {
+      case POSTGRES:
+        return toJsonbPGobject(props);
+      case MYSQL:
+      case H2:
+      default:
+        return props; 
+    }
+  }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
@@ -216,13 +216,8 @@ public class ModelEntity implements Converter<PolarisBaseEntity> {
     map.put("purge_timestamp", this.getPurgeTimestamp());
     map.put("to_purge_timestamp", this.getToPurgeTimestamp());
     map.put("last_update_timestamp", this.getLastUpdateTimestamp());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("properties", toJsonbPGobject(this.getProperties()));
-      map.put("internal_properties", toJsonbPGobject(this.getInternalProperties()));
-    } else {
-      map.put("properties", this.getProperties());
-      map.put("internal_properties", this.getInternalProperties());
-    }
+    map.put("properties", toJsonObject(this.getProperties(), databaseType));
+    map.put("internal_properties", toJsonObject(this.getInternalProperties(), databaseType));
     map.put("grant_records_version", this.getGrantRecordsVersion());
     map.put("location_without_scheme", this.getLocationWithoutScheme());
     return map;

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -102,11 +102,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
     map.put("principal_name", getPrincipalName());
     map.put("resource_type", getResourceType().toString());
     map.put("resource_identifier", getResourceIdentifier());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("additional_properties", toJsonbPGobject(getAdditionalProperties()));
-    } else {
-      map.put("additional_properties", getAdditionalProperties());
-    }
+    map.put("additional_properties", toJsonObject(getAdditionalProperties(), databaseType));
     return map;
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
@@ -175,11 +175,7 @@ public class ModelPolicyMappingRecord implements Converter<PolarisPolicyMappingR
     map.put("policy_type_code", policyTypeCode);
     map.put("policy_catalog_id", policyCatalogId);
     map.put("policy_id", policyId);
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("parameters", toJsonbPGobject(this.getParameters()));
-    } else {
-      map.put("parameters", this.getParameters());
-    }
+    map.put("parameters", toJsonObject(this.getParameters(), databaseType));
     return map;
   }
 }

--- a/persistence/relational-jdbc/src/main/resources/mysql/schema-v1.sql
+++ b/persistence/relational-jdbc/src/main/resources/mysql/schema-v1.sql
@@ -1,0 +1,104 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Changes from v2:
+--  * Added `events` table
+
+CREATE DATABASE IF NOT EXISTS POLARIS_SCHEMA;
+USE POLARIS_SCHEMA;
+
+CREATE TABLE IF NOT EXISTS version (
+    version_key VARCHAR(255) PRIMARY KEY,
+    version_value INTEGER NOT NULL
+);
+INSERT INTO version (version_key, version_value)
+VALUES ('version', 3)
+ON DUPLICATE KEY UPDATE version_value = VALUES(version_value);
+
+CREATE TABLE IF NOT EXISTS entities (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    id BIGINT NOT NULL,
+    parent_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    entity_version INT NOT NULL,
+    type_code INT NOT NULL,
+    sub_type_code INT NOT NULL,
+    create_timestamp BIGINT NOT NULL,
+    drop_timestamp BIGINT NOT NULL,
+    purge_timestamp BIGINT NOT NULL,
+    to_purge_timestamp BIGINT NOT NULL,
+    last_update_timestamp BIGINT NOT NULL,
+    properties JSON NOT NULL DEFAULT ('{}'),
+    internal_properties JSON NOT NULL DEFAULT ('{}'),
+    grant_records_version INT NOT NULL,
+    location_without_scheme TEXT,
+    PRIMARY KEY (realm_id, id),
+    UNIQUE KEY constraint_name (realm_id, catalog_id, parent_id, type_code, name)
+);
+
+-- TODO: create indexes based on all query pattern.
+CREATE INDEX idx_entities ON entities (realm_id, catalog_id, id);
+CREATE INDEX idx_locations ON entities (realm_id, parent_id, location_without_scheme(255));
+
+CREATE TABLE IF NOT EXISTS grant_records (
+    realm_id VARCHAR(255) NOT NULL,
+    securable_catalog_id BIGINT NOT NULL,
+    securable_id BIGINT NOT NULL,
+    grantee_catalog_id BIGINT NOT NULL,
+    grantee_id BIGINT NOT NULL,
+    privilege_code INTEGER,
+    PRIMARY KEY (realm_id, securable_catalog_id, securable_id, grantee_catalog_id, grantee_id, privilege_code)
+);
+
+CREATE TABLE IF NOT EXISTS principal_authentication_data (
+    realm_id VARCHAR(255) NOT NULL,
+    principal_id BIGINT NOT NULL,
+    principal_client_id VARCHAR(255) NOT NULL,
+    main_secret_hash VARCHAR(255) NOT NULL,
+    secondary_secret_hash VARCHAR(255) NOT NULL,
+    secret_salt VARCHAR(255) NOT NULL,
+    PRIMARY KEY (realm_id, principal_client_id)
+);
+
+CREATE TABLE IF NOT EXISTS policy_mapping_record (
+    realm_id VARCHAR(255) NOT NULL,
+    target_catalog_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    policy_type_code INTEGER NOT NULL,
+    policy_catalog_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    parameters JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (realm_id, target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id)
+);
+
+CREATE INDEX idx_policy_mapping_record ON policy_mapping_record (realm_id, policy_type_code, policy_catalog_id, policy_id, target_catalog_id, target_id);
+
+CREATE TABLE IF NOT EXISTS events (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id VARCHAR(255) NOT NULL,
+    event_id VARCHAR(255) NOT NULL,
+    request_id VARCHAR(255),
+    event_type VARCHAR(255) NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    resource_type VARCHAR(255) NOT NULL,
+    resource_identifier VARCHAR(255) NOT NULL,
+    additional_properties JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (event_id)
+);

--- a/persistence/relational-jdbc/src/main/resources/mysql/schema-v2.sql
+++ b/persistence/relational-jdbc/src/main/resources/mysql/schema-v2.sql
@@ -1,0 +1,104 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Changes from v2:
+--  * Added `events` table
+
+CREATE DATABASE IF NOT EXISTS POLARIS_SCHEMA;
+USE POLARIS_SCHEMA;
+
+CREATE TABLE IF NOT EXISTS version (
+    version_key VARCHAR(255) PRIMARY KEY,
+    version_value INTEGER NOT NULL
+);
+INSERT INTO version (version_key, version_value)
+VALUES ('version', 3)
+ON DUPLICATE KEY UPDATE version_value = VALUES(version_value);
+
+CREATE TABLE IF NOT EXISTS entities (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    id BIGINT NOT NULL,
+    parent_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    entity_version INT NOT NULL,
+    type_code INT NOT NULL,
+    sub_type_code INT NOT NULL,
+    create_timestamp BIGINT NOT NULL,
+    drop_timestamp BIGINT NOT NULL,
+    purge_timestamp BIGINT NOT NULL,
+    to_purge_timestamp BIGINT NOT NULL,
+    last_update_timestamp BIGINT NOT NULL,
+    properties JSON NOT NULL DEFAULT ('{}'),
+    internal_properties JSON NOT NULL DEFAULT ('{}'),
+    grant_records_version INT NOT NULL,
+    location_without_scheme TEXT,
+    PRIMARY KEY (realm_id, id),
+    UNIQUE KEY constraint_name (realm_id, catalog_id, parent_id, type_code, name)
+);
+
+-- TODO: create indexes based on all query pattern.
+CREATE INDEX idx_entities ON entities (realm_id, catalog_id, id);
+CREATE INDEX idx_locations ON entities (realm_id, parent_id, location_without_scheme(255));
+
+CREATE TABLE IF NOT EXISTS grant_records (
+    realm_id VARCHAR(255) NOT NULL,
+    securable_catalog_id BIGINT NOT NULL,
+    securable_id BIGINT NOT NULL,
+    grantee_catalog_id BIGINT NOT NULL,
+    grantee_id BIGINT NOT NULL,
+    privilege_code INTEGER,
+    PRIMARY KEY (realm_id, securable_catalog_id, securable_id, grantee_catalog_id, grantee_id, privilege_code)
+);
+
+CREATE TABLE IF NOT EXISTS principal_authentication_data (
+    realm_id VARCHAR(255) NOT NULL,
+    principal_id BIGINT NOT NULL,
+    principal_client_id VARCHAR(255) NOT NULL,
+    main_secret_hash VARCHAR(255) NOT NULL,
+    secondary_secret_hash VARCHAR(255) NOT NULL,
+    secret_salt VARCHAR(255) NOT NULL,
+    PRIMARY KEY (realm_id, principal_client_id)
+);
+
+CREATE TABLE IF NOT EXISTS policy_mapping_record (
+    realm_id VARCHAR(255) NOT NULL,
+    target_catalog_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    policy_type_code INTEGER NOT NULL,
+    policy_catalog_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    parameters JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (realm_id, target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id)
+);
+
+CREATE INDEX idx_policy_mapping_record ON policy_mapping_record (realm_id, policy_type_code, policy_catalog_id, policy_id, target_catalog_id, target_id);
+
+CREATE TABLE IF NOT EXISTS events (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id VARCHAR(255) NOT NULL,
+    event_id VARCHAR(255) NOT NULL,
+    request_id VARCHAR(255),
+    event_type VARCHAR(255) NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    resource_type VARCHAR(255) NOT NULL,
+    resource_identifier VARCHAR(255) NOT NULL,
+    additional_properties JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (event_id)
+);

--- a/persistence/relational-jdbc/src/main/resources/mysql/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/mysql/schema-v3.sql
@@ -1,0 +1,104 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Changes from v2:
+--  * Added `events` table
+
+CREATE DATABASE IF NOT EXISTS POLARIS_SCHEMA;
+USE POLARIS_SCHEMA;
+
+CREATE TABLE IF NOT EXISTS version (
+    version_key TEXT PRIMARY KEY,
+    version_value INTEGER NOT NULL
+);
+INSERT INTO version (version_key, version_value)
+VALUES ('version', 3)
+ON DUPLICATE KEY UPDATE version_value = VALUES(version_value);
+
+CREATE TABLE IF NOT EXISTS entities (
+    realm_id TEXT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    id BIGINT NOT NULL,
+    parent_id BIGINT NOT NULL,
+    name TEXT NOT NULL,
+    entity_version INT NOT NULL,
+    type_code INT NOT NULL,
+    sub_type_code INT NOT NULL,
+    create_timestamp BIGINT NOT NULL,
+    drop_timestamp BIGINT NOT NULL,
+    purge_timestamp BIGINT NOT NULL,
+    to_purge_timestamp BIGINT NOT NULL,
+    last_update_timestamp BIGINT NOT NULL,
+    properties JSON NOT NULL DEFAULT ('{}'),
+    internal_properties JSON NOT NULL DEFAULT ('{}'),
+    grant_records_version INT NOT NULL,
+    location_without_scheme TEXT,
+    PRIMARY KEY (realm_id, id),
+    UNIQUE KEY constraint_name (realm_id, catalog_id, parent_id, type_code, name)
+);
+
+-- TODO: create indexes based on all query pattern.
+CREATE INDEX idx_entities ON entities (realm_id, catalog_id, id);
+CREATE INDEX idx_locations ON entities (realm_id, parent_id, location_without_scheme(255));
+
+CREATE TABLE IF NOT EXISTS grant_records (
+    realm_id TEXT NOT NULL,
+    securable_catalog_id BIGINT NOT NULL,
+    securable_id BIGINT NOT NULL,
+    grantee_catalog_id BIGINT NOT NULL,
+    grantee_id BIGINT NOT NULL,
+    privilege_code INTEGER,
+    PRIMARY KEY (realm_id, securable_catalog_id, securable_id, grantee_catalog_id, grantee_id, privilege_code)
+);
+
+CREATE TABLE IF NOT EXISTS principal_authentication_data (
+    realm_id TEXT NOT NULL,
+    principal_id BIGINT NOT NULL,
+    principal_client_id TEXT NOT NULL,
+    main_secret_hash TEXT NOT NULL,
+    secondary_secret_hash TEXT NOT NULL,
+    secret_salt TEXT NOT NULL,
+    PRIMARY KEY (realm_id, principal_client_id)
+);
+
+CREATE TABLE IF NOT EXISTS policy_mapping_record (
+    realm_id TEXT NOT NULL,
+    target_catalog_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    policy_type_code INTEGER NOT NULL,
+    policy_catalog_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    parameters JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (realm_id, target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id)
+);
+
+CREATE INDEX idx_policy_mapping_record ON policy_mapping_record (realm_id, policy_type_code, policy_catalog_id, policy_id, target_catalog_id, target_id);
+
+CREATE TABLE IF NOT EXISTS events (
+    realm_id TEXT NOT NULL,
+    catalog_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    request_id TEXT,
+    event_type TEXT NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    principal_name TEXT,
+    resource_type TEXT NOT NULL,
+    resource_identifier TEXT NOT NULL,
+    additional_properties JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (event_id)
+);

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
   runtimeOnly("org.postgresql:postgresql")
   runtimeOnly(project(":polaris-relational-jdbc"))
   runtimeOnly("io.quarkus:quarkus-jdbc-postgresql")
+  implementation("com.mysql:mysql-connector-j:8.0.33")
+  implementation("io.quarkus:quarkus-jdbc-mysql")
   runtimeOnly(project(":polaris-extensions-federation-hadoop"))
 
   if ((project.findProperty("NonRESTCatalogs") as String?)?.contains("HIVE") == true) {

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   runtimeOnly("org.postgresql:postgresql")
   runtimeOnly(project(":polaris-relational-jdbc"))
   runtimeOnly("io.quarkus:quarkus-jdbc-postgresql")
-  implementation("com.mysql:mysql-connector-j:8.0.33")
+  implementation(libs.mysql.connector.j)
   implementation("io.quarkus:quarkus-jdbc-mysql")
   runtimeOnly(project(":polaris-extensions-federation-hadoop"))
 

--- a/runtime/test-common/build.gradle.kts
+++ b/runtime/test-common/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")
   implementation("org.testcontainers:postgresql")
+  implementation("org.testcontainers:mysql")
 
   implementation(libs.testcontainers.keycloak) {
     exclude(group = "org.keycloak", module = "keycloak-admin-client")

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/MySqlRelationalJdbcLifeCycleManagement.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/MySqlRelationalJdbcLifeCycleManagement.java
@@ -22,7 +22,7 @@ import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Map;
 
-public class PostgresRelationalJdbcLifeCycleManagement
+public class MySqlRelationalJdbcLifeCycleManagement
     implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
   public static final String INIT_SCRIPT = RelationalJdbcLifeCycleManagement.INIT_SCRIPT;
@@ -33,7 +33,7 @@ public class PostgresRelationalJdbcLifeCycleManagement
   @Override
   public void init(Map<String, String> initArgs) {
     Map<String, String> enhancedArgs = new java.util.HashMap<>(initArgs);
-    enhancedArgs.put(RelationalJdbcLifeCycleManagement.DATABASE_TYPE, "POSTGRESQL");
+    enhancedArgs.put(RelationalJdbcLifeCycleManagement.DATABASE_TYPE, "MYSQL");
     delegate.init(enhancedArgs);
   }
 

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/RelationalJdbcLifeCycleManagement.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/RelationalJdbcLifeCycleManagement.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.test.commons;
+
+import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpecHelper;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Locale;
+import java.util.Map;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class RelationalJdbcLifeCycleManagement
+    implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+  public static final String INIT_SCRIPT = "init-script";
+  public static final String DATABASE_TYPE = "database-type";
+
+  public enum DatabaseType {
+    POSTGRESQL("postgresql", "postgres", null),
+    MYSQL("mysql", "mysql", null);
+
+    private final String dbKind;
+    private final String containerName;
+    private final String dockerImage;
+
+    DatabaseType(String dbKind, String containerName, String dockerImage) {
+      this.dbKind = dbKind;
+      this.containerName = containerName;
+      this.dockerImage = dockerImage;
+    }
+
+    public String getDbKind() {
+      return dbKind;
+    }
+
+    public String getContainerName() {
+      return containerName;
+    }
+
+    public String getDockerImage() {
+      return dockerImage;
+    }
+  }
+
+  private JdbcDatabaseContainer<?> container;
+  private String initScript;
+  private DevServicesContext context;
+  private DatabaseType databaseType;
+
+  @Override
+  public void init(Map<String, String> initArgs) {
+    initScript = initArgs.get(INIT_SCRIPT);
+    String dbTypeStr = initArgs.getOrDefault(DATABASE_TYPE, "POSTGRESQL");
+    databaseType = DatabaseType.valueOf(dbTypeStr.toUpperCase(Locale.ROOT));
+  }
+
+  @Override
+  @SuppressWarnings("resource")
+  public Map<String, String> start() {
+    container = createContainer(databaseType);
+
+    if (initScript != null) {
+      container.withInitScript(initScript);
+    }
+
+    context.containerNetworkId().ifPresent(container::withNetworkMode);
+    container.start();
+
+    return Map.of(
+        "polaris.persistence.type", "relational-jdbc",
+        "polaris.persistence.relational.jdbc.max-retries", "2",
+        "quarkus.datasource.db-kind", databaseType.getDbKind(),
+        "quarkus.datasource.jdbc.url", container.getJdbcUrl(),
+        "quarkus.datasource.username", container.getUsername(),
+        "quarkus.datasource.password", container.getPassword(),
+        "quarkus.datasource.jdbc.initial-size", "10");
+  }
+
+  private JdbcDatabaseContainer<?> createContainer(DatabaseType dbType) {
+    switch (dbType) {
+      case POSTGRESQL:
+        return new PostgreSQLContainer<>(
+                containerSpecHelper(
+                        dbType.getContainerName(), RelationalJdbcLifeCycleManagement.class)
+                    .dockerImageName(dbType.getDockerImage())
+                    .asCompatibleSubstituteFor(dbType.getContainerName()))
+            .withDatabaseName("polaris_db")
+            .withUsername("polaris")
+            .withPassword("polaris");
+
+      case MYSQL:
+        return new MySQLContainer<>(
+                containerSpecHelper(
+                        dbType.getContainerName(), RelationalJdbcLifeCycleManagement.class)
+                    .dockerImageName(dbType.getDockerImage())
+                    .asCompatibleSubstituteFor(dbType.getContainerName()))
+            .withDatabaseName("polaris_db")
+            .withUsername("polaris")
+            .withPassword("polaris");
+
+      default:
+        throw new IllegalArgumentException("Unsupported database type: " + dbType);
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (container != null) {
+      try {
+        container.stop();
+      } finally {
+        container = null;
+      }
+    }
+  }
+
+  @Override
+  public void setIntegrationTestContext(DevServicesContext context) {
+    this.context = context;
+  }
+}

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/RelationalJdbcProfile.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/RelationalJdbcProfile.java
@@ -23,15 +23,32 @@ import java.util.List;
 import java.util.Map;
 
 public class RelationalJdbcProfile implements QuarkusTestProfile {
+
   @Override
   public Map<String, String> getConfigOverrides() {
     return Map.of("polaris.persistence.auto-bootstrap-types", "relational-jdbc");
   }
 
-  @Override
-  public List<TestResourceEntry> testResources() {
-    return List.of(
-        new QuarkusTestProfile.TestResourceEntry(
-            PostgresRelationalJdbcLifeCycleManagement.class, Map.of()));
+  public static class PostgreSQLProfile extends RelationalJdbcProfile {
+    @Override
+    public List<TestResourceEntry> testResources() {
+      return List.of(new TestResourceEntry(RelationalJdbcLifeCycleManagement.class, Map.of()));
+    }
+  }
+
+  public static class MySQLProfile extends RelationalJdbcProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.persistence.auto-bootstrap-types", "relational-jdbc",
+          "polaris.persistence.type", "relational-jdbc",
+          "quarkus.datasource.active", "true",
+          "quarkus.datasource.db-kind", "mysql");
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+      return List.of(new TestResourceEntry(RelationalJdbcLifeCycleManagement.class, Map.of()));
+    }
   }
 }


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

As discussed in #2491 , there is currently no support for MySQL as a metastore. many organizations (mine included) rely on existing MySQL infrastructure and this PR adds MySQL support to the `relational-jdbc` module with tests. This PR mostly extends existing code for Postgres support, adding MySQL to `DatabaseType` enum, and changing existing methods to handle MySQL `DatabaseType` and adding MySQL JDBC driver to `persistence/relational-jdbc/build.gradle.kts` and `runtime/server/build.gradle.kts` 


