### PR TITLE
NoSQL: reduce heap pressure when running tests

### DIFF
--- a/persistence/nosql/realms/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/realms/store/TestRealmStoreIntegration.java
+++ b/persistence/nosql/realms/store-nosql/src/test/java/org/apache/polaris/persistence/nosql/realms/store/TestRealmStoreIntegration.java
@@ -36,6 +36,7 @@ import java.util.function.IntFunction;
 import java.util.stream.IntStream;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
 import org.apache.polaris.persistence.nosql.realms.api.RealmAlreadyExistsException;
 import org.apache.polaris.persistence.nosql.realms.api.RealmDefinition;
 import org.apache.polaris.persistence.nosql.realms.api.RealmExpectedStateMismatchException;
@@ -62,12 +63,14 @@ public class TestRealmStoreIntegration {
 
   @Test
   public void nonSystemPersistence() {
+    @SuppressWarnings("resource")
+    var backend = mock(Backend.class);
     var nonSystemPersistence = mock(Persistence.class);
     var params = mock(PersistenceParams.class);
     when(nonSystemPersistence.realmId()).thenReturn("nonSystemPersistence");
     when(nonSystemPersistence.params()).thenReturn(params);
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> new RealmStoreImpl(nonSystemPersistence))
+        .isThrownBy(() -> new RealmStoreImpl(nonSystemPersistence, backend))
         .withMessage("Realms management must happen in the ::system:: realm");
   }
 


### PR DESCRIPTION
Some tests generate a lot of realms, likely one realm per test case. While the amount of data per realm is not much, it is nontheless nice to remove that data immediately (for tests).

The maintenance service, which purges data of eligible realms, cannot be run against the in-memory backend (different JVM).

This change adds a rather "test only" workaround to purge the realm data in the in-memory backend immediately.
