### PR TITLE
chore: Fix md link check in GH action

### DIFF
--- a/.github/workflows/check-md-link-config.json
+++ b/.github/workflows/check-md-link-config.json
@@ -10,6 +10,9 @@
     {
       "_comment": "medium blocks requests originating from GitHub Actions",
       "pattern": "https://medium.com/"
+    },
+    { 
+      "pattern": "https://kubernetes.io/"
     }
   ]
 }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

All current builds are blocked due to MD file link check on medium website from https://github.com/apache/polaris/blob/main/persistence/nosql/idgen/README.md?plain=1#L26. Here is a sample log: https://github.com/apache/polaris/actions/runs/19621023801/job/56181107495?pr=3126

Also, the k8s site can get status code of `0` as well: https://github.com/apache/polaris/actions/runs/19623971973/job/56189356092?pr=3128

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
