### PR TITLE
Add location properties from TableMetadata into Table entity internalProps

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1657,7 +1657,18 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   private static Map<String, String> buildTableMetadataPropertiesMap(TableMetadata metadata) {
     Map<String, String> storedProperties = new HashMap<>();
+    // Location specific properties
     storedProperties.put(IcebergTableLikeEntity.LOCATION, metadata.location());
+    if (metadata.properties().containsKey(TableProperties.WRITE_DATA_LOCATION)) {
+      storedProperties.put(
+          IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY,
+          metadata.properties().get(TableProperties.WRITE_DATA_LOCATION));
+    }
+    if (metadata.properties().containsKey(TableProperties.WRITE_METADATA_LOCATION)) {
+      storedProperties.put(
+          IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY,
+          metadata.properties().get(TableProperties.WRITE_METADATA_LOCATION));
+    }
     storedProperties.put(
         IcebergTableLikeEntity.FORMAT_VERSION, String.valueOf(metadata.formatVersion()));
     storedProperties.put(IcebergTableLikeEntity.TABLE_UUID, metadata.uuid());

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -72,6 +72,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.UpdateRequirements;
 import org.apache.iceberg.UpdateSchema;
@@ -2269,6 +2270,16 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
     catalog.createNamespace(NS);
     catalog.buildTable(TABLE, SCHEMA).create();
     catalog.loadTable(TABLE).newFastAppend().appendFile(FILE_A).commit();
+    catalog
+        .loadTable(TABLE)
+        .updateProperties()
+        .set(
+            TableProperties.WRITE_DATA_LOCATION,
+            "s3://my-bucket/path/to/data/newdb/newtable/my-data")
+        .set(
+            TableProperties.WRITE_METADATA_LOCATION,
+            "s3://my-bucket/path/to/data/newdb/newtable/my-metadata")
+        .commit();
     Table afterAppend = catalog.loadTable(TABLE);
     EntityResult schemaResult =
         metaStoreManager.readEntityByName(
@@ -2295,6 +2306,12 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             IcebergTableLikeEntity.CURRENT_SNAPSHOT_ID,
             String.valueOf(afterAppend.currentSnapshot().snapshotId()))
         .containsEntry(IcebergTableLikeEntity.LOCATION, afterAppend.location())
+        .containsEntry(
+            IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY,
+            afterAppend.properties().get(TableProperties.WRITE_DATA_LOCATION))
+        .containsEntry(
+            IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY,
+            afterAppend.properties().get(TableProperties.WRITE_METADATA_LOCATION))
         .containsEntry(IcebergTableLikeEntity.TABLE_UUID, afterAppend.uuid().toString())
         .containsEntry(
             IcebergTableLikeEntity.CURRENT_SCHEMA_ID,


### PR DESCRIPTION
### About the change 

Presently since not all the location properties are stored in the entity one has to do complete loadTable table even for existing use cases such as credential endpoint which in present scenario since polaris doesn't store the complete metadata copy inside the persistence is kind of expensive. 

With this we will have a way to do cred vending, in future (to remote sign) without going to object store. 
Note if we take dependency on this we would have to think of backfill but for step 1 it seems reasonable step, would love to know what other folks think

https://github.com/apache/polaris/blob/8ba112eb09a76707ad346082e4f90436c7ba7c93/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java#L616-L625

co-author : @adutra 

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
