### PR TITLE
CLI: Relax UV version

### DIFF
--- a/regtests/requirements.txt
+++ b/regtests/requirements.txt
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-uv==0.9.24
+uv>=0.9.0


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

In `pyproject.tom`, I do have uv version be `>=0.9.0` but the version in regtests is a spcific version which seems to be problematic as uv appears to have release every 3-4 days (sometime can be 1-2 days: https://github.com/astral-sh/uv/releases). Matching the build version to `pyproject.toml` so less invocation of renovate bot.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
