### PR TITLE
JDBC: Fix Bootstrap with schema options

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
+import java.util.Objects;
 import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 
 public enum DatabaseType {
@@ -53,9 +54,10 @@ public enum DatabaseType {
    * caller.
    */
   public InputStream openInitScriptResource(@Nonnull SchemaOptions schemaOptions) {
-    if (schemaOptions.schemaFile() != null) {
+    if (schemaOptions.schemaFile() != null
+        && !Objects.requireNonNull(schemaOptions.schemaFile()).isEmpty()) {
       try {
-        return new FileInputStream(schemaOptions.schemaFile());
+        return new FileInputStream(Objects.requireNonNull(schemaOptions.schemaFile()));
       } catch (IOException e) {
         throw new IllegalArgumentException("Unable to load file " + schemaOptions.schemaFile(), e);
       }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -18,13 +18,8 @@
  */
 package org.apache.polaris.persistence.relational.jdbc;
 
-import jakarta.annotation.Nonnull;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
-import java.util.Objects;
-import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 
 public enum DatabaseType {
   POSTGRES("postgres"),
@@ -53,27 +48,15 @@ public enum DatabaseType {
    * Open an InputStream that contains data from an init script. This stream should be closed by the
    * caller.
    */
-  public InputStream openInitScriptResource(@Nonnull SchemaOptions schemaOptions) {
-    if (schemaOptions.schemaFile() != null
-        && !Objects.requireNonNull(schemaOptions.schemaFile()).isEmpty()) {
-      try {
-        return new FileInputStream(Objects.requireNonNull(schemaOptions.schemaFile()));
-      } catch (IOException e) {
-        throw new IllegalArgumentException("Unable to load file " + schemaOptions.schemaFile(), e);
-      }
-    } else {
-      final String schemaSuffix;
-      switch (schemaOptions.schemaVersion()) {
-        case null -> schemaSuffix = "schema-v3.sql";
-        case 1 -> schemaSuffix = "schema-v1.sql";
-        case 2 -> schemaSuffix = "schema-v2.sql";
-        case 3 -> schemaSuffix = "schema-v3.sql";
-        default ->
-            throw new IllegalArgumentException(
-                "Unknown schema version " + schemaOptions.schemaVersion());
-      }
-      ClassLoader classLoader = DatasourceOperations.class.getClassLoader();
-      return classLoader.getResourceAsStream(this.getDisplayName() + "/" + schemaSuffix);
+  public InputStream openInitScriptResource(int schemaVersion) {
+    final String schemaSuffix;
+    switch (schemaVersion) {
+      case 1 -> schemaSuffix = "schema-v1.sql";
+      case 2 -> schemaSuffix = "schema-v2.sql";
+      case 3 -> schemaSuffix = "schema-v3.sql";
+      default -> throw new IllegalArgumentException("Unknown schema version " + schemaVersion);
     }
+    ClassLoader classLoader = DatasourceOperations.class.getClassLoader();
+    return classLoader.getResourceAsStream(this.getDisplayName() + "/" + schemaSuffix);
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -49,14 +49,15 @@ public enum DatabaseType {
    * caller.
    */
   public InputStream openInitScriptResource(int schemaVersion) {
-    final String schemaSuffix;
-    switch (schemaVersion) {
-      case 1 -> schemaSuffix = "schema-v1.sql";
-      case 2 -> schemaSuffix = "schema-v2.sql";
-      case 3 -> schemaSuffix = "schema-v3.sql";
-      default -> throw new IllegalArgumentException("Unknown schema version " + schemaVersion);
+    // Preconditions check is simpler and more direct than a switch default
+    if (schemaVersion <= 0 || schemaVersion > 3) {
+      throw new IllegalArgumentException("Unknown or invalid schema version " + schemaVersion);
     }
+
+    final String resourceName =
+        String.format("%s/schema-v%d.sql", this.getDisplayName(), schemaVersion);
+
     ClassLoader classLoader = DatasourceOperations.class.getClassLoader();
-    return classLoader.getResourceAsStream(this.getDisplayName() + "/" + schemaSuffix);
+    return classLoader.getResourceAsStream(resourceName);
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -400,8 +400,9 @@ public class DatasourceOperations {
   }
 
   public boolean isRelationDoesNotExist(SQLException e) {
-    return RELATION_DOES_NOT_EXIST.equals(e.getSQLState())
-        || H2_RELATION_DOES_NOT_EXIST.equals(e.getSQLState());
+    return (RELATION_DOES_NOT_EXIST.equals(e.getSQLState())
+            && databaseType == DatabaseType.POSTGRES)
+        || (H2_RELATION_DOES_NOT_EXIST.equals(e.getSQLState()) && databaseType == DatabaseType.H2);
   }
 
   private Connection borrowConnection() throws SQLException {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -52,8 +52,12 @@ public class DatasourceOperations {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatasourceOperations.class);
 
+  // PG STATUS CODES
   private static final String CONSTRAINT_VIOLATION_SQL_CODE = "23505";
   private static final String RELATION_DOES_NOT_EXIST = "42P01";
+
+  // H2 STATUS CODES
+  private static final String H2_RELATION_DOES_NOT_EXIST = "90079";
 
   // POSTGRES RETRYABLE EXCEPTIONS
   private static final String SERIALIZATION_FAILURE_SQL_CODE = "40001";
@@ -396,7 +400,8 @@ public class DatasourceOperations {
   }
 
   public boolean isRelationDoesNotExist(SQLException e) {
-    return RELATION_DOES_NOT_EXIST.equals(e.getSQLState());
+    return RELATION_DOES_NOT_EXIST.equals(e.getSQLState())
+        || H2_RELATION_DOES_NOT_EXIST.equals(e.getSQLState());
   }
 
   private Connection borrowConnection() throws SQLException {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -748,10 +748,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       }
       return schemaVersion.getFirst().getValue();
     } catch (SQLException e) {
-      LOGGER.error("Failed to load schema version due to {}", e.getMessage(), e);
       if (fallbackOnDoesNotExist && datasourceOperations.isRelationDoesNotExist(e)) {
         return SchemaVersion.MINIMUM.getValue();
       }
+      LOGGER.error("Failed to load schema version due to {}", e.getMessage(), e);
       throw new IllegalStateException("Failed to retrieve schema version", e);
     }
   }
@@ -761,10 +761,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       List<PolarisBaseEntity> entities =
           datasourceOperations.executeSelect(query, new ModelEntity());
-      if (entities == null || entities.isEmpty()) {
-        throw new IllegalStateException("Failed to check if Entities table exist");
-      }
-      return true;
+      return entities != null && !entities.isEmpty();
     } catch (SQLException e) {
       if (datasourceOperations.isRelationDoesNotExist(e)) {
         return false;

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -756,6 +756,23 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
+  static boolean entityTableExists(DatasourceOperations datasourceOperations) {
+    PreparedQuery query = QueryGenerator.generateEntityTableExistQuery();
+    try {
+      List<PolarisBaseEntity> entities =
+          datasourceOperations.executeSelect(query, new ModelEntity());
+      if (entities == null || entities.isEmpty()) {
+        throw new IllegalStateException("Failed to check if Entities table exist");
+      }
+      return true;
+    } catch (SQLException e) {
+      if (datasourceOperations.isRelationDoesNotExist(e)) {
+        return false;
+      }
+      throw new IllegalStateException("Failed to check if Entities table exists", e);
+    }
+  }
+
   /** {@inheritDoc} */
   @Override
   public <T extends PolarisEntity & LocationBasedEntity>

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtils.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtils.java
@@ -20,15 +20,10 @@
 package org.apache.polaris.persistence.relational.jdbc;
 
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.polaris.core.persistence.bootstrap.BootstrapOptions;
 import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 
 public class JdbcBootstrapUtils {
-
-  // Define a pattern to find 'v' followed by one or more digits (\d+)
-  private static final Pattern pattern = Pattern.compile("(v\\d+)");
 
   private JdbcBootstrapUtils() {}
 
@@ -89,14 +84,6 @@ public class JdbcBootstrapUtils {
       Optional<Integer> version = schemaOptions.schemaVersion();
       if (version.isPresent()) {
         return version.get();
-      }
-      Optional<String> schemaFile = schemaOptions.schemaFile();
-      if (schemaFile.isPresent()) {
-        Matcher matcher = pattern.matcher(schemaFile.get());
-        if (matcher.find()) {
-          String versionStr = matcher.group(1); // "v3"
-          return Integer.parseInt(versionStr.substring(1)); // 3
-        }
       }
     }
     return -1;

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtils.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.relational.jdbc;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.polaris.core.persistence.bootstrap.BootstrapOptions;
+import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
+
+public class JdbcBootstrapUtils {
+
+  // Define a pattern to find 'v' followed by one or more digits (\d+)
+  private static final Pattern pattern = Pattern.compile("(v\\d+)");
+
+  private JdbcBootstrapUtils() {}
+
+  /**
+   * Determines the correct schema version to use for bootstrapping a realm.
+   *
+   * @param currentSchemaVersion The current version of the database schema.
+   * @param requiredSchemaVersion The requested schema version (-1 for auto-detection).
+   * @param hasAlreadyBootstrappedRealms Flag indicating if any realms already exist.
+   * @return The calculated bootstrap schema version.
+   * @throws IllegalStateException if the combination of parameters represents an invalid state.
+   */
+  public static int getRealmBootstrapSchemaVersion(
+      int currentSchemaVersion, int requiredSchemaVersion, boolean hasAlreadyBootstrappedRealms) {
+
+    // If versions already match, no change is needed.
+    if (currentSchemaVersion == requiredSchemaVersion) {
+      return requiredSchemaVersion;
+    }
+
+    // Handle fresh installations where no schema version is recorded (version 0).
+    if (currentSchemaVersion == 0) {
+      if (hasAlreadyBootstrappedRealms) {
+        // System was bootstrapped with v1 before schema versioning was introduced.
+        if (requiredSchemaVersion == -1 || requiredSchemaVersion == 1) {
+          return 1;
+        }
+      } else {
+        // A truly fresh start. Default to v3 for auto-detection, otherwise use the specified
+        // version.
+        return requiredSchemaVersion == -1 ? 3 : requiredSchemaVersion;
+      }
+    }
+
+    // Handle auto-detection on an existing installation (current version > 0).
+    if (requiredSchemaVersion == -1) {
+      // Use the current version if realms already exist; otherwise, use v3 for the new realm.
+      return hasAlreadyBootstrappedRealms ? currentSchemaVersion : 3;
+    }
+
+    // Any other combination is an unhandled or invalid migration path.
+    throw new IllegalStateException(
+        String.format(
+            "Cannot determine bootstrap schema version. Current: %d, Required: %d, Bootstrapped: %b",
+            currentSchemaVersion, requiredSchemaVersion, hasAlreadyBootstrappedRealms));
+  }
+
+  /**
+   * Extracts the requested schema version from the provided BootstrapOptions.
+   *
+   * @param bootstrapOptions: The bootstrap options containing schema information from which to
+   *     extract the version.
+   * @return The requested schema version, or -1 if not specified.
+   */
+  public static int getRequestedSchemaVersion(BootstrapOptions bootstrapOptions) {
+    SchemaOptions schemaOptions = bootstrapOptions.schemaOptions();
+    if (schemaOptions != null) {
+      Optional<Integer> version = schemaOptions.schemaVersion();
+      if (version.isPresent()) {
+        return version.get();
+      }
+      Optional<String> schemaFile = schemaOptions.schemaFile();
+      if (schemaFile.isPresent()) {
+        Matcher matcher = pattern.matcher(schemaFile.get());
+        if (matcher.find()) {
+          String versionStr = matcher.group(1); // "v3"
+          return Integer.parseInt(versionStr.substring(1)); // 3
+        }
+      }
+    }
+    return -1;
+  }
+}

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.persistence.relational.jdbc;
 
-import com.google.common.base.Preconditions;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,8 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -72,8 +69,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   final Map<String, PolarisMetaStoreManager> metaStoreManagerMap = new HashMap<>();
   final Map<String, EntityCache> entityCacheMap = new HashMap<>();
   final Map<String, Supplier<BasePersistence>> sessionSupplierMap = new HashMap<>();
-  // Define a pattern to find 'v' followed by one or more digits (\d+)
-  final Pattern pattern = Pattern.compile("(v\\d+)");
 
   @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
@@ -159,25 +154,23 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       RealmContext realmContext = () -> realm;
       if (!metaStoreManagerMap.containsKey(realm)) {
         DatasourceOperations datasourceOperations = getDatasourceOperations();
-        int schemaVersion =
+        int currentSchemaVersion =
             JdbcBasePersistenceImpl.loadSchemaVersion(
                 datasourceOperations,
                 configurationStore.getConfiguration(
                     realmContext, BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE));
-        // skip validation if no schema is specified.
-        int requestedSchemaVersion = getSchemaVersion(bootstrapOptions);
-        Preconditions.checkState(
-            (requestedSchemaVersion == schemaVersion)
-                || (schemaVersion == 0 || requestedSchemaVersion == -1),
-            "Cannot bootstrap due to schema version mismatch. Current: %s, Requested: %s",
-            schemaVersion, // "Current" version
-            requestedSchemaVersion);
+        int requestedSchemaVersion = JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
+        int effectiveSchemaVersion =
+            JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
+                currentSchemaVersion,
+                requestedSchemaVersion,
+                JdbcBasePersistenceImpl.entityTableExists(datasourceOperations));
         try {
           // Run the set-up script to create the tables.
           datasourceOperations.executeScript(
               datasourceOperations
                   .getDatabaseType()
-                  .openInitScriptResource(bootstrapOptions.schemaOptions()));
+                  .openInitScriptResource(effectiveSchemaVersion));
         } catch (SQLException e) {
           throw new RuntimeException(
               String.format("Error executing sql script: %s", e.getMessage()), e);
@@ -298,24 +291,5 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       throw new IllegalStateException(
           "Realm is not bootstrapped, please run server in bootstrap mode.");
     }
-  }
-
-  private int getSchemaVersion(BootstrapOptions bootstrapOptions) {
-    SchemaOptions schemaOptions = bootstrapOptions.schemaOptions();
-    if (schemaOptions != null) {
-      Integer version = schemaOptions.schemaVersion();
-      if (version != null) {
-        return version;
-      }
-      String schemaFile = schemaOptions.schemaFile();
-      if (schemaFile != null) {
-        Matcher matcher = pattern.matcher(schemaFile);
-        if (matcher.find()) {
-          String versionStr = matcher.group(1); // "v3"
-          return Integer.parseInt(versionStr.substring(1)); // 3
-        }
-      }
-    }
-    return -1;
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -164,9 +164,11 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
                 datasourceOperations,
                 configurationStore.getConfiguration(
                     realmContext, BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE));
+        // skip validation if no schema is specified.
         int requestedSchemaVersion = getSchemaVersion(bootstrapOptions);
         Preconditions.checkState(
-            (requestedSchemaVersion == schemaVersion) || (schemaVersion == 0),
+            (requestedSchemaVersion == schemaVersion)
+                || (schemaVersion == 0 || requestedSchemaVersion == -1),
             "Cannot bootstrap due to schema version mismatch. Current: %s, Requested: %s",
             schemaVersion, // "Current" version
             requestedSchemaVersion);
@@ -314,6 +316,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         }
       }
     }
-    return 0;
+    return -1;
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -165,6 +165,10 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
                 currentSchemaVersion,
                 requestedSchemaVersion,
                 JdbcBasePersistenceImpl.entityTableExists(datasourceOperations));
+        LOGGER.info(
+            "Effective schema version: {} for bootstrapping realm: {}",
+            effectiveSchemaVersion,
+            realm);
         try {
           // Run the set-up script to create the tables.
           datasourceOperations.executeScript(

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -256,6 +256,14 @@ public class QueryGenerator {
     return new PreparedQuery("SELECT version_value FROM POLARIS_SCHEMA.VERSION", List.of());
   }
 
+  @VisibleForTesting
+  static PreparedQuery generateEntityTableExistQuery() {
+    return new PreparedQuery(
+        String.format(
+            "SELECT * FROM %s LIMIT 1", getFullyQualifiedTableName(ModelEntity.TABLE_NAME)),
+        List.of());
+  }
+
   /**
    * Generate a SELECT query to find any entities that have a given realm &amp; parent and that may
    * overlap with a given location. The check is performed without consideration for the scheme, so

--- a/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
+++ b/persistence/relational-jdbc/src/main/resources/h2/schema-v3.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS version (
 
 MERGE INTO version (version_key, version_value)
     KEY (version_key)
-    VALUES ('version', 2);
+    VALUES ('version', 3);
 
 -- H2 supports COMMENT, but some modes may ignore it
 COMMENT ON TABLE version IS 'the version of the JDBC schema in use';

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtilsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtilsTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.relational.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.polaris.core.persistence.bootstrap.BootstrapOptions;
+import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+class JdbcBootstrapUtilsTest {
+
+  @Test
+  void getVersion_whenVersionsMatch() {
+    // Arrange
+    int version = 2;
+
+    // Act & Assert
+    assertEquals(
+        version, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(version, version, true));
+    assertEquals(
+        version, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(version, version, false));
+  }
+
+  @Test
+  void getVersion_whenFreshDbAndNoRealms() {
+    // Arrange
+    int currentVersion = 0;
+    boolean hasRealms = false;
+
+    // Act & Assert
+    assertEquals(
+        3, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, -1, hasRealms));
+    assertEquals(
+        2, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, 2, hasRealms));
+    assertEquals(
+        3, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, 3, hasRealms));
+  }
+
+  @Test
+  void getVersion_whenFreshDbAndRealmsExist() {
+    // Arrange
+    int currentVersion = 0;
+    boolean hasRealms = true;
+
+    // Act & Assert
+    assertEquals(
+        1, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, -1, hasRealms));
+    assertEquals(
+        1, JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, 1, hasRealms));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"2, true, 2", "3, true, 3", "2, false, 3", "3, false, 3"})
+  void getVersion_whenExistingDbAndAutoDetect(
+      int currentVersion, boolean hasRealms, int expectedVersion) {
+    // Act & Assert
+    assertEquals(
+        expectedVersion,
+        JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(currentVersion, -1, hasRealms));
+  }
+
+  @Test
+  void throwException_whenFreshDbWithRealmsAndInvalidRequiredVersion() {
+    // Arrange
+    int currentVersion = 0;
+    boolean hasRealms = true;
+    int invalidRequiredVersion = 2;
+
+    // Act & Assert
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
+                currentVersion, invalidRequiredVersion, hasRealms));
+  }
+
+  @Test
+  void throwException_whenExistingDbAndInvalidMigrationPath() {
+    // Arrange
+    int currentVersion = 2;
+    int requiredVersion = 3;
+
+    // Act & Assert
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
+                currentVersion, requiredVersion, true));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
+                currentVersion, requiredVersion, false));
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  class GetRequestedSchemaVersionTests {
+
+    @Mock private BootstrapOptions mockBootstrapOptions;
+    @Mock private SchemaOptions mockSchemaOptions;
+
+    @BeforeEach
+    void setUp() {
+      when(mockBootstrapOptions.schemaOptions()).thenReturn(mockSchemaOptions);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"'path/v3.sql', 3", "'v2.sql', 2", "'v12.sql', 12"})
+    void whenVersionIsInFileName_shouldParseAndReturnIt(String fileName, int expectedVersion) {
+      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
+      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.of(fileName));
+
+      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
+      assertEquals(expectedVersion, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"schema.sql", "version_one.sql", "schema-vx.sql"})
+    void whenFileNameHasNoValidVersion_shouldReturnDefault(String invalidFileName) {
+      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
+      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.of(invalidFileName));
+
+      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
+      assertEquals(-1, result);
+    }
+
+    @Test
+    void whenSchemaOptionsIsNull_shouldReturnDefault() {
+      when(mockBootstrapOptions.schemaOptions()).thenReturn(null);
+      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
+      assertEquals(-1, result);
+    }
+
+    @Test
+    void whenAllOptionsAreEmpty_shouldReturnDefault() {
+      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
+      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.empty());
+      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
+      assertEquals(-1, result);
+    }
+  }
+}

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtilsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBootstrapUtilsTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -136,36 +135,17 @@ class JdbcBootstrapUtilsTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"'path/v3.sql', 3", "'v2.sql', 2", "'v12.sql', 12"})
-    void whenVersionIsInFileName_shouldParseAndReturnIt(String fileName, int expectedVersion) {
-      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
-      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.of(fileName));
+    @CsvSource({"3", "2", "12"})
+    void whenVersionIsInFileName_shouldParseAndReturnIt(int expectedVersion) {
+      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.of(expectedVersion));
 
       int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
       assertEquals(expectedVersion, result);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"schema.sql", "version_one.sql", "schema-vx.sql"})
-    void whenFileNameHasNoValidVersion_shouldReturnDefault(String invalidFileName) {
-      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
-      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.of(invalidFileName));
-
-      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
-      assertEquals(-1, result);
-    }
-
     @Test
     void whenSchemaOptionsIsNull_shouldReturnDefault() {
       when(mockBootstrapOptions.schemaOptions()).thenReturn(null);
-      int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
-      assertEquals(-1, result);
-    }
-
-    @Test
-    void whenAllOptionsAreEmpty_shouldReturnDefault() {
-      when(mockSchemaOptions.schemaVersion()).thenReturn(Optional.empty());
-      when(mockSchemaOptions.schemaFile()).thenReturn(Optional.empty());
       int result = JdbcBootstrapUtils.getRequestedSchemaVersion(mockBootstrapOptions);
       assertEquals(-1, result);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -19,23 +19,19 @@
 
 package org.apache.polaris.core.persistence.bootstrap;
 
-import jakarta.annotation.Nullable;
-import java.util.Objects;
+import java.util.Optional;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
 
 @PolarisImmutable
 public interface SchemaOptions {
-  @Nullable
-  Integer schemaVersion();
+  Optional<Integer> schemaVersion();
 
-  @Nullable
-  String schemaFile();
+  Optional<String> schemaFile();
 
   @Value.Check
   default void validate() {
-    if (schemaVersion() != null
-        && (schemaFile() != null && !Objects.requireNonNull(schemaFile()).isEmpty())) {
+    if (schemaVersion().isPresent() && schemaFile().isPresent()) {
       throw new IllegalStateException("Only one of schemaVersion or schemaFile can be set.");
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -20,6 +20,7 @@
 package org.apache.polaris.core.persistence.bootstrap;
 
 import jakarta.annotation.Nullable;
+import java.util.Objects;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
 
@@ -33,7 +34,8 @@ public interface SchemaOptions {
 
   @Value.Check
   default void validate() {
-    if (schemaVersion() != null && schemaFile() != null) {
+    if (schemaVersion() != null
+        && (schemaFile() != null && !Objects.requireNonNull(schemaFile()).isEmpty())) {
       throw new IllegalStateException("Only one of schemaVersion or schemaFile can be set.");
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/SchemaOptions.java
@@ -21,18 +21,8 @@ package org.apache.polaris.core.persistence.bootstrap;
 
 import java.util.Optional;
 import org.apache.polaris.immutables.PolarisImmutable;
-import org.immutables.value.Value;
 
 @PolarisImmutable
 public interface SchemaOptions {
   Optional<Integer> schemaVersion();
-
-  Optional<String> schemaFile();
-
-  @Value.Check
-  default void validate() {
-    if (schemaVersion().isPresent() && schemaFile().isPresent()) {
-      throw new IllegalStateException("Only one of schemaVersion or schemaFile can be set.");
-    }
-  }
 }

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -93,14 +93,6 @@ public class BootstrapCommand extends BaseCommand {
           paramLabel = "<schema version>",
           description = "The version of the schema to load in [1, 2, 3, LATEST].")
       Integer schemaVersion;
-
-      @CommandLine.Option(
-          names = {"--schema-file"},
-          paramLabel = "<schema file>",
-          description =
-              "A schema file to bootstrap from. If unset, the bundled files will be used.",
-          defaultValue = "")
-      String schemaFile;
     }
   }
 
@@ -142,10 +134,6 @@ public class BootstrapCommand extends BaseCommand {
 
         if (inputOptions.schemaInputOptions.schemaVersion != null) {
           builder.schemaVersion(inputOptions.schemaInputOptions.schemaVersion);
-        }
-
-        if (!inputOptions.schemaInputOptions.schemaFile.isEmpty()) {
-          builder.schemaFile(inputOptions.schemaInputOptions.schemaFile);
         }
 
         schemaOptions = builder.build();

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -83,7 +83,6 @@ public class BootstrapCommand extends BaseCommand {
       @CommandLine.Option(
           names = {"-f", "--credentials-file"},
           paramLabel = "<file>",
-          required = true,
           description = "A file containing root principal credentials to bootstrap.")
       Path file;
     }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
@@ -91,9 +91,7 @@ public abstract class BootstrapCommandTestBase {
   public void testBootstrapInvalidArguments(LaunchResult result) {
     assertThat(result.getErrorOutput())
         .contains(
-            "(-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]) and -f=<file> "
-                + "and (-v=<schema version> | [--schema-file=<schema file>]) are mutually exclusive "
-                + "(specify only one)");
+            "Error: [-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]] and [[-f=<file>]] are mutually exclusive (specify only one)");
   }
 
   @Test

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
@@ -18,8 +18,30 @@
  */
 package org.apache.polaris.admintool.relational.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
 import org.apache.polaris.admintool.BootstrapCommandTestBase;
+import org.junit.jupiter.api.Test;
 
 @TestProfile(RelationalJdbcAdminProfile.class)
-public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase {}
+public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase {
+
+  @Test
+  public void testBootstrapFailsWhenAddingRealmWithDifferentSchemaVersion(
+      QuarkusMainLauncher launcher) {
+    // First, bootstrap the schema to version 1
+    LaunchResult result1 =
+        launcher.launch("bootstrap", "-v", "1", "-r", "realm1", "-c", "realm1,root,s3cr3t");
+    assertThat(result1.exitCode()).isEqualTo(0);
+    assertThat(result1.getOutput()).contains("Bootstrap completed successfully.");
+
+    // TODO: enable this once we enable postgres container reuse in the same test.
+    // LaunchResult result2 = launcher.launch("bootstrap", "-v", "2", "-r", "realm2", "-c",
+    // "realm2,root,s3cr3t");
+    // assertThat(result2.exitCode()).isEqualTo(EXIT_CODE_BOOTSTRAP_ERROR);
+    // assertThat(result2.getOutput()).contains("Cannot bootstrap due to schema version mismatch.");
+  }
+}


### PR DESCRIPTION
### About the change 

1. Fix bootstrapping with schema option, presently its considered mutually exclusive so if give -v option with -r its fails saying they are exlusive, on not giving -r it say no relams configured 
2. schemaFile checks for empty string as not specifying the option means bootstrap can't use with -v either 
3. Adds a check that if the schema table exists then we can't downgrade as the schema is the global value and specially since realm is the part of schema such thing is not possible 


### TODO

while testing i found each QuarkusMainlauncher is launching new PG container, thinking of fix still to reuse it to test already bootstrapped schema.


Note: I don't think its a 1.2 blocker since we can't use this, but would love to know other community member takes.