### PR TITLE
Reproducible builds: use a fixed mtime for all entries in the source tarball

### DIFF
--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -55,6 +55,8 @@ internal fun configureOnRootProject(project: Project) =
         "archive",
         "--prefix=${e.baseName.get()}/",
         "--format=tar.gz",
+        // use a fixed mtime for reproducible tarballs, using the same timestamp as jars do
+        "--mtime=1980-02-01 00:00:00",
         "--output=${e.sourceTarball.get().asFile.relativeTo(projectDir)}",
         "HEAD",
       )


### PR DESCRIPTION
This change makes generated source-tarballs binary-comparable, so that locally built one (via `./gradlew sourceTarball`) should be exactly the same as a staged one.
