### PR TITLE
Build-logic: `GitInfo` refactor

### DIFF
--- a/build-logic/src/main/kotlin/GitInfo.kt
+++ b/build-logic/src/main/kotlin/GitInfo.kt
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.extra
+
+/**
+ * Container to memoize Git information retrieved via `git` command executions across all Gradle
+ * projects.
+ */
+class GitInfo(val gitHead: String, val gitDescribe: String) {
+  companion object {
+    private fun execGit(rootProject: Project, vararg args: Any): String {
+      val out =
+        rootProject.providers
+          .exec {
+            executable = "git"
+            args(args.toList())
+          }
+          .standardOutput
+          .asText
+          .get()
+      return out.trim()
+    }
+
+    fun memoized(project: Project): GitInfo {
+      val rootProject = project.rootProject
+      return if (rootProject.extra.has("gitInfo")) {
+        @Suppress("UNCHECKED_CAST")
+        rootProject.extra["gitInfo"] as GitInfo
+      } else {
+        val isRelease =
+          rootProject.hasProperty("release") || rootProject.hasProperty("jarWithGitInfo")
+        val gitHead = execGit(rootProject, "rev-parse", "HEAD")
+        val gitDescribe =
+          if (isRelease)
+            try {
+              execGit(rootProject, "describe", "--tags")
+            } catch (_: Exception) {
+              execGit(rootProject, "describe", "--always", "--dirty")
+            }
+          else ""
+        val gitInfo = GitInfo(gitHead, gitDescribe)
+        rootProject.extra["gitInfo"] = gitInfo
+        return gitInfo
+      }
+    }
+  }
+}

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -87,7 +87,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       if (isRelease || project.hasProperty("jarWithGitInfo")) {
         // Runs `git`, considered expensive, so guarded behind project properties.
         tasks.withType<Jar>().configureEach {
-          manifest { MemoizedGitInfo.gitInfo(rootProject, attributes) }
+          manifest { MemoizedJarInfo.applyJarManifestAttributes(rootProject, attributes) }
         }
 
         addAdditionalJarContent(this)

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -100,8 +100,7 @@ internal fun configureOnRootProject(project: Project) =
         val e = project.extensions.getByType(PublishingHelperExtension::class.java)
         val asfName = e.asfProjectId.get()
 
-        val gitInfo = MemoizedGitInfo.gitInfo(rootProject)
-        val gitCommitId = gitInfo["Apache-Polaris-Build-Git-Head"]
+        val gitCommitId = GitInfo.memoized(rootProject).gitHead
 
         val repos = project.extensions.getByType(NexusPublishExtension::class.java).repositories
         val repo = repos.iterator().next()


### PR DESCRIPTION
Allows use of `GitInfo` for other use cases than just Jar manifest attributes. SBOM generation will be another use case for Git information.
