### PR TITLE
Split CI jobs, improve overall CI duration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,6 +56,8 @@ github:
           - markdown-link-check
           - "Unit Tests"
           - "Quarkus Tests"
+          - "Quarkus Integration Tests"
+          - "Quarkus Admin Tests"
           - "Integration Tests"
           - regtest
           - spark-plugin-regtest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,8 @@ env:
 
 jobs:
 
+  # Durations (approximates from GH CI):
+  # (all):test 16m
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -77,6 +79,8 @@ jobs:
             **/build/test-results/**
             **/build/reports/tests/**
 
+  # Durations (approximates from GH CI):
+  # - :polaris-runtime-service:test 22m
   quarkus-tests:
     name: Quarkus Tests
     runs-on: ubuntu-latest
@@ -91,28 +95,99 @@ jobs:
           distribution: 'temurin'
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
-      - name: Run Quarkus tests
+      - name: Run Quarkus runtime tests
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
-          ./gradlew \
-            :polaris-runtime-service:test \
-            :polaris-admin:test \
-            --continue
+          ./gradlew :polaris-runtime-service:test --continue
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
-          job-name: 'quarkus-tests'
+          job-name: 'quarkus-runtime-tests'
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: upload-quarkus-test-artifacts
+          name: upload-quarkus-runtime-test-artifacts
           path: |
             **/build/test-results/**
             **/build/reports/tests/**
 
+  # Durations (approximates from GH CI):
+  # - :polaris-runtime-service:intTest 15m
+  quarkus-int-tests:
+    name: Quarkus Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+      - name: Run Quarkus runtime tests
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+        run: |
+          ./gradlew :polaris-runtime-service:intTest --continue
+      - name: Save partial Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          job-name: 'quarkus-runtime-inttests'
+      - name: Archive test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: upload-quarkus-runtime-inttest-artifacts
+          path: |
+            **/build/test-results/**
+            **/build/reports/tests/**
+
+  # Durations (approximates from GH CI):
+  # - :polaris-admin:test 6m
+  quarkus-admin-tests:
+    name: Quarkus Admin Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+      - name: Run Quarkus admin tests
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+        run: |
+          ./gradlew :polaris-admin:test --continue
+      - name: Save partial Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          job-name: 'quarkus-admin-tests'
+      - name: Archive test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: upload-quarkus-admin-test-artifacts
+          path: |
+            **/build/test-results/**
+            **/build/reports/tests/**
+
+  # Durations (approximates from GH CI):
+  # - :polaris-spark-integration-*:intTest 6m (2x)
+  # - :polaris-runtime-spark-tests:intTest 4m
+  # - :polaris-persistence-nosql-mongodb:intTest 1m
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -128,7 +203,11 @@ jobs:
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Run integration tests
-        run: ./gradlew intTest --continue
+        run: |
+          ./gradlew \
+            intTest \
+            -x :polaris-runtime-service:intTest \
+            --continue
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Save partial Gradle build cache


### PR DESCRIPTION
* `Quarkus Integration Tests` removes 15 minutes from `Integration Tests` (leaving 16 minutes total test task runtime)
* `Quarkus Admin Tests` removes 6 minutes from `Quarkus Tests` (leaving 20 minutes total test task runtime)

Intentionally not changing the name of `Quarkus Tests` as it's a required check, changing it would render this change in unmergeable.

Note that the time refer to the test _task_ runtimes. Test task execution overlaps with other tasks.