### PR TITLE
Python: Fix client generation

### DIFF
--- a/regtests/README.md
+++ b/regtests/README.md
@@ -196,7 +196,7 @@ docker run --rm \
   --additional-properties=packageName=polaris.management \
   --additional-properties=apiNamePrefix=polaris
 
-# generate the management api client
+# generate the Polaris catalog api client
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli:v7.9.0 generate \
   -i /local/spec/polaris-catalog-service.yaml \


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix for python client generation for regtests 


### Why are the changes needed?

unable to build client without this change, this force the open-api generator to a version which ignores example empty

```
getting this error Exception: Cannot invoke "io.swagger.v3.oas.models.examples.Example.getValue()" because the return value of "java.util.Map.get(Object)" is null at 


org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:1605) at org.openapitools.codegen.DefaultGenerator.processPaths(DefaultGenerator.java:1473) at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:675) at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:1295) at org.openapitools.codegen.cmd.Generate.execute(Generate.java:535) at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32) at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66) Caused by: java.lang.NullPointerException: Cannot invoke "io.swagger.v3.oas.models.examples.Example.getValue()" because the return value of "java.util.Map.get(Object)" is null at org.openapitools.codegen.utils.ExamplesUtils.unaliasExamples(ExamplesUtils.java:75) at org.openapitools.codegen.DefaultCodegen.unaliasExamples(DefaultCodegen.java:2362) at org.openapitools.codegen.DefaultCodegen.fromResponse(DefaultCodegen.java:5036) at org.openapitools.codegen.DefaultCodegen.fromOperation(DefaultCodegen.java:4693) at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:1573)
```


### Does this PR introduce _any_ user-facing change?

No 


### How was this patch tested?

Error above is gone 

### CHANGELOG.md

May be not 
