### PR TITLE
Site: Replace feather logo

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -175,8 +175,7 @@ menu:
       url: "https://github.com/apache/polaris"
       weight: 400
 
-    - name: "ASF"
-      pre: "<i class='fa-solid fa-feather'></i>"
+    - name: "The ASF"
       identifier: "asf"
       weight: 900
       params:


### PR DESCRIPTION
The ASF has a new logo, a leaf. There is sadly no free icon that matches the new logo, so replacing the "(feather) ASF" with "The ASF" in the top-bar navigation.
