### PR TITLE
chore(enhancement): gitignore application-local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ hs_err_pid*
 
 # Development Experience
 
-# You can create runtime/defaults/src/main/resources/application-dev.properties file
+# You can create runtime/defaults/src/main/resources/application-local.properties file
 # to override default properties for local development.
-# And then use `./gradlew run -Dquarkus.profile=dev` to run Polaris with dev profile.
-application-dev.properties
+# And then use `./gradlew run -Dquarkus.profile=local` to run Polaris with dev profile.
+application-local.properties


### PR DESCRIPTION
You can create `runtime/defaults/src/main/resources/application-local.properties` file to override default properties for local development.
And then use `./gradlew run -Dquarkus.profile=local` to run Polaris with dev profile.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
