### PR TITLE
Add blog for Lance-Polaris integration

### DIFF
--- a/site/content/blog/2026/01/06/lance-integration.md
+++ b/site/content/blog/2026/01/06/lance-integration.md
@@ -69,8 +69,11 @@ Here are some example systems and how they are mapped in Lance Namespace:
 | System         | Structure                                      | Lance Namespace Mapping                     |
 |----------------|------------------------------------------------|---------------------------------------------|
 | Directory      | `/data/users.lance`                            | Table `["users"]`                           |
-| Hive Metastore | `database.table`                               | Table `["default", "orders"]`               |
+| Hive Metastore | `default.orders`                               | Table `["default", "orders"]`               |
 | Apache Polaris | `/my-catalog/namespaces/team_a/tables/vectors` | Table `["my-catalog", "team_a", "vectors"]` |
+
+For Directory namespace, only the `.lance` table directories are tracked as tables,
+while the parent directory (e.g., `/data`) serves as the root path for the namespace.
 
 Apache Polaris supports arbitrary namespace nesting, 
 making it particularly flexible for organizing Lance tables in complex data architectures.
@@ -119,10 +122,11 @@ and the `base-location` pointing to the Lance table root directory.
 ### Table Identification
 
 A table in Apache Polaris is identified as a Lance table when:
+
 - It is registered as a Generic Table
 - The `format` field is set to `lance`
 - The `base-location` points to a valid Lance table root directory
-- The `properties` contain `table_type=lance` for consistency
+- The `properties` contain `table_type=lance` for consistency with other Lance Namespace implementations (e.g., REST, Unity Catalog)
 
 ### Supported Operations
 
@@ -137,7 +141,7 @@ The Lance Namespace Apache Polaris implementation supports the following operati
 | DeclareTable      | Declare a new table exists at a given location          |
 | ListTables        | List all Lance tables in a namespace                    |
 | DescribeTable     | Get table metadata and location                         |
-| DeregisterTable   | Deregister a table from the namespace (no data removal) |
+| DeregisterTable   | Deregister a table from the namespace without deleting the underlying data (similar to DROP TABLE without PURGE) |
 
 ## Using Lance with Apache Polaris
 
@@ -146,9 +150,12 @@ and access them from any engine that supports Lance.
 Whether you're ingesting data with Spark, running feature engineering with Ray,
 building RAG applications with LanceDB, or analyzing with Trino,
 all these engines can work with the same Lance tables managed through Apache Polaris.
+For more information on getting started with Apache Polaris, see the [Apache Polaris Getting Started Guide](https://polaris.apache.org/in-dev/unreleased/getting-started/).
 
 Let's walk through a complete end-to-end workflow using the [BeIR/quora](https://huggingface.co/datasets/BeIR/quora)
 dataset from Hugging Face to build a question-answering system.
+The examples below work against a locally deployed Apache Polaris instance with the endpoint set to `http://localhost:8181`.
+You can update the endpoint to match your deployed Apache Polaris service.
 
 ### Step 1: Ingest Data with Apache Spark
 
@@ -397,13 +404,22 @@ ns = PolarisNamespace({
 We are excited about this collaboration between the Lance and Apache Polaris communities.
 Our integration with the Generic Table API opens up new possibilities for managing AI-native workloads in the open multimodal lakehouse.
 
-Looking ahead, we plan to continue improving the Generic Table API based on our learnings from the Lance Namespace specification.
-For example, Lance Namespace already supports credentials vending end-to-end and is 
-integrated with any engine that uses the Lance Rust/Python/Java SDKs,
-allowing namespace servers to provide temporary credentials for accessing table data.
-We would like to collaborate with the Apache Polaris community to add credentials vending support to the Generic Table API,
-enabling secure, fine-grained access control for Lance tables stored in AWS S3, Azure Blob Storage, and Google Cloud Storage.
-This would allow Apache Polaris to fully manage credentials for Lance tables, just as it does for Iceberg tables today.
+Looking ahead, we plan to continue improving the Generic Table API based on our learnings from the Lance Namespace specification:
+
+- **Credentials Vending:** Lance Namespace already supports credentials vending end-to-end and is
+  integrated with any engine that uses the Lance Rust/Python/Java SDKs,
+  allowing namespace servers to provide temporary credentials for accessing table data.
+  We would like to collaborate with the Apache Polaris community to add credentials vending support to the Generic Table API,
+  enabling secure, fine-grained access control for Lance tables stored in AWS S3, Azure Blob Storage, and Google Cloud Storage.
+  This would allow Apache Polaris to fully manage credentials for Lance tables, just as it does for Iceberg tables today.
+
+- **OAuth Integration:** We plan to integrate with various OAuth workflows for better client connectivity and auth token refresh,
+  making it easier for applications to maintain secure, long-lived connections to Apache Polaris.
+
+- **Table Commit Path:** Formats like Delta Lake and Lance do not go through the catalog for commits after initial table creation.
+  This creates challenges for centralized governance over table update operations.
+  We will continue to evolve the Generic Table API to integrate better with these formats at the commit code path,
+  enabling finer-grained control and governance over table modifications.
 
 We welcome contributions and feedback from the community.
 Join us in building the future of AI-native data management in the open multimodal lakehouse!
@@ -418,4 +434,4 @@ Join us in building the future of AI-native data management in the open multimod
 - [Lance Spark Connector](https://github.com/lance-format/lance-spark) - Apache Spark integration
 - [Lance Ray](https://github.com/lance-format/lance-ray) - Lance Ray integration
 - [Lance Trino Connector](https://github.com/lance-format/lance-trino) - Lance Trino integration
-- [Lance Trino Connector](https://github.com/lance-format/lance-duckdb) - Lance DuckDB integration
+- [Lance DuckDB Connector](https://github.com/lance-format/lance-duckdb) - Lance DuckDB integration


### PR DESCRIPTION
Add a blog post for Polaris integration with [Lance format](https://lance.org) through the Generic Table API. Walk through the overall architecture as well as an example of using it with Apache Spark for ETL, Ray for feature engineering, Trino for OLAP queries and LanceDB for semantic search.

## Checklist
- [x ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x ] 💡 Added comments for complex logic
- [x ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)

Co-authored-by: Yun Zou <yunzou.colostate@gmail.com>