### PR TITLE
Use CDI for more test setups

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
@@ -39,7 +39,7 @@ public class JWTSymmetricKeyGeneratorTest {
   /** Sanity test to verify that we can generate a token */
   @Test
   public void testJWTSymmetricKeyGenerator() {
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, null);
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     long principalId = 123L;
     String mainSecret = "test_secret";

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
@@ -24,13 +24,10 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -39,10 +36,7 @@ import org.apache.polaris.service.types.TokenType;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@QuarkusTest
 public class RSAKeyPairJWTBrokerTest {
-
-  @Inject protected PolarisConfigurationStore configurationStore;
 
   @Test
   public void testSuccessfulTokenGeneration() throws Exception {
@@ -52,7 +46,7 @@ public class RSAKeyPairJWTBrokerTest {
     final String clientId = "test-client-id";
     final String scope = "PRINCIPAL_ROLE:TEST";
 
-    PolarisCallContext polarisCallContext = new PolarisCallContext(null, null, configurationStore);
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
     String mainSecret = "client-secret";
     PolarisPrincipalSecrets principalSecrets =

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -37,8 +37,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
-import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.AsyncTaskType;
@@ -62,10 +60,8 @@ import org.slf4j.LoggerFactory;
 class TableCleanupTaskHandlerTest {
   @Inject Clock clock;
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
-  @Inject PolarisConfigurationStore configurationStore;
-
-  private PolarisMetaStoreManager metaStoreManager;
-  private CallContext callContext;
+  @Inject PolarisMetaStoreManager metaStoreManager;
+  @Inject CallContext callContext;
 
   private final RealmContext realmContext = () -> "realmName";
 
@@ -80,13 +76,6 @@ class TableCleanupTaskHandlerTest {
   @BeforeEach
   void setup() {
     QuarkusMock.installMockForType(realmContext, RealmContext.class);
-
-    metaStoreManager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
-    callContext =
-        new PolarisCallContext(
-            realmContext,
-            metaStoreManagerFactory.getOrCreateSession(realmContext),
-            configurationStore);
   }
 
   @Test


### PR DESCRIPTION
this avoids a bunch of redundant manual setup.

the important parts are establishing a `RealmContext` by calling
`QuarkusMock.installMockForType` and then populating `polarisContext`
from the injected `CallContext`.