### PR TITLE
Fix build issue for docker not found when using latest docker desktop

### DIFF
--- a/runtime/test-common/src/main/resources/docker-java.properties
+++ b/runtime/test-common/src/main/resources/docker-java.properties
@@ -1,0 +1,20 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# Workaround for https://github.com/testcontainers/testcontainers-java/issues/11212 (fixed version is 2.0.2)
+# We will need libs.testcontainers.keycloak and libs.s3mock.testcontainers to be using 2.0.2 as well
+api.version=1.44


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Temporary workaround for https://github.com/apache/polaris/issues/3183 (root cause is https://github.com/testcontainers/testcontainers-java/issues/11212#issuecomment-3516573631). We are on 2.0.2 for most of the dependencies but not all (https://github.com/apache/polaris/pull/3225). Also, we will need `libs.testcontainers.keycloak` and `libs.s3mock.testcontainers` to be using 2.0.2 as well.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
