### PR TITLE
CLI: Skip license check for pyparsing

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -71,6 +71,8 @@ pip-licenses-cli = "==3.0.1"
 [tool.pip-licenses]
 partial-match = true
 allow-only = "Apache;BSD License;BSD-3-Clause;ISC;MIT;Mozilla Public License;PSF-2.0;Python Software Foundation License;The Unlicense"
+# Ignore package 'pyparsing` due to https://github.com/pyparsing/pyparsing/issues/626
+ignore-packages = ["pyparsing"]
 
 [build-system]
 # 7.12.0 is the latest version to use due to OpenAPI spec version we are using


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Root cause is https://github.com/pyparsing/pyparsing/issues/626 (actually issue on not following PEP-639 which cause the false positive on the checker). 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
