### PR TITLE
docs: add feature configuration section to Hive federation guide

### DIFF
--- a/site/content/in-dev/unreleased/federation/hive-metastore-federation.md
+++ b/site/content/in-dev/unreleased/federation/hive-metastore-federation.md
@@ -40,6 +40,26 @@ property to include `HIVE` (and any other non-REST backends you need):
 `runtime/server/build.gradle.kts` wires the extension in only when this flag is present, so binaries
 built without it will reject Hive federation requests.
 
+## Feature configuration
+
+After building Polaris with Hive support, enable the necessary feature flags in your
+`application.properties` file (or equivalent configuration mechanism such as environment variables or
+a Kubernetes ConfigMap):
+
+```properties
+# Allows both REST and HIVE connection type
+polaris.features."SUPPORTED_CATALOG_CONNECTION_TYPES"=["ICEBERG_REST","HIVE"]
+
+# Allows IMPLICIT authentication, needed for Hive federation
+polaris.features."SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES"=["OAUTH","IMPLICIT"]
+
+# Enables the federation feature itself
+polaris.features."ENABLE_CATALOG_FEDERATION"=true
+```
+
+For Kubernetes deployments, add these properties to the ConfigMap mounted into the Polaris container
+(typically at `/deployment/config/application.properties`).
+
 ## Runtime requirements
 
 - **Metastore connectivity:** Expose the HMS Thrift endpoint (`thrift://host:port`) to the Polaris


### PR DESCRIPTION
<!--
    Possible security vulnerabilities: STOP here and contact security@apache.org instead!

    Please update the title of the PR with a meaningful message - do not leave it "empty" or "generated"
    Please update this summary field:

    The summary should cover these topics, if applicable:
    * the motivation for the change
    * a description of the status quo, for example the current behavior
    * the desired behavior
    * etc

    PR checklist:
    - Do a self-review of your code before opening a pull request
    - Make sure that there's good test coverage for the changes included in this PR
    - Run tests locally before pushing a PR (./gradlew check)
    - Code should have comments where applicable. Particularly hard-to-understand
      areas deserve good in-line documentation.
    - Include changes and enhancements to the documentation (in site/content/in-dev/unreleased)
    - For Work In Progress Pull Requests, please use the Draft PR feature.

    Make sure to add the information BELOW this comment.
    Everything in this comment will NOT be added to the PR description.
-->

### What changes were proposed in this pull request?
Add documentation for required feature flags when enabling Hive Metastore federation. Users must configure three properties in `application.properties` before Hive federation will work:

- `SUPPORTED_CATALOG_CONNECTION_TYPES`
- `SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES`
- `ENABLE_CATALOG_FEDERATION`

Inspired from [this](https://apache-polaris.slack.com/archives/C084XDM50CB/p1761851426511259) Slack thread.

### Why are the changes needed?
Adds more details to make it easier for users to enable hive federation.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A

### CHANGELOG.md
N/A
