### PR TITLE
[Releasy] Let Maven artifact publication propagate failures

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -207,7 +207,7 @@ jobs:
           source "${LIBS_DIR}/_exec.sh"
 
           # Publish artifacts to staging repository
-          exec_process ./gradlew publishToApache closeApacheStagingRepository -Prelease -PuseGpgAgent --info 2>&1 | tee gradle_publish_output.txt
+          exec_process ./gradlew publishToApache closeApacheStagingRepository -Prelease -PuseGpgAgent --info 2>&1 | tee gradle_publish_output.txt ; test ${PIPESTATUS[0]} -eq 0
 
           # Extract staging repository ID from Gradle output
           if grep -q "Created staging repository" gradle_publish_output.txt; then


### PR DESCRIPTION
The Gradle build to publish the Maven artifacts is invoked like `./gradlew ... | tee <log>`. The (overall) exit code of pipes is the exit code of the _last_ command. The exit codes of all pipe "parts" is available in bash's `PIPESTATUS` array and needs to be checked.
