### PR TITLE
Disable cloud storage tests that would use @TempDir

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
@@ -19,10 +19,13 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on Azure. */
 public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
@@ -43,4 +46,29 @@ public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, TENANT_ID).anyMatch(Strings::isNullOrEmpty);
   }
+
+  /**
+   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
+   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
+   * cannot make it point to a cloud storage path at the moment.
+   */
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void completeCreateView() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createAndReplaceViewWithLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void updateViewLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
@@ -19,10 +19,13 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on GCP. */
 public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
@@ -44,4 +47,29 @@ public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, SERVICE_ACCOUNT).anyMatch(Strings::isNullOrEmpty);
   }
+
+  /**
+   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
+   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
+   * cannot make it point to a cloud storage path at the moment.
+   */
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void completeCreateView() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createAndReplaceViewWithLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void updateViewLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
@@ -19,11 +19,14 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on AWS. */
 public abstract class PolarisRestCatalogViewS3IntegrationTestBase
@@ -46,4 +49,29 @@ public abstract class PolarisRestCatalogViewS3IntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, ROLE_ARN).anyMatch(Strings::isNullOrEmpty);
   }
+
+  /**
+   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
+   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
+   * cannot make it point to a cloud storage path at the moment.
+   */
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void completeCreateView() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createAndReplaceViewWithLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void updateViewLocation() {}
+
+  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
+  @Override
+  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewAdlsIT.java
+++ b/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewAdlsIT.java
@@ -19,23 +19,9 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
-import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewAdlsIntegrationTestBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "INTEGRATION_TEST_AZURE_PATH", matches = ".+")
-public class RestCatalogViewAdlsIT extends PolarisRestCatalogViewAdlsIntegrationTestBase {
-
-  @BeforeEach
-  public void setUpTempDir(@TempDir Path tempDir) throws Exception {
-    // see https://github.com/quarkusio/quarkus/issues/13261
-    Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
-    field.setAccessible(true);
-    field.set(this, tempDir);
-  }
-}
+public class RestCatalogViewAdlsIT extends PolarisRestCatalogViewAdlsIntegrationTestBase {}

--- a/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewGcsIT.java
+++ b/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewGcsIT.java
@@ -19,23 +19,9 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
-import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewGcsIntegrationTestBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "INTEGRATION_TEST_GCS_PATH", matches = ".+")
-public class RestCatalogViewGcsIT extends PolarisRestCatalogViewGcsIntegrationTestBase {
-
-  @BeforeEach
-  public void setUpTempDir(@TempDir Path tempDir) throws Exception {
-    // see https://github.com/quarkusio/quarkus/issues/13261
-    Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
-    field.setAccessible(true);
-    field.set(this, tempDir);
-  }
-}
+public class RestCatalogViewGcsIT extends PolarisRestCatalogViewGcsIntegrationTestBase {}

--- a/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewS3IT.java
+++ b/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/RestCatalogViewS3IT.java
@@ -19,23 +19,9 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
-import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewS3IntegrationTestBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "INTEGRATION_TEST_S3_PATH", matches = ".+")
-public class RestCatalogViewS3IT extends PolarisRestCatalogViewS3IntegrationTestBase {
-
-  @BeforeEach
-  public void setUpTempDir(@TempDir Path tempDir) throws Exception {
-    // see https://github.com/quarkusio/quarkus/issues/13261
-    Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
-    field.setAccessible(true);
-    field.set(this, tempDir);
-  }
-}
+public class RestCatalogViewS3IT extends PolarisRestCatalogViewS3IntegrationTestBase {}


### PR DESCRIPTION
## Summary

Disables 5 view catalog tests for cloud storage providers (S3, ADLS, GCS) that use `@TempDir`. The `ViewCatalogTests` base class uses `Paths.get()` with the temp directory, which doesn't support cloud storage paths.

Follow-up to https://github.com/apache/polaris/pull/2871.

## Background

These tests inherit from Iceberg's `ViewCatalogTests`, which passes a `@TempDir` path to `Paths.get()`. Since `Paths.get()` only accepts local filesystem paths, it cannot handle cloud storage URIs. For example, when `@TempDir` provides `/tmp/junit123`, `Paths.get()` converts it to a URI like `file:///tmp/junit123`. But for cloud storage base paths like `s3://bucket/path`, it would incorrectly create `s3:/bucket/path` (single slash) instead of the valid `s3://bucket/path` format.

These tests are disabled to prevent false positives - they would pass by testing against local filesystem instead of actually validating cloud storage behavior.

## Changes

**Base test classes** - Added `@Disabled` overrides for 5 tests:
- `PolarisRestCatalogViewAdlsIntegrationTestBase.java`
- `PolarisRestCatalogViewGcsIntegrationTestBase.java`
- `PolarisRestCatalogViewS3IntegrationTestBase.java`

**Concrete test classes** - Removed reflection workaround:
- `RestCatalogViewAdlsIT.java`
- `RestCatalogViewGcsIT.java`
- `RestCatalogViewS3IT.java`

## Testing

Run cloud tests: `./gradlew cloudTest`

## Future Work

Will follow up with changes to Iceberg's `ViewCatalogTests` to avoid using `Paths.get()` with `@TempDir`. Once that's done, these tests can be re-enabled.