### PR TITLE
[tech debt] Cleanup `gradle/libs.versions.toml`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,10 +46,10 @@ awssdk-bom = { module = "software.amazon.awssdk:bom", version = "2.41.1" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version = "1.3.3" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.3" }
 cel-bom = { module = "org.projectnessie.cel:cel-bom", version = "0.6.0" }
-checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" } # required by the polaris-java plugin
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.20.0" }
 commons-text = { module = "org.apache.commons:commons-text", version = "1.15.0" }
-errorprone = { module = "com.google.errorprone:error_prone_core", version = "2.45.0" }
+errorprone = { module = "com.google.errorprone:error_prone_core", version = "2.45.0" } # required by the polaris-java plugin
 google-cloud-iamcredentials = { module = "com.google.cloud:google-cloud-iamcredentials", version = "2.81.0" }
 google-cloud-storage-bom = { module = "com.google.cloud:google-cloud-storage-bom", version = "2.61.0" }
 guava = { module = "com.google.guava:guava", version = "33.5.0-jre" }
@@ -112,4 +112,4 @@ jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 openapi-generator = { id = "org.openapi.generator", version = "7.12.0" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
-smallrye-openapi = { id = "io.smallrye.openapi", version = "4.1.1" }
+


### PR DESCRIPTION
This change removes unreferenced dependency references, inlines single usages of a version-reference and adds a dependency for checkstyle to get that version managed by renovate.
