### PR TITLE
Adding 1.2.0 as one of active releases

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -65,6 +65,7 @@ params:
   # at the very right in the navbar.
   active_releases:
     # Mention all active releases here, in semver descending order
+    - "1.2.0"
     - "1.1.0"
     - "1.0.1"
     - "1.0.0"


### PR DESCRIPTION
<img width="464" height="443" alt="Screenshot 2025-10-27 at 4 07 28 PM" src="https://github.com/user-attachments/assets/4b9e3022-d5e2-4ab5-8705-b1b16b1175df" />
It may fix the mismatch. Couldn't test it locally though. 