### PR TITLE
PRs: Re-add markdown-links-check step

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -39,9 +39,9 @@ jobs:
     - uses: actions/checkout@master
     - name: Setup test environment
       uses: ./.github/actions/setup-test-env
-#    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
-#      with:
-#        use-quiet-mode: 'yes'
-#        config-file: '.github/workflows/check-md-link-config.json'
-#        folder-path: 'regtests, .github, build-logic, polaris-core, runtime, persistence, spec, getting-started, helm'
-#        file-path: 'CHAT_BYLAWS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, README.md, SECURITY.md'
+    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.github/workflows/check-md-link-config.json'
+        folder-path: 'regtests, .github, build-logic, polaris-core, runtime, persistence, spec, getting-started, helm'
+        file-path: 'CHAT_BYLAWS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, README.md, SECURITY.md'


### PR DESCRIPTION
The step was disabled in #3102 to pass CI and enable merging.