### PR TITLE
Release workflows should retry svn checkout in case of failure

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -183,22 +183,7 @@ jobs:
           dist_dev_dir=${RELEASEY_DIR}/polaris-dist-dev
 
           # Retry logic for SVN checkout (Apache SVN can have transient connectivity issues)
-          max_attempts=5
-          attempt=1
-          while true; do
-            if exec_process svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"; then
-              break
-            fi
-            if [[ $attempt -ge $max_attempts ]]; then
-              echo "ERROR: SVN checkout failed after ${max_attempts} attempts"
-              exit 1
-            fi
-            echo "WARNING: SVN checkout failed (attempt ${attempt}/${max_attempts}), retrying in 60 seconds..."
-            # Clean up any partial checkout before retrying
-            rm -rf "${dist_dev_dir}"
-            sleep 60
-            ((attempt++))
-          done
+          exec_process_with_retries 5 60 "${dist_dev_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"
 
           version_dir="${dist_dev_dir}/${version_without_rc}"
           exec_process mkdir -p "${version_dir}"
@@ -412,22 +397,7 @@ jobs:
           dist_dev_dir=${RELEASEY_DIR}/polaris-dist-dev
 
           # Retry logic for SVN checkout (Apache SVN can have transient connectivity issues)
-          max_attempts=5
-          attempt=1
-          while true; do
-            if exec_process svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"; then
-              break
-            fi
-            if [[ $attempt -ge $max_attempts ]]; then
-              echo "ERROR: SVN checkout failed after ${max_attempts} attempts"
-              exit 1
-            fi
-            echo "WARNING: SVN checkout failed (attempt ${attempt}/${max_attempts}), retrying in 60 seconds..."
-            # Clean up any partial checkout before retrying
-            rm -rf "${dist_dev_dir}"
-            sleep 60
-            ((attempt++))
-          done
+          exec_process_with_retries 5 60 "${dist_dev_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"
 
           exec_process mkdir -p "${dist_dev_dir}/helm-chart/${version_without_rc}"
           exec_process cp helm/polaris-${version_without_rc}.tgz* "${dist_dev_dir}/helm-chart/${version_without_rc}/"

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -227,22 +227,7 @@ jobs:
           release_helm_url="${APACHE_DIST_URL}/release/incubator/polaris/helm-chart"
 
           # Retry logic for SVN checkout (Apache SVN can have transient connectivity issues)
-          max_attempts=5
-          attempt=1
-          while true; do
-            if exec_process svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_helm_url}" "${release_helm_dir}"; then
-              break
-            fi
-            if [[ $attempt -ge $max_attempts ]]; then
-              echo "ERROR: SVN checkout failed after ${max_attempts} attempts"
-              exit 1
-            fi
-            echo "WARNING: SVN checkout failed (attempt ${attempt}/${max_attempts}), retrying in 60 seconds..."
-            # Clean up any partial checkout before retrying
-            rm -rf "${release_helm_dir}"
-            sleep 60
-            ((attempt++))
-          done
+          exec_process_with_retries 5 60 "${release_helm_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_helm_url}" "${release_helm_dir}"
 
           exec_process cd "${release_helm_dir}"
           exec_process helm repo index .

--- a/releasey/libs/_exec.sh
+++ b/releasey/libs/_exec.sh
@@ -32,6 +32,42 @@ function exec_process {
   fi
 }
 
+# Executes a command with retry logic
+# Args:
+#   $1: max_attempts - Maximum number of retry attempts
+#   $2: sleep_duration - Seconds to wait between retries
+#   $3: cleanup_path - Path to clean up before retrying (can be empty)
+#   $@: Command and arguments to execute
+function exec_process_with_retries {
+  if [[ $# -lt 4 ]]; then
+    echo "ERROR: exec_process_with_retries requires: max_attempts sleep_duration cleanup_path command [args...]"
+    exit 1
+  fi
+
+  local max_attempts="${1}"
+  local sleep_duration="${2}"
+  local cleanup_path="${3}"
+  shift 3
+
+  local attempt=1
+  while true; do
+    if exec_process "$@"; then
+      break
+    fi
+    if [[ $attempt -ge $max_attempts ]]; then
+      echo "ERROR: Command failed after ${max_attempts} attempts: ${*}"
+      exit 1
+    fi
+    echo "WARNING: Command failed (attempt ${attempt}/${max_attempts}), retrying in ${sleep_duration} seconds..."
+    # Clean up any partial state before retrying
+    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]]; then
+      rm -rf "${cleanup_path}"
+    fi
+    sleep "${sleep_duration}"
+    ((attempt++))
+  done
+}
+
 function calculate_sha512 {
   local source_file="$1"
   local target_file="${source_file}.sha512"


### PR DESCRIPTION
During workflow development, I ran into issues like this one during Helm charts build job:

```
svn: E170013: Unable to connect to a repository at URL 'https://dist.apache.org/repos/dist/dev/incubator/polaris'
svn: E000110: Error running context: Connection timed out
Error: Process completed with exit code 1.
```

Example: https://github.com/pingtimeout/polaris/actions/runs/20792183122/job/59719038791

This is not expected as there is another job in the same workflow that executes the same `svn checkout` command and succeeds.  I suspect a rate limit on ASF Infra side.  This PR adds a sleep-then-retry mechanism to workflows so that they do not fail immediately.

Here is an example of a successful run.  Unfortunately, that time, the rate limit did not trigger, so it only shows that the workflow continue running identically with the code change: https://github.com/pingtimeout/polaris/actions/runs/20825202531/job/59827207724