### PR TITLE
Root POM: link to project's LICENSE, add NOTICE+DISCLAIMER to comment

### DIFF
--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -75,6 +75,7 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
 
         task.doFirst {
           mavenPom.run {
+            val gitInfo = GitInfo.memoized(project)
             val asfProject = AsfProject.memoized(project, e.asfProjectId.get())
             val asfProjectId = asfProject.apacheId
 
@@ -85,7 +86,14 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
             licenses {
               license {
                 name.set("Apache-2.0") // SPDX identifier
-                url.set(asfProject.licenseUrl)
+                url.set(gitInfo.rawGithubLink("LICENSE"))
+                comments.set(
+                  """
+                  NOTICE: ${gitInfo.rawGithubLink("NOTICE")}
+                  DISCLAIMER: ${gitInfo.rawGithubLink("DISCLAIMER")}
+                  """
+                    .trimIndent()
+                )
               }
             }
             mailingLists {


### PR DESCRIPTION
This change replaces the project's license URL in the parent POM from the AL-2.0 template to the `LICENSE` file in the project's root directory.

Before (in `pom.xml`):
```
  <licenses>
    <license>
      <name>Apache-2.0</name>
      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>;
    </license>
  </licenses>
```

With this change:
```
  <licenses>
    <license>
      <name>Apache-2.0</name>
      <url>https://raw.githubusercontent.com/apache/polaris/HEAD/LICENSE</url>
      <comments>NOTICE: https://raw.githubusercontent.com/apache/polaris/HEAD/NOTICE
DISCLAIMER: https://raw.githubusercontent.com/apache/polaris/HEAD/DISCLAIMER</comments>
    </license>
  </licenses>
```