### PR TITLE
Errorprone: prepare for v2.46.0

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -75,7 +75,9 @@ checkstyle {
 tasks.withType<Checkstyle>().configureEach { tasks.findByName("jandex")?.let { mustRunAfter(it) } }
 
 tasks.withType(JavaCompile::class.java).configureEach {
-  options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
+  options.compilerArgs.addAll(
+    listOf("-Xlint:unchecked", "-Xlint:deprecation", "-XDaddTypeAnnotationsToSymbol=true")
+  )
   options.errorprone.disableAllWarnings = true
   options.errorprone.disableWarningsInGeneratedCode = true
   options.errorprone.excludedPaths =


### PR DESCRIPTION
This tackles the current failure in #3382: `-XDaddTypeAnnotationsToSymbol=true is required by Error Prone on JDK 21`
