### PR TITLE
NoSQL: Add CDI/common+testing + necessary nosql-store implementations

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -47,15 +47,19 @@ dependencies {
     api(project(":polaris-nodes-api"))
     api(project(":polaris-nodes-impl"))
     api(project(":polaris-nodes-spi"))
+    api(project(":polaris-nodes-store-nosql"))
 
     api(project(":polaris-persistence-nosql-realms-api"))
     api(project(":polaris-persistence-nosql-realms-impl"))
     api(project(":polaris-persistence-nosql-realms-spi"))
+    api(project(":polaris-persistence-nosql-realms-store-nosql"))
 
     api(project(":polaris-persistence-nosql-api"))
     api(project(":polaris-persistence-nosql-impl"))
     api(project(":polaris-persistence-nosql-benchmark"))
     api(project(":polaris-persistence-nosql-correctness"))
+    api(project(":polaris-persistence-nosql-cdi-common"))
+    api(project(":polaris-persistence-nosql-cdi-weld"))
     api(project(":polaris-persistence-nosql-standalone"))
     api(project(":polaris-persistence-nosql-testextension"))
 

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -62,15 +62,19 @@ polaris-idgen-spi=persistence/nosql/idgen/spi
 polaris-nodes-api=persistence/nosql/nodes/api
 polaris-nodes-impl=persistence/nosql/nodes/impl
 polaris-nodes-spi=persistence/nosql/nodes/spi
+polaris-nodes-store-nosql=persistence/nosql/nodes/store-nosql
 # realms
 polaris-persistence-nosql-realms-api=persistence/nosql/realms/api
 polaris-persistence-nosql-realms-impl=persistence/nosql/realms/impl
 polaris-persistence-nosql-realms-spi=persistence/nosql/realms/spi
+polaris-persistence-nosql-realms-store-nosql=persistence/nosql/realms/store-nosql
 # persistence / database agnostic
 polaris-persistence-nosql-api=persistence/nosql/persistence/api
 polaris-persistence-nosql-impl=persistence/nosql/persistence/impl
 polaris-persistence-nosql-benchmark=persistence/nosql/persistence/benchmark
 polaris-persistence-nosql-correctness=persistence/nosql/persistence/correctness
+polaris-persistence-nosql-cdi-common=persistence/nosql/persistence/cdi/common
+polaris-persistence-nosql-cdi-weld=persistence/nosql/persistence/cdi/weld
 polaris-persistence-nosql-standalone=persistence/nosql/persistence/standalone
 polaris-persistence-nosql-testextension=persistence/nosql/persistence/testextension
 polaris-persistence-nosql-varint=persistence/nosql/persistence/varint

--- a/persistence/nosql/nodes/store-nosql/build.gradle.kts
+++ b/persistence/nosql/nodes/store-nosql/build.gradle.kts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  id("org.kordamp.gradle.jandex")
+  id("polaris-server")
+}
+
+description = "Polaris nodes NoSQL persistence"
+
+dependencies {
+  implementation(project(":polaris-nodes-api"))
+  implementation(project(":polaris-nodes-spi"))
+  implementation(project(":polaris-idgen-api"))
+  implementation(project(":polaris-persistence-nosql-api"))
+  implementation(project(":polaris-persistence-nosql-maintenance-spi"))
+
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
+
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.core:jackson-core")
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-guava")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.jakarta.inject.api)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+
+  testFixturesRuntimeOnly(project(":polaris-persistence-nosql-cdi-weld"))
+  testFixturesApi(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
+
+  testFixturesApi(libs.weld.se.core)
+  testFixturesApi(libs.weld.junit5)
+  testFixturesRuntimeOnly(libs.smallrye.jandex)
+
+  testImplementation(project(":polaris-idgen-impl"))
+  testImplementation(testFixtures(project(":polaris-persistence-nosql-inmemory")))
+  testImplementation(testFixtures(project(":polaris-nodes-impl")))
+  testImplementation(libs.threeten.extra)
+
+  testCompileOnly(libs.jakarta.annotation.api)
+  testCompileOnly(libs.jakarta.validation.api)
+  testCompileOnly(libs.jakarta.inject.api)
+  testCompileOnly(libs.jakarta.enterprise.cdi.api)
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeManagementObj.java
+++ b/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeManagementObj.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.annotation.Nullable;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.apache.polaris.persistence.nosql.api.obj.AbstractObjType;
+import org.apache.polaris.persistence.nosql.api.obj.Obj;
+import org.apache.polaris.persistence.nosql.api.obj.ObjType;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeManagementState;
+
+@PolarisImmutable
+@JsonSerialize(as = ImmutableNodeManagementObj.class)
+@JsonDeserialize(as = ImmutableNodeManagementObj.class)
+public interface NodeManagementObj extends Obj, NodeManagementState {
+  ObjType TYPE = new NodeManagementObjType();
+  long CONSTANT_ID = Long.MAX_VALUE;
+
+  @Nullable
+  @Override
+  default String versionToken() {
+    return "immutable";
+  }
+
+  @Override
+  default long id() {
+    return CONSTANT_ID; // constant
+  }
+
+  @Override
+  default ObjType type() {
+    return TYPE;
+  }
+
+  final class NodeManagementObjType extends AbstractObjType<NodeManagementObj> {
+    public NodeManagementObjType() {
+      super("nodes", "Nodes", NodeManagementObj.class);
+    }
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeManagementRetainedIdentifier.java
+++ b/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeManagementRetainedIdentifier.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
+
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.stream.IntStream;
+import org.apache.polaris.persistence.nosql.maintenance.spi.PerRealmRetainedIdentifier;
+import org.apache.polaris.persistence.nosql.maintenance.spi.RetainedCollector;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeManagement;
+
+@ApplicationScoped
+class NodeManagementRetainedIdentifier implements PerRealmRetainedIdentifier {
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  NodeManagement nodeManagement;
+
+  @Override
+  public String name() {
+    return "Nodes";
+  }
+
+  @Override
+  public boolean identifyRetained(@Nonnull RetainedCollector collector) {
+    if (!collector.isSystemRealm()) {
+      return false;
+    }
+
+    IntStream.range(0, nodeManagement.maxNumberOfNodes())
+        .mapToLong(nodeId -> nodeManagement.systemIdForNode(nodeId))
+        .mapToObj(NodeStoreImpl::constructObjId)
+        .forEach(collector::retainObject);
+
+    collector.retainObject(objRef(NodeManagementObj.TYPE, NodeManagementObj.CONSTANT_ID));
+
+    // Intentionally return false, let the maintenance service's identifier decide
+    return false;
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeObj.java
+++ b/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeObj.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Instant;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.apache.polaris.persistence.nosql.api.obj.AbstractObjType;
+import org.apache.polaris.persistence.nosql.api.obj.Obj;
+import org.apache.polaris.persistence.nosql.api.obj.ObjType;
+
+@PolarisImmutable
+@JsonSerialize(as = ImmutableNodeObj.class)
+@JsonDeserialize(as = ImmutableNodeObj.class)
+public interface NodeObj extends Obj {
+  ObjType TYPE = new NodeObjType();
+
+  Instant leaseTimestamp();
+
+  Instant expirationTimestamp();
+
+  @Override
+  default ObjType type() {
+    return TYPE;
+  }
+
+  final class NodeObjType extends AbstractObjType<NodeObj> {
+    public NodeObjType() {
+      super("node", "Node", NodeObj.class);
+    }
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeStoreFactoryImpl.java
+++ b/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeStoreFactoryImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
+
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.StartupPersistence;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeManagementState;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeStore;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeStoreFactory;
+
+@ApplicationScoped
+class NodeStoreFactoryImpl implements NodeStoreFactory {
+  private final Persistence startupPersistence;
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  NodeStoreFactoryImpl(@StartupPersistence Persistence startupPersistence) {
+    checkArgument(
+        SYSTEM_REALM_ID.equals(startupPersistence.realmId()),
+        "Realms management must happen in the %s realm",
+        SYSTEM_REALM_ID);
+    this.startupPersistence = startupPersistence;
+  }
+
+  @Override
+  @Nonnull
+  public NodeStore createNodeStore(@Nonnull IdGenerator idGenerator) {
+    return new NodeStoreImpl(startupPersistence, idGenerator);
+  }
+
+  @Override
+  public Optional<NodeManagementState> fetchManagementState() {
+    return Optional.ofNullable(
+        startupPersistence.fetch(
+            objRef(NodeManagementObj.TYPE, NodeManagementObj.CONSTANT_ID, 1),
+            NodeManagementObj.class));
+  }
+
+  @Override
+  public boolean storeManagementState(@Nonnull NodeManagementState state) {
+    return startupPersistence.conditionalInsert(
+            ImmutableNodeManagementObj.builder().from(state).build(), NodeManagementObj.class)
+        != null;
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeStoreImpl.java
+++ b/persistence/nosql/nodes/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/nodeids/store/NodeStoreImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.apache.polaris.persistence.nosql.nodeids.spi.ImmutableNodeState;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeState;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeStore;
+
+record NodeStoreImpl(Persistence startupPersistence, IdGenerator idGenerator) implements NodeStore {
+  NodeStoreImpl {
+    checkArgument(
+        SYSTEM_REALM_ID.equals(startupPersistence.realmId()),
+        "Realms management must happen in the %s realm",
+        SYSTEM_REALM_ID);
+  }
+
+  @Override
+  @Nullable
+  public NodeState persist(
+      int nodeId, Optional<NodeState> expectedNodeState, @Nonnull NodeState newState) {
+    checkArgument(nodeId >= 0, "Illegal node ID %s", nodeId);
+
+    var persistenceId = idGenerator.systemIdForNode(nodeId);
+    var newObj =
+        ImmutableNodeObj.builder()
+            .leaseTimestamp(newState.leaseTimestamp())
+            .expirationTimestamp(newState.expirationTimestamp())
+            .id(persistenceId)
+            .versionToken(UUID.randomUUID().toString())
+            .build();
+
+    var existing = startupPersistence.fetch(constructObjId(persistenceId), NodeObj.class);
+    if (expectedNodeState.isEmpty()) {
+      return existing == null
+          ? asNodeState(startupPersistence.conditionalInsert(newObj, NodeObj.class))
+          : null;
+    } else {
+      if (existing == null) {
+        return null;
+      }
+      var expected = expectedNodeState.get();
+      var real = asNodeState(existing);
+      if (!expected.equals(real)) {
+        return null;
+      }
+      return asNodeState(startupPersistence.conditionalUpdate(existing, newObj, NodeObj.class));
+    }
+  }
+
+  @Override
+  @Nonnull
+  public NodeState[] fetchMany(@Nonnull int... nodeIds) {
+    var objIds = new ObjRef[nodeIds.length];
+    for (int i = 0; i < nodeIds.length; i++) {
+      var nodeId = nodeIds[i];
+      checkArgument(nodeId >= 0, "Illegal node ID %s", nodeId);
+      objIds[i] = objIdForNode(nodeId);
+    }
+    var fetched = startupPersistence.fetchMany(NodeObj.class, objIds);
+    var result = new NodeState[nodeIds.length];
+    for (int i = 0; i < nodeIds.length; i++) {
+      result[i] = asNodeState(fetched[i]);
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<NodeState> fetch(int nodeId) {
+    var objId = objIdForNode(nodeId);
+    return Optional.ofNullable(asNodeState(startupPersistence.fetch(objId, NodeObj.class)));
+  }
+
+  private static NodeState asNodeState(NodeObj result) {
+    return result != null
+        ? ImmutableNodeState.builder()
+            .leaseTimestamp(result.leaseTimestamp())
+            .expirationTimestamp(result.expirationTimestamp())
+            .build()
+        : null;
+  }
+
+  ObjRef objIdForNode(int nodeId) {
+    return constructObjId(idGenerator.systemIdForNode(nodeId));
+  }
+
+  static ObjRef constructObjId(long persistenceId) {
+    return objRef(NodeObj.TYPE.id(), persistenceId, 1);
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/main/resources/META-INF/beans.xml
+++ b/persistence/nosql/nodes/store-nosql/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/nodes/store-nosql/src/main/resources/META-INF/services/org.apache.polaris.persistence.nosql.api.obj.ObjType
+++ b/persistence/nosql/nodes/store-nosql/src/main/resources/META-INF/services/org.apache.polaris.persistence.nosql.api.obj.ObjType
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.apache.polaris.persistence.nosql.nodeids.store.NodeObj$NodeObjType
+org.apache.polaris.persistence.nosql.nodeids.store.NodeManagementObj$NodeManagementObjType

--- a/persistence/nosql/nodes/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/nodeids/store/TestNodeStoreIntegration.java
+++ b/persistence/nosql/nodes/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/nodeids/store/TestNodeStoreIntegration.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.nodeids.store;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.polaris.persistence.nosql.nodeids.impl.Util.idgenSpecFromManagementState;
+
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import org.apache.polaris.ids.api.IdGeneratorSpec;
+import org.apache.polaris.ids.api.ImmutableIdGeneratorSpec;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeLease;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeManagement;
+import org.apache.polaris.persistence.nosql.nodeids.spi.ImmutableBuildableNodeManagementState;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeManagementState;
+import org.apache.polaris.persistence.nosql.nodeids.spi.NodeStoreFactory;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@SuppressWarnings("CdiInjectionPointsInspection")
+@ExtendWith(SoftAssertionsExtension.class)
+@EnableWeld
+public class TestNodeStoreIntegration {
+  @InjectSoftAssertions protected SoftAssertions soft;
+  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+
+  @Inject NodeStoreFactory nodeStoreFactory;
+  @Inject NodeManagement nodeManagement;
+  @Inject MonotonicClock clock;
+
+  @Test
+  public void managementState() {
+    soft.assertThat(nodeStoreFactory.fetchManagementState()).isEmpty();
+
+    var buildableIdgenSpec = IdGeneratorSpec.BuildableIdGeneratorSpec.builder().build();
+    var idgenSpec = ImmutableIdGeneratorSpec.builder().from(buildableIdgenSpec).build();
+    var nodeManagementSpec =
+        ImmutableBuildableNodeManagementState.builder().idGeneratorSpec(idgenSpec).build();
+
+    soft.assertThat(nodeStoreFactory.storeManagementState(nodeManagementSpec)).isTrue();
+    var fetched = nodeStoreFactory.fetchManagementState();
+    soft.assertThat(fetched).isPresent();
+    soft.assertThat(fetched)
+        .get()
+        .extracting(
+            NodeManagementState::idGeneratorSpec,
+            InstanceOfAssertFactories.optional(IdGeneratorSpec.class))
+        .get()
+        .isEqualTo(idgenSpec);
+    var specFromFetched = idgenSpecFromManagementState(fetched);
+    soft.assertThat(specFromFetched).isEqualTo(idgenSpec);
+    soft.assertThat(nodeStoreFactory.storeManagementState(nodeManagementSpec)).isFalse();
+  }
+
+  @Test
+  public void simple() {
+    var lease = nodeManagement.lease();
+    soft.assertThat(lease).isNotNull();
+    soft.assertThat(lease.nodeIdIfValid()).isNotEqualTo(-1);
+  }
+
+  @Test
+  public void allocateAll() {
+    var numNodeIds = nodeManagement.maxNumberOfNodes();
+    var leases = new ArrayList<NodeLease>();
+    for (int i = 0; i < numNodeIds; i++) {
+      soft.assertThatCode(() -> leases.add(nodeManagement.lease()))
+          .describedAs("n = %d", i)
+          .doesNotThrowAnyException();
+    }
+    soft.assertThatIllegalStateException()
+        .isThrownBy(nodeManagement::lease)
+        .withMessage("Could not lease any node ID");
+
+    soft.assertThat(leases).hasSize(numNodeIds);
+
+    for (var lease : leases) {
+      soft.assertThat(lease.nodeIdIfValid()).isNotEqualTo(-1);
+      soft.assertThat(
+              requireNonNull(lease.node())
+                  .valid(requireNonNull(lease.node()).expirationTimestamp().toEpochMilli()))
+          .isFalse();
+    }
+
+    clock.waitUntilTimeMillisAdvanced();
+
+    // Renew all leases
+
+    for (var lease : leases) {
+      var nodeId = lease.nodeIdIfValid();
+      var beforeRelease = nodeManagement.getNodeInfo(nodeId).orElseThrow();
+      soft.assertThat(beforeRelease).isEqualTo(lease.node());
+      var n = requireNonNull(lease.node());
+      var beforeExpire = n.expirationTimestamp();
+      var beforeRenew = n.renewLeaseTimestamp();
+      var beforeLease = n.leaseTimestamp();
+
+      lease.renew();
+      var fetched = nodeManagement.getNodeInfo(nodeId).orElseThrow();
+      soft.assertThat(fetched).isEqualTo(lease.node());
+
+      n = requireNonNull(lease.node());
+      soft.assertThat(n.expirationTimestamp()).isAfter(beforeExpire);
+      soft.assertThat(n.renewLeaseTimestamp()).isAfter(beforeRenew);
+      soft.assertThat(n.leaseTimestamp()).isEqualTo(beforeLease);
+
+      soft.assertAll();
+    }
+
+    // Release all leases
+
+    for (var lease : leases) {
+      var nodeId = lease.nodeIdIfValid();
+      var beforeRelease = nodeManagement.getNodeInfo(nodeId).orElseThrow();
+      var n = requireNonNull(lease.node());
+      soft.assertThat(beforeRelease).isEqualTo(n);
+      var beforeExpire = n.expirationTimestamp();
+      var beforeLease = n.leaseTimestamp();
+
+      lease.release();
+      soft.assertThat(lease.nodeIdIfValid()).isEqualTo(-1);
+
+      var fetched = nodeManagement.getNodeInfo(nodeId).orElseThrow();
+      soft.assertThat(fetched.expirationTimestamp())
+          .isBeforeOrEqualTo(clock.currentInstant())
+          .isNotEqualTo(beforeExpire);
+      soft.assertThat(fetched.leaseTimestamp()).isEqualTo(beforeLease);
+
+      soft.assertThat(fetched.valid(clock.currentTimeMillis())).isFalse();
+      nodeManagement.getNodeInfo(nodeId);
+
+      soft.assertAll();
+    }
+
+    leases.clear();
+
+    // Repeat allocation of all nodes
+
+    clock.waitUntilTimeMillisAdvanced();
+
+    for (int i = 0; i < numNodeIds; i++) {
+      soft.assertThatCode(() -> leases.add(nodeManagement.lease()))
+          .describedAs("n = %d", i)
+          .doesNotThrowAnyException();
+
+      soft.assertAll();
+    }
+    soft.assertThatIllegalStateException()
+        .isThrownBy(nodeManagement::lease)
+        .withMessage("Could not lease any node ID");
+
+    soft.assertThat(leases).hasSize(numNodeIds);
+  }
+}

--- a/persistence/nosql/nodes/store-nosql/src/test/resources/logback-test.xml
+++ b/persistence/nosql/nodes/store-nosql/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${test.log.level:-INFO}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/persistence/nosql/nodes/store-nosql/src/test/resources/weld.properties
+++ b/persistence/nosql/nodes/store-nosql/src/test/resources/weld.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# See https://bugs.openjdk.org/browse/JDK-8349545
+org.jboss.weld.bootstrap.concurrentDeployment=false

--- a/persistence/nosql/persistence/cdi/README.md
+++ b/persistence/nosql/persistence/cdi/README.md
@@ -1,0 +1,41 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# CDI functionality for Polaris NoSQL persistence
+
+NoSQL persistence provides three modules for CDI:
+* A module for Quarkus, which Polaris used for production deployments.
+* A module for Weld, which is used for testing purposes.
+* A module with shared CDI functionality for both Quarkus and Weld.
+
+Polaris runs on top of the Quarkus framework, leveraging CDI.
+
+To build and run tests in a more performant way, many test classes in Polaris NoSQL persistence
+uses the CDI reference implementation Weld instead of Quarkus, as it requires no intermediate
+augmentation (think: Quarkus build).
+
+The biggest difference between the Quarkus and Weld variants is the way how database specific
+`Backend` instances are produced, because the Weld variant targets testing purposes.
+* Weld locates the `Backend` instances using Java's service loader mechanism via 
+  `org.apache.polaris.persistence.nosql.api.backend.BackendLoader.findFactoryByName()`, which is
+  also what the the NoSQL persistence JUnit test extension uses.
+* In Quarkus, the `Backend` instances are located using a CDI identifier-based mechanism.
+  There are also backend specific builders that leverage Quarkus extensions for the respective
+  database backends.
+  The Quarkus variant also adds OpenTelemetry instrumentation to the `Backend` instances.

--- a/persistence/nosql/persistence/cdi/common/build.gradle.kts
+++ b/persistence/nosql/persistence/cdi/common/build.gradle.kts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  id("org.kordamp.gradle.jandex")
+  id("polaris-server")
+}
+
+description = "Polaris NoSQL persistence, providers for CDI (not Quarkus)."
+
+dependencies {
+  implementation(project(":polaris-persistence-nosql-api"))
+  implementation(project(":polaris-persistence-nosql-realms-api"))
+  implementation(project(":polaris-async-api"))
+  implementation(project(":polaris-idgen-api"))
+  implementation(project(":polaris-nodes-api"))
+  runtimeOnly(project(":polaris-nodes-impl"))
+  runtimeOnly(project(":polaris-nodes-store-nosql"))
+  runtimeOnly(project(":polaris-persistence-nosql-realms-impl"))
+  runtimeOnly(project(":polaris-persistence-nosql-realms-store-nosql"))
+
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  compileOnly("com.fasterxml.jackson.core:jackson-databind")
+
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
+
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.jakarta.inject.api)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+}
+
+tasks.withType<Javadoc> { isFailOnError = false }

--- a/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/IdGeneratorProvider.java
+++ b/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/IdGeneratorProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeLease;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeManagement;
+
+@ApplicationScoped
+class IdGeneratorProvider {
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Produces
+  @ApplicationScoped
+  IdGenerator idGenerator(NodeLease leasedNode, NodeManagement nodeManagement) {
+    return nodeManagement.buildIdGenerator(leasedNode);
+  }
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Produces
+  @ApplicationScoped
+  NodeLease leasedNode(NodeManagement nodeManagement) {
+    return nodeManagement.lease();
+  }
+}

--- a/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/PersistenceDecorators.java
+++ b/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/PersistenceDecorators.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.cdi.persistence;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.PersistenceDecorator;
+
+/** Applies {@link PersistenceDecorator}s sorted by {@link PersistenceDecorator#priority()}. */
+@ApplicationScoped
+public class PersistenceDecorators {
+  @Inject Instance<PersistenceDecorator> persistenceDecorators;
+
+  private List<PersistenceDecorator> activeDecorators;
+
+  @PostConstruct
+  void init() {
+    this.activeDecorators =
+        persistenceDecorators.stream()
+            .filter(PersistenceDecorator::active)
+            .sorted(Comparator.comparingInt(PersistenceDecorator::priority))
+            .toList();
+  }
+
+  public Persistence decorate(Persistence persistence) {
+    for (var decorator : activeDecorators) {
+      persistence = decorator.decorate(persistence);
+    }
+    return persistence;
+  }
+}

--- a/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/PersistenceProducers.java
+++ b/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/PersistenceProducers.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.cdi.persistence;
+
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.api.StartupPersistence;
+import org.apache.polaris.persistence.nosql.api.SystemPersistence;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+
+@ApplicationScoped
+class PersistenceProducers {
+
+  private final Backend backend;
+  private final IdGenerator idGenerator;
+  private final MonotonicClock monotonicClock;
+  private final PersistenceDecorators persistenceDecorators;
+  private final PersistenceParams persistenceParams;
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  PersistenceProducers(
+      Backend backend,
+      IdGenerator idGenerator,
+      MonotonicClock monotonicClock,
+      PersistenceDecorators persistenceDecorators,
+      PersistenceParams persistenceParams) {
+    this.backend = backend;
+    this.idGenerator = idGenerator;
+    this.monotonicClock = monotonicClock;
+    this.persistenceDecorators = persistenceDecorators;
+    this.persistenceParams = persistenceParams;
+  }
+
+  @ApplicationScoped
+  @Produces
+  @StartupPersistence
+  Persistence startupPersistence() {
+    var persistence =
+        backend.newPersistence(
+            x -> backend,
+            PersistenceParams.BuildablePersistenceParams.builder().build(),
+            SYSTEM_REALM_ID,
+            monotonicClock,
+            IdGenerator.NONE);
+    return persistenceDecorators.decorate(persistence);
+  }
+
+  @ApplicationScoped
+  @Produces
+  @SystemPersistence
+  Persistence systemPersistence() {
+    var persistence =
+        backend.newPersistence(
+            x -> backend, persistenceParams, SYSTEM_REALM_ID, monotonicClock, idGenerator);
+    return persistenceDecorators.decorate(persistence);
+  }
+}

--- a/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/RealmPersistence.java
+++ b/persistence/nosql/persistence/cdi/common/src/main/java/org/apache/polaris/persistence/nosql/cdi/persistence/RealmPersistence.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.cdi.persistence;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+
+@ApplicationScoped
+class RealmPersistence implements RealmPersistenceFactory {
+  private final PersistenceParams persistenceConfig;
+  private final Backend backend;
+  private final IdGenerator idGenerator;
+  private final MonotonicClock monotonicClock;
+  private final PersistenceDecorators persistenceDecorators;
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  RealmPersistence(
+      PersistenceParams persistenceConfig,
+      Backend backend,
+      IdGenerator idGenerator,
+      MonotonicClock monotonicClock,
+      PersistenceDecorators persistenceDecorators) {
+    this.persistenceConfig = persistenceConfig;
+    this.backend = backend;
+    this.idGenerator = idGenerator;
+    this.monotonicClock = monotonicClock;
+    this.persistenceDecorators = persistenceDecorators;
+  }
+
+  @Override
+  public RealmPersistenceBuilder newBuilder() {
+    return new RealmPersistenceBuilder() {
+      private boolean skipDecorators;
+      private String realmId;
+      private boolean consumed;
+
+      @Override
+      public RealmPersistenceBuilder realmId(@Nonnull String realmId) {
+        checkState(this.realmId == null, "RealmPersistenceBuilder can only be used once");
+        this.realmId = realmId;
+        return this;
+      }
+
+      @Override
+      public RealmPersistenceBuilder skipDecorators() {
+        this.skipDecorators = true;
+        return this;
+      }
+
+      @Override
+      public Persistence build() {
+        checkState(!consumed, "RealmPersistenceBuilder can only be used once");
+        checkState(realmId != null, "Must call RealmPersistenceBuilder.setRealmId() before .build");
+        consumed = true;
+
+        var persistence =
+            backend.newPersistence(
+                x -> backend, persistenceConfig, realmId, monotonicClock, idGenerator);
+        return skipDecorators ? persistence : persistenceDecorators.decorate(persistence);
+      }
+    };
+  }
+}

--- a/persistence/nosql/persistence/cdi/common/src/main/resources/META-INF/beans.xml
+++ b/persistence/nosql/persistence/cdi/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/persistence/cdi/weld/build.gradle.kts
+++ b/persistence/nosql/persistence/cdi/weld/build.gradle.kts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  id("org.kordamp.gradle.jandex")
+  id("polaris-server")
+}
+
+description = "Polaris NoSQL persistence, providers for CDI/Weld."
+
+dependencies {
+  implementation(project(":polaris-persistence-nosql-cdi-common"))
+  implementation(project(":polaris-persistence-nosql-api"))
+  runtimeOnly(project(":polaris-nodes-impl"))
+  runtimeOnly(project(":polaris-nodes-store-nosql"))
+  runtimeOnly(project(":polaris-persistence-nosql-realms-impl"))
+  runtimeOnly(project(":polaris-persistence-nosql-realms-store-nosql"))
+
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  compileOnly("com.fasterxml.jackson.core:jackson-databind")
+
+  compileOnly(libs.smallrye.config.core)
+  compileOnly(platform(libs.quarkus.bom))
+  compileOnly("io.quarkus:quarkus-core")
+
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
+
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.jakarta.inject.api)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
+  testFixturesApi(project(":polaris-persistence-nosql-api"))
+  testFixturesApi(project(":polaris-persistence-nosql-realms-api"))
+  testFixturesApi(platform(libs.jackson.bom))
+  testFixturesApi("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
+  testFixturesApi(project(":polaris-persistence-nosql-inmemory"))
+  testFixturesApi(testFixtures(project(":polaris-persistence-nosql-inmemory")))
+  testFixturesImplementation(project(":polaris-persistence-nosql-cdi-common"))
+  testFixturesImplementation(project(":polaris-async-api"))
+  testFixturesRuntimeOnly(project(":polaris-async-java"))
+  testFixturesApi(libs.jakarta.inject.api)
+  testFixturesApi(libs.jakarta.enterprise.cdi.api)
+  testFixturesApi(project(":polaris-idgen-api"))
+  testFixturesApi(project(":polaris-nodes-api"))
+  testFixturesRuntimeOnly(libs.smallrye.config.core)
+
+  testImplementation(libs.weld.se.core)
+  testImplementation(libs.weld.junit5)
+  testRuntimeOnly(libs.smallrye.jandex)
+}
+
+tasks.withType<Javadoc> { isFailOnError = false }

--- a/persistence/nosql/persistence/cdi/weld/src/main/java/org/apache/polaris/persistence/nosql/weld/BackendProvider.java
+++ b/persistence/nosql/persistence/cdi/weld/src/main/java/org/apache/polaris/persistence/nosql/weld/BackendProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.weld;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import java.util.stream.Collectors;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.apache.polaris.persistence.nosql.api.backend.BackendConfiguration;
+import org.apache.polaris.persistence.nosql.api.backend.BackendFactory;
+import org.apache.polaris.persistence.nosql.api.backend.BackendLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+class BackendProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BackendProvider.class);
+
+  @Produces
+  @ApplicationScoped
+  Backend backend(
+      BackendConfiguration backendConfiguration, Instance<Object> backendSpecificConfigs) {
+
+    var factory =
+        backendConfiguration
+            .type()
+            .map(BackendLoader::findFactoryByName)
+            .map(
+                f -> {
+                  @SuppressWarnings("unchecked")
+                  var r = (BackendFactory<Object, Object>) f;
+                  return r;
+                })
+            .orElseGet(
+                () -> {
+                  try {
+                    @SuppressWarnings("unchecked")
+                    var r = (BackendFactory<Object, Object>) BackendLoader.findFactory(x -> true);
+                    return r;
+                  } catch (IllegalStateException e) {
+                    throw new RuntimeException(
+                        "Backend factory type is configured using the configuration option polaris.persistence.backend.type - available are: "
+                            + BackendLoader.availableFactories()
+                                .map(BackendFactory::name)
+                                .collect(Collectors.joining(", ")),
+                        e);
+                  }
+                });
+    var configType = factory.configurationInterface();
+    var config = backendSpecificConfigs.select(configType).get();
+    var runtimeConfig = factory.buildConfiguration(config);
+
+    var backend = factory.buildBackend(runtimeConfig);
+    try {
+      var setupSchemaResult = backend.setupSchema().orElse("");
+      LOGGER.info("Opened new persistence backend '{}' {}", backend.type(), setupSchemaResult);
+
+      return backend;
+    } catch (Exception e) {
+      try {
+        backend.close();
+      } catch (Exception e2) {
+        e.addSuppressed(e2);
+      }
+      throw e;
+    }
+  }
+}

--- a/persistence/nosql/persistence/cdi/weld/src/main/resources/META-INF/beans.xml
+++ b/persistence/nosql/persistence/cdi/weld/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/persistence/cdi/weld/src/test/java/org/apache/polaris/persistence/nosql/weld/TestProviders.java
+++ b/persistence/nosql/persistence/cdi/weld/src/test/java/org/apache/polaris/persistence/nosql/weld/TestProviders.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.weld;
+
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
+import org.apache.polaris.persistence.nosql.api.SystemPersistence;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.apache.polaris.persistence.nosql.realms.api.RealmManagement;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({SoftAssertionsExtension.class})
+@EnableWeld
+public class TestProviders {
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+
+  @Test
+  public void checkProviders() {
+    var backend = weld.select(Backend.class).get();
+    soft.assertThat(backend.type()).isEqualTo("InMemory");
+
+    var realmManagement = weld.select(RealmManagement.class).get();
+    soft.assertThat(realmManagement.get("fooBar")).isEmpty();
+
+    var systemPersistence = weld.select(Persistence.class, new SystemPersistence.Literal()).get();
+    soft.assertThat(systemPersistence.realmId()).isEqualTo(SYSTEM_REALM_ID);
+
+    var requestScopedRunner = weld.select(RequestScopedRunner.class).get();
+    requestScopedRunner.runWithRequestContext(
+        () -> {
+          var builder1 = weld.select(RealmPersistenceFactory.class).get();
+          var persistence1 = builder1.newBuilder().realmId("my-realm").build();
+          soft.assertThat(persistence1.realmId()).isEqualTo("my-realm");
+
+          var builder2 = weld.select(RealmPersistenceFactory.class).get();
+          var persistence2 = builder2.newBuilder().realmId("other-realm").build();
+          soft.assertThat(persistence2.realmId()).isEqualTo("other-realm");
+
+          // Trigger IdGenerator "activation"
+          persistence1.generateId();
+
+          // Trigger IdGenerator "activation"
+          persistence2.generateId();
+        });
+  }
+}

--- a/persistence/nosql/persistence/cdi/weld/src/test/resources/META-INF/beans.xml
+++ b/persistence/nosql/persistence/cdi/weld/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/persistence/cdi/weld/src/test/resources/logback-test.xml
+++ b/persistence/nosql/persistence/cdi/weld/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${test.log.level:-INFO}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/persistence/nosql/persistence/cdi/weld/src/test/resources/weld.properties
+++ b/persistence/nosql/persistence/cdi/weld/src/test/resources/weld.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# See https://bugs.openjdk.org/browse/JDK-8349545
+org.jboss.weld.bootstrap.concurrentDeployment=false

--- a/persistence/nosql/persistence/cdi/weld/src/testFixtures/java/org/apache/polaris/persistence/nosql/weld/CdiTestingProviders.java
+++ b/persistence/nosql/persistence/cdi/weld/src/testFixtures/java/org/apache/polaris/persistence/nosql/weld/CdiTestingProviders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.weld;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.polaris.ids.api.IdGeneratorSpec;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.misc.types.memorysize.MemorySize;
+import org.apache.polaris.nosql.async.AsyncConfiguration;
+import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.api.backend.BackendConfiguration;
+import org.apache.polaris.persistence.nosql.api.cache.CacheConfig;
+import org.apache.polaris.persistence.nosql.api.cache.CacheSizing;
+import org.apache.polaris.persistence.nosql.inmemory.InMemoryConfiguration;
+import org.apache.polaris.persistence.nosql.nodeids.api.NodeManagementConfig;
+
+@ApplicationScoped
+public class CdiTestingProviders {
+
+  @Produces
+  @ApplicationScoped
+  AsyncConfiguration asyncConfiguration() {
+    return AsyncConfiguration.builder().build();
+  }
+
+  @Produces
+  @ApplicationScoped
+  BackendConfiguration backendConfiguration() {
+    return BackendConfiguration.BuildableBackendConfiguration.builder().type("InMemory").build();
+  }
+
+  @Produces
+  @ApplicationScoped
+  InMemoryConfiguration inMemoryConfiguration() {
+    return new InMemoryConfiguration() {};
+  }
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Produces
+  @ApplicationScoped
+  CacheConfig cacheConfig(MonotonicClock monotonicClock) {
+    return CacheConfig.BuildableCacheConfig.builder()
+        .sizing(CacheSizing.builder().fixedSize(MemorySize.ofMega(32)).build())
+        .clockNanos(monotonicClock::nanoTime)
+        .build();
+  }
+
+  @Produces
+  @ApplicationScoped
+  NodeManagementConfig nodeManagementConfig() {
+    return NodeManagementConfig.BuildableNodeManagementConfig.builder()
+        .idGeneratorSpec(IdGeneratorSpec.BuildableIdGeneratorSpec.builder().build())
+        .build();
+  }
+
+  @Produces
+  @ApplicationScoped
+  PersistenceParams persistenceBaseConfig() {
+    return PersistenceParams.BuildablePersistenceParams.builder().build();
+  }
+
+  private ScheduledExecutorService executorService;
+
+  @PostConstruct
+  void initScheduler() {
+    executorService = Executors.newScheduledThreadPool(2);
+  }
+
+  @PreDestroy
+  void stopScheduler() {
+    // "Forget" tasks scheduled in the future
+    executorService.shutdownNow();
+    // Properly close
+    executorService.close();
+  }
+}

--- a/persistence/nosql/persistence/cdi/weld/src/testFixtures/java/org/apache/polaris/persistence/nosql/weld/RequestScopedRunner.java
+++ b/persistence/nosql/persistence/cdi/weld/src/testFixtures/java/org/apache/polaris/persistence/nosql/weld/RequestScopedRunner.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.weld;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import java.util.concurrent.Callable;
+
+/** Helper for tests to run code in the CDI request scope. */
+@ApplicationScoped
+public class RequestScopedRunner {
+  @ActivateRequestContext
+  public void runWithRequestContext(Runnable r) {
+    r.run();
+  }
+
+  @ActivateRequestContext
+  public <R> R callWithRequestContext(Callable<R> r) throws Exception {
+    return r.call();
+  }
+}

--- a/persistence/nosql/persistence/cdi/weld/src/testFixtures/resources/META-INF/beans.xml
+++ b/persistence/nosql/persistence/cdi/weld/src/testFixtures/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/realms/store-nosql/build.gradle.kts
+++ b/persistence/nosql/realms/store-nosql/build.gradle.kts
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  id("org.kordamp.gradle.jandex")
+  id("polaris-server")
+}
+
+description = "Polaris realms NoSQL persistence"
+
+dependencies {
+  implementation(project(":polaris-persistence-nosql-realms-api"))
+  implementation(project(":polaris-persistence-nosql-realms-spi"))
+  implementation(project(":polaris-persistence-nosql-api"))
+  implementation(project(":polaris-persistence-nosql-maintenance-spi"))
+
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
+
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.core:jackson-core")
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-guava")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
+  compileOnly(project(":polaris-immutables"))
+  annotationProcessor(project(":polaris-immutables", configuration = "processor"))
+
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.jakarta.inject.api)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+
+  testFixturesRuntimeOnly(project(":polaris-persistence-nosql-cdi-weld"))
+  testFixturesApi(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
+
+  testFixturesApi(libs.weld.se.core)
+  testFixturesApi(libs.weld.junit5)
+  testFixturesRuntimeOnly(libs.smallrye.jandex)
+
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.junit.pioneer)
+
+  testCompileOnly(libs.jakarta.annotation.api)
+  testCompileOnly(libs.jakarta.validation.api)
+  testCompileOnly(libs.jakarta.inject.api)
+  testCompileOnly(libs.jakarta.enterprise.cdi.api)
+}

--- a/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmManagementRetainedIdentifier.java
+++ b/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmManagementRetainedIdentifier.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.realms.store;
+
+import static org.apache.polaris.persistence.nosql.realms.store.RealmsStateObj.REALMS_REF_NAME;
+
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.polaris.persistence.nosql.api.exceptions.ReferenceNotFoundException;
+import org.apache.polaris.persistence.nosql.maintenance.spi.CountDownPredicate;
+import org.apache.polaris.persistence.nosql.maintenance.spi.PerRealmRetainedIdentifier;
+import org.apache.polaris.persistence.nosql.maintenance.spi.RetainedCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+class RealmManagementRetainedIdentifier implements PerRealmRetainedIdentifier {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(RealmManagementRetainedIdentifier.class);
+
+  @Override
+  public String name() {
+    return "Realm management";
+  }
+
+  @Override
+  public boolean identifyRetained(@Nonnull RetainedCollector collector) {
+    if (!collector.isSystemRealm()) {
+      return false;
+    }
+
+    // TODO follow-up: configurable limit number of historic realm states to retain
+    try {
+      collector.refRetainIndexToSingleObj(
+          REALMS_REF_NAME,
+          RealmsStateObj.class,
+          new CountDownPredicate<>(10),
+          RealmsStateObj::realmIndex);
+    } catch (ReferenceNotFoundException e) {
+      // logged, but otherwise ignored
+      LOGGER.debug(
+          "Reference '{}' not found while identifying retained items: {}, this might be expected",
+          REALMS_REF_NAME,
+          e.getMessage());
+    }
+
+    // Intentionally return false, let the maintenance service's identifier decide
+    return false;
+  }
+}

--- a/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmObj.java
+++ b/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmObj.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.realms.store;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.apache.polaris.persistence.nosql.api.obj.AbstractObjType;
+import org.apache.polaris.persistence.nosql.api.obj.Obj;
+import org.apache.polaris.persistence.nosql.api.obj.ObjType;
+import org.apache.polaris.persistence.nosql.realms.api.RealmDefinition;
+
+/** Represents the persisted state of a {@link RealmDefinition}. */
+@PolarisImmutable
+@JsonSerialize(as = ImmutableRealmObj.class)
+@JsonDeserialize(as = ImmutableRealmObj.class)
+public interface RealmObj extends Obj {
+  ObjType TYPE = new RealmObjType();
+
+  @Override
+  default ObjType type() {
+    return TYPE;
+  }
+
+  Instant created();
+
+  Instant updated();
+
+  RealmDefinition.RealmStatus status();
+
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  Map<String, String> properties();
+
+  static ImmutableRealmObj.Builder builder() {
+    return ImmutableRealmObj.builder();
+  }
+
+  final class RealmObjType extends AbstractObjType<RealmObj> {
+    public RealmObjType() {
+      super("rlm", "Realm", RealmObj.class);
+    }
+  }
+}

--- a/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmStoreImpl.java
+++ b/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmStoreImpl.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.realms.store;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.OBJ_REF_SERIALIZER;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
+import static org.apache.polaris.persistence.nosql.realms.store.RealmsStateObj.REALMS_REF_NAME;
+
+import com.google.common.collect.Streams;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.StreamUtil;
+import org.apache.polaris.persistence.nosql.api.SystemPersistence;
+import org.apache.polaris.persistence.nosql.api.commit.Committer;
+import org.apache.polaris.persistence.nosql.api.index.IndexContainer;
+import org.apache.polaris.persistence.nosql.api.index.IndexKey;
+import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.apache.polaris.persistence.nosql.realms.api.RealmAlreadyExistsException;
+import org.apache.polaris.persistence.nosql.realms.api.RealmDefinition;
+import org.apache.polaris.persistence.nosql.realms.api.RealmNotFoundException;
+import org.apache.polaris.persistence.nosql.realms.spi.RealmStore;
+
+@ApplicationScoped
+class RealmStoreImpl implements RealmStore {
+  private final Persistence systemPersistence;
+  private final Committer<RealmsStateObj, RealmObj> committer;
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  RealmStoreImpl(@Nonnull @SystemPersistence Persistence systemPersistence) {
+    checkArgument(
+        SYSTEM_REALM_ID.equals(systemPersistence.realmId()),
+        "Realms management must happen in the %s realm",
+        SYSTEM_REALM_ID);
+
+    this.systemPersistence = systemPersistence;
+
+    this.committer =
+        systemPersistence.createCommitter(REALMS_REF_NAME, RealmsStateObj.class, RealmObj.class);
+  }
+
+  @PostConstruct
+  void init() {
+    // Do this in a @PostConstruct method as it involves I/O, which isn't a good thing to do in a
+    // constructor, especially in CDI
+    systemPersistence.createReferenceSilent(REALMS_REF_NAME);
+  }
+
+  @Override
+  public Stream<RealmDefinition> list() {
+    var realmsIndex =
+        systemPersistence
+            .fetchReferenceHead(REALMS_REF_NAME, RealmsStateObj.class)
+            .map(realms -> realms.realmIndex().indexForRead(systemPersistence, OBJ_REF_SERIALIZER));
+    return realmsIndex.stream()
+        .flatMap(
+            entries ->
+                StreamUtil.bucketized(
+                        Streams.stream(entries),
+                        bucket -> {
+                          var objRefs =
+                              bucket.stream().map(Map.Entry::getValue).toArray(ObjRef[]::new);
+                          var objs = systemPersistence.fetchMany(RealmObj.class, objRefs);
+                          var defs = new ArrayList<RealmDefinition>(bucket.size());
+
+                          for (int i = 0; i < objs.length; i++) {
+                            var obj = objs[i];
+                            if (obj != null) {
+                              defs.add(objToDefinition(bucket.get(i).getKey().toString(), obj));
+                            }
+                          }
+                          return defs;
+                        },
+                        systemPersistence.params().bucketizedBulkFetchSize())
+                    .filter(Objects::nonNull));
+  }
+
+  @Override
+  public Optional<RealmDefinition> get(String realmId) {
+    return systemPersistence
+        .fetchReferenceHead(REALMS_REF_NAME, RealmsStateObj.class)
+        .flatMap(realms -> Optional.ofNullable(realmFromState(realms, realmId)));
+  }
+
+  @SuppressWarnings("DuplicatedCode") // looks similar, but extracting isn't worth it
+  @Override
+  public RealmDefinition create(String realmId, RealmDefinition definition) {
+    var realm =
+        committer.commitRuntimeException(
+            (state, refObjSupplier) -> {
+              var refObj = refObjSupplier.get();
+              var current = refObj.orElse(null);
+
+              var key = IndexKey.key(realmId);
+
+              var index =
+                  current != null
+                      ? current.realmIndex().asUpdatableIndex(systemPersistence, OBJ_REF_SERIALIZER)
+                      : IndexContainer.newUpdatableIndex(systemPersistence, OBJ_REF_SERIALIZER);
+              if (index.contains(key)) {
+                throw new RealmAlreadyExistsException(
+                    format("A realm with ID '%s' already exists", realmId));
+              }
+
+              var obj =
+                  state.writeIfNew(
+                      "realm",
+                      RealmObj.builder()
+                          .created(definition.created())
+                          .updated(definition.updated())
+                          .id(systemPersistence.generateId())
+                          .status(definition.status())
+                          .properties(definition.properties())
+                          .build(),
+                      RealmObj.class);
+
+              index.put(key, objRef(obj));
+
+              var newRealms =
+                  RealmsStateObj.builder()
+                      .realmIndex(index.toIndexed("idx-", state::writeOrReplace));
+
+              return state.commitResult(obj, newRealms, refObj);
+            });
+
+    return objToDefinition(realmId, realm.orElseThrow());
+  }
+
+  @SuppressWarnings("DuplicatedCode") // looks similar, but extracting isn't worth it
+  @Override
+  public RealmDefinition update(
+      String realmId, Function<RealmDefinition, RealmDefinition> updater) {
+    var realm =
+        committer.commitRuntimeException(
+            (state, refObjSupplier) -> {
+              var refObj = refObjSupplier.get();
+              var current = refObj.orElse(null);
+              if (current == null) {
+                throw getRealmNotFoundException(realmId);
+              }
+
+              var key = IndexKey.key(realmId);
+
+              var index =
+                  current.realmIndex().asUpdatableIndex(systemPersistence, OBJ_REF_SERIALIZER);
+              var currentObjId = index.get(key);
+              if (currentObjId == null) {
+                throw getRealmNotFoundException(realmId);
+              }
+
+              var currentObj = systemPersistence.fetch(currentObjId, RealmObj.class);
+              if (currentObj == null) {
+                throw realmObjNotFoundException(realmId);
+              }
+
+              var update = updater.apply(objToDefinition(realmId, currentObj));
+
+              var obj =
+                  state.writeIfNew(
+                      "realm",
+                      RealmObj.builder()
+                          .created(currentObj.created())
+                          .updated(update.updated())
+                          .id(systemPersistence.generateId())
+                          .status(update.status())
+                          .properties(update.properties())
+                          .build(),
+                      RealmObj.class);
+
+              index.put(key, objRef(obj));
+
+              var newRealms =
+                  RealmsStateObj.builder()
+                      .realmIndex(index.toIndexed("idx-", state::writeOrReplace));
+
+              return state.commitResult(obj, newRealms, refObj);
+            });
+
+    return objToDefinition(realmId, realm.orElseThrow());
+  }
+
+  @SuppressWarnings("DuplicatedCode") // looks similar, but extracting isn't worth it
+  @Override
+  public void delete(String realmId, Consumer<RealmDefinition> callback) {
+    committer.commitRuntimeException(
+        (state, refObjSupplier) -> {
+          var refObj = refObjSupplier.get();
+          var current = refObj.orElse(null);
+          if (current == null) {
+            throw getRealmNotFoundException(realmId);
+          }
+
+          var key = IndexKey.key(realmId);
+
+          var index = current.realmIndex().asUpdatableIndex(systemPersistence, OBJ_REF_SERIALIZER);
+          var currentObjId = index.get(key);
+          if (currentObjId == null) {
+            throw getRealmNotFoundException(realmId);
+          }
+
+          var currentObj = systemPersistence.fetch(currentObjId, RealmObj.class);
+          if (currentObj == null) {
+            throw realmObjNotFoundException(realmId);
+          }
+
+          callback.accept(objToDefinition(realmId, currentObj));
+
+          index.remove(key);
+
+          var newRealms =
+              RealmsStateObj.builder().realmIndex(index.toIndexed("idx-", state::writeOrReplace));
+
+          return state.commitResult(currentObj, newRealms, refObj);
+        });
+  }
+
+  private RealmDefinition realmFromState(RealmsStateObj realms, String realmId) {
+    var index = realms.realmIndex().indexForRead(systemPersistence, OBJ_REF_SERIALIZER);
+    var realmDefId = index.get(IndexKey.key(realmId));
+    if (realmDefId == null) {
+      return null;
+    }
+    var obj = systemPersistence.fetch(realmDefId, RealmObj.class);
+    checkState(obj != null, "No realm definition object for realm ID '%s'", realmId);
+    return objToDefinition(realmId, obj);
+  }
+
+  private static RealmDefinition objToDefinition(String realmId, RealmObj obj) {
+    return RealmDefinition.builder()
+        .id(realmId)
+        .created(obj.created())
+        .updated(obj.updated())
+        .status(obj.status())
+        .properties(obj.properties())
+        .build();
+  }
+
+  private static RealmNotFoundException getRealmNotFoundException(String realmId) {
+    return new RealmNotFoundException(format("No realm with ID '%s' exists", realmId));
+  }
+
+  private static RealmNotFoundException realmObjNotFoundException(String realmId) {
+    return new RealmNotFoundException(
+        format("RealmObj for realm with ID '%s' does not exist", realmId));
+  }
+}

--- a/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmsStateObj.java
+++ b/persistence/nosql/realms/store-nosql/src/main/java/org/apache/polaris/persistence/nosql/realms/store/RealmsStateObj.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.realms.store;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.apache.polaris.persistence.nosql.api.index.IndexContainer;
+import org.apache.polaris.persistence.nosql.api.index.IndexKey;
+import org.apache.polaris.persistence.nosql.api.obj.AbstractObjType;
+import org.apache.polaris.persistence.nosql.api.obj.BaseCommitObj;
+import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.apache.polaris.persistence.nosql.api.obj.ObjType;
+
+/** Represents the persisted and system-wide consistent state of all realms. */
+@PolarisImmutable
+@JsonSerialize(as = ImmutableRealmsStateObj.class)
+@JsonDeserialize(as = ImmutableRealmsStateObj.class)
+public interface RealmsStateObj extends BaseCommitObj {
+  ObjType TYPE = new RealmStateObjType();
+  String REALMS_REF_NAME = "realms";
+
+  @Override
+  default ObjType type() {
+    return TYPE;
+  }
+
+  /**
+   * Index of all realms by ID (via {@link IndexKey#key(String)}) to the {@link ObjRef}s referencing
+   * {@link RealmObj}s.
+   */
+  IndexContainer<ObjRef> realmIndex();
+
+  static ImmutableRealmsStateObj.Builder builder() {
+    return ImmutableRealmsStateObj.builder();
+  }
+
+  final class RealmStateObjType extends AbstractObjType<RealmsStateObj> {
+    public RealmStateObjType() {
+      super("realm-state", "Realms State", RealmsStateObj.class);
+    }
+  }
+
+  interface Builder extends BaseCommitObj.Builder<RealmsStateObj, Builder> {}
+}

--- a/persistence/nosql/realms/store-nosql/src/main/resources/META-INF/beans.xml
+++ b/persistence/nosql/realms/store-nosql/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- File required by Weld (used for testing), not by Quarkus -->
+</beans>

--- a/persistence/nosql/realms/store-nosql/src/main/resources/META-INF/services/org.apache.polaris.persistence.nosql.api.obj.ObjType
+++ b/persistence/nosql/realms/store-nosql/src/main/resources/META-INF/services/org.apache.polaris.persistence.nosql.api.obj.ObjType
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.apache.polaris.persistence.nosql.realms.store.RealmObj$RealmObjType
+org.apache.polaris.persistence.nosql.realms.store.RealmsStateObj$RealmStateObjType

--- a/persistence/nosql/realms/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/realms/store/TestRealmStoreIntegration.java
+++ b/persistence/nosql/realms/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/realms/store/TestRealmStoreIntegration.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.realms.store;
+
+import static java.lang.String.format;
+import static java.time.Instant.now;
+import static org.apache.polaris.persistence.nosql.api.Realms.SYSTEM_REALM_ID;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.ACTIVE;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.CREATED;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.INACTIVE;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.INITIALIZING;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.PURGED;
+import static org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus.PURGING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.realms.api.RealmAlreadyExistsException;
+import org.apache.polaris.persistence.nosql.realms.api.RealmDefinition;
+import org.apache.polaris.persistence.nosql.realms.api.RealmExpectedStateMismatchException;
+import org.apache.polaris.persistence.nosql.realms.api.RealmManagement;
+import org.apache.polaris.persistence.nosql.realms.api.RealmNotFoundException;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SoftAssertionsExtension.class)
+@EnableWeld
+public class TestRealmStoreIntegration {
+  @InjectSoftAssertions protected SoftAssertions soft;
+  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  @Inject
+  RealmManagement realmManagement;
+
+  @Test
+  public void nonSystemPersistence() {
+    var nonSystemPersistence = mock(Persistence.class);
+    var params = mock(PersistenceParams.class);
+    when(nonSystemPersistence.realmId()).thenReturn("nonSystemPersistence");
+    when(nonSystemPersistence.params()).thenReturn(params);
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> new RealmStoreImpl(nonSystemPersistence))
+        .withMessage("Realms management must happen in the ::system:: realm");
+  }
+
+  @Test
+  public void createUpdateDelete() {
+    var something =
+        RealmDefinition.builder()
+            .id("something")
+            .created(now())
+            .updated(now())
+            .status(ACTIVE)
+            .build();
+    var another =
+        RealmDefinition.builder()
+            .id("another")
+            .created(now())
+            .updated(now())
+            .status(ACTIVE)
+            .build();
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> realmManagement.create(SYSTEM_REALM_ID))
+        .withMessage("Invalid realm ID '%s'", SYSTEM_REALM_ID);
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> realmManagement.create("::something"))
+        .withMessage("Invalid realm ID '%s'", "::something");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                realmManagement.update(
+                    something.withId("::something"), something.withId("::something")))
+        .withMessage("Invalid realm ID '%s'", "::something");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> realmManagement.delete(something.withId("::something")))
+        .withMessage("Invalid realm ID '%s'", "::something");
+
+    // empty index
+    soft.assertThatThrownBy(
+            () ->
+                realmManagement.update(
+                    something, RealmDefinition.builder().from(something).build()))
+        .isInstanceOf(RealmNotFoundException.class)
+        .hasMessage("No realm with ID 'something' exists");
+    soft.assertThatThrownBy(() -> realmManagement.delete(something.withStatus(PURGED)))
+        .hasMessage("No realm with ID 'something' exists");
+
+    var created = realmManagement.create(something.id());
+    soft.assertThat(created).extracting(RealmDefinition::id).isEqualTo(something.id());
+    soft.assertThatThrownBy(() -> realmManagement.create(something.id()))
+        .isInstanceOf(RealmAlreadyExistsException.class)
+        .hasMessage("A realm with ID 'something' already exists");
+    var gotOpt = realmManagement.get(something.id());
+    soft.assertThat(gotOpt).contains(created);
+    var got = gotOpt.orElseThrow();
+
+    var createdAnother = realmManagement.create(another.id());
+    soft.assertThat(createdAnother).extracting(RealmDefinition::id).isEqualTo(another.id());
+
+    // RealmsStateObj present
+    soft.assertThatThrownBy(
+            () -> realmManagement.update(something.withId("foo"), something.withId("foo")))
+        .isInstanceOf(RealmNotFoundException.class)
+        .hasMessage("No realm with ID 'foo' exists");
+    soft.assertThatThrownBy(
+            () -> realmManagement.delete(something.withId("foo").withStatus(PURGED)))
+        .isInstanceOf(RealmNotFoundException.class)
+        .hasMessage("No realm with ID 'foo' exists");
+
+    // Update with different realm-IDs (duh!)
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                realmManagement.update(
+                    got, RealmDefinition.builder().from(got).id("something-else").build()));
+    // Update with different expected state
+    soft.assertThatThrownBy(
+            () ->
+                realmManagement.update(
+                    RealmDefinition.builder().from(got).putProperty("foo", "bar").build(),
+                    RealmDefinition.builder().from(got).putProperty("meep", "meep").build()))
+        .isInstanceOf(RealmExpectedStateMismatchException.class)
+        .hasMessage("Realm '%s' does not match the expected state", got.id());
+
+    var updated =
+        realmManagement.update(
+            got, RealmDefinition.builder().from(got).putProperty("foo", "bar").build());
+    soft.assertThat(updated)
+        .extracting(RealmDefinition::id, RealmDefinition::properties)
+        .containsExactly(something.id(), Map.of("foo", "bar"));
+    var got2Opt = realmManagement.get(something.id());
+    soft.assertThat(got2Opt).contains(updated);
+    var got2 = got2Opt.orElseThrow();
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> realmManagement.delete(got2))
+        .withMessage("Realm '%s' must be in state PURGED to be deleted", got2.id());
+    var initializing =
+        realmManagement.update(
+            got2, RealmDefinition.builder().from(got2).status(INITIALIZING).build());
+    var active =
+        realmManagement.update(
+            initializing, RealmDefinition.builder().from(initializing).status(ACTIVE).build());
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> realmManagement.delete(active))
+        .withMessage("Realm '%s' must be in state PURGED to be deleted", active.id());
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                realmManagement.update(
+                    active, RealmDefinition.builder().from(active).status(CREATED).build()))
+        .withMessage(
+            "Invalid realm state transition from ACTIVE to CREATED for realm '%s'", active.id());
+    var inactive =
+        realmManagement.update(
+            active, RealmDefinition.builder().from(got2).status(INACTIVE).build());
+    var purging =
+        realmManagement.update(
+            inactive, RealmDefinition.builder().from(inactive).status(PURGING).build());
+    soft.assertThat(purging).extracting(RealmDefinition::status).isSameAs(PURGING);
+    var purged =
+        realmManagement.update(
+            purging, RealmDefinition.builder().from(inactive).status(PURGED).build());
+    soft.assertThat(purged).extracting(RealmDefinition::status).isSameAs(PURGED);
+    soft.assertThatCode(() -> realmManagement.delete(purged)).doesNotThrowAnyException();
+
+    soft.assertThat(realmManagement.get(something.id())).isEmpty();
+
+    soft.assertThat(realmManagement.get(another.id())).contains(createdAnother);
+  }
+
+  @Test
+  public void list() {
+    var toRealmId = (IntFunction<String>) i -> format("realm_%05d", i);
+
+    // Check that the bucketizing used in .list() implementation works correctly. Need to iterate
+    // more often than the (default) PersistenceParams.bucketizedBulkFetchSize() value.
+    for (int i = 0; i < 47; i++) {
+      try (var realms = realmManagement.list()) {
+        var realmDefs = realms.toList();
+        soft.assertThat(realmDefs)
+            .describedAs("i=%d", i)
+            .hasSize(i)
+            .map(RealmDefinition::id)
+            .containsExactlyElementsOf(IntStream.range(0, i).mapToObj(toRealmId).toList());
+
+        realmManagement.create(toRealmId.apply(i));
+      }
+    }
+  }
+}

--- a/persistence/nosql/realms/store-nosql/src/test/resources/logback-test.xml
+++ b/persistence/nosql/realms/store-nosql/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${test.log.level:-WARN}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/persistence/nosql/realms/store-nosql/src/test/resources/weld.properties
+++ b/persistence/nosql/realms/store-nosql/src/test/resources/weld.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# See https://bugs.openjdk.org/browse/JDK-8349545
+org.jboss.weld.bootstrap.concurrentDeployment=false


### PR DESCRIPTION
Adds common and test-specific CDI functionality. Requires the NoSQL store implementations `:polaris-persistence-nosql-realms-store-nosql` and `:polaris-nodes-store-nosql`.

Those modules have cross-project dependencies for test purposes, hence those are all contained in this PR.

CDI for Quarkus will be added in a follow-up.
