### PR TITLE
[doc]: Bump binary version from 1.0.0 to 1.2.0 and fix health port

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/binary-distribution.md
+++ b/site/content/in-dev/unreleased/getting-started/binary-distribution.md
@@ -32,8 +32,8 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.0.0-incubating/polaris-bin-1.0.0-incubating.tgz | tar xz
-cd polaris-distribution-1.0.0-incubating
+curl -L https://downloads.apache.org/incubator/polaris/1.2.0-incubating/polaris-bin-1.2.0-incubating.tgz | tar xz
+cd polaris-distribution-1.2.0-incubating
 ```
 
 Start the Polaris server:
@@ -42,10 +42,10 @@ Start the Polaris server:
 bin/server
 ```
 
-The server will start and listen on http://localhost:8181. Health and metrics endpoints are available under /q.
+The server will start and listen on http://localhost:8182. Health and metrics endpoints are available under /q.
 
 You can verify the server is running by checking the health endpoint:
 
 ```bash
-curl http://localhost:8181/q/health
+curl http://localhost:8182/q/health
 ```


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Bump version of binary from 1.0.0 to 1.2.0 and change health port from 8181 to 8182. 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
