### PR TITLE
[chore]: Match openapi-generator-cli version in build system to dependency

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -64,7 +64,8 @@ types-python-dateutil = ">= 2.8.19.14"
 mypy = ">=1.19, <=1.19.1"
 pyiceberg = "==0.10.0"
 pre-commit = "==4.5.1"
-openapi-generator-cli = "==7.17.0"
+# 7.12.0 is the latest version to use due to OpenAPI spec version we are using
+openapi-generator-cli = "==7.12.0"
 pip-licenses-cli = "==3.0.1"
 
 [tool.pip-licenses]
@@ -72,7 +73,8 @@ partial-match = true
 allow-only = "Apache;BSD License;BSD-3-Clause;ISC;MIT;Mozilla Public License;PSF-2.0;Python Software Foundation License;The Unlicense"
 
 [build-system]
-requires = ["poetry-core==2.2.1", "openapi-generator-cli==7.17.0"]
+# 7.12.0 is the latest version to use due to OpenAPI spec version we are using
+requires = ["poetry-core==2.2.1", "openapi-generator-cli==7.12.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.build]


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently the required version in dependency is 7.17.0 but the build system is still referring to 7.12.0. Only 7.12.0 is working (detail in https://github.com/apache/polaris/pull/2800)


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
