### PR TITLE
Add properties from TableMetadata into Table entity internalProperties

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntity.java
@@ -411,7 +411,7 @@ public class PolarisEntity extends PolarisBaseEntity {
       return (B) this;
     }
 
-    public B setInternalProperties(Map<String, String> internalProperties) {
+    public B setInternalProperties(@Nonnull Map<String, String> internalProperties) {
       this.internalProperties = new HashMap<>(internalProperties);
       return (B) this;
     }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/EntityWeigherTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/EntityWeigherTest.java
@@ -124,7 +124,7 @@ public class EntityWeigherTest {
                     "location",
                     "{\"a\": \"b\"}",
                     Optional.of("{\"c\": \"d\", \"e\": \"f\"}")));
-    Assertions.assertThat(preciseWeight).isEqualTo(1090);
+    Assertions.assertThat(preciseWeight).isEqualTo(1255); // :( this is hard-coded
   }
 
   private static Map<String, String> getPropertiesMap(String properties) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1566,6 +1566,32 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               "Generic table with same name already exists: %s", tableIdentifier);
         }
       }
+      Map<String, String> storedProperties = new HashMap<>();
+      storedProperties.put("location", metadata.location());
+      storedProperties.put("format-version", String.valueOf(metadata.formatVersion()));
+      storedProperties.put("table-uuid", metadata.uuid());
+      storedProperties.put("current-schema-id", String.valueOf(metadata.currentSchemaId()));
+      if (metadata.currentSnapshot() != null) {
+        storedProperties.put(
+            "current-snapshot-id", String.valueOf(metadata.currentSnapshot().snapshotId()));
+      }
+      storedProperties.put("last-column-id", String.valueOf(metadata.lastColumnId()));
+      storedProperties.put("next-row-id", String.valueOf(metadata.nextRowId()));
+      storedProperties.put("last-sequence-number", String.valueOf(metadata.lastSequenceNumber()));
+      storedProperties.put("last-updated-ms", String.valueOf(metadata.lastUpdatedMillis()));
+      if (metadata.sortOrder() != null) {
+        storedProperties.put(
+            "default-sort-order-id", String.valueOf(metadata.defaultSortOrderId()));
+      }
+      if (metadata.spec() != null) {
+        storedProperties.put("default-spec-id", String.valueOf(metadata.defaultSpecId()));
+        storedProperties.put(
+            "last-partition-id", String.valueOf(metadata.lastAssignedPartitionId()));
+      }
+      if (metadata.currentSnapshot() != null) {
+        storedProperties.put(
+            "current-snapshot-id", String.valueOf(metadata.currentSnapshot().snapshotId()));
+      }
       IcebergTableLikeEntity entity =
           IcebergTableLikeEntity.of(resolvedPath == null ? null : resolvedPath.getRawLeafEntity());
       String existingLocation;
@@ -1573,7 +1599,11 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         existingLocation = null;
         entity =
             new IcebergTableLikeEntity.Builder(
-                    PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier, newLocation)
+                    PolarisEntitySubType.ICEBERG_TABLE,
+                    tableIdentifier,
+                    Map.of(),
+                    storedProperties,
+                    newLocation)
                 .setCatalogId(getCatalogId())
                 .setBaseLocation(metadata.location())
                 .setId(
@@ -1583,6 +1613,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         existingLocation = entity.getMetadataLocation();
         entity =
             new IcebergTableLikeEntity.Builder(entity)
+                .setInternalProperties(storedProperties)
                 .setBaseLocation(metadata.location())
                 .setMetadataLocation(newLocation)
                 .build();


### PR DESCRIPTION
It's helpful to be able to look at the Table entities in persistence and immediately know the state of the current snapshot, current schema, partition scheme, etc. without having to load the whole TableMetadata. This copies some of the primitive properties from the TableMetadata structure sticks them into the Table PolarisEntity as internalProperties. 

Currently, there are no other properties being stored except the metadata file location, the parent namespace, and the last notification timestamp. Currently, as is, we'll drop any other properties that are added to the internalProperties map. I went this approach to avoid the properties map always being additive, but happy to hear if folks think we should defer to always copying the previous map, then overwriting properties. 

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
