### PR TITLE
fix type cast warning in PolarisCatalogUtils

### DIFF
--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/utils/PolarisCatalogUtils.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/utils/PolarisCatalogUtils.java
@@ -40,6 +40,9 @@ import org.apache.spark.sql.execution.datasources.DataSource;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Option;
+import scala.Tuple2;
+import scala.collection.immutable.Map$;
+import scala.collection.mutable.Builder;
 
 public class PolarisCatalogUtils {
 
@@ -125,10 +128,10 @@ public class PolarisCatalogUtils {
         new TableIdentifier(
             identifier.name(), Option.apply(namespacePath), Option.apply(catalogName));
 
-    scala.collection.immutable.Map<String, String> scalaOptions =
-        (scala.collection.immutable.Map<String, String>)
-            scala.collection.immutable.Map$.MODULE$.apply(
-                scala.collection.JavaConverters.mapAsScalaMap(tableProperties).toSeq());
+    Builder<Tuple2<String, String>, scala.collection.immutable.Map<String, String>> mb =
+        Map$.MODULE$.newBuilder();
+    tableProperties.forEach((k, v) -> mb.$plus$eq(Tuple2.apply(k, v)));
+    scala.collection.immutable.Map<String, String> scalaOptions = mb.result();
 
     org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat storage =
         DataSource.buildStorageFormatFromOptions(scalaOptions);


### PR DESCRIPTION
```
plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/utils/PolarisCatalogUtils.java:131: warning: [unchecked] unchecked cast
            scala.collection.immutable.Map$.MODULE$.apply(
                                                         ^
  required: Map<String,String>
  found:    Map
```

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
