### PR TITLE
Remove readEntity() call

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestConfigurationEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestConfigurationEventServiceDelegator.java
@@ -46,7 +46,7 @@ public class IcebergRestConfigurationEventServiceDelegator
         new IcebergRestCatalogEvents.BeforeGetConfigEvent(warehouse));
     Response resp = delegate.getConfig(warehouse, realmContext, securityContext);
     polarisEventListener.onAfterGetConfig(
-        new IcebergRestCatalogEvents.AfterGetConfigEvent(resp.readEntity(ConfigResponse.class)));
+        new IcebergRestCatalogEvents.AfterGetConfigEvent((ConfigResponse) resp.getEntity()));
     return resp;
   }
 }


### PR DESCRIPTION
Calling readEntity() is not allowed server-side by some HTTP servers.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
