### PR TITLE
Add request ID to CloudWatch events

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/jsonEventListener/PropertyMapEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/jsonEventListener/PropertyMapEventListener.java
@@ -19,6 +19,7 @@
 
 package org.apache.polaris.service.events.jsonEventListener;
 
+import jakarta.annotation.Nullable;
 import java.util.HashMap;
 import org.apache.polaris.service.events.IcebergRestCatalogEvents;
 import org.apache.polaris.service.events.listeners.PolarisEventListener;
@@ -32,6 +33,9 @@ import org.apache.polaris.service.events.listeners.PolarisEventListener;
  */
 public abstract class PropertyMapEventListener implements PolarisEventListener {
   protected abstract void transformAndSendEvent(HashMap<String, Object> properties);
+
+  @Nullable
+  protected abstract String getRequestId();
 
   @Override
   public void onAfterRefreshTable(IcebergRestCatalogEvents.AfterRefreshTableEvent event) {


### PR DESCRIPTION
## Add Request ID to CloudWatch Events
### Summary
Adds request ID tracking to AWS CloudWatch events to enable correlation between events and request logs.

### Details
- CloudWatch events now include "request_id" field in the JSON output when available
- Follows the same pattern as InMemoryBufferEventListener for consistency

### Testing
Updated AwsCloudWatchEventListenerTest to mock ContainerRequestContext and verify request ID appears in CloudWatch event messages


