### PR TITLE
[Minor] [Site] fix scheduled meetings table

### DIFF
--- a/site/content/community/meetings/_index.adoc
+++ b/site/content/community/meetings/_index.adoc
@@ -41,8 +41,6 @@ https://meet.google.com/pii-faxn-woh[Google Meet Link]
 |===
 | Date | Time
 
-| 2026-01-08 | 09:00 PST, 18:00 CET
-
 | 2026-01-22 | 09:00 PST, 18:00 CET
 
 | 2026-02-05 | 09:00 PST, 18:00 CET
@@ -59,6 +57,10 @@ https://meet.google.com/pii-faxn-woh[Google Meet Link]
 [cols="1,3,3"]
 |===
 | Date | Notes | Recording
+
+| 2026-01-08
+|
+|
 
 | 2025-12-11
 | https://docs.google.com/document/d/1TAAMjCtk4KuWSwfxpCBhhK9vM1k_3n7YE4L28slclXU/edit?tab=t.juoe1e8vb1c6[Meeting Notes]


### PR DESCRIPTION
Super minor change to the site. Noticed that the "Scheduled Meetings" table was formatted incorrectly. 
<img width="478" height="520" alt="Screenshot 2026-01-12 at 3 29 06 PM" src="https://github.com/user-attachments/assets/ac085db9-daa0-483d-906a-08eee5552745" />

Updated it to add a new column, aligned the time format to 24h, and moved the 01-08 row to the past meetings table to await recording and notes links.
<img width="451" height="342" alt="Screenshot 2026-01-12 at 3 37 28 PM" src="https://github.com/user-attachments/assets/8e2bccce-f505-417f-a2f6-0680ef8a8b83" />