### PR TITLE
Increase javadoc visibility in `nosql/realms`

### DIFF
--- a/persistence/nosql/realms/impl/build.gradle.kts
+++ b/persistence/nosql/realms/impl/build.gradle.kts
@@ -53,4 +53,7 @@ dependencies {
   testCompileOnly(libs.jakarta.enterprise.cdi.api)
 }
 
-tasks.withType<Javadoc> { isFailOnError = false }
+tasks.withType<Javadoc> {
+  isFailOnError = false
+  options.memberLevel = JavadocMemberLevel.PACKAGE
+}


### PR DESCRIPTION
This is to fix javadoc error: `No public or protected classes found to document`

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
