### PR TITLE
Do not fail a release when markdown-link-check check fails as it is flaky

### DIFF
--- a/releasey/libs/_github.sh
+++ b/releasey/libs/_github.sh
@@ -43,7 +43,7 @@ function check_github_checks_passed() {
   local repo_info="$GITHUB_REPOSITORY"
 
   local num_invalid_checks
-  local num_invalid_checks_retrieval_command="gh api repos/${repo_info}/commits/${commit_sha}/check-runs --jq '[.check_runs[] | select(.conclusion != \"success\" and .conclusion != \"skipped\" and (.name | startswith(\"Release - \") | not))] | length'"
+  local num_invalid_checks_retrieval_command="gh api repos/${repo_info}/commits/${commit_sha}/check-runs --jq '[.check_runs[] | select(.conclusion != \"success\" and .conclusion != \"skipped\" and (.name | startswith(\"Release - \") | not) and (.name != \"markdown-link-check\"))] | length'"
   if [ ${DRY_RUN} -eq 1 ]; then
     print_info "DRY_RUN is enabled, skipping GitHub check verification"
     print_command "${num_invalid_checks_retrieval_command}"


### PR DESCRIPTION
We are being rate limited by medium and that fails the check `markdown-link-check`.  Problem: the release workflows currently require *all* checks to pass.  This commit skips the verification for the `markdown-link-check`.