### PR TITLE
Add NOTES.txt to Helm chart with installation instructions

### DIFF
--- a/helm/polaris/templates/NOTES.txt
+++ b/helm/polaris/templates/NOTES.txt
@@ -16,6 +16,38 @@
   specific language governing permissions and limitations
   under the License.
 */}}
+{{/*
+  Helper template to generate access instructions for a service.
+  Parameters:
+  - serviceType: ClusterIP, NodePort, or LoadBalancer
+  - serviceName: Kubernetes service name
+  - port: Service port number
+  - namespace: Kubernetes namespace
+  - label: Display label (e.g., "API" or "Health")
+  - path: Optional URL path (e.g., "/q/health")
+  - isFirstNodePort: Whether to export NODE_IP (set to true only for the first NodePort service to avoid duplicate exports)
+*/}}
+{{- define "polaris.accessInstructions" -}}
+{{- $serviceType := .serviceType -}}
+{{- $serviceName := .serviceName -}}
+{{- $port := .port -}}
+{{- $namespace := .namespace -}}
+{{- $label := .label -}}
+{{- $path := .path | default "" -}}
+{{- $isFirstNodePort := .isFirstNodePort | default false }}
+{{- if eq $serviceType "LoadBalancer" }}
+  export {{ upper $label }}_IP=$(kubectl get svc -n {{ $namespace }} {{ $serviceName }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "{{ $label }}: http://${{ upper $label }}_IP:{{ $port }}{{ $path }}"
+{{- else if eq $serviceType "NodePort" }}
+{{- if $isFirstNodePort }}
+  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+{{- end }}
+  export {{ upper $label }}_PORT=$(kubectl get svc -n {{ $namespace }} {{ $serviceName }} -o jsonpath='{.spec.ports[0].nodePort}')
+  echo "{{ $label }}: http://$NODE_IP:${{ upper $label }}_PORT{{ $path }}"
+{{- else }}
+  {{ $label }}: http://localhost:{{ $port }}{{ $path }}
+{{- end }}
+{{- end -}}
 
 Apache Polaris deployed successfully!
 
@@ -29,48 +61,22 @@ Version:    {{ .Chart.Version }} (App: {{ .Chart.AppVersion }})
 {{- end }}
 
 Access Polaris:
-{{- if eq .Values.service.type "LoadBalancer" }}
-
-  export SERVICE_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "API: http://$SERVICE_IP:{{ (first .Values.service.ports).port }}"
-{{- else if eq .Values.service.type "NodePort" }}
-
-  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
-  export NODE_PORT=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
-  echo "API: http://$NODE_IP:$NODE_PORT"
-{{- else }}
+{{- if eq .Values.service.type "ClusterIP" }}
 
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "polaris.fullname" . }} {{ (first .Values.service.ports).port }}:{{ (first .Values.service.ports).port }}
-  echo "API: http://localhost:{{ (first .Values.service.ports).port }}"
 {{- end }}
-{{- if eq .Values.service.type .Values.managementService.type }}
-{{- if eq .Values.managementService.type "LoadBalancer" }}
+{{ include "polaris.accessInstructions" (dict "serviceType" .Values.service.type "serviceName" (include "polaris.fullname" .) "port" (first .Values.service.ports).port "namespace" .Release.Namespace "label" "API" "isFirstNodePort" true) }}
+{{- if and (ne .Values.service.type "ClusterIP") (ne .Values.managementService.type "ClusterIP") }}
 
-  export MGMT_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "Health: http://$MGMT_IP:{{ (first .Values.managementService.ports).port }}/q/health"
-{{- else if eq .Values.managementService.type "NodePort" }}
-
-  export MGMT_PORT=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} -o jsonpath='{.spec.ports[0].nodePort}')
-  echo "Health: http://$NODE_IP:$MGMT_PORT/q/health"
-{{- else }}
-
-  echo "Health: http://localhost:{{ (first .Values.managementService.ports).port }}/q/health"
 {{- end }}
-{{- else }}
-{{- if eq .Values.managementService.type "LoadBalancer" }}
-
-  export MGMT_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "Health: http://$MGMT_IP:{{ (first .Values.managementService.ports).port }}/q/health"
-{{- else if eq .Values.managementService.type "NodePort" }}
-
-  export MGMT_PORT=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} -o jsonpath='{.spec.ports[0].nodePort}')
-  echo "Health: http://$NODE_IP:$MGMT_PORT/q/health"
-{{- else }}
+{{- if and (ne .Values.service.type "ClusterIP") (eq .Values.managementService.type "ClusterIP") }}
 
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} {{ (first .Values.managementService.ports).port }}:{{ (first .Values.managementService.ports).port }}
-  echo "Health: http://localhost:{{ (first .Values.managementService.ports).port }}/q/health"
+{{- else if and (eq .Values.service.type "ClusterIP") (eq .Values.managementService.type "ClusterIP") }}
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "polaris.fullnameWithSuffix" (list . "mgmt") }} {{ (first .Values.managementService.ports).port }}:{{ (first .Values.managementService.ports).port }}
 {{- end }}
