### PR TITLE
Add Server header to Polaris API responses to indicate Polaris version

### DIFF
--- a/site/content/in-dev/unreleased/configuring-polaris-for-production.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production.md
@@ -124,6 +124,7 @@ polaris.realm-context.require-header=true
 
 This will cause Polaris to also return a `404 Not Found` response if the realm header is not present
 in the request.
+
 ### Metastore Configuration
 
 A metastore should be configured with an implementation that durably persists Polaris entities. By


### PR DESCRIPTION
Fixes https://github.com/apache/polaris/issues/2785

This change adds a Server response header to all HTTP responses, formatted as:

**Server: Polaris/1.1**

**Details**

PR to use the Quarkus http.header mechanism for enabling Polaris version

When enabled, the header will be included in all outgoing HTTP responses.

The primary purpose of this feature is observability — allowing clients or monitoring tools to identify the responding service version.

**Testing:**

- Added unit tests to verify:
  Header inclusion when the flag is enabled.
  Absence of the header when the flag is disable
- Verified using Postman

<img width="1073" height="796" alt="image" src="https://github.com/user-attachments/assets/b94d4460-1b5d-4819-9ed1-0962a20aa10f" />
