### PR TITLE
Add support to disable S3 trailing checksum

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -63,6 +63,8 @@ public class DefaultFileIOFactory implements FileIOFactory {
         storageAccessConfig.extraProperties().get("disable.s3.trailing.checksum");
 
     if (Boolean.parseBoolean(disableChecksum)) {
+      // Iceberg’s S3FileIO consumes "s3.checksum.enabled" to configure
+      // the AWS SDK S3 client and disable trailing checksum validation.
       properties.put("s3.checksum.enabled", "false");
     }
 


### PR DESCRIPTION
Addresses apache/polaris#3346

This change adds support for disabling S3 trailing checksum validation via AWS storage configuration.
The logic is applied at the FileIO layer to ensure it affects all S3-based Iceberg operations consistently.