### PR TITLE
Skip release e-mail templates from svn dist copy

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -174,6 +174,7 @@ jobs:
           exec_process mkdir -p "${version_dir}"
           exec_process cp build/distributions/* "${version_dir}/"
           exec_process cp runtime/distribution/build/distributions/* "${version_dir}/"
+          exec_process rm -f "${version_dir}/*vote-email{-subject,-body}.txt"
 
           exec_process cd "${dist_dev_dir}"
           exec_process svn add "${version_without_rc}"


### PR DESCRIPTION
During 1.3.0-incubating-rc0, we noticed that two additional files made it to svn dist dev: `apache-polaris-1.3.0-incubating.vote-email-subject.txt` and `apache-polaris-1.3.0-incubating.vote-email-subject.txt`.  They should not be put there.  This PR ensures they are not.