### PR TITLE
NoSQL: add to config-docs

### DIFF
--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -26,6 +26,14 @@ description = "Polaris site - reference docs"
 
 val genProjectPaths = listOf(
   ":polaris-async-api",
+  ":polaris-nodes-api",
+  ":polaris-persistence-nosql-api",
+  ":polaris-persistence-nosql-impl",
+  ":polaris-persistence-nosql-cdi-quarkus",
+  ":polaris-persistence-nosql-cdi-quarkus-distcache",
+  ":polaris-persistence-nosql-maintenance-api",
+  ":polaris-persistence-nosql-mongodb",
+  ":polaris-persistence-nosql-metastore-types",
   ":polaris-runtime-service",
 )
 


### PR DESCRIPTION
Add the NoSQL specific configurtion options to the configuration docs generation module.
