### PR TITLE
fix OPA javadoc referencing `OpaSchemaGenerator`

### DIFF
--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/model/package-info.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/model/package-info.java
@@ -26,7 +26,7 @@
  *
  * <h2>Schema Generation</h2>
  *
- * <p>The JSON Schema for these models can be generated using the {@link
+ * <p>The JSON Schema for these models can be generated using the {@code
  * org.apache.polaris.extension.auth.opa.model.OpaSchemaGenerator} utility or by running the Gradle
  * task:
  *


### PR DESCRIPTION
`OpaSchemaGenerator` is not on the classpath of `opa/impl/main` so the javadoc tool is not able to resolve a `@link` to it.

Use `@code` instead to avoid build warnings like the following:

```
extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/model/package-info.java:29: warning: reference not found: org.apache.polaris.extension.auth.opa.model.OpaSchemaGenerator
 * <p>The JSON Schema for these models can be generated using the {@link
```

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
