### PR TITLE
Remove runtime-common and defaults from service deps

### DIFF
--- a/extensions/auth/opa/tests/build.gradle.kts
+++ b/extensions/auth/opa/tests/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
   implementation(project(":polaris-extensions-auth-opa"))
 
   // Include all runtime-service dependencies
+  implementation(project(":polaris-runtime-defaults"))
+  implementation(project(":polaris-runtime-common"))
   implementation(project(":polaris-runtime-service"))
 
   // Test common for integration testing

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -38,6 +38,8 @@ val distributionElements by
   }
 
 dependencies {
+  implementation(project(":polaris-runtime-defaults"))
+  implementation(project(":polaris-runtime-common"))
   implementation(project(":polaris-runtime-service"))
 
   runtimeOnly("org.postgresql:postgresql")

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -33,9 +33,6 @@ dependencies {
 
   runtimeOnly(project(":polaris-relational-jdbc"))
 
-  implementation(project(":polaris-runtime-defaults"))
-  implementation(project(":polaris-runtime-common"))
-
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
 
@@ -185,6 +182,8 @@ dependencies {
   testFixturesImplementation("com.azure:azure-storage-blob")
   testFixturesImplementation("com.azure:azure-storage-file-datalake")
 
+  intTestRuntimeOnly(project(":polaris-runtime-defaults"))
+  intTestRuntimeOnly(project(":polaris-runtime-common"))
   // This dependency brings in RESTEasy Classic, which conflicts with Quarkus RESTEasy Reactive;
   // it must not be present during Quarkus augmentation otherwise Quarkus tests won't start.
   intTestRuntimeOnly(libs.keycloak.admin.client)


### PR DESCRIPTION
The main idea is to avoid exposing RDS (added in #2650) as a primary dependency of runtime-service since it is conceptually only a dependency on leaf modules (like runtime-server, admin and tests).

This is expected to simplify dependency management in downstream projects since runtime-service has a reduced set of transitive dependencies now.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
