### PR TITLE
Add new PolaisAuthorizer.authorizeOrThrow for Fine Grained AuthorizableOperations

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
@@ -41,4 +41,18 @@ public interface PolarisAuthorizer {
       @Nonnull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries);
+
+  void authorizeOrThrow(
+      @Nonnull PolarisPrincipal polarisPrincipal,
+      @Nonnull Set<PolarisBaseEntity> activatedEntities,
+      @Nonnull Set<PolarisAuthorizableOperation> authzOps,
+      @Nullable PolarisResolvedPathWrapper target,
+      @Nullable PolarisResolvedPathWrapper secondary);
+
+  void authorizeOrThrow(
+      @Nonnull PolarisPrincipal polarisPrincipal,
+      @Nonnull Set<PolarisBaseEntity> activatedEntities,
+      @Nonnull Set<PolarisAuthorizableOperation> authzOps,
+      @Nullable List<PolarisResolvedPathWrapper> targets,
+      @Nullable List<PolarisResolvedPathWrapper> secondaries);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
@@ -275,14 +275,12 @@ public abstract class CatalogHandler {
       throwNotFoundExceptionForTableLikeEntity(identifier, List.of(subType));
     }
 
-    for (PolarisAuthorizableOperation op : ops) {
-      authorizer.authorizeOrThrow(
-          polarisPrincipal,
-          resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
-          op,
-          target,
-          null /* secondary */);
-    }
+    authorizer.authorizeOrThrow(
+        polarisPrincipal,
+        resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
+        ops,
+        target,
+        null /* secondary */);
 
     initializeCatalog();
   }


### PR DESCRIPTION
In https://github.com/apache/polaris/pull/2697, we introduce fine grained authorizable operations which creates the need to authorize multiple `authorizableOperations` for one request.

This PR introduce new `authorizeOrThrow` api to help batch authorize multiple operations, instead of doing so in a for loop in CatalogHandler
Previous
```
for (PolarisAuthorizableOperation op : ops) {
      authorizer.authorizeOrThrow(
          polarisPrincipal,
          resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
          op,
          target,
          null /* secondary */);
    }
```

Now:
```
authorizer.authorizeOrThrow(
        polarisPrincipal,
        resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
        ops,
        target,
        null /* secondary */);
```

This will be helpful for authorizer backed by external backend, like `OpaAuthorizer`: https://github.com/apache/polaris/pull/2680, which will send a rest request for every `authorizeOrThrow` call. Making `authorizeOrThrow` takes multiple operations allow the implementation to send a batch authorization request to the backend.

cc: @travis-bowen @collado-mike @dimas-b 

<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->
