### PR TITLE
Increase javadoc visibility in `:polaris-async-vertx`

### DIFF
--- a/persistence/nosql/async/vertx/build.gradle.kts
+++ b/persistence/nosql/async/vertx/build.gradle.kts
@@ -52,4 +52,7 @@ dependencies {
   testImplementation(testFixtures(project(":polaris-async-api")))
 }
 
-tasks.withType<Javadoc> { isFailOnError = false }
+tasks.withType<Javadoc> {
+  isFailOnError = false
+  options.memberLevel = JavadocMemberLevel.PACKAGE
+}


### PR DESCRIPTION
This is to fix javadoc error: `No public or protected classes found to document`