### PR TITLE
Build/nit: cache output of `generatedMarkdownDocs`

### DIFF
--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -53,6 +53,7 @@ val generatedMarkdownDocs = tasks.register<JavaExec>("generatedMarkdownDocs") {
 
   mainClass = "org.apache.polaris.docs.generator.ReferenceConfigDocsGenerator"
 
+  outputs.cacheIf { true }
   outputs.dir(generatedMarkdownDocsDir)
   inputs.files(doclet)
   inputs.files(genProjects)


### PR DESCRIPTION
`(Java)Exec` tasks are not cacheable by default, as annotated with `@DisableCachingByDefault`. Adding an `outputs.cacheIf { true }` enables caching on those tasks.
