### PR TITLE
Make CallContextCatalogFactory request-scoped

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -267,9 +267,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
       this.baseCatalog = federatedCatalog;
     } else {
       LOGGER.atInfo().log("Initializing non-federated catalog");
-      this.baseCatalog =
-          catalogFactory.createCallContextCatalog(
-              callContext, polarisPrincipal, resolutionManifest);
+      this.baseCatalog = catalogFactory.createCallContextCatalog(resolutionManifest);
     }
     this.namespaceCatalog =
         (baseCatalog instanceof SupportsNamespaces) ? (SupportsNamespaces) baseCatalog : null;

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/CallContextCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/CallContextCatalogFactory.java
@@ -19,14 +19,9 @@
 package org.apache.polaris.service.context.catalog;
 
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 
 public interface CallContextCatalogFactory {
 
-  Catalog createCallContextCatalog(
-      CallContext context,
-      PolarisPrincipal polarisPrincipal,
-      PolarisResolutionManifest resolvedManifest);
+  Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest);
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -257,6 +257,7 @@ public abstract class PolarisAuthzTestBase {
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
     this.authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
+    QuarkusMock.installMockForType(authenticatedRoot, PolarisPrincipal.class);
 
     this.adminService =
         new PolarisAdminService(
@@ -518,36 +519,37 @@ public abstract class PolarisAuthzTestBase {
 
     @SuppressWarnings("unused") // Required by CDI
     protected TestPolarisCallContextCatalogFactory() {
-      this(null, null, null, null, null, null, null);
+      this(null, null, null, null, null, null, null, null, null);
     }
 
     @Inject
     public TestPolarisCallContextCatalogFactory(
         PolarisDiagnostics diagnostics,
         ResolverFactory resolverFactory,
-        MetaStoreManagerFactory metaStoreManagerFactory,
         TaskExecutor taskExecutor,
         AccessConfigProvider accessConfigProvider,
         FileIOFactory fileIOFactory,
-        PolarisEventListener polarisEventListener) {
+        PolarisEventListener polarisEventListener,
+        PolarisMetaStoreManager metaStoreManager,
+        CallContext callContext,
+        PolarisPrincipal principal) {
       super(
           diagnostics,
           resolverFactory,
-          metaStoreManagerFactory,
           taskExecutor,
           accessConfigProvider,
           fileIOFactory,
-          polarisEventListener);
+          polarisEventListener,
+          metaStoreManager,
+          callContext,
+          principal);
     }
 
     @Override
-    public Catalog createCallContextCatalog(
-        CallContext context,
-        PolarisPrincipal polarisPrincipal,
-        final PolarisResolutionManifest resolvedManifest) {
+    public Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest) {
       // This depends on the BasePolarisCatalog allowing calling initialize multiple times
       // to override the previous config.
-      Catalog catalog = super.createCallContextCatalog(context, polarisPrincipal, resolvedManifest);
+      Catalog catalog = super.createCallContextCatalog(resolvedManifest);
       catalog.initialize(
           CATALOG_NAME,
           ImmutableMap.of(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerAuthzTest.java
@@ -1124,8 +1124,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
     CallContextCatalogFactory mockFactory = Mockito.mock(CallContextCatalogFactory.class);
 
     // Mock the catalog factory to return our regular catalog but with mocked config
-    Mockito.when(mockFactory.createCallContextCatalog(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(baseCatalog);
+    Mockito.when(mockFactory.createCallContextCatalog(Mockito.any())).thenReturn(baseCatalog);
 
     return newWrapperWithFineLevelAuthDisabled(Set.of(), CATALOG_NAME, mockFactory, false);
   }
@@ -1894,18 +1893,16 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
         new PolarisCallContextCatalogFactory(
             diagServices,
             resolverFactory,
-            managerFactory,
             Mockito.mock(),
             accessConfigProvider,
             new DefaultFileIOFactory(),
-            polarisEventListener) {
+            polarisEventListener,
+            metaStoreManager,
+            callContext,
+            authenticatedRoot) {
           @Override
-          public Catalog createCallContextCatalog(
-              CallContext context,
-              PolarisPrincipal polarisPrincipal,
-              PolarisResolutionManifest resolvedManifest) {
-            Catalog catalog =
-                super.createCallContextCatalog(context, polarisPrincipal, resolvedManifest);
+          public Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest) {
+            Catalog catalog = super.createCallContextCatalog(resolvedManifest);
             String fileIoImpl = "org.apache.iceberg.inmemory.InMemoryFileIO";
             catalog.initialize(
                 externalCatalog, ImmutableMap.of(CatalogProperties.FILE_IO_IMPL, fileIoImpl));

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -205,6 +205,39 @@ public record TestServices(
       PolarisMetaStoreManager metaStoreManager =
           metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
 
+      CreatePrincipalResult createdPrincipal =
+          metaStoreManager.createPrincipal(
+              callContext.getPolarisCallContext(),
+              new PrincipalEntity.Builder()
+                  .setName("test-principal")
+                  .setCreateTimestamp(Instant.now().toEpochMilli())
+                  .setCredentialRotationRequiredState()
+                  .build());
+      PolarisPrincipal principal = PolarisPrincipal.of(createdPrincipal.getPrincipal(), Set.of());
+
+      SecurityContext securityContext =
+          new SecurityContext() {
+            @Override
+            public Principal getUserPrincipal() {
+              return principal;
+            }
+
+            @Override
+            public boolean isUserInRole(String s) {
+              return false;
+            }
+
+            @Override
+            public boolean isSecure() {
+              return true;
+            }
+
+            @Override
+            public String getAuthenticationScheme() {
+              return "";
+            }
+          };
+
       EntityCache entityCache =
           metaStoreManagerFactory.getOrCreateEntityCache(realmContext, realmConfig);
       ResolverFactory resolverFactory =
@@ -250,11 +283,13 @@ public record TestServices(
           new PolarisCallContextCatalogFactory(
               diagnostics,
               resolverFactory,
-              metaStoreManagerFactory,
               taskExecutor,
               accessConfigProvider,
               fileIOFactory,
-              polarisEventListener);
+              polarisEventListener,
+              metaStoreManager,
+              callContext,
+              principal);
 
       ReservedProperties reservedProperties = ReservedProperties.NONE;
 
@@ -286,39 +321,6 @@ public record TestServices(
       IcebergRestCatalogApi restApi = new IcebergRestCatalogApi(catalogService);
       IcebergRestConfigurationApi restConfigurationApi =
           new IcebergRestConfigurationApi(catalogService);
-
-      CreatePrincipalResult createdPrincipal =
-          metaStoreManager.createPrincipal(
-              callContext.getPolarisCallContext(),
-              new PrincipalEntity.Builder()
-                  .setName("test-principal")
-                  .setCreateTimestamp(Instant.now().toEpochMilli())
-                  .setCredentialRotationRequiredState()
-                  .build());
-      PolarisPrincipal principal = PolarisPrincipal.of(createdPrincipal.getPrincipal(), Set.of());
-
-      SecurityContext securityContext =
-          new SecurityContext() {
-            @Override
-            public Principal getUserPrincipal() {
-              return principal;
-            }
-
-            @Override
-            public boolean isUserInRole(String s) {
-              return false;
-            }
-
-            @Override
-            public boolean isSecure() {
-              return true;
-            }
-
-            @Override
-            public String getAuthenticationScheme() {
-              return "";
-            }
-          };
 
       PolarisAdminService adminService =
           new PolarisAdminService(


### PR DESCRIPTION
note the only non-test usage spot is `IcebergCatalogHandler#initializeCatalog`
and `IcebergCatalogHandler` is getting created by `IcebergCatalogAdapter`
which is already `@RequestScoped`.