### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/plugins/spark/v3.5/integration/build.gradle.kts
+++ b/plugins/spark/v3.5/integration/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     exclude(group = "org.scala-lang", module = "scala-reflect")
   }
 
-  implementation(project(":polaris-runtime-defaults"))
   implementation(project(":polaris-runtime-service"))
 
   testImplementation(


### PR DESCRIPTION
`polaris-runtime-service` depends on `polaris-runtime-defaults`, there is no needed add it again in the spark client module.