### PR TITLE
Deprecate untyped `RealmConfig.getConfig()`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/RealmConfig.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/RealmConfig.java
@@ -31,7 +31,9 @@ public interface RealmConfig {
    * @param <T> the type of the configuration value
    * @param configName the name of the configuration key to check
    * @return the current value set for the configuration key, or null if not set
+   * @deprecated Use typed {@link #getConfig(PolarisConfiguration)} instead.
    */
+  @Deprecated
   <T> @Nullable T getConfig(String configName);
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -77,7 +78,7 @@ public class CatalogUtils {
             restrictions -> restrictions.validate(realmConfig, identifier, locations),
             () -> {
               List<String> allowedStorageTypes =
-                  realmConfig.getConfig("SUPPORTED_CATALOG_STORAGE_TYPES");
+                  realmConfig.getConfig(FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES);
               if (allowedStorageTypes != null
                   && !allowedStorageTypes.contains(StorageConfigInfo.StorageTypeEnum.FILE.name())) {
                 List<String> invalidLocations =


### PR DESCRIPTION
* `getConfig(String)` has a generic return type, but the call path that gets the value does not perform any type validation.

* Deprecate this method in favour of well-typed `getConfig(PolarisConfiguration)`

* Migrate the single use case in Polaris code to the well-typed method.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
