### PR TITLE
Document Updated: Added GCS related Bucket Properties for vending credentials.

### DIFF
--- a/site/content/in-dev/unreleased/configuring-polaris-for-production/_index.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production/_index.md
@@ -173,7 +173,7 @@ Depending on your database, this may not be convenient as the generated credenti
 in clear text in the database.
 
 In order to provide your own credentials for `root` principal (so you can request tokens via
-`api/catalog/v1/oauth/tokens`), use the [Polaris Admin Tool]({{% ref "admin-tool" %}})
+`api/catalog/v1/oauth/tokens`), use the [Polaris Admin Tool](../../../../docs/admin-tool.md)
 
 You can verify the setup by attempting a token issue for the `root` principal:
 

--- a/site/content/in-dev/unreleased/configuring-polaris-for-production/configuring-gcs-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuring-polaris-for-production/configuring-gcs-cloud-storage-specific.md
@@ -23,15 +23,10 @@ type: docs
 weight: 600
 ---
 
-This page provides guidance for Configuring GCS Cloud Storage provider for use with Polaris. 
-It covers credential vending, IAM roles, ACL requirements, and best practices to ensure secure and reliable integration.
+This page provides guidance for configuring GCS Cloud Storage provider for use with Polaris. It covers credential vending, IAM roles, ACL requirements, and best practices to ensure secure and reliable integration.
 
-#### GCS
+All catalog operations in Polaris for Google Cloud Storage (GCS)—including listing, reading, and writing objects—are performed using credential vending, which issues scoped (vended) tokens for secure access.
 
-When using credential vending for Google Cloud Storage (GCS) with Apache Iceberg on
-Polaris, ensure that both IAM roles and HNS ACLs (if HNS is enabled) are properly configured. Even with the correct IAM
-role (e.g., `roles/storage.objectAdmin`), access to paths such as `gs://<bucket>/idsp_ns/sample_table4/` may fail with
-403 errors if HNS ACLs are missing for scoped tokens. The original access token may work, but scoped (vended) tokens
-require HNS ACLs on the base path or relevant subpath. Polaris does not require HNS to be enabled for basic operation,
-but if HNS is enabled and credential vending is used, HNS ACLs are mandatory for scoped token access. Always verify HNS ACLs
-in addition to IAM roles when troubleshooting GCS access issues with credential vending and HNS enabled.
+Polaris requires both IAM roles and [Hierarchical Namespace (HNS)](https://docs.cloud.google.com/storage/docs/hns-overview) ACLs (if HNS is enabled) to be properly configured. Even with the correct IAM role (e.g., `roles/storage.objectAdmin`), access to paths such as `gs://<bucket>/idsp_ns/sample_table4/` may fail with 403 errors if HNS ACLs are missing for scoped tokens. The original access token may work, but scoped (vended) tokens require HNS ACLs on the base path or relevant subpath.
+
+**Note:** HNS is not mandatory when using GCS for a catalog in Polaris. If HNS is not enabled on the bucket, only IAM roles are required for access. Always verify HNS ACLs in addition to IAM roles when troubleshooting GCS access issues with credential vending and HNS enabled.


### PR DESCRIPTION
==> Document Updated on 18th Nov 2025

1. Added GCS related Properties for vending credentials. 
2. Added Headers which were missing.
3. Added line width to 120 char.

==> Edit on 20th Nov 2025
1. As per the comments, For the changes "Added GCS related Properties for vending credentials" i have added a new sub page "Configuring Cloud Storage" under the existing page "Production Configuration"
2. Reverted above changes 2 and 3.
