### PR TITLE
fix(docs): Generify S3 index page

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/creating-a-catalog/s3/_index.md
+++ b/site/content/in-dev/unreleased/getting-started/creating-a-catalog/s3/_index.md
@@ -27,7 +27,7 @@ Several S3 compatible storage providers can be configured as backends for your P
 Refer to child pages under this documentation section for some of the possible options. 
 
 For the `polaris catalogs create` [command]({{% ref "../../../command-line-interface#create" %}})
-there are a few s3-only options
+there are a few s3-only options:
 
 ```text
 --storage-type s3


### PR DESCRIPTION
* Remove the mention of "cloud" since not all possible storage options are provided in "cloud".

* Avoid listing specific child pages in the doc test. Rely on Hugo-general index (on the left-hand pane).

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
