### PR TITLE
Fix namespace creation in multi-realm setup

### DIFF
--- a/client/python/apache_polaris/cli/command/utils.py
+++ b/client/python/apache_polaris/cli/command/utils.py
@@ -42,11 +42,11 @@ def get_catalog_api_client(api: PolarisDefaultApi) -> ApiClient:
         configuration.proxy_headers = mgmt_config.proxy_headers
 
     catalog_client = ApiClient(configuration)
-    
+
     # Preserve custom headers (like Polaris-Realm) from management client
     if hasattr(api.api_client, "default_headers"):
         for header_name, header_value in api.api_client.default_headers.items():
             if header_name != "User-Agent":  # Don't override User-Agent
                 catalog_client.set_default_header(header_name, header_value)
-    
+
     return catalog_client

--- a/client/python/generate_clients.py
+++ b/client/python/generate_clients.py
@@ -95,6 +95,7 @@ EXCLUDE_EXTENSIONS = [
     "iml",
     "keep",
     "gitignore",
+    "pyc",
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Bootstrap multiple realm, now try to create namespace using non-default realm. Creation request fails with 401 unathorized access due to missing header.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
