### PR TITLE
Add Arguments to Various Event Records

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
@@ -275,7 +275,8 @@ public class IcebergRestCatalogEventServiceDelegator
             realmContext,
             securityContext);
     polarisEventListener.onAfterLoadTable(
-        new AfterLoadTableEvent(catalogName, namespaceObj, (LoadTableResponse) resp.getEntity()));
+        new AfterLoadTableEvent(
+            catalogName, namespaceObj, table, (LoadTableResponse) resp.getEntity()));
     return resp;
   }
 
@@ -331,7 +332,10 @@ public class IcebergRestCatalogEventServiceDelegator
             prefix, namespace, registerTableRequest, realmContext, securityContext);
     polarisEventListener.onAfterRegisterTable(
         new AfterRegisterTableEvent(
-            catalogName, namespaceObj, (LoadTableResponse) resp.getEntity()));
+            catalogName,
+            namespaceObj,
+            registerTableRequest.name(),
+            (LoadTableResponse) resp.getEntity()));
     return resp;
   }
 
@@ -367,7 +371,11 @@ public class IcebergRestCatalogEventServiceDelegator
             prefix, namespace, table, commitTableRequest, realmContext, securityContext);
     polarisEventListener.onAfterUpdateTable(
         new AfterUpdateTableEvent(
-            catalogName, namespaceObj, table, (LoadTableResponse) resp.getEntity()));
+            catalogName,
+            namespaceObj,
+            table,
+            commitTableRequest,
+            (LoadTableResponse) resp.getEntity()));
     return resp;
   }
 
@@ -385,7 +393,11 @@ public class IcebergRestCatalogEventServiceDelegator
     Response resp =
         delegate.createView(prefix, namespace, createViewRequest, realmContext, securityContext);
     polarisEventListener.onAfterCreateView(
-        new AfterCreateViewEvent(catalogName, namespaceObj, (LoadViewResponse) resp.getEntity()));
+        new AfterCreateViewEvent(
+            catalogName,
+            namespaceObj,
+            createViewRequest.name(),
+            (LoadViewResponse) resp.getEntity()));
     return resp;
   }
 
@@ -436,7 +448,8 @@ public class IcebergRestCatalogEventServiceDelegator
     polarisEventListener.onBeforeLoadView(new BeforeLoadViewEvent(catalogName, namespaceObj, view));
     Response resp = delegate.loadView(prefix, namespace, view, realmContext, securityContext);
     polarisEventListener.onAfterLoadView(
-        new AfterLoadViewEvent(catalogName, namespaceObj, (LoadViewResponse) resp.getEntity()));
+        new AfterLoadViewEvent(
+            catalogName, namespaceObj, view, (LoadViewResponse) resp.getEntity()));
     return resp;
   }
 
@@ -504,7 +517,11 @@ public class IcebergRestCatalogEventServiceDelegator
             prefix, namespace, view, commitViewRequest, realmContext, securityContext);
     polarisEventListener.onAfterReplaceView(
         new AfterReplaceViewEvent(
-            catalogName, namespaceObj, view, (LoadViewResponse) resp.getEntity()));
+            catalogName,
+            namespaceObj,
+            view,
+            commitViewRequest,
+            (LoadViewResponse) resp.getEntity()));
     return resp;
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/IcebergRestCatalogEvents.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/IcebergRestCatalogEvents.java
@@ -121,7 +121,10 @@ public class IcebergRestCatalogEvents {
       implements PolarisEvent {}
 
   public record AfterLoadTableEvent(
-      String catalogName, Namespace namespace, LoadTableResponse loadTableResponse)
+      String catalogName,
+      Namespace namespace,
+      String tableName,
+      LoadTableResponse loadTableResponse)
       implements PolarisEvent {}
 
   public record BeforeCheckExistsTableEvent(String catalogName, Namespace namespace, String table)
@@ -143,7 +146,10 @@ public class IcebergRestCatalogEvents {
       implements PolarisEvent {}
 
   public record AfterRegisterTableEvent(
-      String catalogName, Namespace namespace, LoadTableResponse loadTableResponse)
+      String catalogName,
+      Namespace namespace,
+      String tableName,
+      LoadTableResponse loadTableResponse)
       implements PolarisEvent {}
 
   public record BeforeRenameTableEvent(String catalogName, RenameTableRequest renameTableRequest)
@@ -163,6 +169,7 @@ public class IcebergRestCatalogEvents {
       String catalogName,
       Namespace namespace,
       String sourceTable,
+      CommitTableRequest commitTableRequest,
       LoadTableResponse loadTableResponse)
       implements PolarisEvent {}
 
@@ -172,7 +179,7 @@ public class IcebergRestCatalogEvents {
       implements PolarisEvent {}
 
   public record AfterCreateViewEvent(
-      String catalogName, Namespace namespace, LoadViewResponse loadViewResponse)
+      String catalogName, Namespace namespace, String viewName, LoadViewResponse loadViewResponse)
       implements PolarisEvent {}
 
   public record BeforeListViewsEvent(String catalogName, Namespace namespace)
@@ -185,7 +192,7 @@ public class IcebergRestCatalogEvents {
       implements PolarisEvent {}
 
   public record AfterLoadViewEvent(
-      String catalogName, Namespace namespace, LoadViewResponse loadViewResponse)
+      String catalogName, Namespace namespace, String viewName, LoadViewResponse loadViewResponse)
       implements PolarisEvent {}
 
   public record BeforeCheckExistsViewEvent(String catalogName, Namespace namespace, String view)
@@ -214,7 +221,11 @@ public class IcebergRestCatalogEvents {
       implements PolarisEvent {}
 
   public record AfterReplaceViewEvent(
-      String catalogName, Namespace namespace, String sourceView, LoadViewResponse loadViewResponse)
+      String catalogName,
+      Namespace namespace,
+      String sourceView,
+      CommitViewRequest commitViewRequest,
+      LoadViewResponse loadViewResponse)
       implements PolarisEvent {}
 
   // Credential Events


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

The following events are modified with the corresponding reasons:
* AfterLoadTableEvent, AfterRegisterTableEvent, AfterCreateViewEvent, AfterLoadViewEvent: The table/view names were not in the `Load(Table/View)Response` objects, so we did not have a way to get that information in the `After*` events - so I've added those as an explicit argument.
* AfterReplaceViewEvent/AfterUpdateTableEvent: The actual MetadataUpdate objects that were applied as a result of this request could not be found earlier, so I've added the request object to the `After*` event as well.