-{{- end }}
+{{ include "polaris.accessInstructions" (dict "serviceType" .Values.managementService.type "serviceName" (include "polaris.fullnameWithSuffix" (list . "mgmt")) "port" (first .Values.managementService.ports).port "namespace" .Release.Namespace "label" "Health" "path" "/q/health" "isFirstNodePort" (ne .Values.service.type "NodePort")) }}
 
 View logs:
 


### PR DESCRIPTION
## Summary

This PR adds a `NOTES.txt` template to the Helm chart to improve the user experience after installation. Users will immediately see how to access Polaris (via port-forward commands), check the health endpoint, and view logs for troubleshooting.

For now, this focuses on the essential getting-started information. In the future, we could extend this to include database bootstrap commands (polaris-admin), credential information, or other advanced setup instructions.

During `helm install` or `helm upgrade`, it prints the following:

## Current output

```
1. ClusterIP / ClusterIP
------------------------------------------
Command: helm install polaris ./helm/polaris 

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  kubectl port-forward -n default svc/polaris 8181:8181

  API: http://localhost:8181

  kubectl port-forward -n default svc/polaris-mgmt 8182:8182

  Health: http://localhost:8182/q/health

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


2. ClusterIP / NodePort
------------------------------------------
Command: helm install polaris ./helm/polaris --set managementService.type=NodePort

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  kubectl port-forward -n default svc/polaris 8181:8181

  API: http://localhost:8181

  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
  export HEALTH_PORT=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.spec.ports[0].nodePort}')
  echo "Health: http://$NODE_IP:$HEALTH_PORT/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


3. ClusterIP / LoadBalancer
------------------------------------------
Command: helm install polaris ./helm/polaris --set managementService.type=LoadBalancer

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  kubectl port-forward -n default svc/polaris 8181:8181

  API: http://localhost:8181

  export HEALTH_IP=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "Health: http://$HEALTH_IP:8182/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


========== NodePort Main Service ==========

4. NodePort / ClusterIP
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=NodePort

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
  export API_PORT=$(kubectl get svc -n default polaris -o jsonpath='{.spec.ports[0].nodePort}')
  echo "API: http://$NODE_IP:$API_PORT"

  kubectl port-forward -n default svc/polaris-mgmt 8182:8182

  Health: http://localhost:8182/q/health

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


5. NodePort / NodePort
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=NodePort --set managementService.type=NodePort

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
  export API_PORT=$(kubectl get svc -n default polaris -o jsonpath='{.spec.ports[0].nodePort}')
  echo "API: http://$NODE_IP:$API_PORT"

  export HEALTH_PORT=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.spec.ports[0].nodePort}')
  echo "Health: http://$NODE_IP:$HEALTH_PORT/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


6. NodePort / LoadBalancer
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=NodePort --set managementService.type=LoadBalancer

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
  export API_PORT=$(kubectl get svc -n default polaris -o jsonpath='{.spec.ports[0].nodePort}')
  echo "API: http://$NODE_IP:$API_PORT"

  export HEALTH_IP=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "Health: http://$HEALTH_IP:8182/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


========== LoadBalancer Main Service ==========

7. LoadBalancer / ClusterIP
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=LoadBalancer

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export API_IP=$(kubectl get svc -n default polaris -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "API: http://$API_IP:8181"

  kubectl port-forward -n default svc/polaris-mgmt 8182:8182

  Health: http://localhost:8182/q/health

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


8. LoadBalancer / NodePort
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=LoadBalancer --set managementService.type=NodePort

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export API_IP=$(kubectl get svc -n default polaris -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "API: http://$API_IP:8181"

  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
  export HEALTH_PORT=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.spec.ports[0].nodePort}')
  echo "Health: http://$NODE_IP:$HEALTH_PORT/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f


9. LoadBalancer / LoadBalancer
------------------------------------------
Command: helm install polaris ./helm/polaris --set service.type=LoadBalancer --set managementService.type=LoadBalancer

NOTES:
Apache Polaris deployed successfully!

Release:    polaris
Namespace:  default
Version:    1.2.0-incubating-SNAPSHOT (App: 1.2.0-incubating-SNAPSHOT)

⚠️  WARNING: Using IN-MEMORY persistence - data will be lost on pod restart!

Access Polaris:

  export API_IP=$(kubectl get svc -n default polaris -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "API: http://$API_IP:8181"

  export HEALTH_IP=$(kubectl get svc -n default polaris-mgmt -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "Health: http://$HEALTH_IP:8182/q/health"

View logs:

  kubectl logs -l app.kubernetes.io/name=polaris -n default --tail=50 -f
```