### PR TITLE
Fix `delegationModes` parameter propagation in `createTableStaged()`

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -553,7 +553,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     return buildLoadTableResponseWithDelegationCredentials(
             ident,
             metadata,
-            EnumSet.of(VENDED_CREDENTIALS),
+            delegationModes,
             Set.of(PolarisStorageActions.ALL),
             refreshCredentialsEndpoint)
         .build();


### PR DESCRIPTION
This is follow-up bugfix for #2589

The bugfix part of #2711 is extracted here since #2711 proved to be non-trivial and may require extra time.

* Use the `delegationModes` method parameter as intended (as opposed to a local constant).

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
