### PR TITLE
Setup gradle using Github action to avoid downloading from services.gradle.org

### DIFF
--- a/.github/workflows/release-2-update-release-candidate.yml
+++ b/.github/workflows/release-2-update-release-candidate.yml
@@ -145,6 +145,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+
       - name: Update project versions
         if: env.rc_number == '0'
         run: |

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -146,6 +146,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+
       - name: Install Subversion
         run: |
           sudo apt-get update
@@ -280,6 +283,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
 
       - name: Build Polaris Server Docker image
         run: |

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -274,6 +274,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+
       - name: Log in to Docker Hub
         if: env.DRY_RUN == '0'
         run: |


### PR DESCRIPTION
During workflow development, Github runners may be temporarily banned from services.gradle.org.  This PR ensures that Gradle and the Gradle wrapper are set up using the proper Github Action and therefore from Github mirrors so that the issue does not happen anymore.

Example of issue: https://github.com/pingtimeout/polaris/actions/runs/20488431923/job/58875553318

```
Error: Exception in thread "main" java.io.IOException: Downloading from https://services.gradle.org/distributions/gradle-9.2.1-bin.zip failed: timeout (10000ms)
```