### PR TITLE
Add timeout and retry logic to Azure token fetch

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -439,46 +439,42 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(true)
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Integer> STORAGE_API_TIMEOUT_MILLIS =
+  public static final FeatureConfiguration<Integer> AZURE_TIMEOUT_MILLIS =
       PolarisConfiguration.<Integer>builder()
-          .key("STORAGE_API_TIMEOUT_MILLIS")
+          .key("AZURE_TIMEOUT_MILLIS")
           .description(
-              "Timeout in milliseconds for cloud storage provider API requests. "
-                  + "Prevents indefinite blocking when cloud provider endpoints are slow or unresponsive. "
-                  + "Used internally by storage integrations for credential vending and other cloud operations. "
-                  + "Currently only used by Azure storage integration. Designed to be applicable to AWS S3, GCP, and other cloud storage providers.")
+              "Timeout in milliseconds for Azure API requests. "
+                  + "Prevents indefinite blocking when Azure endpoints are slow or unresponsive. "
+                  + "Used internally by Azure storage integration for credential vending and other operations.")
           .defaultValue(15000)
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Integer> STORAGE_API_RETRY_COUNT =
+  public static final FeatureConfiguration<Integer> AZURE_RETRY_COUNT =
       PolarisConfiguration.<Integer>builder()
-          .key("STORAGE_API_RETRY_COUNT")
+          .key("AZURE_RETRY_COUNT")
           .description(
-              "Number of retry attempts for cloud storage provider API requests. "
-                  + "Uses exponential backoff with jitter to handle transient failures. "
-                  + "Currently only used by Azure storage integration. Designed to be applicable to AWS S3, GCP, and other cloud storage providers.")
+              "Number of retry attempts for Azure API requests. "
+                  + "Uses exponential backoff with jitter to handle transient failures.")
           .defaultValue(3)
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Integer> STORAGE_API_RETRY_DELAY_MILLIS =
+  public static final FeatureConfiguration<Integer> AZURE_RETRY_DELAY_MILLIS =
       PolarisConfiguration.<Integer>builder()
-          .key("STORAGE_API_RETRY_DELAY_MILLIS")
+          .key("AZURE_RETRY_DELAY_MILLIS")
           .description(
-              "Initial delay in milliseconds before first retry for cloud storage provider API requests. "
-                  + "Delay doubles with each retry (exponential backoff). "
-                  + "Currently only used by Azure storage integration. Designed to be applicable to AWS S3, GCP, and other cloud storage providers.")
+              "Initial delay in milliseconds before first retry for Azure API requests. "
+                  + "Delay doubles with each retry (exponential backoff).")
           .defaultValue(2000)
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Double> STORAGE_API_RETRY_JITTER_FACTOR =
+  public static final FeatureConfiguration<Double> AZURE_RETRY_JITTER_FACTOR =
       PolarisConfiguration.<Double>builder()
-          .key("STORAGE_API_RETRY_JITTER_FACTOR")
+          .key("AZURE_RETRY_JITTER_FACTOR")
           .description(
-              "Jitter factor (0.0 to 1.0) applied to retry delays for cloud storage provider API requests. "
+              "Jitter factor (0.0 to 1.0) applied to retry delays for Azure API requests. "
                   + "The jitter is applied as a random percentage of the computed exponential backoff delay. "
                   + "For example, 0.5 means up to 50%% random jitter will be added to each retry delay. "
-                  + "Helps prevent thundering herd when multiple requests fail simultaneously. "
-                  + "Currently only used by Azure storage integration. Designed to be applicable to AWS S3, GCP, and other cloud storage providers.")
+                  + "Helps prevent thundering herd when multiple requests fail simultaneously.")
           .defaultValue(0.5)
           .buildFeatureConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -18,10 +18,10 @@
  */
 package org.apache.polaris.core.storage.azure;
 
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_API_RETRY_COUNT;
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_API_RETRY_DELAY_MILLIS;
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_API_RETRY_JITTER_FACTOR;
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_API_TIMEOUT_MILLIS;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_COUNT;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_DELAY_MILLIS;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_JITTER_FACTOR;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_TIMEOUT_MILLIS;
 import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
 
 import com.azure.core.credential.AccessToken;
@@ -327,12 +327,11 @@ public class AzureCredentialsStorageIntegration
    * <p>This method implements a defensive strategy against slow or failing cloud provider requests:
    *
    * <ul>
