### PR TITLE
Source tarball reproducible

### DIFF
--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -64,7 +64,7 @@ internal fun configureOnRootProject(project: Project) =
           archive \
           --prefix="${e.baseName.get()}/" \
           --format=tar \
-          --mtime="1980-02-01 00:00:00" \
+          --mtime="1980-02-01 00:00:00 UTC" \
           HEAD | gzip -6 --no-name > "${e.sourceTarball.get().asFile.relativeTo(projectDir)}"
           """
             .trimIndent(),


### PR DESCRIPTION
`git --mtime` MUST use the time zone for reproducible builds.
