### PR TITLE
Remove Admin tests from required_status_checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,7 +56,6 @@ github:
           - "Unit Tests"
           - "Quarkus Tests"
           - "Quarkus Integration Tests"
-          - "Quarkus Admin Tests"
           - "Integration Tests"
           - regtest
           - spark-plugin-regtest


### PR DESCRIPTION
This is to unblock #3340 CI.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
