### PR TITLE
Build: remove unnecessary explicit vertx-core dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,6 @@ swagger-jaxrs = { module = "io.swagger:swagger-jaxrs", version.ref = "swagger" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.21.3" }
 testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "3.8.0" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
-vertx-core = { module = "io.vertx:vertx-core", version = "5.0.4" }
 weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "6.0.3.Final" }
 weld-junit5 = { module = "org.jboss.weld:weld-junit5", version = "5.0.2.Final" }
 

--- a/persistence/nosql/async/vertx/build.gradle.kts
+++ b/persistence/nosql/async/vertx/build.gradle.kts
@@ -29,7 +29,9 @@ dependencies {
 
   implementation(libs.slf4j.api)
   implementation(libs.guava)
-  implementation(libs.vertx.core)
+
+  compileOnly(enforcedPlatform(libs.quarkus.bom))
+  compileOnly("io.vertx:vertx-core")
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
@@ -44,7 +46,8 @@ dependencies {
   testFixturesApi(libs.jakarta.inject.api)
   testFixturesApi(libs.jakarta.enterprise.cdi.api)
 
-  testFixturesApi(libs.vertx.core)
+  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi("io.vertx:vertx-core")
 
   testImplementation(testFixtures(project(":polaris-async-api")))
 }


### PR DESCRIPTION
The async-vertx implementation should not propagate a different Vert.X dependency than Quarkus provides. This wouldn't be an issue if we could just use `enforcedPlatform()` for all Quarkus-builds, but sadly we cannot for the spark-plugin-inttests.