### PR TITLE
Ignore SSL Verification

### DIFF
--- a/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
+++ b/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
@@ -71,6 +71,7 @@ public class CatalogSerializationTest {
                 + "\"storageConfigInfo\":{"
                 + "\"roleArn\":\"arn:aws:iam::123456789012:role/test-role\","
                 + "\"pathStyleAccess\":false,"
+                + "\"ignoreSSLVerification\":false,"
                 + "\"storageType\":\"S3\","
                 + "\"allowedLocations\":[]"
                 + "}}");

--- a/getting-started/minio-https/README.md
+++ b/getting-started/minio-https/README.md
@@ -1,0 +1,94 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Getting Started with Apache Polaris and MinIO (HTTPS)
+
+## Overview
+
+This example uses MinIO (HTTPS) as a storage provider with Polaris, it can be used for other S3-Compatible Storage API with Ignoring SSL Verification for Development/Test Purposes
+
+Spark is used as a query engine. This example assumes a local Spark installation.
+See the [Spark Notebooks Example](../spark/README.md) for a more advanced Spark setup.
+
+## Starting the Example
+
+1. Build the Polaris server image if it's not already present locally:
+
+    ```shell
+    ./gradlew \
+       :polaris-server:assemble \
+       :polaris-server:quarkusAppPartsBuild --rerun \
+       -Dquarkus.container-image.build=true
+    ```
+
+2. Start the docker compose group by running the following command from the root of the repository:
+
+    ```shell
+    docker compose -f getting-started/minio/docker-compose.yml up
+    ```
+
+## Connecting From Spark
+
+```shell
+bin/spark-sql \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,org.apache.iceberg:iceberg-aws-bundle:1.9.0 \
+    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+    --conf spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.polaris.type=rest \
+    --conf spark.sql.catalog.polaris.uri=http://localhost:8181/api/catalog \
+    --conf spark.sql.catalog.polaris.token-refresh-enabled=false \
+    --conf spark.sql.catalog.polaris.warehouse=quickstart_catalog \
+    --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
+    --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=vended-credentials \
+    --conf spark.sql.catalog.polaris.credential=root:s3cr3t \
+    --conf spark.sql.catalog.polaris.client.region=irrelevant
+```
+
+Note: `s3cr3t` is defined as the password for the `root` users in the `docker-compose.yml` file.
+
+Note: The `client.region` configuration is required for the AWS S3 client to work, but it is not used in this example
+since MinIO does not require a specific region.
+
+## Running Queries
+
+Run inside the Spark SQL shell:
+
+```
+spark-sql (default)> use polaris;
+Time taken: 0.837 seconds
+
+spark-sql ()> create namespace ns;
+Time taken: 0.374 seconds
+
+spark-sql ()> create table ns.t1 as select 'abc';
+Time taken: 2.192 seconds
+
+spark-sql ()> select * from ns.t1;
+abc
+Time taken: 0.579 seconds, Fetched 1 row(s)
+```
+
+## MinIO Endpoints
+
+Note that the catalog configuration defined in the `docker-compose.yml` contains
+different endpoints for the Polaris Server and the client (Spark). Specifically,
+the client endpoint is `https://localhost:9000`, but `endpointInternal` is `https://minio:9000`.
+
+This is necessary because clients running on `localhost` do not normally see service
+names (such as `minio`) that are internal to the docker compose environment.

--- a/getting-started/minio-https/docker-compose.yml
+++ b/getting-started/minio-https/docker-compose.yml
@@ -1,0 +1,150 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+services:
+
+  minio:
+    image: quay.io/minio/minio:latest
+    ports:
+      # API port
+      - "9000:9000"
+      # UI port
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio_root
+      MINIO_ROOT_PASSWORD: m1n1opwd
+    command:
+      - "server"
+      - "/data"
+      - "--console-address"
+      - ":9001"
+    volumes:
+      # Mount the generated certs volume into MinIO
+      - minio_certs:/root/.minio/certs
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+    healthcheck:
+      # Use HTTPS healthcheck now that MinIO will serve TLS on 9000
+      test: ["CMD", "curl", "-k", "https://127.0.0.1:9000/minio/health/live"]
+      interval: 1s
+      timeout: 10s
+
+  polaris:
+    image: apache/polaris:latest
+    ports:
+      # API port
+      - "8181:8181"
+      # Optional, allows attaching a debugger to the Polaris JVM
+      - "5005:5005"
+    depends_on:
+      minio:
+        condition: service_healthy
+      setup_bucket:
+        condition: service_completed_successfully
+    environment:
+      JAVA_DEBUG: true
+      JAVA_DEBUG_PORT: "*:5005"
+      AWS_REGION: us-west-2
+      AWS_ACCESS_KEY_ID: minio_root
+      AWS_SECRET_ACCESS_KEY: m1n1opwd
+      POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
+      polaris.realm-context.realms: POLARIS
+      quarkus.otel.sdk.disabled: "true"
+      quarkus.log.category."org.apache.polaris".level: DEBUG
+      quarkus.log.category."org.apache.polaris.catalog".level: DEBUG
+      quarkus.log.category."org.apache.polaris.table".level: DEBUG
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
+
+  setup_bucket:
+    image: quay.io/minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: "/bin/sh"
+    command:
+      - "-c"
+      - >-
+        echo Creating MinIO bucket...;
+        mc alias set pol https://minio:9000 minio_root m1n1opwd --insecure;
+        mc mb pol/bucket123 --insecure;
+        mc ls pol --insecure;
+        echo Bucket setup complete.;
+        
+  # TLS certs are created at `docker compose up` by the certs-init one-shot service
+  certs-init:
+    image: alpine:3.18
+    entrypoint: "/bin/sh"
+    command:
+      - "-c"
+      - >-
+        apk add --no-cache openssl;
+        printf '%s\n' "[req]" "ndistinguished_name = req_distinguished_name" "req_extensions = v3_req" "prompt = no" "" \
+          "[req_distinguished_name]" "CN = localhost" "" "[v3_req]" "subjectAltName = @alt_names" "" "[alt_names]" "DNS.1 = localhost" "DNS.2 = minio" "IP.1 = 127.0.0.1" \
+          > /openssl.cnf;
+        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+          -keyout /certs/private.key -out /certs/public.crt \
+          -subj "/C=US/ST=State/L=City/O=Org/CN=localhost" -extensions v3_req -config /openssl.cnf;
+        chmod 600 /certs/private.key || true; chmod 644 /certs/public.crt || true;
+        echo Generated certs.;
+    volumes:
+      - minio_certs:/certs
+    restart: "no"
+
+  polaris-setup:
+    image: alpine/curl
+    depends_on:
+      polaris:
+        condition: service_healthy
+    environment:
+      CLIENT_ID: root
+      CLIENT_SECRET: s3cr3t
+      # Use HTTPS endpoints and indicate to Polaris to ignore SSL verification for this self-signed setup
+      STORAGE_CONFIG_INFO: '{"storageType":"S3","endpoint":"https://localhost:9000","endpointInternal":"https://minio:9000","pathStyleAccess":true,"ignoreSSLVerification":true, "stsUnavailable":true}'
+      STORAGE_LOCATION: 's3://bucket123'
+    volumes:
+      - ../assets/polaris/:/polaris
+    entrypoint: "/bin/sh"
+    command:
+      - "-c"
+      - >-
+        chmod +x /polaris/create-catalog.sh;
+        chmod +x /polaris/obtain-token.sh;
+        source /polaris/obtain-token.sh;
+        echo Creating catalog...;
+        /polaris/create-catalog.sh POLARIS $$TOKEN;
+        echo Extra grants...;
+        curl -H "Authorization: Bearer $$TOKEN" -H 'Content-Type: application/json' \
+          -X PUT \
+          http://polaris:8181/api/management/v1/catalogs/quickstart_catalog/catalog-roles/catalog_admin/grants \
+          -d '{"type":"catalog", "privilege":"CATALOG_MANAGE_CONTENT"}';
+        echo Done.;
+
+volumes:
+  minio_certs:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: "size=1m,mode=1777"

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -166,6 +166,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setRegion(awsConfig.getRegion())
             .setEndpoint(awsConfig.getEndpoint())
             .setStsEndpoint(awsConfig.getStsEndpoint())
