### PR TITLE
ensure AddressResolver supports localhost even if ipv6 is disabled in sysctl but not /etc/hosts

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/AddressResolver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/AddressResolver.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,14 +55,27 @@ record AddressResolver(DnsClient dnsClient, List<String> searchList) {
 
   static {
     try {
+      IP_V4_ONLY = Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack", "false"));
       LOCAL_ADDRESSES =
           networkInterfaces()
               .flatMap(
                   ni ->
-                      ni.getInterfaceAddresses().stream()
-                          // Need to do this InetAddress->byte[]->InetAddress dance to get rid of
-                          // host-address suffixes as in `0:0:0:0:0:0:0:1%lo`
-                          .map(InterfaceAddress::getAddress)
+                      Stream.concat(
+                              // localhost can be ipv6 when sysctl disable ipv6
+                              // if ::1 is registered for localhost in /etc/hosts
+                              // in this case java stack can still capture it
+                              // and it will work (even if not great)
+                              // this is a workaround to ensure at least localhost is
+                              // in the list but this could be more general to all /etc/hosts
+                              // mappings
+                              IP_V4_ONLY || !"lo".equalsIgnoreCase(ni.getName())
+                                  ? Stream.empty()
+                                  : findLocalhostAddresses(),
+                              ni.getInterfaceAddresses().stream()
+                                  // Need to do this InetAddress->byte[]->InetAddress dance to get
+                                  // rid of
+                                  // host-address suffixes as in `0:0:0:0:0:0:0:1%lo`
+                                  .map(InterfaceAddress::getAddress))
                           .map(InetAddress::getAddress)
                           .map(
                               a -> {
@@ -75,10 +89,16 @@ record AddressResolver(DnsClient dnsClient, List<String> searchList) {
                               })
                           .map(InetAddress::getHostAddress))
               .collect(toUnmodifiableSet());
-
-      IP_V4_ONLY = Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack", "false"));
     } catch (SocketException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  private static @NonNull Stream<InetAddress> findLocalhostAddresses() {
+    try {
+      return Stream.of(InetAddress.getAllByName("localhost"));
+    } catch (final RuntimeException | UnknownHostException e) {
+      return Stream.empty();
     }
   }
 


### PR DESCRIPTION
if ::1 is mapped to localhost in /etc/hosts then java stack and dns resolver of polaris can pick it up (`0:0:...:1`) but if sysctl disabled ipv6 then it will still be able to picj the ipv6 using /etc/hosts - can depend network manager but on ubuntu it does by default.

this is bothering cause `LOCAL_ADDRESS` set was wrong but still everything was functional

just fixed it for localhost since it hits in tests but can be a more general issue even if less likely to be used for other cases/outside tests since address would be explicitly passed IMHO

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how - not really possible without playing with OS tools, likely undesired)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed - not needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed - not needed)
