### PR TITLE
Fix RDS devservices config + adopt for `:polaris-admin:test`

### DIFF
--- a/runtime/admin/src/main/resources/application.properties
+++ b/runtime/admin/src/main/resources/application.properties
@@ -32,8 +32,11 @@ quarkus.container-image.group=apache
 quarkus.container-image.name=polaris-admin-tool
 quarkus.container-image.additional-tags=latest
 quarkus.datasource.db-kind=postgresql
-#https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-rds.html#_configuring_rds_clients
+# if set to true it will try to start localstack at build and run time for the local environment
+# https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-rds.html#_configuration_reference for more details
+quarkus.rds.devservices.enabled=false
 quarkus.rds.sync-client.type=apache
+
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.
 

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -125,13 +125,10 @@ polaris.persistence.type=in-memory
 # polaris.persistence.type=relational-jdbc
 
 polaris.secrets-manager.type=in-memory
-# disable localstack
 # if set to true it will try to start localstack at build and run time for the local environment
 # https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-rds.html#_configuration_reference for more details
-quarkus.devservices.enabled=false
+quarkus.rds.devservices.enabled=false
 quarkus.rds.sync-client.type=apache
-
-
 
 polaris.file-io.type=default
 


### PR DESCRIPTION
Changes:
* Disables devservices for `:polaris-admin` tests as well, which is necessary to _not_ spin up test containers.
* Use the explicit devservices-config as everywhere else.

The first bullet point can cause excessive memory usage, especially with more test classes, eventually killing the whole GH runner.
