### PR TITLE
CLI: Remove the trailing comma

### DIFF
--- a/client/python/cli/command/__init__.py
+++ b/client/python/cli/command/__init__.py
@@ -40,7 +40,7 @@ class Command(ABC):
         set_properties = Parser.parse_properties(options_get(Arguments.SET_PROPERTY))
         remove_properties = options_get(Arguments.REMOVE_PROPERTY)
         catalog_client_scopes = options_get(Arguments.CATALOG_CLIENT_SCOPE)
-        parameters = Parser.parse_properties(options_get(Arguments.PARAMETERS)),
+        parameters = Parser.parse_properties(options_get(Arguments.PARAMETERS))
 
         command = None
         if options.command == Commands.CATALOGS:

--- a/client/python/test/test_cli_parsing.py
+++ b/client/python/test/test_cli_parsing.py
@@ -618,6 +618,17 @@ class TestCliParsing(unittest.TestCase):
                 (1, 'client_secret'): 'e469c048cf866dfae469c048cf866df1',
             })
 
+    def test_policies_attach_parameters_parsed_to_dict(self):
+        options = Parser.parse([
+            'policies', 'attach', 'policy-name',
+            '--catalog', 'cat',
+            '--attachment-type', 'catalog',
+            '--parameters', 'key=value',
+        ])
+        command = Command.from_options(options)
+        self.assertIsInstance(command.parameters, dict)
+        self.assertEqual({'key': 'value'}, command.parameters)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The trailing comma makes the `parameter` a tuple, rather than a dict.
```
> cd client/python
> ../../polaris-venv/bin/python -m pytest test/test_cli_parsing.py::TestCliParsing::test_policies_attach_parameters_parsed_to_dict -q

    def test_policies_attach_parameters_parsed_to_dict(self):
        options = Parser.parse([
            'policies', 'attach', 'policy-name',
            '--catalog', 'cat',
            '--attachment-type', 'catalog',
            '--parameters', 'key=value',
        ])
        command = Command.from_options(options)
>       self.assertIsInstance(command.parameters, dict)
E       AssertionError: ({'key': 'value'},) is not an instance of <class 'dict'>

test/test_cli_parsing.py:629: AssertionError

FAILED test/test_cli_parsing.py::TestCliParsing::test_policies_attach_parameters_parsed_to_dict - AssertionError: ({'key': 'value'},) is not an instance of <class 'dict'>
1 failed in 0.47s

```