### PR TITLE
(feat)CLI: Change parser option to be required

### DIFF
--- a/client/python/apache_polaris/cli/options/parser.py
+++ b/client/python/apache_polaris/cli/options/parser.py
@@ -112,14 +112,14 @@ class Parser(object):
                     )
                 if option.children:
                     children_subparser = option_parser.add_subparsers(
-                        dest=f"{option.name}_subcommand", required=False
+                        dest=f"{option.name}_subcommand", required=True
                     )
                     recurse_options(children_subparser, option.children)
 
         parser = TreeHelpParser(description="Polaris CLI")
         add_arguments(parser, Parser._ROOT_ARGUMENTS)
 
-        subparser = parser.add_subparsers(dest="command", required=False)
+        subparser = parser.add_subparsers(dest="command", required=True)
         recurse_options(subparser, OptionTree.get_tree())
         return parser
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently the sub-parser and options parsers are both not required this result the following:
```
# no command provided
➜  polaris git:(main) ./polaris
Traceback (most recent call last):
...
Exception: Please provide credentials via either --client-id & --client-secret or --access-token. Alternatively, you may set the environment variables CLIENT_ID & CLIENT_SECRET.

# no sub-command option provided
➜  polaris git:(main) ./polaris --profile dev catalogs
An unexpected error occurred: None is not supported in the CLI
```

As these should be required (not seeing an obvious use case where this should be keep as False), I created this PR to set them to be True and here is now the new output (better UX imo):
```
# no command provided
➜  polaris git:(cli_parser_required) ./polaris
usage: polaris [-h] [--host HOST] [--port PORT] [--base-url BASE_URL] [--client-id CLIENT_ID] [--client-secret CLIENT_SECRET] [--access-token ACCESS_TOKEN]
               [--realm REALM] [--header HEADER] [--profile PROFILE] [--proxy PROXY] [--debug]
               {catalogs,principals,principal-roles,catalog-roles,privileges,namespaces,profiles,policies} ...
polaris: error: the following arguments are required: command

# no sub-command option provided
➜  polaris git:(cli_parser_required) ./polaris --profile dev catalogs
usage: polaris catalogs [-h] {create,delete,get,list,update} ...
polaris catalogs: error: the following arguments are required: catalogs_subcommand
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
