### PR TITLE
Testing: add test-parallelism-constraint and unify testing constaints

### DIFF
--- a/plugins/spark/v3.5/integration/build.gradle.kts
+++ b/plugins/spark/v3.5/integration/build.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
 }
 
 tasks.named<Test>("intTest").configure {
-  maxParallelForks = 1
   if (System.getenv("AWS_REGION") == null) {
     environment("AWS_REGION", "us-west-2")
   }

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -86,16 +86,3 @@ val distributionElements by
 artifacts {
   add("distributionElements", layout.buildDirectory.dir("quarkus-app")) { builtBy("quarkusBuild") }
 }
-
-tasks.withType(Test::class.java).configureEach {
-  maxParallelForks = 4
-  forkEvery = 1
-}
-
-tasks.named<Test>("test").configure {
-  // enlarge the max heap size to avoid out of memory error
-  maxHeapSize = "4g"
-  // Silence the 'OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader
-  // classes because bootstrap classpath has been appended' warning from OpenJDK.
-  jvmArgs("-Xshare:off")
-}

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -187,7 +187,6 @@ dependencies {
 tasks.named("javadoc") { dependsOn("jandex") }
 
 tasks.withType(Test::class.java).configureEach {
-  forkEvery = 1
   if (System.getenv("AWS_REGION") == null) {
     environment("AWS_REGION", "us-west-2")
   }
@@ -198,15 +197,6 @@ tasks.withType(Test::class.java).configureEach {
   // Need to allow a java security manager after Java 21, for Subject.getSubject to work
   // "getSubject is supported only if a security manager is allowed".
   systemProperty("java.security.manager", "allow")
-}
-
-tasks.named<Test>("test").configure {
-  maxParallelForks = 4
-  // enlarge the max heap size to avoid out of memory error
-  maxHeapSize = "4g"
-  // Silence the 'OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader
-  // classes because bootstrap classpath has been appended' warning from OpenJDK.
-  jvmArgs("-Xshare:off")
 }
 
 listOf("intTest", "cloudTest")

--- a/runtime/spark-tests/build.gradle.kts
+++ b/runtime/spark-tests/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
 }
 
 tasks.named<Test>("intTest").configure {
-  maxParallelForks = 1
   if (System.getenv("AWS_REGION") == null) {
     environment("AWS_REGION", "us-west-2")
   }


### PR DESCRIPTION
This changes introduces a build-scoped limit on concurrently running `test` tasks and other test task like `intTest`. The defaults are:
* "num-available-processory / 4" for `Test` tasks except `test`, optionally configurable via the system property `polaris.intTestParallelism`
* "num-available-processory / 2" for `Test` tasks named `test`, optionally configurable via the system property `polaris.testParallelism`

This change also moves the common fork and heap related settings for Quarkus tests to the `polaris-runtime` build plugin.

Overall, this change helps constraining the CPU/heap pressure to any developer system.