### PR TITLE
Validate namespace depth during creation to prevent oversized AWS STS policies

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/NamespaceEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/NamespaceEntity.java
@@ -91,8 +91,7 @@ public class NamespaceEntity extends PolarisEntity implements LocationBasedEntit
                 "Namespace depth %d exceeds supported limit of %d. "
                     + "Deeply nested namespaces can generate oversized AWS STS policies. "
                     + "Consider flattening the namespace hierarchy.",
-                depth,
-                MAX_NAMESPACE_DEPTH));
+                depth, MAX_NAMESPACE_DEPTH));
       }
 
       setType(PolarisEntityType.NAMESPACE);


### PR DESCRIPTION
This PR adds early validation for excessively deep namespace hierarchies during namespace creation.

Without validation, deeply nested namespaces can generate oversized AWS STS policies that fail late with unclear AWS-level errors. This change fails fast with a clear Polaris-level message while ensuring existing namespaces remain unaffected.

Fixes #3243
