### PR TITLE
infra: update markdown lint check

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Setup test environment
       uses: ./.github/actions/setup-test-env
-    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+    - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/check-md-link-config.json'


### PR DESCRIPTION
use tcort/github-action-markdown-link-check, gaurav-nelson/github-action-markdown-link-check is deprecated

See https://github.com/apache/infrastructure-actions/issues/371
Resolves https://github.com/apache/polaris/issues/3058

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
