### PR TITLE
Prefer PolarisPrincipal.getRoles in Resolver

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
@@ -69,7 +70,6 @@ public class Resolver {
 
   // the id of the principal making the call or 0 if unknown
   private final @Nonnull PolarisPrincipal polarisPrincipal;
-  private final @Nonnull SecurityContext securityContext;
 
   // reference catalog name for name resolution
   private final String referenceCatalogName;
@@ -137,7 +137,6 @@ public class Resolver {
     this.diagnostics = diagnostics;
     this.polarisMetaStoreManager = polarisMetaStoreManager;
     this.cache = cache;
-    this.securityContext = securityContext;
     this.referenceCatalogName = referenceCatalogName;
 
     // validate inputs
@@ -467,11 +466,11 @@ public class Resolver {
 
     // update all principal roles with latest
     if (!this.resolvedCallerPrincipalRoles.isEmpty()) {
-      List<ResolvedPolarisEntity> refreshedResolvedCallerPrincipalRoles =
-          new ArrayList<>(this.resolvedCallerPrincipalRoles.size());
-      this.resolvedCallerPrincipalRoles.forEach(
-          ce -> refreshedResolvedCallerPrincipalRoles.add(this.getFreshlyResolved(ce)));
-      this.resolvedCallerPrincipalRoles = refreshedResolvedCallerPrincipalRoles;
+      this.resolvedCallerPrincipalRoles =
+          resolvedCallerPrincipalRoles.stream()
+              .map(this::getFreshlyResolved)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
     }
 
     // update referenced catalog
@@ -776,13 +775,11 @@ public class Resolver {
   /**
    * Resolve all principal roles that the principal has grants for
    *
-   * @param toValidate
-   * @param resolvedCallerPrincipal1
    * @return the list of resolved principal roles the principal has grants for
    */
   private List<ResolvedPolarisEntity> resolveAllPrincipalRoles(
-      List<ResolvedPolarisEntity> toValidate, ResolvedPolarisEntity resolvedCallerPrincipal1) {
-    return resolvedCallerPrincipal1.getGrantRecordsAsGrantee().stream()
+      List<ResolvedPolarisEntity> toValidate, ResolvedPolarisEntity callerPrincipal) {
+    return callerPrincipal.getGrantRecordsAsGrantee().stream()
         .filter(gr -> gr.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode())
         .map(
             gr ->
@@ -791,22 +788,22 @@ public class Resolver {
                     PolarisEntityType.PRINCIPAL_ROLE,
                     PolarisEntityConstants.getRootEntityId(),
                     gr.getSecurableId()))
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 
   /**
-   * Resolve the specified list of principal roles. The SecurityContext is used to determine whether
-   * the principal actually has the roles specified.
+   * Resolve the specified list of principal roles. The PolarisPrincipal is used to determine
+   * whether the principal actually has the roles specified.
    *
-   * @param toValidate
-   * @param roleNames
    * @return the filtered list of resolved principal roles
    */
   private List<ResolvedPolarisEntity> resolvePrincipalRolesByName(
       List<ResolvedPolarisEntity> toValidate, Set<String> roleNames) {
     return roleNames.stream()
-        .filter(securityContext::isUserInRole)
+        .filter(roleName -> polarisPrincipal.getRoles().contains(roleName))
         .map(roleName -> resolveByName(toValidate, PolarisEntityType.PRINCIPAL_ROLE, roleName))
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -167,7 +167,6 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-    when(securityContext.isUserInRole(isA(String.class))).thenReturn(true);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -316,7 +316,6 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-    when(securityContext.isUserInRole(isA(String.class))).thenReturn(true);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     reservedProperties = new ReservedProperties() {};

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
@@ -173,7 +173,6 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
 
     SecurityContext securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-    when(securityContext.isUserInRole(Mockito.anyString())).thenReturn(true);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -188,7 +188,6 @@ public abstract class AbstractPolicyCatalogTest {
 
     securityContext = Mockito.mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-    when(securityContext.isUserInRole(isA(String.class))).thenReturn(true);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;


### PR DESCRIPTION
it should be sufficient to rely on `SecurityContext.getUserPrincipal` alone, we dont need to call `isUserInRole` explicitly.

note due to the `ResolverTest` testing with non-existent roles we have to add null-filtering to the `Resolver`.