-   *   <li>Per-attempt timeout (configurable via STORAGE_API_TIMEOUT_MILLIS, default 15000ms)
-   *   <li>Exponential backoff retry (configurable count and initial delay via
-   *       STORAGE_API_RETRY_COUNT and STORAGE_API_RETRY_DELAY_MILLIS, defaults: 3 attempts starting
-   *       at 2000ms)
-   *   <li>Jitter to prevent thundering herd (configurable via STORAGE_API_RETRY_JITTER_FACTOR,
-   *       default 0.5 = 50%%) default 0.5 = 50%%)
+   *   <li>Per-attempt timeout (configurable via AZURE_TIMEOUT_MILLIS, default 15000ms)
+   *   <li>Exponential backoff retry (configurable count and initial delay via AZURE_RETRY_COUNT and
+   *       AZURE_RETRY_DELAY_MILLIS, defaults: 3 attempts starting at 2000ms)
+   *   <li>Jitter to prevent thundering herd (configurable via AZURE_RETRY_JITTER_FACTOR, default
+   *       0.5 = 50%%)
    * </ul>
    *
    * @param realmConfig the realm configuration to get timeout and retry settings
@@ -341,10 +340,10 @@ public class AzureCredentialsStorageIntegration
    * @throws RuntimeException if token fetch fails after all retries or times out
    */
   private AccessToken getAccessToken(RealmConfig realmConfig, String tenantId) {
-    int timeoutMillis = realmConfig.getConfig(STORAGE_API_TIMEOUT_MILLIS);
-    int retryCount = realmConfig.getConfig(STORAGE_API_RETRY_COUNT);
-    int initialDelayMillis = realmConfig.getConfig(STORAGE_API_RETRY_DELAY_MILLIS);
-    double jitter = realmConfig.getConfig(STORAGE_API_RETRY_JITTER_FACTOR);
+    int timeoutMillis = realmConfig.getConfig(AZURE_TIMEOUT_MILLIS);
+    int retryCount = realmConfig.getConfig(AZURE_RETRY_COUNT);
+    int initialDelayMillis = realmConfig.getConfig(AZURE_RETRY_DELAY_MILLIS);
+    double jitter = realmConfig.getConfig(AZURE_RETRY_JITTER_FACTOR);
     int maxAttempts = retryCount + 1;
 
     String scope = "https://storage.azure.com/.default";


### PR DESCRIPTION
### Problem
The `getAccessToken()` method in `AzureCredentialsStorageIntegration` used an unbounded blocking call which could hang indefinitely if Azure's token endpoint was slow or unresponsive. This could lead to:
- Thread pool exhaustion in high-concurrency scenarios
- Cascading failures when Azure AD experiences degraded performance
- Poor user experience with no visibility into token fetch failures

### Solution
This PR adds defensive timeout and retry mechanisms using Project Reactor's built-in capabilities:

- **15-second timeout** per individual token request attempt to prevent indefinite blocking
- **Exponential backoff retry** (3 attempts with delays: 2s, 4s, 8s) with 50% jitter to prevent thundering herd during mass failures
- **90-second overall timeout** as a safety net for the complete operation
- **Intelligent retry filtering** for known transient Azure AD errors:
  - `AADSTS50058` - Token endpoint timeout
  - `AADSTS50078` - Service temporarily unavailable  
  - `AADSTS700084` - Token refresh required
  - `503` - Service unavailable
  - `429` - Too many requests
- **Enhanced logging** for better observability (warnings on errors, info on retries)

### Testing
- Code leverages existing reactor dependencies (no new dependencies)
- Follows existing Polaris patterns for reactive error handling

### Benefits
- Improves system resilience to transient Azure service issues
- Prevents indefinite blocking that could cascade to request timeouts
- Provides better observability with structured logging
- Uses well-established retry patterns with exponential backoff and jitter

## Checklist
- [x] 🛡️ Don't disclose security issues! (Not applicable - this is a resilience improvement)
- [x] 🔗 Clearly explained why the changes are needed
- [x] 🧪 Manually tested via compilation; reactive behavior follows reactor-core semantics
- [x] 💡 Added comprehensive Javadoc explaining the retry strategy
- [ ] 🧾 Updated `CHANGELOG.md` (awaiting maintainer guidance on format)
- [ ] 📚 Updated documentation (no user-facing config changes)