+            .setIgnoreSSLVerification(awsConfig.getIgnoreSSLVerification())
             .setPathStyleAccess(awsConfig.getPathStyleAccess())
             .setStsUnavailable(awsConfig.getStsUnavailable())
             .setEndpointInternal(awsConfig.getEndpointInternal())
@@ -315,6 +316,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                     .pathStyleAccess(awsConfigModel.getPathStyleAccess())
                     .stsUnavailable(awsConfigModel.getStsUnavailable())
                     .endpointInternal(awsConfigModel.getEndpointInternal())
+                    .ignoreSSLVerification(awsConfigModel.getIgnoreSSLVerification())
                     .build();
             config = awsConfig;
             break;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -102,7 +102,11 @@ public class AwsCredentialsStorageIntegration
       @SuppressWarnings("resource")
       // Note: stsClientProvider returns "thin" clients that do not need closing
       StsClient stsClient =
-          stsClientProvider.stsClient(StsDestination.of(storageConfig.getStsEndpointUri(), region));
+          stsClientProvider.stsClient(
+              StsDestination.of(
+                  storageConfig.getStsEndpointUri(),
+                  region,
+                  storageConfig.getIgnoreSSLVerification()));
 
       AssumeRoleResponse response = stsClient.assumeRole(request.build());
       accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
@@ -137,6 +141,12 @@ public class AwsCredentialsStorageIntegration
     if (internalEndpointUri != null) {
       accessConfig.putInternalProperty(
           StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), internalEndpointUri.toString());
+    }
+
+    // Propagate ignore SSL verification flag so callers (e.g., FileIOFactory) can honor it when
+    // constructing S3 clients for metadata ops.
+    if (Boolean.TRUE.equals(storageConfig.getIgnoreSSLVerification())) {
+      accessConfig.putInternalProperty("polaris.ignore-ssl-verification", "true");
     }
 
     if (Boolean.TRUE.equals(storageConfig.getPathStyleAccess())) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -108,6 +108,9 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
   @Nullable
   public abstract String getStsEndpoint();
 
