### PR TITLE
Fix homepage Get Started button layout

### DIFF
--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -25,7 +25,9 @@ cascade:
 {{< blocks/cover title="Welcome to the Apache Polaris™ (incubating) web site!" image_anchor="center" color="primary" >}}
 Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. It implements Iceberg's REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™, Dremio® OSS, StarRocks, and Trino.
 
+<div class="text-center">
 <a href="/in-dev/unreleased/getting-started/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
+</div>
 
 {{< /blocks/cover >}}
 


### PR DESCRIPTION
## Fix homepage "Get Started" button layout

### Problem
At certain screen widths, the "Get Started" button was becoming inline with the description text instead of remaining on its own line.

### Solution
Wrapped the button in a `<div class="text-center">` container within the `blocks/cover` shortcode to 
ensure it stays as a separate block element at all viewport sizes.

### Changes
- Added `<div class="text-center">` wrapper around the "Get Started" button in the cover block

### Reference
Follows the Docsy [blocks/cover shortcode pattern](https://www.docsy.dev/docs/content/shortcodes/#blockscover) for adding buttons to cover blocks.
Before:
<img width="1183" height="592" alt="before" src="https://github.com/user-attachments/assets/6b9cb647-ab24-4e02-959b-02043dd00566" />
After:
<img width="1207" height="532" alt="after" src="https://github.com/user-attachments/assets/288b6cd5-3e88-471a-9033-1db8e9b19834" />
