### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -28,9 +28,9 @@ name: Check Markdown links
 
 on:
   push:
-    branches:
-      - 'main'
+    branches: [ "main", "release/*" ]
   pull_request:
+    branches: [ "main", "release/*" ]
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
     branches: [ "main", "release/*" ]
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,7 +26,7 @@ name: Helm tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
     branches: [ "main", "release/*" ]
 

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -28,7 +28,7 @@ name: Python Client CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
     branches: [ "main", "release/*" ]
 

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -20,7 +20,7 @@
 name: Regression Tests
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
     branches: [ "main", "release/*" ]
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,8 +20,9 @@
 name: "Hugo Site"
 on:
   push:
-    branches: [ "main", "versioned-docs" ]
+    branches: [ "main", "release/*", "versioned-docs" ]
   pull_request:
+    branches: [ "main", "release/*" ]
 
 jobs:
   site:

--- a/.github/workflows/spark_client_regtests.yml
+++ b/.github/workflows/spark_client_regtests.yml
@@ -20,7 +20,7 @@
 name: Spark Client Regression Tests
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
     branches: [ "main", "release/*" ]
 


### PR DESCRIPTION
The release workflows check whether CI passes for the required checks. This would fail, because CI isn't configured to run on release branches.

This change lets CI run on `release/*` branches.
