### PR TITLE
CI: Split-jobs - fix store-cache dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -238,6 +238,8 @@ jobs:
     needs:
       - unit-tests
       - quarkus-tests
+      - quarkus-admin-tests
+      - quarkus-int-tests
       - integration-tests
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
follow-up of #2733
