### PR TITLE
Build: Simplify signing + fix execution in polaris-distribution

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -79,7 +79,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       extensions.create("publishingHelper", PublishingHelperExtension::class.java)
 
       val isRelease = project.hasProperty("release")
-      val isSigning = isRelease || project.hasProperty("signArtifacts")
 
       // Adds Git/Build/System related information to the generated jars, if the `release` project
       // property is present. Do not add that information in development builds, so that the
@@ -102,7 +101,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
         configureOnRootProject(project)
       }
 
-      if (isSigning) {
+      if (isSigningEnabled()) {
         plugins.withType<SigningPlugin>().configureEach {
           configure<SigningExtension> {
             val signingKey: String? by project

--- a/build-logic/src/main/kotlin/publishing/signing.kt
+++ b/build-logic/src/main/kotlin/publishing/signing.kt
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package publishing
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.extensions.stdlib.capitalized
+import org.gradle.plugins.signing.SigningExtension
+
+fun Project.isSigningEnabled(): Boolean = hasProperty("release") || hasProperty("signArtifacts")
+
+/**
+ * Convenience function to sign all output files of the given task.
+ *
+ * Only triggers signing, if the `release` or `signArtifacts` project property is set.
+ */
+fun Project.signTaskOutputs(task: TaskProvider<*>): Unit {
+  if (isSigningEnabled()) {
+    val signingTask = tasks.register("sign" + task.name.capitalized())
+    signingTask.configure {
+      dependsOn(task)
+      actions.addLast {
+        val files = task.get().outputs.files.files
+        files.forEach { file -> logger.info("Signing $file for '${task.get().path}'") }
+        val ext = project.extensions.getByType(SigningExtension::class.java)
+        ext.sign(*files.toTypedArray())
+      }
+    }
+    task.configure { finalizedBy(signingTask) }
+  }
+}

--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import publishing.GenerateDigest
 import publishing.PublishingHelperPlugin
+import publishing.signTaskOutputs
 
 plugins {
   id("distribution")
@@ -98,9 +99,6 @@ distTar.configure { finalizedBy(digestDistTar) }
 
 distZip.configure { finalizedBy(digestDistZip) }
 
-if (project.hasProperty("release") || project.hasProperty("signArtifacts")) {
-  signing {
-    sign(distTar.get())
-    sign(distZip.get())
-  }
-}
+signTaskOutputs(distTar)
+
+signTaskOutputs(distZip)


### PR DESCRIPTION
This change simplifies generation of non-publication artifacts by adding a function taking the task which outputs shall be signed. That function takes care of setting up the correct task dependencies and task execution.

Also fixes an issue that signing does not always happen when running `./gradlew :polaris-distribution:assemble`, because the task dependency graph for the archive tasks and the corresponding signing tasks isn't properly set up.
