### PR TITLE
Migrate to Jackson mapper builder pattern

### DIFF
--- a/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
+++ b/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ public class CatalogSerializationTest {
 
   @BeforeEach
   public void setUp() {
-    mapper = new ObjectMapper();
+    mapper = JsonMapper.builder().build();
   }
 
   @ParameterizedTest(name = "{0}")

--- a/extensions/auth/opa/impl/src/jsonSchemaGenerator/java/org/apache/polaris/extension/auth/opa/model/OpaSchemaGenerator.java
+++ b/extensions/auth/opa/impl/src/jsonSchemaGenerator/java/org/apache/polaris/extension/auth/opa/model/OpaSchemaGenerator.java
@@ -20,6 +20,7 @@ package org.apache.polaris.extension.auth.opa.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
 import java.io.IOException;
@@ -44,8 +45,7 @@ public class OpaSchemaGenerator {
    * @throws IOException if schema generation fails
    */
   public static String generateSchema() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    ObjectMapper mapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
 
     JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(mapper);
     JsonSchema schema = schemaGen.generateSchema(OpaAuthorizationInput.class);

--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactory.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.extension.auth.opa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -60,7 +61,7 @@ class OpaPolarisAuthorizerFactory implements PolarisAuthorizerFactory {
     this.opaConfig = opaConfig;
     this.clock = clock;
     this.asyncExec = asyncExec;
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = JsonMapper.builder().build();
   }
 
   /**

--- a/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
+++ b/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -75,7 +76,7 @@ public class OpaPolarisAuthorizerTest {
               "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
       OpaPolarisAuthorizer authorizer =
           new OpaPolarisAuthorizer(
-              policyUri, HttpClients.createDefault(), new ObjectMapper(), null);
+              policyUri, HttpClients.createDefault(), JsonMapper.builder().build(), null);
 
       PolarisPrincipal principal =
           PolarisPrincipal.of("eve", Map.of("department", "finance"), Set.of("auditor"));
@@ -95,7 +96,7 @@ public class OpaPolarisAuthorizerTest {
                       secondary));
 
       // Parse and verify JSON structure from captured request
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       JsonNode root = mapper.readTree(capturedRequestBody[0]);
       assertThat(root.has("input")).as("Root should have 'input' field").isTrue();
       var input = root.get("input");
@@ -120,7 +121,7 @@ public class OpaPolarisAuthorizerTest {
               "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
       OpaPolarisAuthorizer authorizer =
           new OpaPolarisAuthorizer(
-              policyUri, HttpClients.createDefault(), new ObjectMapper(), null);
+              policyUri, HttpClients.createDefault(), JsonMapper.builder().build(), null);
 
       // Set up a realistic principal
       PolarisPrincipal principal =
@@ -185,7 +186,7 @@ public class OpaPolarisAuthorizerTest {
                       null));
 
       // Parse and verify the complete JSON structure
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       JsonNode root = mapper.readTree(capturedRequestBody[0]);
 
       // Verify top-level structure
@@ -273,7 +274,7 @@ public class OpaPolarisAuthorizerTest {
               "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
       OpaPolarisAuthorizer authorizer =
           new OpaPolarisAuthorizer(
-              policyUri, HttpClients.createDefault(), new ObjectMapper(), null);
+              policyUri, HttpClients.createDefault(), JsonMapper.builder().build(), null);
 
       // Set up a realistic principal
       PolarisPrincipal principal =
@@ -350,7 +351,7 @@ public class OpaPolarisAuthorizerTest {
                       null));
 
       // Parse and verify the complete JSON structure
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       JsonNode root = mapper.readTree(capturedRequestBody[0]);
 
       // Verify top-level structure
@@ -437,7 +438,7 @@ public class OpaPolarisAuthorizerTest {
               "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
       OpaPolarisAuthorizer authorizer =
           new OpaPolarisAuthorizer(
-              policyUri, HttpClients.createDefault(), new ObjectMapper(), null);
+              policyUri, HttpClients.createDefault(), JsonMapper.builder().build(), null);
 
       PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("admin"));
 
@@ -483,7 +484,7 @@ public class OpaPolarisAuthorizerTest {
     URI policyUri = URI.create("http://opa.example.com:8181/v1/data/polaris/allow");
     OpaPolarisAuthorizer authorizer =
         new OpaPolarisAuthorizer(
-            policyUri, HttpClients.createDefault(), new ObjectMapper(), tokenProvider);
+            policyUri, HttpClients.createDefault(), JsonMapper.builder().build(), tokenProvider);
 
     assertThat(authorizer).isNotNull();
   }
@@ -499,7 +500,10 @@ public class OpaPolarisAuthorizerTest {
     BearerTokenProvider tokenProvider = new StaticBearerTokenProvider("test-bearer-token");
     OpaPolarisAuthorizer authorizer =
         new OpaPolarisAuthorizer(
-            policyUri, mock(CloseableHttpClient.class), new ObjectMapper(), tokenProvider) {
+            policyUri,
+            mock(CloseableHttpClient.class),
+            JsonMapper.builder().build(),
+            tokenProvider) {
           @Override
           <T> T httpClientExecute(
               ClassicHttpRequest request, HttpClientResponseHandler<? extends T> responseHandler)
@@ -541,7 +545,10 @@ public class OpaPolarisAuthorizerTest {
     // Create authorizer with the token provider instead of static token
     OpaPolarisAuthorizer authorizer =
         new OpaPolarisAuthorizer(
-            policyUri, mock(CloseableHttpClient.class), new ObjectMapper(), tokenProvider) {
+            policyUri,
+            mock(CloseableHttpClient.class),
+            JsonMapper.builder().build(),
+            tokenProvider) {
           @Override
           <T> T httpClientExecute(
               ClassicHttpRequest request, HttpClientResponseHandler<? extends T> responseHandler)

--- a/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
+++ b/extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -401,7 +402,7 @@ public class FileBearerTokenProviderTest {
   /** Helper method to create a JWT with a specific expiration time. */
   private String createJwtWithExpiration(Instant expiration) {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
 
       // Create header
       Map<String, Object> header = new HashMap<>();
@@ -438,7 +439,7 @@ public class FileBearerTokenProviderTest {
   /** Helper method to create a JWT without an expiration claim. */
   private String createJwtWithoutExpiration() {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
 
       // Create header
       Map<String, Object> header = new HashMap<>();

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolarisClient.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.ws.rs.client.Client;
 import java.net.URI;
 import java.util.Map;
@@ -64,7 +65,7 @@ public final class PolarisClient implements AutoCloseable {
    * ObjectMapper} if the make custom {@link PolarisServerManager#createClient() clients}.
    */
   public static ObjectMapper buildObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.setPropertyNamingStrategy(new PropertyNamingStrategies.KebabCaseStrategy());

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import jakarta.ws.rs.client.Entity;
@@ -159,7 +160,7 @@ public class PolarisManagementServiceIntegrationTest {
                     .build())
             .build();
 
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     String json = mapper.writeValueAsString(catalog);
     System.out.println(json);
     Catalog deserialized = mapper.readValue(json, Catalog.class);
@@ -334,7 +335,7 @@ public class PolarisManagementServiceIntegrationTest {
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setAllowedLocations(List.of("s3://my-old-bucket/path/to/data"))
             .build();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode storageConfig = mapper.valueToTree(awsConfigModel);
     ObjectNode catalogNode = mapper.createObjectNode();
     catalogNode.set("storageConfigInfo", storageConfig);
@@ -359,7 +360,7 @@ public class PolarisManagementServiceIntegrationTest {
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setAllowedLocations(List.of("s3://my-old-bucket/path/to/data"))
             .build();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode storageConfig = mapper.valueToTree(awsConfigModel);
     ObjectNode catalogNode = mapper.createObjectNode();
     catalogNode.set("storageConfigInfo", storageConfig);
@@ -513,7 +514,7 @@ public class PolarisManagementServiceIntegrationTest {
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setAllowedLocations(List.of("s3://my-old-bucket/path/to/data"))
             .build();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode storageConfig = mapper.valueToTree(awsConfigModel);
     ObjectNode catalogNode = mapper.createObjectNode();
     catalogNode.set("storageConfigInfo", storageConfig);
@@ -534,7 +535,7 @@ public class PolarisManagementServiceIntegrationTest {
   @Test
   public void serialization() {
     CatalogProperties properties = new CatalogProperties("s3://my-bucket/path/to/data");
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     CatalogProperties translated = mapper.convertValue(properties, CatalogProperties.class);
     assertThat(translated.toMap())
         .containsEntry("default-base-location", "s3://my-bucket/path/to/data");

--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclEntryImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclEntryImpl.java
@@ -18,7 +18,11 @@
  */
 package org.apache.polaris.persistence.nosql.authz.impl;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.apache.polaris.persistence.nosql.authz.api.AclEntry;
 import org.apache.polaris.persistence.nosql.authz.api.Privilege;
@@ -39,7 +43,12 @@ public class TestAclEntryImpl {
 
   @BeforeAll
   static void setUp() {
-    mapper = new ObjectMapper().findAndRegisterModules();
+    mapper =
+        JsonMapper.builder()
+            .findAndAddModules()
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DEFAULT_VIEW_INCLUSION)
+            .build();
     privileges =
         new PrivilegesImpl(Stream.of(new PrivilegesTestProvider()), new PrivilegesTestRepository());
     JacksonPrivilegesModule.CDIResolver.setResolver(x -> privileges);

--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclImpl.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.persistence.nosql.authz.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.apache.polaris.persistence.nosql.authz.api.Acl;
 import org.apache.polaris.persistence.nosql.authz.api.Privilege;
@@ -41,7 +42,7 @@ public class TestAclImpl {
 
   @BeforeAll
   static void setUp() {
-    mapper = new ObjectMapper().findAndRegisterModules();
+    mapper = JsonMapper.builder().findAndAddModules().build();
     privileges =
         new PrivilegesImpl(Stream.of(new PrivilegesTestProvider()), new PrivilegesTestRepository());
     JacksonPrivilegesModule.CDIResolver.setResolver(x -> privileges);

--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
@@ -18,11 +18,14 @@
  */
 package org.apache.polaris.persistence.nosql.authz.impl;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.ArrayList;
 import java.util.Set;
@@ -54,7 +57,12 @@ public class TestPrivilegeSetImpl {
 
   @BeforeAll
   static void setUp() {
-    mapper = new ObjectMapper().findAndRegisterModules();
+    mapper =
+        JsonMapper.builder()
+            .findAndAddModules()
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DEFAULT_VIEW_INCLUSION)
+            .build();
     privileges =
         new PrivilegesImpl(Stream.of(new PrivilegesTestProvider()), new PrivilegesTestRepository());
     JacksonPrivilegesModule.CDIResolver.setResolver(x -> privileges);

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/backend/TestPersistId.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/backend/TestPersistId.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -47,8 +48,8 @@ public class TestPersistId {
 
   @BeforeEach
   protected void setUp() {
-    mapper = new ObjectMapper();
-    smile = new SmileMapper();
+    mapper = JsonMapper.builder().build();
+    smile = SmileMapper.builder().build();
   }
 
   @Test

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestGenericObj.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestGenericObj.java
@@ -18,11 +18,13 @@
  */
 package org.apache.polaris.persistence.nosql.api.obj;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION;
 import static org.apache.polaris.persistence.nosql.api.obj.ObjSerializationHelper.contextualReader;
 import static org.apache.polaris.persistence.nosql.api.obj.ObjTypes.objTypeById;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -41,7 +43,12 @@ public class TestGenericObj {
   @ParameterizedTest
   @MethodSource
   public void genericObj(ObjType realType, long id, Obj realObj) throws Exception {
-    var mapper = new ObjectMapper().findAndRegisterModules();
+    var mapper =
+        JsonMapper.builder()
+            .findAndAddModules()
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DEFAULT_VIEW_INCLUSION)
+            .build();
     // Use some view to exclude the type,id,createdAtMicros,versionToken attributes from being
     // serialized by Jackson.
     var writerAllAttributes = mapper.writer();

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestObjRef.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestObjRef.java
@@ -23,6 +23,7 @@ import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.OBJ_REF_SERIAL
 import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -46,8 +47,8 @@ public class TestObjRef {
 
   @BeforeEach
   protected void setUp() {
-    mapper = new ObjectMapper();
-    smile = new SmileMapper();
+    mapper = JsonMapper.builder().build();
+    smile = SmileMapper.builder().build();
   }
 
   @Test

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationReceiver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationReceiver.java
@@ -22,6 +22,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.quarkus.vertx.http.ManagementInterface;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -70,9 +71,10 @@ class CacheInvalidationReceiver {
     this.validTokens =
         new HashSet<>(storeConfig.cacheInvalidationValidTokens().orElse(emptyList()));
     this.objectMapper =
-        new ObjectMapper()
+        JsonMapper.builder()
             // forward compatibility
-            .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
   }
 
   void registerManagementRoutes(@Observes ManagementInterface mi) {

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationSender.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationSender.java
@@ -31,6 +31,7 @@ import static org.apache.polaris.persistence.nosql.quarkus.distcache.QuarkusDist
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.quarkus.runtime.Startup;
 import io.vertx.core.Future;
@@ -85,7 +86,7 @@ class CacheInvalidationSender implements DistributedCacheInvalidation.Sender {
   private final String invalidationUri;
   private final long requestTimeout;
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = JsonMapper.builder().build();
   private final Lock lock = new ReentrantLock();
   private final int batchSize;
   private final BlockingQueue<CacheInvalidation> invalidations = new LinkedBlockingQueue<>();

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/PersistenceImplementation.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/PersistenceImplementation.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.persistence.nosql.impl;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
@@ -28,7 +30,6 @@ import static org.apache.polaris.persistence.nosql.api.obj.ObjSerializationHelpe
 import static org.apache.polaris.persistence.nosql.api.obj.ObjTypes.objTypeById;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
@@ -77,9 +78,11 @@ import org.apache.polaris.persistence.nosql.impl.indexes.IndexesProvider;
  */
 public final class PersistenceImplementation implements Persistence {
   private static final ObjectMapper SMILE_MAPPER =
-      new SmileMapper()
-          .findAndRegisterModules()
-          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      SmileMapper.builder()
+          .findAndAddModules()
+          .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(DEFAULT_VIEW_INCLUSION)
+          .build();
   private static final ObjectWriter OBJ_WRITER =
       SMILE_MAPPER.writer().withView(Obj.StorageView.class);
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/cache/CaffeineCacheBackend.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/cache/CaffeineCacheBackend.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.persistence.nosql.impl.cache;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -39,7 +41,6 @@ import static org.apache.polaris.persistence.varint.VarInt.readVarInt;
 import static org.apache.polaris.persistence.varint.VarInt.varIntLen;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
@@ -699,9 +700,11 @@ class CaffeineCacheBackend implements CacheBackend {
   static final int CAFFEINE_OBJ_OVERHEAD = 2 * 32;
 
   static final ObjectMapper SMILE_MAPPER =
-      new SmileMapper()
-          .findAndRegisterModules()
-          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      SmileMapper.builder()
+          .findAndAddModules()
+          .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(DEFAULT_VIEW_INCLUSION)
+          .build();
   private static final ObjectWriter OBJ_WRITER = SMILE_MAPPER.writer().withView(Object.class);
 
   static byte[] serializeObj(Obj obj) {

--- a/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/changes/ChangeSerializer.java
+++ b/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/changes/ChangeSerializer.java
@@ -47,9 +47,10 @@ import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
  */
 final class ChangeSerializer implements IndexValueSerializer<Change> {
   static ObjectMapper MAPPER =
-      new SmileMapper()
-          .findAndRegisterModules()
-          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      SmileMapper.builder()
+          .findAndAddModules()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .build();
 
   @Override
   public int serializedSize(@Nullable Change value) {

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/mapping/BaseTestMapping.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/mapping/BaseTestMapping.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public abstract class BaseTestMapping {
 
   @BeforeAll
   public static void beforeAll() {
-    objectMapper = new ObjectMapper().findAndRegisterModules();
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
   }
 
   public BaseMapping<?, ?> mapping;

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.net.MalformedURLException;
@@ -123,9 +124,13 @@ public abstract class ConnectionConfigInfoDpo implements IcebergCatalogPropertie
   private static final ObjectMapper DEFAULT_MAPPER;
 
   static {
-    DEFAULT_MAPPER = new ObjectMapper();
-    DEFAULT_MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
-    DEFAULT_MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    DEFAULT_MAPPER =
+        JsonMapper.builder()
+            .defaultPropertyInclusion(
+                JsonInclude.Value.construct(
+                    JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
   }
 
   public String serialize() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEvent.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEvent.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.annotation.Nullable;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ public class PolarisEvent {
 
   // to serialize/deserialize properties
   // TODO: Look into using the CDI-managed `ObjectMapper` object
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
 
   // catalog id
   private final String catalogId;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.Map;
@@ -42,7 +43,7 @@ public final class PolarisObjectMapperUtil {
   private static final ObjectMapper MAPPER = configureMapper();
 
   private static ObjectMapper configureMapper() {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     mapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
     RESTSerializers.registerAll(mapper);
     return mapper;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -151,9 +151,8 @@ public interface RootCredentialsSet {
   }
 
   private static RootCredentialsSet fromInputStream(InputStream in) throws IOException {
-    YAMLFactory factory = new YAMLFactory();
-    ObjectMapper mapper = new ObjectMapper(factory).configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
-    try (var parser = factory.createParser(in)) {
+    ObjectMapper mapper = YAMLMapper.builder().configure(FAIL_ON_UNKNOWN_PROPERTIES, false).build();
+    try (var parser = mapper.createParser(in)) {
       var values = mapper.readValues(parser, RootCredentialsSet.class);
       var builder = ImmutableRootCredentialsSet.builder();
       while (values.hasNext()) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -44,7 +44,8 @@ import java.util.function.BooleanSupplier;
 
 final class PageTokenUtil {
 
-  private static final ObjectMapper SMILE_MAPPER = new SmileMapper().findAndRegisterModules();
+  private static final ObjectMapper SMILE_MAPPER =
+      SmileMapper.builder().findAndAddModules().build();
 
   /** Constant for {@link PageToken#readEverything()}. */
   static final PageToken READ_EVERYTHING =

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import java.util.Objects;
 public class PolarisPolicyMappingRecord {
   // to serialize/deserialize properties
   public static final String EMPTY_MAP_STRING = "{}";
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
 
   // id of the catalog where target entity resides
   private long targetCatalogId;

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/content/PolicyContentUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/content/PolicyContentUtil.java
@@ -20,12 +20,13 @@ package org.apache.polaris.core.policy.content;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class PolicyContentUtil {
   public static final ObjectMapper MAPPER = configureMapper();
 
   private static ObjectMapper configureMapper() {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     // Fails if a required field (in the constructor) is missing
     mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
     // Fails if a required field is present but explicitly null, e.g., {"enable": null}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,9 +88,13 @@ public abstract class PolarisStorageConfigurationInfo {
   private static final ObjectMapper DEFAULT_MAPPER;
 
   static {
-    DEFAULT_MAPPER = new ObjectMapper();
-    DEFAULT_MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
-    DEFAULT_MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    DEFAULT_MAPPER =
+        JsonMapper.builder()
+            .defaultPropertyInclusion(
+                JsonInclude.Value.construct(
+                    JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
   }
 
   public String serialize() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.storage.gcp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
@@ -68,6 +69,8 @@ public class GcpCredentialsStorageIntegration
   public static final String SERVICE_ACCOUNT_PREFIX = "projects/-/serviceAccounts/";
   public static final String IMPERSONATION_SCOPE =
       "https://www.googleapis.com/auth/devstorage.read_write";
+
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
   private final GoogleCredentials sourceCredentials;
   private final HttpTransportFactory transportFactory;
@@ -181,7 +184,7 @@ public class GcpCredentialsStorageIntegration
 
   private String convertToString(CredentialAccessBoundary accessBoundary) {
     try {
-      return new ObjectMapper().writeValueAsString(accessBoundary);
+      return OBJECT_MAPPER.writeValueAsString(accessBoundary);
     } catch (JsonProcessingException e) {
       LOGGER.warn("Unable to convert access boundary to json", e);
       return Objects.toString(accessBoundary);

--- a/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.AwsIamServiceIdentityInfo;
 import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
@@ -34,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class ConnectionConfigInfoDpoTest {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = JsonMapper.builder().build();
 
   static {
     objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);

--- a/polaris-core/src/test/java/org/apache/polaris/core/secrets/UserSecretsManagerBaseTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/secrets/UserSecretsManagerBaseTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.secrets;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.assertj.core.api.Assertions;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
  * implementation-specific unittests.
  */
 public abstract class UserSecretsManagerBaseTest {
-  private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper DEFAULT_MAPPER = JsonMapper.builder().build();
 
   /**
    * @return a fresh instance of a UserSecretsManager to use in test cases.

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisStorageConfigurationInfoTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.apache.polaris.core.storage.FileStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -46,7 +47,7 @@ public class PolarisStorageConfigurationInfoTest {
 
   @BeforeAll
   public static void setup() {
-    mapper = new ObjectMapper();
+    mapper = JsonMapper.builder().build();
   }
 
   @ParameterizedTest

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -199,7 +200,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true, Set.of("gs://bucket1/path/to/data"), Set.of("gs://bucket1/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundary.json");
     assertThat(parsedRules)
@@ -221,7 +222,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 "gs://bucket2/a/super/path/to/data"),
             Set.of("gs://bucket1/normal/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules =
         readResource(mapper, "gcp-testGenerateAccessBoundaryWithMultipleBuckets.json");
@@ -241,7 +242,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             Set.of("gs://bucket1/path/to/data", "gs://bucket1/another/path/to/data"),
             Set.of("gs://bucket1/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundaryWithoutList.json");
     assertThat(parsedRules)
@@ -260,7 +261,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             Set.of("gs://bucket1/normal/path/to/data", "gs://bucket1/awesome/path/to/data"),
             Set.of());
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundaryWithoutWrites.json");
     assertThat(parsedRules)

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -20,7 +20,7 @@ package org.apache.polaris.service.config;
 
 import static java.lang.String.format;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Startup;
@@ -254,7 +254,7 @@ public class ProductionReadinessChecks {
             });
 
     var storageTypes = FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES;
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var defaults = featureConfiguration.parseDefaults(mapper);
     var realmOverrides = featureConfiguration.parseRealmOverrides(mapper);
     @SuppressWarnings("unchecked")
@@ -329,7 +329,7 @@ public class ProductionReadinessChecks {
   public ProductionReadinessCheck checkConnectionCredentialVendors(
       Instance<ConnectionCredentialVendor> credentialVendors,
       FeaturesConfiguration featureConfiguration) {
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var defaults = featureConfiguration.parseDefaults(mapper);
     var realmOverrides = featureConfiguration.parseRealmOverrides(mapper);
 


### PR DESCRIPTION
Mappers and factories are fully immutable objects in Jackson 3. This change is rather a no-op, but migrates the code to use the builder-pattern.

This is only a little building-block for "real" Jackson 3 support, there's more to do and more that's required from other frameworks.