### PR TITLE
Corrected `stsUnavailable` typo in  1.2.0 release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The `ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS` was added to support sub-catalog (initially namespace and table) RBAC for federated catalogs.
   The setting can be configured on a per-catalog basis by setting the catalog property: `polaris.config.enable-sub-catalog-rbac-for-federated-catalogs`.
   The realm-level feature flag `ALLOW_SETTING_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS` (default: true) controls whether this functionality can be enabled or modified at the catalog level.
-- Added support for S3-compatible storage that does not have STS (use `stsUavailable: true` in catalog storage configuration)
+- Added support for S3-compatible storage that does not have STS (use `stsUnavailable: true` in catalog storage configuration)
 - Python client: added support for custom realm and header
 - Python client: added support for policy management
 

--- a/site/content/downloads/_index.md
+++ b/site/content/downloads/_index.md
@@ -53,7 +53,7 @@ Apache Polaris 1.2.0-incubating was released on October 23rd, 2025.
   - The `ENABLE_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS` was added to support sub-catalog (initially namespace and table) RBAC for federated catalogs.
     The setting can be configured on a per-catalog basis by setting the catalog property: `polaris.config.enable-sub-catalog-rbac-for-federated-catalogs`.
     The realm-level feature flag `ALLOW_SETTING_SUB_CATALOG_RBAC_FOR_FEDERATED_CATALOGS` (default: true) controls whether this functionality can be enabled or modified at the catalog level.
-  - Added support for S3-compatible storage that does not have STS (use `stsUavailable: true` in catalog storage configuration)
+  - Added support for S3-compatible storage that does not have STS (use `stsUnavailable: true` in catalog storage configuration)
   - Added a Management API endpoint to reset principal credentials, controlled by the `ENABLE_CREDENTIAL_RESET` (default: true) feature flag.
   - **Events Persistence (Preview)**: Introduced new event types and added support for persisting events to both Relational JDBC Persistence and AWS CloudWatch.
   


### PR DESCRIPTION
Corrected `stsUnavailable` typo in  1.2.0 release note.

I spent a little bit time troubleshooting why the program kept entering the STS logic layer when `stsUnavailable` is true, and eventually discovered an error in the documentation through the logs.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
