### PR TITLE
Relax `client_id`, `client_secret` regex/pattern validation on reset endpoint call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added `hierarchical` flag to `AzureStorageConfigInfo` to allow more precise SAS token down-scoping in ADLS when
   the [hierarchical namespace](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace)
   feature is enabled in Azure.
+- Relaxed `client_id`, `client_secret` regex/pattern validation on reset endpoint call
 
 ### Changes
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -136,18 +136,6 @@ public class PolarisServiceImpl
     return Response.status(Response.Status.CREATED).entity(newCatalog).build();
   }
 
-  private void validateClientId(String clientId) {
-    if (!clientId.matches("^[0-9a-f]{16}$")) {
-      throw new IllegalArgumentException("Invalid clientId format");
-    }
-  }
-
-  private void validateClientSecret(String clientSecret) {
-    if (!clientSecret.matches("^[0-9a-f]{32}$")) {
-      throw new IllegalArgumentException("Invalid clientSecret format");
-    }
-  }
-
   private void validateStorageConfig(StorageConfigInfo storageConfigInfo) {
     List<String> allowedStorageTypes =
         realmConfig.getConfig(FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
@@ -304,12 +292,6 @@ public class PolarisServiceImpl
             ? resetPrincipalRequest
             : new ResetPrincipalRequest(null, null);
 
-    if (safeResetPrincipalRequest.getClientId() != null) {
-      validateClientId(safeResetPrincipalRequest.getClientId());
-    }
-    if (safeResetPrincipalRequest.getClientSecret() != null) {
-      validateClientSecret(safeResetPrincipalRequest.getClientSecret());
-    }
     return Response.ok(adminService.resetCredentials(principalName, safeResetPrincipalRequest))
         .build();
   }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

client_id/client_secret patterns are validated when calling reset endpoint but the pattern is hardcoded which can be too rigid.
this PR just enables to configure it. 

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
