### PR TITLE
Skip Hugo Site workflow on forks

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,6 +27,7 @@ jobs:
   site:
 
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/polaris'
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
forks usually don't have the "versioned-docs" tag and thus PRs
against forks or rebasing the main branch on a fork currently
always causes workflow failures.