### PR TITLE
Log root cause exceptions in mappers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -98,7 +98,8 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
     } else {
       getLoggerForExceptionLogging()
           .atLevel(responseCode > 500 ? Level.INFO : Level.DEBUG)
-          .log("Full RuntimeException", runtimeException);
+          .setCause(runtimeException)
+          .log("Full RuntimeException");
     }
 
     ErrorResponse icebergErrorResponse =

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -68,7 +68,8 @@ public class PolarisExceptionMapper implements ExceptionMapper<PolarisException>
     getLogger()
         .atLevel(
             status.getFamily() == Response.Status.Family.SERVER_ERROR ? Level.INFO : Level.DEBUG)
-        .log("Full PolarisException", exception);
+        .setCause(exception)
+        .log("Full PolarisException");
 
     ErrorResponse errorResponse =
         ErrorResponse.builder()


### PR DESCRIPTION
Fix `IcebergExceptionMapper` and `PolarisExceptionMapper` to pass exceptions as "cause" to the logger (as opposed to unreferenced log parameters).
