### PR TITLE
Testing: increase visibility + make PCC/PMSM accessible

### DIFF
--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -65,7 +65,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
 
   protected final MutableClock clock = MutableClock.of(Instant.now(), ZoneOffset.UTC);
 
-  private PolarisTestMetaStoreManager polarisTestMetaStoreManager;
+  protected PolarisTestMetaStoreManager polarisTestMetaStoreManager;
 
   @BeforeEach
   public void setupPolarisMetaStoreManager() {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -98,6 +98,14 @@ public class PolarisTestMetaStoreManager {
     this.doRetry = false;
   }
 
+  public PolarisCallContext polarisCallContext() {
+    return polarisCallContext;
+  }
+
+  public PolarisMetaStoreManager polarisMetaStoreManager() {
+    return polarisMetaStoreManager;
+  }
+
   public void forceRetry() {
     this.doRetry = true;
   }

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
@@ -42,9 +42,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase {
 
-  private static final String BUCKET_URI_PREFIX = "/minio-test-polaris";
-  private static final String MINIO_ACCESS_KEY = "test-ak-123-polaris";
-  private static final String MINIO_SECRET_KEY = "test-sk-123-polaris";
+  protected static final String BUCKET_URI_PREFIX = "/minio-test-polaris";
+  protected static final String MINIO_ACCESS_KEY = "test-ak-123-polaris";
+  protected static final String MINIO_SECRET_KEY = "test-sk-123-polaris";
 
   public static class Profile implements QuarkusTestProfile {
 


### PR DESCRIPTION
* `BasePolarisMetaStoreManagerTest`: make `PolarisCallContext` + `PolarisMetaStoreManager` + `PolarisTestMetaStoreManager` accessible by subclasses
* Make constants of `PolarisRestCatalogMinIOIT` accessible
