### PR TITLE
Fix: Build task syncNoticeAndLicense fails on Windows

### DIFF
--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -32,9 +32,9 @@ description =
 val syncNoticeAndLicense by
   tasks.registering(Sync::class) {
     // Have to manually declare the inputs of this task here on top of the from/include below
-    inputs.files(rootProject.fileTree(rootProject.rootDir) {
-      include("NOTICE*", "LICENSE*", "version.txt")
-    })
+    inputs.files(
+      rootProject.fileTree(rootProject.rootDir) { include("NOTICE*", "LICENSE*", "version.txt") }
+    )
     inputs.property("version", project.version)
     destinationDir = project.layout.buildDirectory.dir("notice-licenses").get().asFile
     from(rootProject.rootDir) {

--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -32,7 +32,9 @@ description =
 val syncNoticeAndLicense by
   tasks.registering(Sync::class) {
     // Have to manually declare the inputs of this task here on top of the from/include below
-    inputs.files(rootProject.layout.files("NOTICE*", "LICENSE*", "version.txt"))
+    inputs.files(rootProject.fileTree(rootProject.rootDir) {
+      include("NOTICE*", "LICENSE*", "version.txt")
+    })
     inputs.property("version", project.version)
     destinationDir = project.layout.buildDirectory.dir("notice-licenses").get().asFile
     from(rootProject.rootDir) {


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

Glob patterns were not resolved by Windows shell that expects a filename, used fileTree instead

Fixes #2525