### PR TITLE
Workflow to build python CLI snapshot for nightly publishing (sdist + wheels)

### DIFF
--- a/.github/workflows/python-client-build-artifacts.yml
+++ b/.github/workflows/python-client-build-artifacts.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install Poetry
+        run: make client-install-poetry
+
       - name: Generate snapshot version
         id: version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,16 @@ $(VENV_DIR):
 	@python3 -m venv $(VENV_DIR)
 	@echo "Virtual environment created."
 
-.PHONY: client-install-dependencies
-client-install-dependencies: $(VENV_DIR)
-	@echo "Installing Poetry and project dependencies into $(VENV_DIR)..."
-	@$(VENV_DIR)/bin/pip install --upgrade pip
+.PHONY: client-install-poetry
+client-install-poetry: $(VENV_DIR) ## Install Poetry into the virtual environment
+	@$(VENV_DIR)/bin/pip install --upgrade pip -q
 	@if [ ! -f "$(VENV_DIR)/bin/poetry" ]; then \
-		$(VENV_DIR)/bin/pip install --upgrade "poetry$(POETRY_VERSION)"; \
+		$(VENV_DIR)/bin/pip install --upgrade "poetry$(POETRY_VERSION)" -q; \
 	fi
+
+.PHONY: client-install-dependencies
+client-install-dependencies: client-install-poetry
+	@echo "Installing project dependencies into $(VENV_DIR)..."
 	@$(ACTIVATE_AND_CD) && poetry lock && poetry install --all-extras
 	@echo "Poetry and dependencies installed."
 
@@ -132,7 +135,7 @@ client-lint: client-setup-env ## Run linting checks for Polaris client
 	@echo "--- Client linting checks complete ---"
 
 .PHONY: client-get-version
-client-get-version: client-setup-env ## Get Python client version
+client-get-version: ## Get Python client version (requires poetry to be installed)
 	@$(ACTIVATE_AND_CD) && poetry version --short
 
 .PHONY: client-set-version


### PR DESCRIPTION
This PR include a github workflow, "Python Client Build Artifacts", to build wheels for multiple os/platform for nightly build and release automation in the future. It will produce a zip containing
contain sdist and wheels built for macos and linux (TODO: support windows)
```
> tar -tzf python-client-artifacts-20141056849.zip
apache_polaris-1.2.0-cp310-cp310-macosx_14_0_arm64.whl
apache_polaris-1.2.0-cp310-cp310-manylinux_2_39_x86_64.whl
apache_polaris-1.2.0-cp310-cp310-macosx_15_0_arm64.whl
apache_polaris-1.2.0-cp311-cp311-macosx_14_0_arm64.whl
apache_polaris-1.2.0-cp311-cp311-macosx_15_0_arm64.whl
apache_polaris-1.2.0-cp311-cp311-manylinux_2_39_x86_64.whl
apache_polaris-1.2.0-cp312-cp312-macosx_14_0_arm64.whl
apache_polaris-1.2.0-cp312-cp312-macosx_15_0_arm64.whl
apache_polaris-1.2.0-cp312-cp312-manylinux_2_39_x86_64.whl
apache_polaris-1.2.0-cp313-cp313-macosx_14_0_arm64.whl
apache_polaris-1.2.0-cp313-cp313-macosx_15_0_arm64.whl
apache_polaris-1.2.0-cp313-cp313-manylinux_2_39_x86_64.whl
apache_polaris-1.2.0.tar.gz
```

The expected usage for this workflow is:
1. Triggered for every python client changes to verify that changes will not break wheel building
2. Called by other workflow (e.g. nightly build) like
```
python-client-snapshot-build:
    if: github.repository == 'apache/polaris'
    uses: ./.github/workflows/python-client-build-artifacts.yml

python-client-snapshot-publish:
  runs-on: ubuntu-latest
  needs: python-client-snapshot-build
  if: github.repository == 'apache/polaris'
  steps:
    - name: Download artifacts
      uses: actions/download-artifact@v4
      with:
        name: ${{ needs.python-client-snapshot-build.outputs.artifact-name }}
        path: dist/

    - name: List artifacts
      run: ls -la dist/

   - name: Publish to TestPyPI
     id: publish-testpypi
     continue-on-error: true
     uses: pypa/gh-action-pypi-publish@release/v1
     with:
       repository-url: https://test.pypi.org/legacy/
       skip-existing: true
       verbose: true
....
```
3. Called by maintainer directly for test purpose.

The build of a release candidate that include proper sig, checksum, is out-of-scope of this PR and should be included in separate PR/workflow for python client release automation

cc: @binarycat0 @MonkeyCanCode @flyrain @snazy 
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
