### PR TITLE
Reproducible builds: ensure unix permissions are reproducible

### DIFF
--- a/build-logic/src/main/kotlin/polaris-reproducible.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-reproducible.gradle.kts
@@ -22,4 +22,15 @@
 tasks.withType<AbstractArchiveTask>().configureEach {
   isPreserveFileTimestamps = false
   isReproducibleFileOrder = true
+
+  dirPermissions { unix("755") }
+  filePermissions {
+    // do not force the "execute" bit in case the file _is_ executable
+    user.read = true
+    user.write = true
+    group.read = true
+    group.write = false
+    other.read = true
+    other.write = false
+  }
 }


### PR DESCRIPTION
Zip and tar files contain the unix file/directory permissions for the included zip/tar entries. The "default" values for those can differ depending on the platform those are built on. This change ensures `755` for directories and owner/group/other=read+write for files. The "executable" bit isn't forcefully set in case the archived file _is_ an executable.
