### PR TITLE
Make homepage image full-width

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -24,3 +24,14 @@
 .td-sidebar-toc {
   padding-top: 1.75rem;
 }
+
+// Make image span full viewport width by canceling out
+// container padding
+.imageblock.full-width {
+  margin-inline: calc(0px - var(--bs-gutter-x));
+  width: calc(100% + var(--bs-gutter-x) + var(--bs-gutter-x));
+
+  img {
+    width: 100%;
+  }
+}

--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -29,6 +29,7 @@ Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. 
 
 {{< /blocks/cover >}}
 
+[.full-width]
 image::img/Polaris-Catalog-BLOG-symmetrical-subhead.png[Polaris Catalog]
 
 {{< blocks/section color="dark" type="row" >}}


### PR DESCRIPTION
## Summary

Makes the homepage hero image display at full viewport width without left/right margins.

## Problem

The homepage hero image was displaying with unwanted left and right spacing. This was caused by the `.td-content` container padding (controlled by Bootstrap's `--bs-gutter-x` variable) that wraps all home page content.

## Solution

The container padding comes from Hugo's Docsy theme layout and should not be modified as it provides comfortable reading margins for text content. Instead, added `.imageblock.full-width` CSS class that uses negative margins to pull specific images out to the viewport edges, compensating for the container's padding without affecting other content.

Applied the class to the homepage image using AsciiDoc role attribute `[.full-width]`.

This approach is targeted and reusable - any image can be made full-width by adding `[.full-width]` before the `image::` directive in AsciiDoc.

## Before/After

**Before:** 
<img width="1430" height="605" alt="before" src="https://github.com/user-attachments/assets/322beae2-51a9-4f1f-b660-7a9ccd72936a" />
**After:**
<img width="1429" height="599" alt="after" src="https://github.com/user-attachments/assets/a2c9b34b-d2e9-43d8-8cca-af5097e89ac1" />
