### PR TITLE
Handle poetry lock update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ client-install-dependencies: $(VENV_DIR)
 	@if [ ! -f "$(VENV_DIR)/bin/poetry" ]; then \
 		$(VENV_DIR)/bin/pip install --upgrade "poetry$(POETRY_VERSION)"; \
 	fi
-	@$(ACTIVATE_AND_CD) && poetry install --all-extras
+	@$(ACTIVATE_AND_CD) && poetry lock && poetry install --all-extras
 	@echo "Poetry and dependencies installed."
 
 .PHONY: client-setup-env


### PR DESCRIPTION
Once a while we can get the following error when dependencies got updated:
```
➜  polaris git:(poetry_lock) ✗ make client-regenerate

Installing Poetry and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (25.3)
Installing dependencies from lock file

pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock` to fix the lock file.
```

One way to solve it is using `./polaris --repair` which we will remove the lock file and update the dependencies. This is the only dependency we have currently with `polaris` bash script. To help deprecate this (or help people who like to use Makefile), this PR added `poetry lock` (ref: https://python-poetry.org/docs/cli#lock)

Here is the output with this change after getting error above:
```
➜  polaris git:(poetry_lock) ✗ make client-regenerate

Installing Poetry and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (25.3)
Installing dependencies from lock file

pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock` to fix the lock file.
make: *** [client-install-dependencies] Error 1
➜  polaris git:(poetry_lock) ✗ make client-regenerate

Installing Poetry and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (25.3)
Resolving dependencies... (0.4s)

Writing lock file
Installing dependencies from lock file

Package operations: 0 installs, 2 updates, 0 removals

  - Updating pip-licenses-lib (0.6.0 -> 1.0.0)
  - Updating pip-licenses-cli (2.0.0 -> 3.0.0)

Installing the current project: polaris (1.2.0)
....
```
