### PR TITLE
chore(enhancement): make custom hidden tasks visible in ./gradlew tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,7 +237,7 @@ changelog {
 }
 
 tasks.register("showVersion") {
-  group = "Application"
+  group = "application"
   description = "Show the Polaris version"
   actions.add {
     logger.lifecycle(

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -73,9 +73,9 @@ quarkus {
 }
 
 tasks.register("run") {
-    group = "application"
-    description = "Runs the Apache Polaris server application"
-    dependsOn("quarkusRun")
+  group = "application"
+  description = "Runs the Apache Polaris server application"
+  dependsOn("quarkusRun")
 }
 
 tasks.named<QuarkusRun>("quarkusRun") {


### PR DESCRIPTION
Make `run`, `buildPythonClient`, `showVersion` tasks visible in `./gradlew tasks`

----
```
> ./gradlew tasks

------------------------------------------------------------
Tasks runnable from root project 'polaris'
------------------------------------------------------------

Application tasks
-----------------
run - Runs the Apache Polaris server application
showVersion - Show the Polaris version

Build tasks
-----------
...
buildPythonClient - Build the python client
...
```


<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
