### PR TITLE
(doc): Disable sectionPagesMenu in Hugo

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -20,7 +20,6 @@
 baseURL: 'https://polaris.apache.org/'
 languageCode: 'en-us'
 title: 'Apache Polaris'
-sectionPagesMenu: 'main'
 enableRobotsTXT: true
 
 permalinks:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently we have 3 extra list item (one point to downloads as well and the other two are empty):
<img width="1234" height="318" alt="image" src="https://github.com/user-attachments/assets/6a682839-45a6-4928-bbaa-23c17c62a921" />

These appears to be auto populated by `sectionPagesMenu`. As we are using `menu.main` implicitly already, it may makes more senses to disable this so we don't have wrong auto populated lists.

Here is the fixed version from my local:
<img width="1234" height="350" alt="image" src="https://github.com/user-attachments/assets/f2525efa-829f-49e7-8c46-17d4538917a6" />


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