+  /** Flag indicating whether SSL certificate verification should be disabled */
+  public abstract @Nullable Boolean getIgnoreSSLVerification();
+
   /** Returns the STS endpoint if set, defaulting to {@link #getEndpointUri()} otherwise. */
   @JsonIgnore
   @Nullable

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/StsClientProvider.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/StsClientProvider.java
@@ -52,8 +52,16 @@ public interface StsClientProvider {
     @Value.Parameter(order = 2)
     Optional<String> region();
 
-    static StsDestination of(@Nullable URI endpoint, @Nullable String region) {
-      return ImmutableStsDestination.of(Optional.ofNullable(endpoint), Optional.ofNullable(region));
+    /** Whether to ignore SSL certificate verification */
+    @Value.Parameter(order = 3)
+    Optional<Boolean> ignoreSSLVerification();
+
+    static StsDestination of(
+        @Nullable URI endpoint, @Nullable String region, @Nullable Boolean ignoreSSLVerification) {
+      return ImmutableStsDestination.of(
+          Optional.ofNullable(endpoint),
+          Optional.ofNullable(region),
+          Optional.ofNullable(ignoreSSLVerification));
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjector.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjector.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.io.s3;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Map;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+/**
+ * Best-effort reflective injector that attempts to wire a pre-built S3Client into Iceberg's
+ * S3FileIO instance. This avoids needing to modify Iceberg.
+ */
+public final class ReflectionS3ClientInjector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReflectionS3ClientInjector.class);
+
+  private ReflectionS3ClientInjector() {}
+
+  /**
+   * For Iceberg's S3FileIO implementation, PrefixedS3Client holds SerializableSupplier<S3Client>
+   * fields named 's3' and 's3Async' which are used to lazily construct the real clients. To ensure
+   * Iceberg will use our prebuilt S3Client (configured with the provided SdkHttpClient), replace
+   * those supplier fields with suppliers that return the provided instances.
+   */
+  public static boolean injectSupplierIntoS3FileIO(
+      Object s3FileIOInstance, S3Client prebuiltS3Client, S3AsyncClient prebuiltS3AsyncClient) {
+    if (s3FileIOInstance == null) {
+      return false;
+    }
+
+    Class<?> clazz = s3FileIOInstance.getClass();
+    boolean changed = false;
+    while (clazz != null) {
+      try {
+        Field s3Field = null;
+        Field s3AsyncField = null;
+        try {
+          s3Field = clazz.getDeclaredField("s3");
+        } catch (NoSuchFieldException ignored) {
+        }
+        try {
+          s3AsyncField = clazz.getDeclaredField("s3Async");
+        } catch (NoSuchFieldException ignored) {
+        }
+
+        if (s3Field != null) {
+          s3Field.setAccessible(true);
+          // Build a SerializableSupplier that returns our prebuilt S3Client.
+          // Use a simple SerializableSupplier implementation used by Iceberg:
+          // org.apache.iceberg.util.SerializableSupplier
+          try {
+            Class<?> serializableSupplierClazz =
+                Class.forName("org.apache.iceberg.util.SerializableSupplier");
+            Object serializableSupplier =
+                java.lang.reflect.Proxy.newProxyInstance(
+                    serializableSupplierClazz.getClassLoader(),
+                    new Class<?>[] {serializableSupplierClazz, java.io.Serializable.class},
+                    (proxy, method, args) -> {
+                      if ("get".equals(method.getName())) {
+                        return prebuiltS3Client;
+                      }
+                      // default proxy behavior
+                      return method.invoke(proxy, args);
+                    });
+
+            s3Field.set(s3FileIOInstance, serializableSupplier);
+            changed = true;
+          } catch (ClassNotFoundException cnfe) {
+            // Fallback: try to set any field assignable from java.util.function.Supplier
+            Object simple = (java.util.function.Supplier<S3Client>) () -> prebuiltS3Client;
+            s3Field.set(s3FileIOInstance, simple);
+            changed = true;
+          }
+        }
+
+        if (s3AsyncField != null && prebuiltS3AsyncClient != null) {
+          s3AsyncField.setAccessible(true);
+          try {
+            Class<?> serializableSupplierClazz =
+                Class.forName("org.apache.iceberg.util.SerializableSupplier");
+            Object serializableSupplierAsync =
+                java.lang.reflect.Proxy.newProxyInstance(
+                    serializableSupplierClazz.getClassLoader(),
+                    new Class<?>[] {serializableSupplierClazz, java.io.Serializable.class},
+                    (proxy, method, args) -> {
+                      if ("get".equals(method.getName())) {
+                        return prebuiltS3AsyncClient;
+                      }
+                      return method.invoke(proxy, args);
+                    });
+
+            s3AsyncField.set(s3FileIOInstance, serializableSupplierAsync);
+            changed = true;
+          } catch (ClassNotFoundException cnfe) {
+            Object simpleAsync =
+                (java.util.function.Supplier<S3AsyncClient>) () -> prebuiltS3AsyncClient;
+            s3AsyncField.set(s3FileIOInstance, simpleAsync);
+            changed = true;
+          }
+        }
+      } catch (Throwable t) {
+        LOGGER.debug("Failed to set supplier fields on {}: {}", clazz, t.getMessage());
+      }
+
+      clazz = clazz.getSuperclass();
+    }
+
+    return changed;
+  }
+
+  public static S3Client buildS3Client(SdkHttpClient httpClient, Map<String, String> properties) {
+    S3ClientBuilder builder = S3Client.builder();
+    if (httpClient != null) {
+      builder.httpClient(httpClient);
+    }
+    AwsCredentialsProvider creds = credentialsProviderFrom(properties);
+    if (creds != null) builder.credentialsProvider(creds);
+
+    applyRegionAndEndpoint(builder, properties);
+    builder.serviceConfiguration(s3ConfigurationFrom(properties));
+
+    return builder.build();
+  }
+
+  public static S3AsyncClient buildS3AsyncClient(
+      SdkHttpClient httpClient, Map<String, String> properties) {
+    try {
+      // Attempt to build an async client. If the provided httpClient is an instance that also
+      // implements the async HTTP client interface, use it. Otherwise fall back to the
+      // default async client builder.
+      software.amazon.awssdk.http.async.SdkAsyncHttpClient asyncHttpClient = null;
+      if (httpClient instanceof software.amazon.awssdk.http.async.SdkAsyncHttpClient async) {
+        asyncHttpClient = async;
+      }
+
+      software.amazon.awssdk.services.s3.S3AsyncClientBuilder asyncBuilder =
+          software.amazon.awssdk.services.s3.S3AsyncClient.builder();
+
+      if (asyncHttpClient != null) {
+        asyncBuilder.httpClient(asyncHttpClient);
+      }
+
+      AwsCredentialsProvider creds = credentialsProviderFrom(properties);
+      if (creds != null) asyncBuilder.credentialsProvider(creds);
+
+      applyRegionAndEndpoint(asyncBuilder, properties);
+      asyncBuilder.serviceConfiguration(s3ConfigurationFrom(properties));
+
+      return asyncBuilder.build();
+    } catch (Exception e) {
+      LOGGER.debug("Failed to build S3AsyncClient: {}", e.toString());
+      return null;
+    }
+  }
+
+  private static AwsCredentialsProvider credentialsProviderFrom(Map<String, String> properties) {
+    String accessKey = properties.get(StorageAccessProperty.AWS_KEY_ID.getPropertyName());
+    String secretKey = properties.get(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName());
+    if (accessKey != null && secretKey != null) {
+      AwsBasicCredentials creds = AwsBasicCredentials.create(accessKey, secretKey);
+      return StaticCredentialsProvider.create(creds);
+    }
+    return null;
+  }
+
+  private static void applyRegionAndEndpoint(Object builder, Map<String, String> properties) {
+    String region = properties.get(StorageAccessProperty.CLIENT_REGION.getPropertyName());
+    if (region != null) {
+      try {
+        Method m = builder.getClass().getMethod("region", Region.class);
+        m.invoke(builder, Region.of(region));
+      } catch (Exception ignored) {
+        LOGGER.debug("Unable to apply region to builder {}", builder.getClass().getName());
+      }
+    }
+
+    String endpoint = properties.get(StorageAccessProperty.AWS_ENDPOINT.getPropertyName());
+    if (endpoint != null) {
+      try {
+        Method m = builder.getClass().getMethod("endpointOverride", URI.class);
+        m.invoke(builder, URI.create(endpoint));
+      } catch (Exception ignored) {
+        LOGGER.debug(
+            "Unable to apply endpointOverride to builder {}", builder.getClass().getName());
+      }
+    }
+  }
+
+  private static S3Configuration s3ConfigurationFrom(Map<String, String> properties) {
+    String pathStyle =
+        properties.get(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName());
+    boolean forcePathStyle = "true".equals(pathStyle);
+    return S3Configuration.builder().pathStyleAccessEnabled(forcePathStyle).build();
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
@@ -144,7 +144,8 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
     // Get STS client from the provider (potentially pooled)
     // The Polaris service identity credentials are set on the AssumeRole request via
     // overrideConfiguration, not on the STS client itself
-    // TODO: Configure proper StsDestination with region/endpoint from sigv4Params
-    return stsClientProvider.stsClient(StsClientProvider.StsDestination.of(null, null));
+    // TODO: Configure proper StsDestination with region/endpoint/ignoreSSLVerification from
+    // sigv4Params
+    return stsClientProvider.stsClient(StsClientProvider.StsDestination.of(null, null, null));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/StsClientsPool.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/aws/StsClientsPool.java
@@ -45,8 +45,8 @@ public class StsClientsPool implements StsClientProvider {
 
   private static final String CACHE_NAME = "sts-clients";
 
-  private final Cache<StsDestination, StsClient> clients;
-  private final Function<StsDestination, StsClient> clientBuilder;
+  private final Cache<StsClientProvider.StsDestination, StsClient> clients;
+  private final Function<StsClientProvider.StsDestination, StsClient> clientBuilder;
 
   public StsClientsPool(
       int clientsCacheMaxSize, SdkHttpClient sdkHttpClient, MeterRegistry meterRegistry) {
@@ -56,10 +56,21 @@ public class StsClientsPool implements StsClientProvider {
         Optional.ofNullable(meterRegistry));
   }
 
+  public StsClientsPool(
+      int clientsCacheMaxSize,
+      SdkHttpClient sdkHttpClient,
+      SdkHttpClient insecureHttpClient,
+      MeterRegistry meterRegistry) {
+    this(
+        clientsCacheMaxSize,
+        key -> createStsClient(key, sdkHttpClient, insecureHttpClient),
+        Optional.of(meterRegistry));
+  }
+
   @VisibleForTesting
   StsClientsPool(
       int maxSize,
-      Function<StsDestination, StsClient> clientBuilder,
+      Function<StsClientProvider.StsDestination, StsClient> clientBuilder,
       Optional<MeterRegistry> meterRegistry) {
     this.clientBuilder = clientBuilder;
     this.clients =
@@ -70,11 +81,12 @@ public class StsClientsPool implements StsClientProvider {
   }
 
   @Override
-  public StsClient stsClient(StsDestination destination) {
+  public StsClient stsClient(StsClientProvider.StsDestination destination) {
     return clients.get(destination, clientBuilder);
   }
 
-  private static StsClient defaultStsClient(StsDestination parameters, SdkHttpClient sdkClient) {
+  private static StsClient defaultStsClient(
+      StsClientProvider.StsDestination parameters, SdkHttpClient sdkClient) {
     StsClientBuilder builder = StsClient.builder();
     builder.httpClient(sdkClient);
     if (parameters.endpoint().isPresent()) {
@@ -97,5 +109,25 @@ public class StsClientsPool implements StsClientProvider {
       return new CaffeineStatsCounter(meterRegistry.get(), CACHE_NAME);
     }
     return StatsCounter.disabledStatsCounter();
+  }
+
+  private static StsClient createStsClient(
+      StsClientProvider.StsDestination parameters,
+      SdkHttpClient secureClient,
+      SdkHttpClient insecureClient) {
+    StsClientBuilder builder = StsClient.builder();
+
+    boolean ignoreSSL = parameters.ignoreSSLVerification().orElse(false);
+    builder.httpClient(ignoreSSL ? insecureClient : secureClient);
+
+    if (parameters.endpoint().isPresent()) {
+      CompletableFuture<Endpoint> endpointFuture =
+          completedFuture(Endpoint.builder().url(parameters.endpoint().get()).build());
+      builder.endpointProvider(params -> endpointFuture);
+    }
+
+    parameters.region().ifPresent(r -> builder.region(Region.of(r)));
+
+    return builder.build();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorConfigTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorConfigTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.io.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+/** Tests that S3 client builders apply region/endpoint/path-style/credentials as expected. */
+@SuppressWarnings("unused")
+public class ReflectionS3ClientInjectorConfigTest {
+
+  private Map<String, String> makeProps(String region, String endpoint, boolean pathStyle) {
+    Map<String, String> p = new HashMap<>();
+    p.put(StorageAccessProperty.CLIENT_REGION.getPropertyName(), region);
+    p.put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint);
+    p.put(
+        StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), Boolean.toString(pathStyle));
+    p.put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), "AKIA_TEST");
+    p.put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), "SECRET_TEST");
+    return p;
+  }
+
+  // helper removed: deep traversal not used after switching to reflective checks
+
+  @Test
+  public void testBuildS3Client_appliesConfiguration() throws Exception {
+    Map<String, String> props = makeProps("us-west-2", "https://custom.example:9000", true);
+
+    // Verify credentials helper
+    Method credsMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod("credentialsProviderFrom", Map.class);
+    credsMethod.setAccessible(true);
+    Object credsProv = credsMethod.invoke(null, props);
+    assertTrue(credsProv instanceof AwsCredentialsProvider);
+    AwsCredentialsProvider prov = (AwsCredentialsProvider) credsProv;
+    var creds = prov.resolveCredentials();
+    assertTrue("AKIA_TEST".equals(creds.accessKeyId()));
+    assertTrue("SECRET_TEST".equals(creds.secretAccessKey()));
+
+    // Verify S3Configuration helper
+    Method s3ConfMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod("s3ConfigurationFrom", Map.class);
+    s3ConfMethod.setAccessible(true);
+    Object s3Conf = s3ConfMethod.invoke(null, props);
+    assertTrue(s3Conf instanceof S3Configuration);
+    assertTrue(((S3Configuration) s3Conf).pathStyleAccessEnabled());
+
+    // Verify applyRegionAndEndpoint applies to arbitrary builder-like objects
+    @SuppressWarnings("unused")
+    class TestBuilder {
+      public Region regionVal;
+      public URI endpointVal;
+
+      public TestBuilder region(Region r) {
+        this.regionVal = r;
+        return this;
+      }
+
+      public TestBuilder endpointOverride(URI u) {
+        this.endpointVal = u;
+        return this;
+      }
+    }
+
+    TestBuilder tb = new TestBuilder();
+    Method applyMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod(
+            "applyRegionAndEndpoint", Object.class, Map.class);
+    applyMethod.setAccessible(true);
+    applyMethod.invoke(null, tb, props);
+    assertEquals("us-west-2", tb.regionVal.id());
+    assertEquals(new URI("https://custom.example:9000"), tb.endpointVal);
+  }
+
+  @Test
+  public void testBuildS3AsyncClient_appliesConfiguration() throws Exception {
+    Map<String, String> props = makeProps("eu-central-1", "https://async.example:9000", false);
+
+    // credentials
+    Method credsMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod("credentialsProviderFrom", Map.class);
+    credsMethod.setAccessible(true);
+    Object credsProv = credsMethod.invoke(null, props);
+    assertTrue(credsProv instanceof AwsCredentialsProvider);
+    AwsCredentialsProvider prov = (AwsCredentialsProvider) credsProv;
+    var creds = prov.resolveCredentials();
+    assertEquals("AKIA_TEST", creds.accessKeyId());
+
+    // s3 config
+    Method s3ConfMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod("s3ConfigurationFrom", Map.class);
+    s3ConfMethod.setAccessible(true);
+    Object s3Conf = s3ConfMethod.invoke(null, props);
+    assertTrue(s3Conf instanceof S3Configuration);
+    assertTrue(!((S3Configuration) s3Conf).pathStyleAccessEnabled());
+
+    // applyRegionAndEndpoint on TestBuilder
+    @SuppressWarnings("unused")
+    class TestBuilder {
+      public Region regionVal;
+      public URI endpointVal;
+
+      public TestBuilder region(Region r) {
+        this.regionVal = r;
+        return this;
+      }
+
+      public TestBuilder endpointOverride(URI u) {
+        this.endpointVal = u;
+        return this;
+      }
+    }
+
+    TestBuilder tb = new TestBuilder();
+    Method applyMethod =
+        ReflectionS3ClientInjector.class.getDeclaredMethod(
+            "applyRegionAndEndpoint", Object.class, Map.class);
+    applyMethod.setAccessible(true);
+    applyMethod.invoke(null, tb, props);
+    assertEquals("eu-central-1", tb.regionVal.id());
+    assertEquals(new URI("https://async.example:9000"), tb.endpointVal);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.io.s3;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/** Unit tests for ReflectionS3ClientInjector. */
+public class ReflectionS3ClientInjectorTest {
+
+  private static class DummyS3FileIO {
+    // Simulate Iceberg's SerializableSupplier<S3Client> and SerializableSupplier<S3AsyncClient>
+    public Supplier<S3Client> s3;
+    public Supplier<S3AsyncClient> s3Async;
+  }
+
+  @Test
+  public void testInjectSupplierIntoS3FileIO_replacesSuppliers() {
+    DummyS3FileIO fileIO = new DummyS3FileIO();
+
+    // Build simple clients with default builders (they won't be used to actually call network)
+    S3Client prebuilt = S3Client.builder().build();
+    S3AsyncClient prebuiltAsync = S3AsyncClient.builder().build();
+
+    boolean injected =
+        ReflectionS3ClientInjector.injectSupplierIntoS3FileIO(fileIO, prebuilt, prebuiltAsync);
+    assertTrue(injected, "Expected supplier injection to return true");
+
+    // The injected suppliers should return the prebuilt instances
+    Supplier<S3Client> s3Supplier = fileIO.s3;
+    Supplier<S3AsyncClient> s3AsyncSupplier = fileIO.s3Async;
+
+    assertSame(prebuilt, s3Supplier.get());
+    assertSame(prebuiltAsync, s3AsyncSupplier.get());
+  }
+}

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1139,6 +1139,14 @@ components:
                 Whether S3 requests to files in this catalog should use 'path-style addressing for buckets'.
               example: true
               default: false
+            ignoreSSLVerification:
+              type: boolean
+              description: >-
+                Whether SSL certificate verification should be disabled for STS and S3 endpoints (optional).
+                WARNING: This should only be used for development and testing environments with self-signed certificates.
+                Disabling SSL verification in production environments compromises security.
+              example: false
+              default: false
 
     AzureStorageConfigInfo:
       type: object


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Support Ignore SSL Verification for S3-Compatible Storage (S3 Endpoint, STS Endpoint) for Development/Test Purposes https://github.com/apache/polaris/discussions/2705
- Add getting-started/minio-https example for MinIO (HTTPS) using Self-Signed Certificates with Polaris for Development 
- Breakdown of Issue - https://github.com/apache/polaris/issues/2743

### Why are the changes needed?
- Unable to create table with HTTPS (self-signed certificates)
```
curl --location 'http://localhost:8181/api/catalog/v1/quickstart_catalog/namespaces/minio_polaris_ns/tables' \
-H "Authorization: Bearer $TOKEN" \
-H 'Content-Type: application/json' \
-H 'Polaris-Realm: POLARIS' \
--data '{
  "name": "minio_polaris_ns_table01",
  "schema": {
    "type": "struct",
    "fields": [
      {
        "id": 0,
        "name": "id",
        "type": "string",
        "required": true,
        "doc": "car model"
      },
      {
        "id": 1,
        "name": "first_name",
        "type": "string",
        "required": true,
        "doc": "first name"
      }
    ]
  }
}' | jq

{
  "error": {
    "message": "Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target (SDK Attempt Count: 6)",
    "type": "SdkClientException",
    "code": 500
  }
}
```
Polaris Logs:
```
polaris-1        | 2025-10-13 15:20:52,403 INFO  [io.qua.htt.access-log] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000007,POLARIS] [,,,] (executor-thread-1) 172.18.0.1 - root [13/Oct/2025:15:20:52 +0000] "GET /api/catalog/v1/quickstart_catalog/namespaces HTTP/1.1" 200 60
polaris-1        | 2025-10-13 15:21:05,522 INFO  [org.apa.pol.ser.cat.ice.IcebergCatalogHandler] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Initializing non-federated catalog
polaris-1        | 2025-10-13 15:21:05,530 INFO  [org.apa.ice.BaseMetastoreCatalog] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Table properties set at catalog level through catalog properties: {}
polaris-1        | 2025-10-13 15:21:05,533 INFO  [org.apa.ice.BaseMetastoreCatalog] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Table properties enforced at catalog level through catalog properties: {}
polaris-1        | 2025-10-13 15:21:05,717 WARN  [org.apa.pol.ser.con.ServiceProducers] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Creating HTTP client with SSL certificate verification disabled. Use only in development!
polaris-1        | 2025-10-13 15:21:05,791 INFO  [org.apa.ice.CatalogUtil] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Loading custom FileIO implementation: org.apache.iceberg.aws.s3.S3FileIO
polaris-1        | 2025-10-13 15:21:06,177 INFO  [org.apa.pol.ser.cat.io.s3.ReflectionS3ClientInjector] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Successfully injected S3Client into org.apache.iceberg.aws.s3.S3FileIO
polaris-1        | 2025-10-13 15:21:06,178 INFO  [org.apa.pol.ser.cat.io.DefaultFileIOFactory] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Injected insecure S3Client into Iceberg S3FileIO for ioImpl=org.apache.iceberg.aws.s3.S3FileIO
polaris-1        | 2025-10-13 15:21:08,723 INFO  [org.apa.pol.ser.exc.IcebergExceptionMapper] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Handling runtimeException Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target (SDK Attempt Count: 6)
polaris-1        | 2025-10-13 15:21:08,733 ERROR [org.apa.pol.ser.exc.IcebergExceptionMapper] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) Unhandled exception returning INTERNAL_SERVER_ERROR: software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target (SDK Attempt Count: 6)
polaris-1        |      at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:130)
polaris-1        |      at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:95)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.retryPolicyDisallowedRetryException(RetryableStageHelper.java:168)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:73)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:53)
polaris-1        |      at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:35)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:82)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:62)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:43)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
polaris-1        |      at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:210)
polaris-1        |      at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
polaris-1        |      at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:173)
polaris-1        |      at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:80)
polaris-1        |      at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:182)
polaris-1        |      at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:74)
polaris-1        |      at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
polaris-1        |      at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:53)
polaris-1        |      at software.amazon.awssdk.services.s3.DefaultS3Client.putObject(DefaultS3Client.java:11883)
polaris-1        |      at org.apache.iceberg.aws.s3.S3OutputStream.completeUploads(S3OutputStream.java:443)
polaris-1        |      at org.apache.iceberg.aws.s3.S3OutputStream.close(S3OutputStream.java:269)
polaris-1        |      at org.apache.iceberg.aws.s3.S3OutputStream.close(S3OutputStream.java:255)
polaris-1        |      at java.base/sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:435)
polaris-1        |      at java.base/sun.nio.cs.StreamEncoder.lockedClose(StreamEncoder.java:237)
polaris-1        |      at java.base/sun.nio.cs.StreamEncoder.close(StreamEncoder.java:222)
polaris-1        |      at java.base/java.io.OutputStreamWriter.close(OutputStreamWriter.java:266)
polaris-1        |      at org.apache.iceberg.TableMetadataParser.internalWrite(TableMetadataParser.java:135)
polaris-1        |      at org.apache.iceberg.TableMetadataParser.overwrite(TableMetadataParser.java:119)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalog$BasePolarisTableOperations.writeNewMetadata(IcebergCatalog.java:1647)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalog$BasePolarisTableOperations.writeNewMetadataIfRequired(IcebergCatalog.java:1636)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalog$BasePolarisTableOperations.doCommit(IcebergCatalog.java:1505)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalog$BasePolarisTableOperations.commit(IcebergCatalog.java:1356)
polaris-1        |      at org.apache.iceberg.BaseMetastoreCatalog$BaseMetastoreCatalogTableBuilder.create(BaseMetastoreCatalog.java:201)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandler.createTableDirect(IcebergCatalogHandler.java:456)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter.lambda$createTable$6(IcebergCatalogAdapter.java:394)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter.withCatalog(IcebergCatalogAdapter.java:209)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter.createTable(IcebergCatalogAdapter.java:378)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter_Subclass.createTable$$superforward(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergRestCatalogEventServiceDelegator_Gj_WCptqTcdHu-fbZfgVkAwPXCI_Delegate_Subclass.createTable(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergRestCatalogEventServiceDelegator.createTable(IcebergRestCatalogEventServiceDelegator.java:217)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter_Subclass.createTable(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter_ClientProxy.createTable(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi.createTable(IcebergRestCatalogApi.java:193)
polaris-1        |      at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi_Subclass.createTable$$superforward(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi_Subclass$$function$$3.apply(Unknown Source)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:73)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext$NextAroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:97)
polaris-1        |      at io.smallrye.faulttolerance.FaultToleranceInterceptor.lambda$syncFlow$8(FaultToleranceInterceptor.java:364)
polaris-1        |      at io.smallrye.faulttolerance.core.Future.from(Future.java:85)
polaris-1        |      at io.smallrye.faulttolerance.FaultToleranceInterceptor.lambda$syncFlow$9(FaultToleranceInterceptor.java:364)
polaris-1        |      at io.smallrye.faulttolerance.core.FaultToleranceContext.call(FaultToleranceContext.java:20)
polaris-1        |      at io.smallrye.faulttolerance.core.Invocation.apply(Invocation.java:29)
polaris-1        |      at io.smallrye.faulttolerance.core.metrics.MetricsCollector.apply(MetricsCollector.java:98)
polaris-1        |      at io.smallrye.faulttolerance.FaultToleranceInterceptor.syncFlow(FaultToleranceInterceptor.java:367)
polaris-1        |      at io.smallrye.faulttolerance.FaultToleranceInterceptor.intercept(FaultToleranceInterceptor.java:205)
polaris-1        |      at io.smallrye.faulttolerance.FaultToleranceInterceptor_Bean.intercept(Unknown Source)
polaris-1        |      at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:70)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext$NextAroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:97)
polaris-1        |      at io.quarkus.micrometer.runtime.MicrometerTimedInterceptor.timedMethod(MicrometerTimedInterceptor.java:79)
polaris-1        |      at io.quarkus.micrometer.runtime.MicrometerTimedInterceptor_Bean.intercept(Unknown Source)
polaris-1        |      at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:70)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext$NextAroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:97)
polaris-1        |      at io.quarkus.security.runtime.interceptor.SecurityHandler.handle(SecurityHandler.java:27)
polaris-1        |      at io.quarkus.security.runtime.interceptor.RolesAllowedInterceptor.intercept(RolesAllowedInterceptor.java:29)
polaris-1        |      at io.quarkus.security.runtime.interceptor.RolesAllowedInterceptor_Bean.intercept(Unknown Source)
polaris-1        |      at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:70)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:62)
polaris-1        |      at io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor.intercept(StandardSecurityCheckInterceptor.java:44)
polaris-1        |      at io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor_RolesAllowedInterceptor_Bean.intercept(Unknown Source)
polaris-1        |      at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
polaris-1        |      at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:30)
polaris-1        |      at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:27)
polaris-1        |      at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi_Subclass.createTable(Unknown Source)
polaris-1        |      at org.apache.polaris.service.catalog.api.IcebergRestCatalogApi$quarkusrestinvoker$createTable_01f5a1bd6d7815fd3314a553161c943c8cd03101.invoke(Unknown Source)
polaris-1        |      at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
polaris-1        |      at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:183)
polaris-1        |      at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
polaris-1        |      at io.quarkus.vertx.core.runtime.VertxCoreRecorder$15.runWith(VertxCoreRecorder.java:645)
polaris-1        |      at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
polaris-1        |      at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
polaris-1        |      at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
polaris-1        |      at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
polaris-1        |      at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
polaris-1        |      at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
polaris-1        |      at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
polaris-1        |      at java.base/java.lang.Thread.run(Thread.java:1583)
polaris-1        |      Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 1 failure: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 2 failure: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 3 failure: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 4 failure: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 5 failure: Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        | Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:130)
polaris-1        |      at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:383)
polaris-1        |      at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:326)
polaris-1        |      at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:321)
polaris-1        |      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1327)
polaris-1        |      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1204)
polaris-1        |      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1147)
polaris-1        |      at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:393)
polaris-1        |      at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:476)
polaris-1        |      at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:447)
polaris-1        |      at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:206)
polaris-1        |      at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
polaris-1        |      at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
polaris-1        |      at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
polaris-1        |      at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
polaris-1        |      at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
polaris-1        |      at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket(SSLConnectionSocketFactory.java:436)
polaris-1        |      at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(SSLConnectionSocketFactory.java:384)
polaris-1        |      at software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory.connectSocket(SdkTlsSocketFactory.java:63)
polaris-1        |      at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:142)
polaris-1        |      at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
polaris-1        |      at software.amazon.awssdk.http.apache.internal.conn.ClientConnectionManagerFactory$DelegatingHttpClientConnectionManager.connect(ClientConnectionManagerFactory.java:86)
polaris-1        |      at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)
polaris-1        |      at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
polaris-1        |      at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
polaris-1        |      at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
polaris-1        |      at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
polaris-1        |      at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
polaris-1        |      at software.amazon.awssdk.http.apache.internal.impl.ApacheSdkHttpClient.execute(ApacheSdkHttpClient.java:72)
polaris-1        |      at software.amazon.awssdk.http.apache.ApacheHttpClient.execute(ApacheHttpClient.java:261)
polaris-1        |      at software.amazon.awssdk.http.apache.ApacheHttpClient.access$600(ApacheHttpClient.java:106)
polaris-1        |      at software.amazon.awssdk.http.apache.ApacheHttpClient$1.call(ApacheHttpClient.java:238)
polaris-1        |      at software.amazon.awssdk.http.apache.ApacheHttpClient$1.call(ApacheHttpClient.java:235)
polaris-1        |      at software.amazon.awssdk.core.internal.util.MetricUtils.measureDurationUnsafe(MetricUtils.java:103)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.executeHttpRequest(MakeHttpRequestStage.java:88)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:64)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:46)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:74)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:43)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:79)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:41)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:55)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:39)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.executeRequest(RetryableStage.java:93)
polaris-1        |      at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:56)
polaris-1        |      ... 92 more
polaris-1        | Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      at java.base/sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:388)
polaris-1        |      at java.base/sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:271)
polaris-1        |      at java.base/sun.security.validator.Validator.validate(Validator.java:256)
polaris-1        |      at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:230)
polaris-1        |      at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:132)
polaris-1        |      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1311)
polaris-1        |      ... 136 more
polaris-1        | Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
polaris-1        |      at java.base/sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:148)
polaris-1        |      at java.base/sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:129)
polaris-1        |      at java.base/java.security.cert.CertPathBuilder.build(CertPathBuilder.java:297)
polaris-1        |      at java.base/sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:383)
polaris-1        |      ... 141 more
polaris-1        | 
polaris-1        | 2025-10-13 15:21:08,739 INFO  [io.qua.htt.access-log] [a97e3793-1931-405c-aa0d-b402ebb7b4dc_0000000000000000008,POLARIS] [,,,] (executor-thread-1) 172.18.0.1 - root [13/Oct/2025:15:21:08 +0000] "POST /api/catalog/v1/quickstart_catalog/namespaces/minio_polaris_ns/tables HTTP/1.1" 500 264
```


### Does this PR introduce _any_ user-facing change?
- Yes, it introduces ignoreSSLVerification flag for S3 Storage Type Parameters


### How was this patch tested?
- Full Gradle Tests were successful
- Updated the following tests
  - api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
  - runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
- Added following tests
  - runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorConfigTest.java
  - runtime/service/src/test/java/org/apache/polaris/service/catalog/io/s3/ReflectionS3ClientInjectorTest.java
- Create Table Rest API is successful
```
curl --location 'http://localhost:8181/api/catalog/v1/quickstart_catalog/namespaces/minio_polaris_ns/tables' \
-H "Authorization: Bearer $TOKEN" \
-H 'Content-Type: application/json' \
-H 'Polaris-Realm: POLARIS' \
--data '{
  "name": "minio_polaris_ns_table01",
  "schema": {
    "type": "struct",
    "fields": [
      {
        "id": 0,
        "name": "id",
        "type": "string",
        "required": true,
        "doc": "car model"
      },
      {
        "id": 1,
        "name": "first_name",
        "type": "string",
        "required": true,
        "doc": "first name"
      }
    ]
  }
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1454  100  1073  100   381    863    306  0:00:01  0:00:01 --:--:--  1170
{
  "metadata-location": "s3://bucket123/minio_polaris_ns/minio_polaris_ns_table01/metadata/00000-6e118173-519e-401c-87ea-549eb70b939e.metadata.json",
  "metadata": {
    "format-version": 2,
    "table-uuid": "29f5d242-8bab-4052-be02-4313b4ec6a31",
    "location": "s3://bucket123/minio_polaris_ns/minio_polaris_ns_table01",
    "last-sequence-number": 0,
    "last-updated-ms": 1760372568321,
    "last-column-id": 2,
    "current-schema-id": 0,
    "schemas": [
      {
        "type": "struct",
        "schema-id": 0,
        "fields": [
          {
            "id": 1,
            "name": "id",
            "required": true,
            "type": "string",
            "doc": "car model"
          },
          {
            "id": 2,
            "name": "first_name",
            "required": true,
            "type": "string",
            "doc": "first name"
          }
        ]
      }
    ],
    "default-spec-id": 0,
    "partition-specs": [
      {
        "spec-id": 0,
        "fields": []
      }
    ],
    "last-partition-id": 999,
    "default-sort-order-id": 0,
    "sort-orders": [
      {
        "order-id": 0,
        "fields": []
      }
    ],
    "properties": {
      "created-at": "2025-10-13T16:22:48.289344333Z",
      "write.parquet.compression-codec": "zstd"
    },
    "current-snapshot-id": -1,
    "refs": {},
    "snapshots": [],
    "statistics": [],
    "partition-statistics": [],
    "snapshot-log": [],
    "metadata-log": []
  },
  "config": {
    "s3.path-style-access": "true",
    "s3.endpoint": "https://localhost:9000"
  }
}
``` 
```
polaris-1        | 2025-10-13 16:22:16,633 INFO  [io.qua.htt.access-log] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000004,POLARIS] [,,,] (executor-thread-1) 172.18.0.1 - - [13/Oct/2025:16:22:16 +0000] "POST /api/catalog/v1/oauth/tokens HTTP/1.1" 200 757
polaris-1        | 2025-10-13 16:22:25,631 INFO  [org.apa.pol.ser.cat.ice.IcebergCatalogHandler] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000005,POLARIS] [,,,] (executor-thread-1) Initializing non-federated catalog
polaris-1        | 2025-10-13 16:22:25,676 INFO  [io.qua.htt.access-log] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000005,POLARIS] [,,,] (executor-thread-1) 172.18.0.1 - root [13/Oct/2025:16:22:25 +0000] "POST /api/catalog/v1/quickstart_catalog/namespaces/ HTTP/1.1" 200 95
polaris-1        | 2025-10-13 16:22:48,284 INFO  [org.apa.pol.ser.cat.ice.IcebergCatalogHandler] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Initializing non-federated catalog
polaris-1        | 2025-10-13 16:22:48,293 INFO  [org.apa.ice.BaseMetastoreCatalog] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Table properties set at catalog level through catalog properties: {}
polaris-1        | 2025-10-13 16:22:48,296 INFO  [org.apa.ice.BaseMetastoreCatalog] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Table properties enforced at catalog level through catalog properties: {}
polaris-1        | 2025-10-13 16:22:48,501 WARN  [org.apa.pol.ser.con.ServiceProducers] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Creating HTTP client with SSL certificate verification disabled. Use only in development!
polaris-1        | 2025-10-13 16:22:48,586 INFO  [org.apa.ice.CatalogUtil] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Loading custom FileIO implementation: org.apache.iceberg.aws.s3.S3FileIO
polaris-1        | 2025-10-13 16:22:49,010 INFO  [org.apa.pol.ser.cat.io.DefaultFileIOFactory] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Injected SerializableSupplier for insecure S3 client into Iceberg S3FileIO for ioImpl=org.apache.iceberg.aws.s3.S3FileIO
polaris-1        | 2025-10-13 16:22:49,478 INFO  [org.apa.pol.ser.cat.ice.IcebergCatalog] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) Successfully committed to table quickstart_catalog.minio_polaris_ns.minio_polaris_ns_table01 in 1151 ms
polaris-1        | 2025-10-13 16:22:49,495 INFO  [io.qua.htt.access-log] [02f56580-8e05-4dcd-a818-636533aafecd_0000000000000000006,POLARIS] [,,,] (executor-thread-1) 172.18.0.1 - root [13/Oct/2025:16:22:49 +0000] "POST /api/catalog/v1/quickstart_catalog/namespaces/minio_polaris_ns/tables HTTP/1.1" 200 1073
```

### CHANGELOG.md
<!--
If the changes need to be included in CHANGELOG.md, please add a line here and in CHANGELOG.md.
-->
fcc779b81 Ignore SSL Verification