### PR TITLE
FIX REG tests with cloud providers

### DIFF
--- a/regtests/README.md
+++ b/regtests/README.md
@@ -85,12 +85,13 @@ project, just run:
 env POLARIS_HOST=localhost ./regtests/run.sh
 ```
 
-The catalog federation tests rely on the following configurations in `application.properties` to
+The catalog federation tests and some cloud providers test rely on the following configurations in `application.properties` to
 be set in order to succeed.
 
 ```
 polaris.features."ENABLE_CATALOG_FEDERATION"=true
 polaris.features."ALLOW_OVERLAPPING_CATALOG_URLS"=true
+polaris.features."ALLOW_NAMESPACE_CUSTOM_LOCATION"=true
 ```
 
 To run the tests in verbose mode, with test stdout printing to console, set the `VERBOSE`

--- a/regtests/docker-compose.yml
+++ b/regtests/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"
       polaris.features."ALLOW_OVERLAPPING_CATALOG_URLS": "true"
-      polaris.config.namespace-custom-location.enabled: "true"
+      polaris.features."ALLOW_NAMESPACE_CUSTOM_LOCATION": "true"
       polaris.features."ENABLE_CATALOG_FEDERATION": "true"
       polaris.readiness.ignore-severe-issues: "true"
     volumes:


### PR DESCRIPTION
Always start polaris with the `namespace-custom-location` to preserve the behaviour test expects before a breaking change was introduced in 1.2