### PR TITLE
Update Pull Request Template to prompt contributors to add CHANGELOG entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,44 @@
     Make sure to add the information BELOW this comment.
     Everything in this comment will NOT be added to the PR description.
 -->
+
+### What changes were proposed in this pull request?
+<!--
+Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
+If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
+  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
+  2. If you fix some IRC features, you can provide some references of other IRC implementations / IRC spec.
+  3. If there is design documentation, please add the link.
+  4. If there is a discussion in the mailing list, please add the link.
+-->
+
+
+### Why are the changes needed?
+<!--
+Please clarify why the changes are needed. For instance,
+  1. If you propose a new API, clarify the use case for a new API.
+  2. If you fix a bug, you can clarify why it is a bug.
+-->
+
+
+### Does this PR introduce _any_ user-facing change?
+<!--
+Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.
+
+If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
+If possible, please also clarify if this is a user-facing change compared to the released Polaris versions or within the unreleased branches such as master.
+If no, write 'No'.
+-->
+
+
+### How was this patch tested?
+<!--
+If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
+If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
+If tests were not added, please describe why they were not added and/or why it was difficult to add.
+-->
+
+### CHANGELOG.md
+<!--
+If the changes need to be included in CHANGELOG.md, please add a line here and in CHANGELOG.md.
+-->


### PR DESCRIPTION
### About the change
We decided that CHANGELOG.md would serve as release notes, but its very hard to enforce a CHANGELOG entry per PR as a result CHANGELOG doesn't correctly all the features / bugs community worked, hence adding it in the PR template so that user are promted proactively to do so and the reviews can take a call accordingly.

This add some more sections to make the reviews smooth