### PR TITLE
Authorizer: expose the required level of detail

### DIFF
--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -95,6 +95,21 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
     this.objectMapper = objectMapper;
   }
 
+  @Override
+  public boolean requiresPrincipalRoles() {
+    return false;
+  }
+
+  @Override
+  public boolean requiresCatalogRoles() {
+    return false;
+  }
+
+  @Override
+  public boolean requiresResolvedEntities() {
+    return false;
+  }
+
   /**
    * Authorizes a single target and secondary entity for the given principal and operation.
    *

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
@@ -28,6 +28,42 @@ import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 /** Interface for invoking authorization checks. */
 public interface PolarisAuthorizer {
 
+  /**
+   * Whether the implementation expects Polaris principal roles to be present in the {@code
+   * activatedEntities} parameters of the {@link #authorizeOrThrow(PolarisPrincipal, Set,
+   * PolarisAuthorizableOperation, PolarisResolvedPathWrapper, PolarisResolvedPathWrapper)}
+   * functions.
+   *
+   * <p>If {@code false}, call sites may choose to not pass principal roles.
+   */
+  default boolean requiresPrincipalRoles() {
+    return true;
+  }
+
+  /**
+   * Whether the implementation expects Polaris catalog roles to be present in the {@code
+   * activatedEntities} parameters of the {@link #authorizeOrThrow(PolarisPrincipal, Set,
+   * PolarisAuthorizableOperation, PolarisResolvedPathWrapper, PolarisResolvedPathWrapper)}
+   * functions.
+   *
+   * <p>If {@code false}, call sites may choose to not pass catalog roles.
+   */
+  default boolean requiresCatalogRoles() {
+    return true;
+  }
+
+  /**
+   * Whether the implementation expects the {@link
+   * org.apache.polaris.core.persistence.ResolvedPolarisEntity}s in the {@link
+   * PolarisResolvedPathWrapper} instances of the {@code target} and {@code secondary} parameters to
+   * contain grant records information.
+   *
+   * <p>If {@code false}, call sites may choose to not pass grant records.
+   */
+  default boolean requiresResolvedEntities() {
+    return true;
+  }
+
   void authorizeOrThrow(
       @Nonnull PolarisPrincipal polarisPrincipal,
       @Nonnull Set<PolarisBaseEntity> activatedEntities,


### PR DESCRIPTION
Adds informative functions for `PolarisAuthorizer` call sites whether principal roles, catalog roles and resolved entities are required.

This change allows call sites to skip certain lookups against the backend database for information that's not needed for authorizers.

For example the OPA authorizer neither needs roles nor any grant information from `ResolvedPolarisEntity`.

This change only adds the informative functions to `Authorizer` but does not add any optimization to the call sites.
