### PR TITLE
Use Iterable for realms in BootstrapCommand

### DIFF
--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -100,13 +100,13 @@ public class BootstrapCommand extends BaseCommand {
   public Integer call() {
     try {
       RootCredentialsSet rootCredentialsSet;
-      List<String> realms; // TODO Iterable
+      Iterable<String> realms;
 
       if (inputOptions.rootCredentialsOptions.fileOptions != null) {
         rootCredentialsSet =
             RootCredentialsSet.fromUri(
                 inputOptions.rootCredentialsOptions.fileOptions.file.toUri());
-        realms = rootCredentialsSet.credentials().keySet().stream().toList();
+        realms = rootCredentialsSet.credentials().keySet();
       } else {
         realms = inputOptions.rootCredentialsOptions.stdinOptions.realms;
         rootCredentialsSet =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactors the realms variable in BootstrapCommand from `List<String>` to `Iterable<String>` to avoid an unnecessary type conversion.

### Why are the changes needed?
Cleaner code.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test suits.

### CHANGELOG.md
N/A