### PR TITLE
Propagate previous task exceptions as "suppressed"

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -183,7 +183,9 @@ public class TaskExecutorImpl implements TaskExecutor {
             executor)
         .exceptionallyComposeAsync(
             (t) -> {
-              t.addSuppressed(previousError);
+              if (previousError != null) {
+                t.addSuppressed(previousError);
+              }
               LOGGER.warn("Failed to handle task entity id {}", taskEntityId, t);
               errorHandler.ifPresent(h -> h.accept(taskEntityId, false, t));
               return tryHandleTask(taskEntityId, callContext, eventMetadata, t, attempt + 1);


### PR DESCRIPTION
Task retries may fail in different ways in each attempt, however only the last exception used to be exposed to the caller.

This change propagates exceptions from all previous tasks execution attempts as "suppressed" exceptions chained to the final tasks failure exception.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
