### PR TITLE
Remove unnecessary version spec in jdbc persistence build file

### DIFF
--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -45,6 +45,6 @@ dependencies {
 
   testImplementation(platform(libs.testcontainers.bom))
 
-  testImplementation("org.testcontainers:junit-jupiter:1.20.3")
-  testImplementation("org.testcontainers:postgresql:1.20.3")
+  testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+  testImplementation("org.testcontainers:testcontainers-postgresql")
 }


### PR DESCRIPTION
The testcontainers BOM is already included, so the version spec, which doesn't match the BOM version, is unnecessary.
