### PR TITLE
Prefer PolarisPrincipal over SecurityContext

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.persistence.resolver;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,7 +51,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisResolutionManifest.class);
 
   private final ResolverFactory resolverFactory;
-  private final SecurityContext securityContext;
+  private final PolarisPrincipal principal;
   private final RealmContext realmContext;
   private final String catalogName;
   private final Resolver primaryResolver;
@@ -73,20 +72,15 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
       PolarisDiagnostics diagnostics,
       RealmContext realmContext,
       ResolverFactory resolverFactory,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       String catalogName) {
     this.realmContext = realmContext;
     this.resolverFactory = resolverFactory;
     this.catalogName = catalogName;
-    this.primaryResolver = resolverFactory.createResolver(securityContext, catalogName);
     this.diagnostics = diagnostics;
-    this.diagnostics.checkNotNull(securityContext, "null_security_context_for_resolution_manifest");
-    this.securityContext = securityContext;
-    diagnostics.check(
-        securityContext.getUserPrincipal() instanceof PolarisPrincipal,
-        "invalid_principal_type_for_resolution_manifest",
-        "principal={}",
-        securityContext.getUserPrincipal());
+    this.diagnostics.checkNotNull(principal, "null_principal_for_resolution_manifest");
+    this.principal = principal;
+    this.primaryResolver = resolverFactory.createResolver(principal, catalogName);
 
     // TODO: Make the rootContainer lookup no longer optional in the persistence store.
     // For now, we'll try to resolve the rootContainer as "optional", and only if we fail to find
@@ -186,7 +180,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
     ResolverPath requestedPath = passthroughPaths.get(key);
 
     // Run a single-use Resolver for this path.
-    Resolver passthroughResolver = resolverFactory.createResolver(securityContext, catalogName);
+    Resolver passthroughResolver = resolverFactory.createResolver(principal, catalogName);
     passthroughResolver.addPath(requestedPath);
     ResolverStatus status = passthroughResolver.resolveAll();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactory.java
@@ -21,11 +21,11 @@ package org.apache.polaris.core.persistence.resolver;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 
 public interface ResolutionManifestFactory {
 
   @Nonnull
   PolarisResolutionManifest createResolutionManifest(
-      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName);
+      @Nonnull PolarisPrincipal principal, @Nullable String referenceCatalogName);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactoryImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolutionManifestFactoryImpl.java
@@ -21,8 +21,8 @@ package org.apache.polaris.core.persistence.resolver;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.RealmContext;
 
 public class ResolutionManifestFactoryImpl implements ResolutionManifestFactory {
@@ -43,8 +43,8 @@ public class ResolutionManifestFactoryImpl implements ResolutionManifestFactory 
   @Nonnull
   @Override
   public PolarisResolutionManifest createResolutionManifest(
-      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName) {
+      @Nonnull PolarisPrincipal principal, @Nullable String referenceCatalogName) {
     return new PolarisResolutionManifest(
-        diagnostics, realmContext, resolverFactory, securityContext, referenceCatalogName);
+        diagnostics, realmContext, resolverFactory, principal, referenceCatalogName);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.persistence.resolver;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -116,7 +115,7 @@ public class Resolver {
    *
    * @param polarisCallContext the polaris call context
    * @param polarisMetaStoreManager meta store manager
-   * @param securityContext The {@link SecurityContext} for the current request
+   * @param principal The {@link PolarisPrincipal} for the current request
    * @param cache shared entity cache
    * @param referenceCatalogName if not null, specifies the name of the reference catalog. The
    *     reference catalog is the catalog used to resolve catalog roles and catalog path. Also, if a
@@ -130,7 +129,7 @@ public class Resolver {
       @Nonnull PolarisDiagnostics diagnostics,
       @Nonnull PolarisCallContext polarisCallContext,
       @Nonnull PolarisMetaStoreManager polarisMetaStoreManager,
-      @Nonnull SecurityContext securityContext,
+      @Nonnull PolarisPrincipal principal,
       @Nullable EntityCache cache,
       @Nullable String referenceCatalogName) {
     this.polarisCallContext = polarisCallContext;
@@ -143,16 +142,9 @@ public class Resolver {
     this.diagnostics.checkNotNull(polarisCallContext, "unexpected_null_polarisCallContext");
     this.diagnostics.checkNotNull(
         polarisMetaStoreManager, "unexpected_null_polarisMetaStoreManager");
-    this.diagnostics.checkNotNull(securityContext, "security_context_must_be_specified");
-    this.diagnostics.checkNotNull(
-        securityContext.getUserPrincipal(), "principal_must_be_specified");
-    this.diagnostics.check(
-        securityContext.getUserPrincipal() instanceof PolarisPrincipal,
-        "unexpected_principal_type",
-        "class={}",
-        securityContext.getUserPrincipal().getClass().getName());
+    this.diagnostics.checkNotNull(principal, "principal_must_be_specified");
 
-    this.polarisPrincipal = (PolarisPrincipal) securityContext.getUserPrincipal();
+    this.polarisPrincipal = principal;
     // paths to resolve
     this.pathsToResolve = new ArrayList<>();
     this.resolvedPaths = new ArrayList<>();

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverFactory.java
@@ -21,9 +21,9 @@ package org.apache.polaris.core.persistence.resolver;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 
 public interface ResolverFactory {
   Resolver createResolver(
-      @Nonnull SecurityContext securityContext, @Nullable String referenceCatalogName);
+      @Nonnull PolarisPrincipal principal, @Nullable String referenceCatalogName);
 }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
@@ -20,8 +20,6 @@ package org.apache.polaris.core.persistence;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -442,29 +440,7 @@ public abstract class BaseResolverTest {
         diagServices,
         callCtx(),
         metaStoreManager(),
-        new SecurityContext() {
-          @Override
-          public Principal getUserPrincipal() {
-            return authenticatedPrincipal;
-          }
-
-          @Override
-          public boolean isUserInRole(String role) {
-            return roleEntities
-                .map(l -> l.stream().map(PrincipalRoleEntity::getName).anyMatch(role::equals))
-                .orElse(allRoles);
-          }
-
-          @Override
-          public boolean isSecure() {
-            return false;
-          }
-
-          @Override
-          public String getAuthenticationScheme() {
-            return "";
-          }
-        },
+        authenticatedPrincipal,
         this.shouldUseCache ? this.cache : null,
         referenceCatalogName);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogAdapter.java
@@ -35,10 +35,11 @@ public interface CatalogAdapter {
     return RESTUtil.decodeNamespace(URLEncoder.encode(namespace, Charset.defaultCharset()));
   }
 
-  default void validatePrincipal(SecurityContext securityContext) {
-    var authenticatedPrincipal = (PolarisPrincipal) securityContext.getUserPrincipal();
-    if (authenticatedPrincipal == null) {
-      throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
+  default PolarisPrincipal validatePrincipal(SecurityContext securityContext) {
+    var authenticatedPrincipal = securityContext.getUserPrincipal();
+    if (authenticatedPrincipal instanceof PolarisPrincipal polarisPrincipal) {
+      return polarisPrincipal;
     }
+    throw new NotAuthorizedException("Failed to find authenticatedPrincipal in SecurityContext");
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.common;
 import static org.apache.polaris.core.entity.PolarisEntitySubType.ICEBERG_TABLE;
 
 import jakarta.enterprise.inject.Instance;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -70,13 +69,12 @@ public abstract class CatalogHandler {
   protected final CallContext callContext;
   protected final RealmConfig realmConfig;
   protected final PolarisPrincipal polarisPrincipal;
-  protected final SecurityContext securityContext;
 
   public CatalogHandler(
       PolarisDiagnostics diagnostics,
       CallContext callContext,
       ResolutionManifestFactory resolutionManifestFactory,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       String catalogName,
       PolarisAuthorizer authorizer,
       PolarisCredentialManager credentialManager,
@@ -86,14 +84,7 @@ public abstract class CatalogHandler {
     this.realmConfig = callContext.getRealmConfig();
     this.resolutionManifestFactory = resolutionManifestFactory;
     this.catalogName = catalogName;
-    diagnostics.checkNotNull(securityContext, "null_security_context");
-    diagnostics.checkNotNull(securityContext.getUserPrincipal(), "null_user_principal");
-    diagnostics.check(
-        securityContext.getUserPrincipal() instanceof PolarisPrincipal,
-        "invalid_principal_type",
-        "Principal must be a PolarisPrincipal");
-    this.securityContext = securityContext;
-    this.polarisPrincipal = (PolarisPrincipal) securityContext.getUserPrincipal();
+    this.polarisPrincipal = principal;
     this.authorizer = authorizer;
     this.credentialManager = credentialManager;
     this.externalCatalogFactories = externalCatalogFactories;
@@ -104,7 +95,7 @@ public abstract class CatalogHandler {
   }
 
   protected PolarisResolutionManifest newResolutionManifest() {
-    return resolutionManifestFactory.createResolutionManifest(securityContext, catalogName);
+    return resolutionManifestFactory.createResolutionManifest(polarisPrincipal, catalogName);
   }
 
   /** Initialize the catalog once authorized. Called after all `authorize...` methods. */

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
@@ -92,14 +93,14 @@ public class GenericTableCatalogAdapter
       SecurityContext securityContext, String prefix) {
     FeatureConfiguration.enforceFeatureEnabledOrThrow(
         realmConfig, FeatureConfiguration.ENABLE_GENERIC_TABLES);
-    validatePrincipal(securityContext);
+    PolarisPrincipal principal = validatePrincipal(securityContext);
 
     return new GenericTableCatalogHandler(
         diagnostics,
         callContext,
         resolutionManifestFactory,
         metaStoreManager,
-        securityContext,
+        principal,
         prefixParser.prefixToCatalogName(realmContext, prefix),
         polarisAuthorizer,
         polarisCredentialManager,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.catalog.generic;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.inject.Instance;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
@@ -28,6 +27,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.catalog.GenericTableCatalog;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -59,7 +59,7 @@ public class GenericTableCatalogHandler extends CatalogHandler {
       CallContext callContext,
       ResolutionManifestFactory resolutionManifestFactory,
       PolarisMetaStoreManager metaStoreManager,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       String catalogName,
       PolarisAuthorizer authorizer,
       PolarisCredentialManager polarisCredentialManager,
@@ -68,7 +68,7 @@ public class GenericTableCatalogHandler extends CatalogHandler {
         diagnostics,
         callContext,
         resolutionManifestFactory,
-        securityContext,
+        principal,
         catalogName,
         authorizer,
         polarisCredentialManager,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -28,7 +28,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.ws.rs.core.SecurityContext;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -90,6 +89,7 @@ import org.apache.iceberg.view.ViewProperties;
 import org.apache.iceberg.view.ViewUtil;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -166,7 +166,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   private final PolarisResolutionManifestCatalogView resolvedEntityView;
   private final CatalogEntity catalogEntity;
   private final TaskExecutor taskExecutor;
-  private final SecurityContext securityContext;
+  private final PolarisPrincipal principal;
   private final PolarisEventListener polarisEventListener;
   private final AtomicBoolean loggedPrefixOverlapWarning = new AtomicBoolean(false);
 
@@ -195,7 +195,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext,
       PolarisResolutionManifestCatalogView resolvedEntityView,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       TaskExecutor taskExecutor,
       AccessConfigProvider accessConfigProvider,
       FileIOFactory fileIOFactory,
@@ -206,7 +206,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     this.realmConfig = callContext.getRealmConfig();
     this.resolvedEntityView = resolvedEntityView;
     this.catalogEntity = resolvedEntityView.getResolvedCatalogEntity();
-    this.securityContext = securityContext;
+    this.principal = principal;
     this.taskExecutor = taskExecutor;
     this.catalogId = catalogEntity.getId();
     this.catalogName = catalogEntity.getName();
@@ -1163,7 +1163,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             diagnostics,
             callContext.getRealmContext(),
             resolverFactory,
-            securityContext,
+            principal,
             parentPath.getFirst().getName());
     siblingTables.forEach(
         tbl ->

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -208,7 +208,7 @@ public class IcebergCatalogAdapter
 
   @VisibleForTesting
   IcebergCatalogHandler newHandlerWrapper(SecurityContext securityContext, String catalogName) {
-    validatePrincipal(securityContext);
+    PolarisPrincipal principal = validatePrincipal(securityContext);
 
     return new IcebergCatalogHandler(
         diagnostics,
@@ -216,7 +216,7 @@ public class IcebergCatalogAdapter
         resolutionManifestFactory,
         metaStoreManager,
         credentialManager,
-        securityContext,
+        principal,
         catalogFactory,
         catalogName,
         polarisAuthorizer,
@@ -799,7 +799,7 @@ public class IcebergCatalogAdapter
     if (warehouse == null) {
       throw new BadRequestException("Please specify a warehouse");
     }
-    Resolver resolver = resolverFactory.createResolver(securityContext, warehouse);
+    Resolver resolver = resolverFactory.createResolver(authenticatedPrincipal, warehouse);
     ResolverStatus resolverStatus = resolver.resolveAll();
     if (!resolverStatus.getStatus().equals(ResolverStatus.StatusEnum.SUCCESS)) {
       throw new NotFoundException("Unable to find warehouse %s", warehouse);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -28,7 +28,6 @@ import io.smallrye.common.annotation.Identifier;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.inject.Instance;
-import jakarta.ws.rs.core.SecurityContext;
 import java.io.Closeable;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -80,6 +79,7 @@ import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
@@ -156,7 +156,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
       ResolutionManifestFactory resolutionManifestFactory,
       PolarisMetaStoreManager metaStoreManager,
       PolarisCredentialManager credentialManager,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       CallContextCatalogFactory catalogFactory,
       String catalogName,
       PolarisAuthorizer authorizer,
@@ -169,7 +169,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
         diagnostics,
         callContext,
         resolutionManifestFactory,
-        securityContext,
+        principal,
         catalogName,
         authorizer,
         credentialManager,
@@ -269,7 +269,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
       LOGGER.atInfo().log("Initializing non-federated catalog");
       this.baseCatalog =
           catalogFactory.createCallContextCatalog(
-              callContext, polarisPrincipal, securityContext, resolutionManifest);
+              callContext, polarisPrincipal, resolutionManifest);
     }
     this.namespaceCatalog =
         (baseCatalog instanceof SupportsNamespaces) ? (SupportsNamespaces) baseCatalog : null;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
@@ -92,14 +93,14 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
   private PolicyCatalogHandler newHandlerWrapper(SecurityContext securityContext, String prefix) {
     FeatureConfiguration.enforceFeatureEnabledOrThrow(
         realmConfig, FeatureConfiguration.ENABLE_POLICY_STORE);
-    validatePrincipal(securityContext);
+    PolarisPrincipal principal = validatePrincipal(securityContext);
 
     return new PolicyCatalogHandler(
         diagnostics,
         callContext,
         resolutionManifestFactory,
         metaStoreManager,
-        securityContext,
+        principal,
         prefixParser.prefixToCatalogName(realmContext, prefix),
         polarisAuthorizer,
         polarisCredentialManager,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.policy;
 import com.google.common.base.Strings;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.inject.Instance;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -33,6 +32,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 import org.apache.polaris.core.context.CallContext;
@@ -68,7 +68,7 @@ public class PolicyCatalogHandler extends CatalogHandler {
       CallContext callContext,
       ResolutionManifestFactory resolutionManifestFactory,
       PolarisMetaStoreManager metaStoreManager,
-      SecurityContext securityContext,
+      PolarisPrincipal principal,
       String catalogName,
       PolarisAuthorizer authorizer,
       PolarisCredentialManager polarisCredentialManager,
@@ -77,7 +77,7 @@ public class PolicyCatalogHandler extends CatalogHandler {
         diagnostics,
         callContext,
         resolutionManifestFactory,
-        securityContext,
+        principal,
         catalogName,
         authorizer,
         polarisCredentialManager,

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/CallContextCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/CallContextCatalogFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.context.catalog;
 
-import jakarta.ws.rs.core.SecurityContext;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
@@ -29,6 +28,5 @@ public interface CallContextCatalogFactory {
   Catalog createCallContextCatalog(
       CallContext context,
       PolarisPrincipal polarisPrincipal,
-      SecurityContext securityContext,
       PolarisResolutionManifest resolvedManifest);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisCallContextCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisCallContextCatalogFactory.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.context.catalog;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
@@ -75,7 +74,6 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
   public Catalog createCallContextCatalog(
       CallContext context,
       PolarisPrincipal polarisPrincipal,
-      SecurityContext securityContext,
       final PolarisResolutionManifest resolvedManifest) {
     CatalogEntity catalog = resolvedManifest.getResolvedCatalogEntity();
     String catalogName = catalog.getName();
@@ -91,7 +89,7 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
             metaStoreManagerFactory.getOrCreateMetaStoreManager(context.getRealmContext()),
             context,
             resolvedManifest,
-            securityContext,
+            polarisPrincipal,
             taskExecutor,
             accessConfigProvider,
             fileIOFactory,

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -22,8 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
-import java.security.Principal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -371,38 +369,19 @@ public class ManagementServiceTest {
 
   private PolarisAdminService setupPolarisAdminService(
       PolarisMetaStoreManager metaStoreManager, PolarisCallContext callContext) {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            new PrincipalEntity.Builder()
+                .setName(PolarisEntityConstants.getRootPrincipalName())
+                .build(),
+            Set.of(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole()));
     return new PolarisAdminService(
-        services.polarisDiagnostics(),
         callContext,
         services.resolutionManifestFactory(),
         metaStoreManager,
         new UnsafeInMemorySecretsManager(),
         new DefaultServiceIdentityProvider(),
-        new SecurityContext() {
-          @Override
-          public Principal getUserPrincipal() {
-            return PolarisPrincipal.of(
-                new PrincipalEntity.Builder()
-                    .setName(PolarisEntityConstants.getRootPrincipalName())
-                    .build(),
-                Set.of(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole()));
-          }
-
-          @Override
-          public boolean isUserInRole(String role) {
-            return true;
-          }
-
-          @Override
-          public boolean isSecure() {
-            return false;
-          }
-
-          @Override
-          public String getAuthenticationScheme() {
-            return "";
-          }
-        },
+        principal,
         new PolarisAuthorizerImpl(services.realmConfig()),
         ReservedProperties.NONE);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
@@ -51,13 +51,12 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final PolarisPrincipal authenticatedPrincipal =
         PolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
     return new PolarisAdminService(
-        diagServices,
         callContext,
         resolutionManifestFactory,
         metaStoreManager,
         userSecretsManager,
         serviceIdentityProvider,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         polarisAuthorizer,
         reservedProperties);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -26,15 +26,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
-import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -67,14 +64,12 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 public class PolarisAdminServiceTest {
-  private PolarisDiagnostics diagnostics = new PolarisDefaultDiagServiceImpl();
   @Mock private CallContext callContext;
   @Mock private PolarisCallContext polarisCallContext;
   @Mock private ResolutionManifestFactory resolutionManifestFactory;
   @Mock private PolarisMetaStoreManager metaStoreManager;
   @Mock private UserSecretsManager userSecretsManager;
   @Mock private ServiceIdentityProvider identityProvider;
-  @Mock private SecurityContext securityContext;
   @Mock private PolarisAuthorizer authorizer;
   @Mock private ReservedProperties reservedProperties;
   @Mock private PolarisPrincipal authenticatedPrincipal;
@@ -87,7 +82,6 @@ public class PolarisAdminServiceTest {
   @BeforeEach
   void setUp() throws Exception {
     MockitoAnnotations.openMocks(this);
-    when(securityContext.getUserPrincipal()).thenReturn(authenticatedPrincipal);
     when(callContext.getPolarisCallContext()).thenReturn(polarisCallContext);
     when(polarisCallContext.getRealmConfig()).thenReturn(realmConfig);
 
@@ -105,13 +99,12 @@ public class PolarisAdminServiceTest {
 
     adminService =
         new PolarisAdminService(
-            diagnostics,
             callContext,
             resolutionManifestFactory,
             metaStoreManager,
             userSecretsManager,
             identityProvider,
-            securityContext,
+            authenticatedPrincipal,
             authorizer,
             reservedProperties);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisServiceImplTest.java
@@ -22,11 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import jakarta.ws.rs.core.SecurityContext;
 import java.lang.reflect.Method;
 import java.util.List;
-import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
-import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogProperties;
@@ -44,19 +41,14 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.secrets.UserSecretsManager;
-import org.apache.polaris.core.secrets.UserSecretsManagerFactory;
 import org.apache.polaris.service.config.ReservedProperties;
-import org.apache.polaris.service.events.listeners.NoOpPolarisEventListener;
-import org.apache.polaris.service.events.listeners.PolarisEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class PolarisServiceImplTest {
 
-  private final PolarisDiagnostics diagnostics = new PolarisDefaultDiagServiceImpl();
   private ResolutionManifestFactory resolutionManifestFactory;
-  private UserSecretsManagerFactory userSecretsManagerFactory;
   private PolarisMetaStoreManager metaStoreManager;
   private UserSecretsManager userSecretsManager;
   private ServiceIdentityProvider serviceIdentityProvider;
@@ -64,7 +56,6 @@ public class PolarisServiceImplTest {
   private CallContext callContext;
   private ReservedProperties reservedProperties;
   private RealmConfig realmConfig;
-  private PolarisEventListener polarisEventListener;
 
   private PolarisAdminService adminService;
   private PolarisServiceImpl polarisService;
@@ -79,10 +70,7 @@ public class PolarisServiceImplTest {
     callContext = Mockito.mock(CallContext.class);
     reservedProperties = Mockito.mock(ReservedProperties.class);
     realmConfig = Mockito.mock(RealmConfig.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    Mockito.when(securityContext.getUserPrincipal())
-        .thenReturn(Mockito.mock(PolarisPrincipal.class));
-    polarisEventListener = new NoOpPolarisEventListener();
+    PolarisPrincipal principal = Mockito.mock(PolarisPrincipal.class);
 
     when(callContext.getRealmConfig()).thenReturn(realmConfig);
     when(realmConfig.getConfig(FeatureConfiguration.SUPPORTED_CATALOG_CONNECTION_TYPES))
@@ -93,13 +81,12 @@ public class PolarisServiceImplTest {
 
     adminService =
         new PolarisAdminService(
-            diagnostics,
             callContext,
             resolutionManifestFactory,
             metaStoreManager,
             userSecretsManager,
             serviceIdentityProvider,
-            securityContext,
+            principal,
             polarisAuthorizer,
             reservedProperties);
     polarisService =

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -120,7 +119,6 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
   private FileIOFactory fileIOFactory;
   private PolarisPrincipal authenticatedRoot;
   private PolarisEntity catalogEntity;
-  private SecurityContext securityContext;
   private AccessConfigProvider accessConfigProvider;
 
   protected static final Schema SCHEMA =
@@ -165,21 +163,17 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
 
-    securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;
 
     adminService =
         new PolarisAdminService(
-            diagServices,
             polarisContext,
             resolutionManifestFactory,
             metaStoreManager,
             userSecretsManager,
             serviceIdentityProvider,
-            securityContext,
+            authenticatedRoot,
             authorizer,
             reservedProperties);
 
@@ -212,7 +206,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, authenticatedRoot, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     this.fileIOFactory = new DefaultFileIOFactory();
 
@@ -246,7 +240,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
             metaStoreManager,
             polarisContext,
             passthroughView,
-            securityContext,
+            authenticatedRoot,
             taskExecutor,
             accessConfigProvider,
             fileIOFactory,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
@@ -50,7 +50,7 @@ public class PolarisGenericTableCatalogHandlerAuthzTest extends PolarisAuthzTest
         callContext,
         resolutionManifestFactory,
         metaStoreManager,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         catalogName,
         polarisAuthorizer,
         null,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
@@ -18,12 +18,9 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
-import static org.mockito.Mockito.when;
-
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -171,21 +168,17 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     PolarisPrincipal authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
 
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;
 
     PolarisAdminService adminService =
         new PolarisAdminService(
-            diagServices,
             polarisContext,
             resolutionManifestFactory,
             metaStoreManager,
             userSecretsManager,
             serviceIdentityProvider,
-            securityContext,
+            authenticatedRoot,
             authorizer,
             reservedProperties);
     adminService.createCatalog(
@@ -208,7 +201,7 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, authenticatedRoot, CATALOG_NAME);
     FileIOFactory fileIOFactory = new DefaultFileIOFactory();
 
     testPolarisEventListener = (TestPolarisEventListener) polarisEventListener;
@@ -220,7 +213,7 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
             metaStoreManager,
             polarisContext,
             passthroughView,
-            securityContext,
+            authenticatedRoot,
             Mockito.mock(),
             accessConfigProvider,
             fileIOFactory,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
@@ -23,7 +23,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.SecurityContext;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -127,7 +126,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         resolutionManifestFactory,
         metaStoreManager,
         credentialManager,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         factory,
         catalogName,
         polarisAuthorizer,
@@ -267,7 +266,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             resolutionManifestFactory,
             metaStoreManager,
             credentialManager,
-            securityContext(authenticatedPrincipal),
+            authenticatedPrincipal,
             callContextCatalogFactory,
             CATALOG_NAME,
             polarisAuthorizer,
@@ -305,7 +304,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             resolutionManifestFactory,
             metaStoreManager,
             credentialManager,
-            securityContext(authenticatedPrincipal1),
+            authenticatedPrincipal1,
             callContextCatalogFactory,
             CATALOG_NAME,
             polarisAuthorizer,
@@ -1125,9 +1124,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
     CallContextCatalogFactory mockFactory = Mockito.mock(CallContextCatalogFactory.class);
 
     // Mock the catalog factory to return our regular catalog but with mocked config
-    Mockito.when(
-            mockFactory.createCallContextCatalog(
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+    Mockito.when(mockFactory.createCallContextCatalog(Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(baseCatalog);
 
     return newWrapperWithFineLevelAuthDisabled(Set.of(), CATALOG_NAME, mockFactory, false);
@@ -1185,7 +1182,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         resolutionManifestFactory,
         metaStoreManager,
         credentialManager,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         factory,
         catalogName,
         polarisAuthorizer,
@@ -1906,11 +1903,9 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
           public Catalog createCallContextCatalog(
               CallContext context,
               PolarisPrincipal polarisPrincipal,
-              SecurityContext securityContext,
               PolarisResolutionManifest resolvedManifest) {
             Catalog catalog =
-                super.createCallContextCatalog(
-                    context, polarisPrincipal, securityContext, resolvedManifest);
+                super.createCallContextCatalog(context, polarisPrincipal, resolvedManifest);
             String fileIoImpl = "org.apache.iceberg.inmemory.InMemoryFileIO";
             catalog.initialize(
                 externalCatalog, ImmutableMap.of(CatalogProperties.FILE_IO_IMPL, fileIoImpl));

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
@@ -63,7 +63,7 @@ public class IcebergCatalogHandlerFineGrainedDisabledTest extends PolarisAuthzTe
         resolutionManifestFactory,
         metaStoreManager,
         credentialManager,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         callContextCatalogFactory,
         CATALOG_NAME,
         polarisAuthorizer,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -206,7 +206,7 @@ public class FileIOFactoryTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            services.resolutionManifestFactory(), services.securityContext(), CATALOG_NAME);
+            services.resolutionManifestFactory(), services.principal(), CATALOG_NAME);
     IcebergCatalog polarisCatalog =
         new IcebergCatalog(
             services.polarisDiagnostics(),
@@ -214,7 +214,7 @@ public class FileIOFactoryTest {
             services.metaStoreManager(),
             callContext,
             passthroughView,
-            services.securityContext(),
+            services.principal(),
             services.taskExecutor(),
             services.accessConfigProvider(),
             services.fileIOFactory(),

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -146,7 +145,6 @@ public abstract class AbstractPolicyCatalogTest {
   private FileIOFactory fileIOFactory;
   private PolarisPrincipal authenticatedRoot;
   private PolarisEntity catalogEntity;
-  private SecurityContext securityContext;
   private AccessConfigProvider accessConfigProvider;
 
   @BeforeAll
@@ -186,21 +184,17 @@ public abstract class AbstractPolicyCatalogTest {
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
 
-    securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getUserPrincipal()).thenReturn(authenticatedRoot);
-
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);
     ReservedProperties reservedProperties = ReservedProperties.NONE;
 
     adminService =
         new PolarisAdminService(
-            diagServices,
             polarisContext,
             resolutionManifestFactory,
             metaStoreManager,
             userSecretsManager,
             serviceIdentityProvider,
-            securityContext,
+            authenticatedRoot,
             authorizer,
             reservedProperties);
 
@@ -231,7 +225,7 @@ public abstract class AbstractPolicyCatalogTest {
 
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
-            resolutionManifestFactory, securityContext, CATALOG_NAME);
+            resolutionManifestFactory, authenticatedRoot, CATALOG_NAME);
     TaskExecutor taskExecutor = Mockito.mock();
     this.fileIOFactory = new DefaultFileIOFactory();
 
@@ -263,7 +257,7 @@ public abstract class AbstractPolicyCatalogTest {
             metaStoreManager,
             polarisContext,
             passthroughView,
-            securityContext,
+            authenticatedRoot,
             taskExecutor,
             accessConfigProvider,
             fileIOFactory,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandlerAuthzTest.java
@@ -55,7 +55,7 @@ public class PolicyCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         callContext,
         resolutionManifestFactory,
         metaStoreManager,
-        securityContext(authenticatedPrincipal),
+        authenticatedPrincipal,
         catalogName,
         polarisAuthorizer,
         null,

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -105,6 +105,7 @@ public record TestServices(
     MetaStoreManagerFactory metaStoreManagerFactory,
     RealmContext realmContext,
     RealmConfig realmConfig,
+    PolarisPrincipal principal,
     SecurityContext securityContext,
     PolarisMetaStoreManager metaStoreManager,
     FileIOFactory fileIOFactory,
@@ -207,12 +208,12 @@ public record TestServices(
       EntityCache entityCache =
           metaStoreManagerFactory.getOrCreateEntityCache(realmContext, realmConfig);
       ResolverFactory resolverFactory =
-          (securityContext, referenceCatalogName) ->
+          (_principal, referenceCatalogName) ->
               new Resolver(
                   diagnostics,
                   callContext.getPolarisCallContext(),
                   metaStoreManager,
-                  securityContext,
+                  _principal,
                   entityCache,
                   referenceCatalogName);
 
@@ -321,13 +322,12 @@ public record TestServices(
 
       PolarisAdminService adminService =
           new PolarisAdminService(
-              diagnostics,
               callContext,
               resolutionManifestFactory,
               metaStoreManager,
               userSecretsManager,
               serviceIdentityProvider,
-              securityContext,
+              principal,
               authorizer,
               reservedProperties);
       PolarisCatalogsApi catalogsApi =
@@ -349,6 +349,7 @@ public record TestServices(
           metaStoreManagerFactory,
           realmContext,
           realmConfig,
+          principal,
           securityContext,
           metaStoreManager,
           fileIOFactory,

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/PolarisPassthroughResolutionView.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/PolarisPassthroughResolutionView.java
@@ -18,10 +18,10 @@
  */
 package org.apache.polaris.service.catalog;
 
-import jakarta.ws.rs.core.SecurityContext;
 import java.util.Arrays;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -41,20 +41,20 @@ import org.apache.polaris.service.types.PolicyIdentifier;
  */
 public class PolarisPassthroughResolutionView implements PolarisResolutionManifestCatalogView {
   private final ResolutionManifestFactory resolutionManifestFactory;
-  private final SecurityContext securityContext;
+  private final PolarisPrincipal polarisPrincipal;
   private final String catalogName;
 
   public PolarisPassthroughResolutionView(
       ResolutionManifestFactory resolutionManifestFactory,
-      SecurityContext securityContext,
+      PolarisPrincipal polarisPrincipal,
       String catalogName) {
     this.resolutionManifestFactory = resolutionManifestFactory;
-    this.securityContext = securityContext;
+    this.polarisPrincipal = polarisPrincipal;
     this.catalogName = catalogName;
   }
 
   private PolarisResolutionManifest newResolutionManifest() {
-    return resolutionManifestFactory.createResolutionManifest(securityContext, catalogName);
+    return resolutionManifestFactory.createResolutionManifest(polarisPrincipal, catalogName);
   }
 
   @Override


### PR DESCRIPTION
Follow-up to https://github.com/apache/polaris/pull/2925

The general idea is that `SecurityContext` comes from `jakarta.ws.rs` and
there is no reason for non-REST related classes to rely on those details.
Instead, once preprocessing of a REST-request has inferred the
`PolarisPrincipal` all inner/core code should rely on only that.

Note that this simplifies a bunch of tests that had to create their own
`SecurityContext` around the principal that they wanted to use, thus
having to decide how to implement `isUserInRole` and the other methods.