### PR TITLE
Use mainstream PostgreSQLContainer

### DIFF
--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/PostgresRelationalJdbcLifeCycleManagement.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/PostgresRelationalJdbcLifeCycleManagement.java
@@ -23,13 +23,13 @@ import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpec
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Map;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 public class PostgresRelationalJdbcLifeCycleManagement
     implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
   public static final String INIT_SCRIPT = "init-script";
 
-  private PostgreSQLContainer<?> postgres;
+  private PostgreSQLContainer postgres;
   private String initScript;
   private DevServicesContext context;
 
@@ -42,7 +42,7 @@ public class PostgresRelationalJdbcLifeCycleManagement
   @SuppressWarnings("resource")
   public Map<String, String> start() {
     postgres =
-        new PostgreSQLContainer<>(
+        new PostgreSQLContainer(
                 containerSpecHelper("postgres", PostgresRelationalJdbcLifeCycleManagement.class)
                     .dockerImageName(null)
                     .asCompatibleSubstituteFor("postgres"))


### PR DESCRIPTION
Migrate from the deprecated PostgreSQLContainer class to the mainstream one as suggested by javadoc.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
