### PR TITLE
OPA: Fail fast when OPA bearer token file is unreadable

### DIFF
--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
@@ -100,12 +100,12 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
     this.clock = clock;
     this.asyncExec = asyncExec;
 
+    checkState(Files.isReadable(tokenFilePath), "OPA token file does not exist or is not readable");
+
     this.nextRefresh = Instant.MIN;
     this.lastRefresh = Instant.MIN;
     // start refreshing the token (immediately)
     scheduleRefreshAttempt(Duration.ZERO);
-
-    checkState(Files.isReadable(tokenFilePath), "OPA token file does not exist or is not readable");
 
     logger.debug(
         "Created file token provider for path: {} with refresh interval: {}, JWT expiration refresh: {}, JWT buffer: {}, next refresh: {}",

--- a/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
+++ b/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
@@ -199,6 +199,9 @@ public class FileBearerTokenProviderTest {
                     .close())
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("OPA token file does not exist or is not readable");
+
+    // No refresh tasks should be scheduled when construction fails fast.
+    assertThat(asyncExec.tasks()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Fail fast when OPA bearer token file is unreadable

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
