### PR TITLE
Simplify digest generation

### DIFF
--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -64,17 +64,7 @@ internal fun configureOnRootProject(project: Project) =
       outputs.file(e.sourceTarball)
     }
 
-    val digestSourceTarball =
-      tasks.register<GenerateDigest>("digestSourceTarball") {
-        description = "Generate the source tarball digest"
-        mustRunAfter(sourceTarball)
-        file.set {
-          val e = project.extensions.getByType(PublishingHelperExtension::class.java)
-          e.sourceTarball.get().asFile
-        }
-      }
-
-    sourceTarball.configure { finalizedBy(digestSourceTarball) }
+    digestTaskOutputs(sourceTarball)
 
     signTaskOutputs(sourceTarball)
 

--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import publishing.GenerateDigest
 import publishing.PublishingHelperPlugin
+import publishing.digestTaskOutputs
 import publishing.signTaskOutputs
 
 plugins {
@@ -81,23 +81,9 @@ val distTar = tasks.named<Tar>("distTar") { compression = Compression.GZIP }
 
 val distZip = tasks.named<Zip>("distZip") {}
 
-val digestDistTar =
-  tasks.register<GenerateDigest>("digestDistTar") {
-    description = "Generate the distribution tar digest"
-    dependsOn(distTar)
-    file.set { distTar.get().archiveFile.get().asFile }
-  }
+digestTaskOutputs(distTar)
 
-val digestDistZip =
-  tasks.register<GenerateDigest>("digestDistZip") {
-    description = "Generate the distribution zip digest"
-    dependsOn(distZip)
-    file.set { distZip.get().archiveFile.get().asFile }
-  }
-
-distTar.configure { finalizedBy(digestDistTar) }
-
-distZip.configure { finalizedBy(digestDistZip) }
+digestTaskOutputs(distZip)
 
 signTaskOutputs(distTar)
 


### PR DESCRIPTION
Similarly to the change to simplify artifact signing, this change simplifies digest generation by introducing a function to digest the output files of any task. That function takes care of setting up the correct task dependencies and task execution.

Also removes an unnecessary double buffering during digest generation.