### PR TITLE
Dependencies: use one testcontainers dependency version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,6 @@ jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "4.0
 jandex = { module = "io.smallrye.jandex:jandex", version ="3.5.0" }
 javax-servlet-api = { module = "javax.servlet:javax.servlet-api", version = "4.0.1" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.14.0" }
-localstack = { module = "org.testcontainers:localstack", version = "1.21.3" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version = "26.0.7" }
 jcstress-core = { module = "org.openjdk.jcstress:jcstress-core", version = "0.16" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -133,7 +133,8 @@ dependencies {
 
   testImplementation("io.rest-assured:rest-assured")
 
-  testImplementation(libs.localstack)
+  testImplementation(platform(libs.testcontainers.bom))
+  testImplementation("org.testcontainers:testcontainers-localstack")
 
   testImplementation(project(":polaris-runtime-test-common"))
   testImplementation(project(":polaris-container-spec-helper"))


### PR DESCRIPTION
The localstack testcontainers dependency, "included" in the whole testcontainers project, is using a different (and older, 1.21.3 vs 2.0.0) version than the testcontainers-bom.

This change prefers to use the bom as the "only reference".