### PR TITLE
Use most parameters from Credentials Cache key

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -775,7 +775,7 @@ record NoSqlMetaStoreManager(
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
 
     checkArgument(

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1601,7 +1601,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
 
     // get meta store session we should be using

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -325,7 +325,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
     return delegate.getSubscopedCredsForEntity(
         callCtx,

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2095,7 +2095,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
 
     // get meta store session we should be using

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisCredentialVendor.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisCredentialVendor.java
@@ -54,6 +54,6 @@ public interface PolarisCredentialVendor {
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint);
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -68,7 +68,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint);
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageCredentialsVendor.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageCredentialsVendor.java
@@ -68,7 +68,7 @@ public class StorageCredentialsVendor {
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
     return polarisCredentialVendor.getSubscopedCredsForEntity(
         callContext.getPolarisCallContext(),

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -83,7 +83,7 @@ public class AwsCredentialsStorageIntegration
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
     int storageCredentialDurationSeconds =
         realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
@@ -96,9 +96,10 @@ public class AwsCredentialsStorageIntegration
         realmConfig.getConfig(FeatureConfiguration.INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL);
 
     String roleSessionName =
-        includePrincipalNameInSubscopedCredential
-            ? "polaris-" + polarisPrincipal.getName()
-            : "PolarisAwsCredentialsStorageIntegration";
+        polarisPrincipal
+            .filter(p -> includePrincipalNameInSubscopedCredential)
+            .map(p -> "polaris-" + p.getName())
+            .orElse("PolarisAwsCredentialsStorageIntegration");
     String cappedRoleSessionName =
         roleSessionName.substring(0, Math.min(roleSessionName.length(), 64));
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -85,7 +85,7 @@ public class AzureCredentialsStorageIntegration
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
     String loc =
         !allowedWriteLocations.isEmpty()

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -140,11 +140,11 @@ public class StorageCredentialCache {
           ScopedCredentialsResult scopedCredentialsResult =
               storageCredentialsVendor.getSubscopedCredsForEntity(
                   polarisEntity,
-                  allowListOperation,
-                  allowedReadLocations,
-                  allowedWriteLocations,
-                  polarisPrincipal,
-                  refreshCredentialsEndpoint);
+                  k.allowedListAction(),
+                  k.allowedReadLocations(),
+                  k.allowedWriteLocations(),
+                  k.principal(),
+                  k.refreshCredentialsEndpoint());
           if (scopedCredentialsResult.isSuccess()) {
             long maxCacheDurationMs = maxCacheDurationMs(realmConfig);
             return new StorageCredentialCacheEntry(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
@@ -53,7 +53,7 @@ public interface StorageCredentialCacheKey {
   Optional<String> refreshCredentialsEndpoint();
 
   @Value.Parameter(order = 8)
-  Optional<String> principalName();
+  Optional<PolarisPrincipal> principal();
 
   static StorageCredentialCacheKey of(
       String realmId,
@@ -75,6 +75,6 @@ public interface StorageCredentialCacheKey {
         allowedReadLocations,
         allowedWriteLocations,
         refreshCredentialsEndpoint,
-        polarisPrincipal.map(PolarisPrincipal::getName));
+        polarisPrincipal);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -93,7 +93,7 @@ public class GcpCredentialsStorageIntegration
       boolean allowListOperation,
       @Nonnull Set<String> allowedReadLocations,
       @Nonnull Set<String> allowedWriteLocations,
-      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<PolarisPrincipal> polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint) {
     try {
       sourceCredentials.refresh();

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/InMemoryStorageIntegrationTest.java
@@ -200,7 +200,7 @@ class InMemoryStorageIntegrationTest {
         boolean allowListOperation,
         @Nonnull Set<String> allowedReadLocations,
         @Nonnull Set<String> allowedWriteLocations,
-        @Nonnull PolarisPrincipal polarisPrincipal,
+        Optional<PolarisPrincipal> polarisPrincipal,
         Optional<String> refreshCredentialsEndpoint) {
       return null;
     }

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -85,8 +85,8 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                   .build())
           .build();
   public static final String AWS_PARTITION = "aws";
-  public static final PolarisPrincipal POLARIS_PRINCIPAL =
-      PolarisPrincipal.of("test-principal", Map.of(), Set.of());
+  public static final Optional<PolarisPrincipal> POLARIS_PRINCIPAL =
+      Optional.of(PolarisPrincipal.of("test-principal", Map.of(), Set.of()));
 
   @ParameterizedTest
   @ValueSource(strings = {"s3a", "s3"})
@@ -950,7 +950,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             true,
             Set.of(warehouseDir + "/namespace/table"),
             Set.of(warehouseDir + "/namespace/table"),
-            polarisPrincipalWithLongName,
+            Optional.of(polarisPrincipalWithLongName),
             Optional.of("/namespace/table/credentials"));
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -357,7 +357,7 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
         allowListAction,
         new HashSet<>(allowedReadLoc),
         new HashSet<>(allowedWriteLoc),
-        PolarisPrincipal.of("principal", Map.of(), Set.of()),
+        Optional.of(PolarisPrincipal.of("principal", Map.of(), Set.of())),
         Optional.empty());
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -184,7 +184,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         allowListAction,
         new HashSet<>(allowedReadLoc),
         new HashSet<>(allowedWriteLoc),
-        PolarisPrincipal.of("principal", Map.of(), Set.of()),
+        Optional.of(PolarisPrincipal.of("principal", Map.of(), Set.of())),
         Optional.of(REFRESH_ENDPOINT));
   }
 
@@ -363,7 +363,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         true,
         Set.of("gs://bucket/path"),
         Set.of("gs://bucket/path"),
-        PolarisPrincipal.of("principal", Map.of(), Set.of()),
+        Optional.of(PolarisPrincipal.of("principal", Map.of(), Set.of())),
         Optional.empty());
 
     Mockito.verify(mockIamClient)

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -115,7 +115,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
                   boolean allowListOperation,
                   @Nonnull Set<String> allowedReadLocations,
                   @Nonnull Set<String> allowedWriteLocations,
-                  @Nonnull PolarisPrincipal polarisPrincipal,
+                  Optional<PolarisPrincipal> polarisPrincipal,
                   Optional<String> refreshCredentialsEndpoint) {
                 return StorageAccessConfig.builder().supportsCredentialVending(false).build();
               }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -1888,7 +1888,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
                 true,
                 Set.of(tableMetadata.location()),
                 Set.of(tableMetadata.location()),
-                authenticatedRoot,
+                Optional.of(authenticatedRoot),
                 Optional.empty())
             .getStorageAccessConfig()
             .credentials();


### PR DESCRIPTION
The Credentials Cache produces cache hits based on the cache key, but the cached data is generated from parameters that are not always reflected in the key (e.g. `PolaricPrincipal`). As a result, it is not evident that positive cache hits always represent exactly the same credentials that would be produced from scratch.

This change takes care of propagating all parameter through the cache key, except the entity, which is a bit complicated to handle and probably needs a separate PR.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
