### PR TITLE
Create PolarisEvent only when event type is actually supported by listener

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisCatalogsEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisCatalogsEventServiceDelegator.java
@@ -61,16 +61,21 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
   public Response createCatalog(
       CreateCatalogRequest request, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, request.getCatalog().getName())));
+        PolarisEventType.BEFORE_CREATE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, request.getCatalog().getName())));
     Response resp = delegate.createCatalog(request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
+        PolarisEventType.AFTER_CREATE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
     return resp;
   }
 
@@ -78,16 +83,20 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
   public Response deleteCatalog(
       String catalogName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DELETE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.BEFORE_DELETE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DELETE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
     Response resp = delegate.deleteCatalog(catalogName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DELETE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.AFTER_DELETE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DELETE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
     return resp;
   }
 
@@ -95,16 +104,20 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
   public Response getCatalog(
       String catalogName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.BEFORE_GET_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
     Response resp = delegate.getCatalog(catalogName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
+        PolarisEventType.AFTER_GET_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
     return resp;
   }
 
@@ -115,35 +128,43 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.UPDATE_CATALOG_REQUEST, updateRequest)));
+        PolarisEventType.BEFORE_UPDATE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.UPDATE_CATALOG_REQUEST, updateRequest)));
     Response resp =
         delegate.updateCatalog(catalogName, updateRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_CATALOG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_CATALOG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_CATALOG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG, (Catalog) resp.getEntity())));
     return resp;
   }
 
   @Override
   public Response listCatalogs(RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_CATALOGS,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.BEFORE_LIST_CATALOGS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_CATALOGS,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     Response resp = delegate.listCatalogs(realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_CATALOGS,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.AFTER_LIST_CATALOGS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_CATALOGS,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     return resp;
   }
 
@@ -154,20 +175,24 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
+        PolarisEventType.BEFORE_CREATE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
     Response resp = delegate.createCatalogRole(catalogName, request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
+        PolarisEventType.AFTER_CREATE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
     return resp;
   }
 
@@ -178,21 +203,25 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DELETE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.BEFORE_DELETE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DELETE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     Response resp =
         delegate.deleteCatalogRole(catalogName, catalogRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DELETE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.AFTER_DELETE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DELETE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     return resp;
   }
 
@@ -203,21 +232,25 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.BEFORE_GET_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     Response resp =
         delegate.getCatalogRole(catalogName, catalogRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
+        PolarisEventType.AFTER_GET_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
     return resp;
   }
 
@@ -229,23 +262,27 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
-                .put(EventAttributes.UPDATE_CATALOG_ROLE_REQUEST, updateRequest)));
+        PolarisEventType.BEFORE_UPDATE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
+                    .put(EventAttributes.UPDATE_CATALOG_ROLE_REQUEST, updateRequest)));
     Response resp =
         delegate.updateCatalogRole(
             catalogName, catalogRoleName, updateRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE, (CatalogRole) resp.getEntity())));
     return resp;
   }
 
@@ -253,16 +290,20 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
   public Response listCatalogRoles(
       String catalogName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_CATALOG_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.BEFORE_LIST_CATALOG_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_CATALOG_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
     Response resp = delegate.listCatalogRoles(catalogName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_CATALOG_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.AFTER_LIST_CATALOG_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_CATALOG_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CATALOG_NAME, catalogName)));
     return resp;
   }
 
@@ -274,26 +315,30 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ADD_GRANT_TO_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
-                .put(EventAttributes.ADD_GRANT_REQUEST, grantRequest)));
+        PolarisEventType.BEFORE_ADD_GRANT_TO_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ADD_GRANT_TO_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
+                    .put(EventAttributes.ADD_GRANT_REQUEST, grantRequest)));
     Response resp =
         delegate.addGrantToCatalogRole(
             catalogName, catalogRoleName, grantRequest, realmContext, securityContext);
     GrantResource grantResource = grantRequest.getGrant();
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_ADD_GRANT_TO_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
-                .put(EventAttributes.PRIVILEGE, getPrivilegeFromGrantResource(grantResource))
-                .put(EventAttributes.GRANT_RESOURCE, grantResource)));
+        PolarisEventType.AFTER_ADD_GRANT_TO_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_ADD_GRANT_TO_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
+                    .put(EventAttributes.PRIVILEGE, getPrivilegeFromGrantResource(grantResource))
+                    .put(EventAttributes.GRANT_RESOURCE, grantResource)));
     return resp;
   }
 
@@ -306,28 +351,32 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_REVOKE_GRANT_FROM_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
-                .put(EventAttributes.REVOKE_GRANT_REQUEST, grantRequest)
-                .put(EventAttributes.CASCADE, cascade)));
+        PolarisEventType.BEFORE_REVOKE_GRANT_FROM_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_REVOKE_GRANT_FROM_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
+                    .put(EventAttributes.REVOKE_GRANT_REQUEST, grantRequest)
+                    .put(EventAttributes.CASCADE, cascade)));
     Response resp =
         delegate.revokeGrantFromCatalogRole(
             catalogName, catalogRoleName, cascade, grantRequest, realmContext, securityContext);
     GrantResource grantResource = grantRequest.getGrant();
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_REVOKE_GRANT_FROM_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
-                .put(EventAttributes.PRIVILEGE, getPrivilegeFromGrantResource(grantResource))
-                .put(EventAttributes.GRANT_RESOURCE, grantResource)
-                .put(EventAttributes.CASCADE, cascade)));
+        PolarisEventType.AFTER_REVOKE_GRANT_FROM_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_REVOKE_GRANT_FROM_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)
+                    .put(EventAttributes.PRIVILEGE, getPrivilegeFromGrantResource(grantResource))
+                    .put(EventAttributes.GRANT_RESOURCE, grantResource)
+                    .put(EventAttributes.CASCADE, cascade)));
     return resp;
   }
 
@@ -338,22 +387,26 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     Response resp =
         delegate.listAssigneePrincipalRolesForCatalogRole(
             catalogName, catalogRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPAL_ROLES_FOR_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     return resp;
   }
 
@@ -364,22 +417,26 @@ public class PolarisCatalogsEventServiceDelegator implements PolarisCatalogsApiS
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_GRANTS_FOR_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.BEFORE_LIST_GRANTS_FOR_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_GRANTS_FOR_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     Response resp =
         delegate.listGrantsForCatalogRole(
             catalogName, catalogRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_GRANTS_FOR_CATALOG_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.AFTER_LIST_GRANTS_FOR_CATALOG_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_GRANTS_FOR_CATALOG_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     return resp;
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisPrincipalRolesEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisPrincipalRolesEventServiceDelegator.java
@@ -52,17 +52,21 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.CREATE_PRINCIPAL_ROLE_REQUEST, request)));
+        PolarisEventType.BEFORE_CREATE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.CREATE_PRINCIPAL_ROLE_REQUEST, request)));
     Response resp = delegate.createPrincipalRole(request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
+        PolarisEventType.AFTER_CREATE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
     return resp;
   }
 
@@ -70,16 +74,20 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
   public Response deletePrincipalRole(
       String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DELETE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.BEFORE_DELETE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DELETE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     Response resp = delegate.deletePrincipalRole(principalRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DELETE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.AFTER_DELETE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DELETE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     return resp;
   }
 
@@ -87,17 +95,21 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
   public Response getPrincipalRole(
       String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.BEFORE_GET_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     Response resp = delegate.getPrincipalRole(principalRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
+        PolarisEventType.AFTER_GET_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
     return resp;
   }
 
@@ -108,37 +120,45 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.UPDATE_PRINCIPAL_ROLE_REQUEST, updateRequest)));
+        PolarisEventType.BEFORE_UPDATE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.UPDATE_PRINCIPAL_ROLE_REQUEST, updateRequest)));
     Response resp =
         delegate.updatePrincipalRole(
             principalRoleName, updateRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE, (PrincipalRole) resp.getEntity())));
     return resp;
   }
 
   @Override
   public Response listPrincipalRoles(RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_PRINCIPAL_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.BEFORE_LIST_PRINCIPAL_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_PRINCIPAL_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     Response resp = delegate.listPrincipalRoles(realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_PRINCIPAL_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.AFTER_LIST_PRINCIPAL_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_PRINCIPAL_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     return resp;
   }
 
@@ -150,24 +170,28 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
+        PolarisEventType.BEFORE_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
     Response resp =
         delegate.assignCatalogRoleToPrincipalRole(
             principalRoleName, catalogName, request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
+        PolarisEventType.AFTER_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_ASSIGN_CATALOG_ROLE_TO_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, request.getCatalogRole().getName())));
     return resp;
   }
 
@@ -179,24 +203,28 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.BEFORE_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     Response resp =
         delegate.revokeCatalogRoleFromPrincipalRole(
             principalRoleName, catalogName, catalogRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
+        PolarisEventType.AFTER_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CATALOG_ROLE_NAME, catalogRoleName)));
     return resp;
   }
 
@@ -204,18 +232,22 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
   public Response listAssigneePrincipalsForPrincipalRole(
       String principalRoleName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     Response resp =
         delegate.listAssigneePrincipalsForPrincipalRole(
             principalRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_ASSIGNEE_PRINCIPALS_FOR_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     return resp;
   }
 
@@ -226,22 +258,26 @@ public class PolarisPrincipalRolesEventServiceDelegator implements PolarisPrinci
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.BEFORE_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)));
     Response resp =
         delegate.listCatalogRolesForPrincipalRole(
             principalRoleName, catalogName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
-                .put(EventAttributes.CATALOG_NAME, catalogName)));
+        PolarisEventType.AFTER_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_CATALOG_ROLES_FOR_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)
+                    .put(EventAttributes.CATALOG_NAME, catalogName)));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisPrincipalsEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisPrincipalsEventServiceDelegator.java
@@ -52,20 +52,24 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
   public Response createPrincipal(
       CreatePrincipalRequest request, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, request.getPrincipal().getName())));
+        PolarisEventType.BEFORE_CREATE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, request.getPrincipal().getName())));
     Response resp = delegate.createPrincipal(request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(
-                    EventAttributes.PRINCIPAL,
-                    ((PrincipalWithCredentials) resp.getEntity()).getPrincipal())));
+        PolarisEventType.AFTER_CREATE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(
+                        EventAttributes.PRINCIPAL,
+                        ((PrincipalWithCredentials) resp.getEntity()).getPrincipal())));
     return resp;
   }
 
@@ -76,21 +80,25 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_RESET_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.BEFORE_RESET_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_RESET_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     Response resp =
         delegate.resetCredentials(
             principalName, resetPrincipalRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_RESET_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(
-                    EventAttributes.PRINCIPAL,
-                    ((PrincipalWithCredentials) resp.getEntity()).getPrincipal())));
+        PolarisEventType.AFTER_RESET_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_RESET_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(
+                        EventAttributes.PRINCIPAL,
+                        ((PrincipalWithCredentials) resp.getEntity()).getPrincipal())));
     return resp;
   }
 
@@ -98,16 +106,20 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
   public Response deletePrincipal(
       String principalName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DELETE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.BEFORE_DELETE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DELETE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     Response resp = delegate.deletePrincipal(principalName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DELETE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.AFTER_DELETE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DELETE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     return resp;
   }
 
@@ -115,16 +127,20 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
   public Response getPrincipal(
       String principalName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.BEFORE_GET_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     Response resp = delegate.getPrincipal(principalName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL, (Principal) resp.getEntity())));
+        PolarisEventType.AFTER_GET_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL, (Principal) resp.getEntity())));
     return resp;
   }
 
@@ -135,19 +151,23 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, principalName)
-                .put(EventAttributes.UPDATE_PRINCIPAL_REQUEST, updateRequest)));
+        PolarisEventType.BEFORE_UPDATE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, principalName)
+                    .put(EventAttributes.UPDATE_PRINCIPAL_REQUEST, updateRequest)));
     Response resp =
         delegate.updatePrincipal(principalName, updateRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_PRINCIPAL,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL, (Principal) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_PRINCIPAL,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_PRINCIPAL,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL, (Principal) resp.getEntity())));
     return resp;
   }
 
@@ -155,34 +175,42 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
   public Response rotateCredentials(
       String principalName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ROTATE_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.BEFORE_ROTATE_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ROTATE_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     Response resp = delegate.rotateCredentials(principalName, realmContext, securityContext);
     PrincipalWithCredentials principalWithCredentials = (PrincipalWithCredentials) resp.getEntity();
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_ROTATE_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL, principalWithCredentials.getPrincipal())));
+        PolarisEventType.AFTER_ROTATE_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_ROTATE_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL, principalWithCredentials.getPrincipal())));
     return resp;
   }
 
   @Override
   public Response listPrincipals(RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_PRINCIPALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.BEFORE_LIST_PRINCIPALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_PRINCIPALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     Response resp = delegate.listPrincipals(realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_PRINCIPALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()));
+        PolarisEventType.AFTER_LIST_PRINCIPALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_PRINCIPALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()));
     return resp;
   }
 
@@ -193,21 +221,25 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ASSIGN_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, principalName)
-                .put(EventAttributes.PRINCIPAL_ROLE, request.getPrincipalRole())));
+        PolarisEventType.BEFORE_ASSIGN_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ASSIGN_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, principalName)
+                    .put(EventAttributes.PRINCIPAL_ROLE, request.getPrincipalRole())));
     Response resp =
         delegate.assignPrincipalRole(principalName, request, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_ASSIGN_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, principalName)
-                .put(EventAttributes.PRINCIPAL_ROLE, request.getPrincipalRole())));
+        PolarisEventType.AFTER_ASSIGN_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_ASSIGN_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, principalName)
+                    .put(EventAttributes.PRINCIPAL_ROLE, request.getPrincipalRole())));
     return resp;
   }
 
@@ -218,22 +250,26 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
       RealmContext realmContext,
       SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_REVOKE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, principalName)
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.BEFORE_REVOKE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_REVOKE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, principalName)
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     Response resp =
         delegate.revokePrincipalRole(
             principalName, principalRoleName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_REVOKE_PRINCIPAL_ROLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.PRINCIPAL_NAME, principalName)
-                .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
+        PolarisEventType.AFTER_REVOKE_PRINCIPAL_ROLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_REVOKE_PRINCIPAL_ROLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.PRINCIPAL_NAME, principalName)
+                    .put(EventAttributes.PRINCIPAL_ROLE_NAME, principalRoleName)));
     return resp;
   }
 
@@ -241,17 +277,21 @@ public class PolarisPrincipalsEventServiceDelegator implements PolarisPrincipals
   public Response listPrincipalRolesAssigned(
       String principalName, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_ASSIGNED_PRINCIPAL_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.BEFORE_LIST_ASSIGNED_PRINCIPAL_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_ASSIGNED_PRINCIPAL_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     Response resp =
         delegate.listPrincipalRolesAssigned(principalName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_ASSIGNED_PRINCIPAL_ROLES,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
+        PolarisEventType.AFTER_LIST_ASSIGNED_PRINCIPAL_ROLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_ASSIGNED_PRINCIPAL_ROLES,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.PRINCIPAL_NAME, principalName)));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
@@ -57,26 +57,30 @@ public class CatalogGenericTableEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.CREATE_GENERIC_TABLE_REQUEST, createGenericTableRequest)));
+        PolarisEventType.BEFORE_CREATE_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.CREATE_GENERIC_TABLE_REQUEST, createGenericTableRequest)));
     Response resp =
         delegate.createGenericTable(
             prefix, namespace, createGenericTableRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(
-                    EventAttributes.GENERIC_TABLE,
-                    ((LoadGenericTableResponse) resp.getEntity()).getTable())));
+        PolarisEventType.AFTER_CREATE_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(
+                        EventAttributes.GENERIC_TABLE,
+                        ((LoadGenericTableResponse) resp.getEntity()).getTable())));
     return resp;
   }
 
@@ -89,23 +93,27 @@ public class CatalogGenericTableEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
+        PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
     Response resp =
         delegate.dropGenericTable(prefix, namespace, genericTable, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DROP_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
+        PolarisEventType.AFTER_DROP_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DROP_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
     return resp;
   }
 
@@ -119,22 +127,26 @@ public class CatalogGenericTableEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_GENERIC_TABLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)));
+        PolarisEventType.BEFORE_LIST_GENERIC_TABLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_GENERIC_TABLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)));
     Response resp =
         delegate.listGenericTables(
             prefix, namespace, pageToken, pageSize, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_GENERIC_TABLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)));
+        PolarisEventType.AFTER_LIST_GENERIC_TABLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_GENERIC_TABLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)));
     return resp;
   }
 
@@ -147,25 +159,29 @@ public class CatalogGenericTableEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
+        PolarisEventType.BEFORE_LOAD_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
     Response resp =
         delegate.loadGenericTable(prefix, namespace, genericTable, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_GENERIC_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(
-                    EventAttributes.GENERIC_TABLE,
-                    ((LoadGenericTableResponse) resp.getEntity()).getTable())));
+        PolarisEventType.AFTER_LOAD_GENERIC_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_GENERIC_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(
+                        EventAttributes.GENERIC_TABLE,
+                        ((LoadGenericTableResponse) resp.getEntity()).getTable())));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1384,12 +1384,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         disableRefresh();
       } else {
         polarisEventListener.onEvent(
-            new PolarisEvent(
-                PolarisEventType.BEFORE_REFRESH_TABLE,
-                eventMetadataFactory.create(),
-                new AttributeMap()
-                    .put(EventAttributes.CATALOG_NAME, catalogName)
-                    .put(EventAttributes.TABLE_IDENTIFIER, tableIdentifier)));
+            PolarisEventType.BEFORE_REFRESH_TABLE,
+            () ->
+                new PolarisEvent(
+                    PolarisEventType.BEFORE_REFRESH_TABLE,
+                    eventMetadataFactory.create(),
+                    new AttributeMap()
+                        .put(EventAttributes.CATALOG_NAME, catalogName)
+                        .put(EventAttributes.TABLE_IDENTIFIER, tableIdentifier)));
         refreshFromMetadataLocation(
             latestLocation,
             SHOULD_RETRY_REFRESH_PREDICATE,
@@ -1410,12 +1412,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               return TableMetadataParser.read(fileIO, metadataLocation);
             });
         polarisEventListener.onEvent(
-            new PolarisEvent(
-                PolarisEventType.AFTER_REFRESH_TABLE,
-                eventMetadataFactory.create(),
-                new AttributeMap()
-                    .put(EventAttributes.CATALOG_NAME, catalogName)
-                    .put(EventAttributes.TABLE_IDENTIFIER, tableIdentifier)));
+            PolarisEventType.AFTER_REFRESH_TABLE,
+            () ->
+                new PolarisEvent(
+                    PolarisEventType.AFTER_REFRESH_TABLE,
+                    eventMetadataFactory.create(),
+                    new AttributeMap()
+                        .put(EventAttributes.CATALOG_NAME, catalogName)
+                        .put(EventAttributes.TABLE_IDENTIFIER, tableIdentifier)));
       }
     }
 
@@ -1794,12 +1798,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         disableRefresh();
       } else {
         polarisEventListener.onEvent(
-            new PolarisEvent(
-                PolarisEventType.BEFORE_REFRESH_VIEW,
-                eventMetadataFactory.create(),
-                new AttributeMap()
-                    .put(EventAttributes.CATALOG_NAME, catalogName)
-                    .put(EventAttributes.VIEW_IDENTIFIER, identifier)));
+            PolarisEventType.BEFORE_REFRESH_VIEW,
+            () ->
+                new PolarisEvent(
+                    PolarisEventType.BEFORE_REFRESH_VIEW,
+                    eventMetadataFactory.create(),
+                    new AttributeMap()
+                        .put(EventAttributes.CATALOG_NAME, catalogName)
+                        .put(EventAttributes.VIEW_IDENTIFIER, identifier)));
         refreshFromMetadataLocation(
             latestLocation,
             SHOULD_RETRY_REFRESH_PREDICATE,
@@ -1822,25 +1828,29 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               return ViewMetadataParser.read(fileIO.newInputFile(metadataLocation));
             });
         polarisEventListener.onEvent(
-            new PolarisEvent(
-                PolarisEventType.AFTER_REFRESH_VIEW,
-                eventMetadataFactory.create(),
-                new AttributeMap()
-                    .put(EventAttributes.CATALOG_NAME, catalogName)
-                    .put(EventAttributes.VIEW_IDENTIFIER, identifier)));
+            PolarisEventType.AFTER_REFRESH_VIEW,
+            () ->
+                new PolarisEvent(
+                    PolarisEventType.AFTER_REFRESH_VIEW,
+                    eventMetadataFactory.create(),
+                    new AttributeMap()
+                        .put(EventAttributes.CATALOG_NAME, catalogName)
+                        .put(EventAttributes.VIEW_IDENTIFIER, identifier)));
       }
     }
 
     public void doCommit(ViewMetadata base, ViewMetadata metadata) {
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.BEFORE_COMMIT_VIEW,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, catalogName)
-                  .put(EventAttributes.VIEW_IDENTIFIER, identifier)
-                  .put(EventAttributes.VIEW_METADATA_BEFORE, base)
-                  .put(EventAttributes.VIEW_METADATA_AFTER, metadata)));
+          PolarisEventType.BEFORE_COMMIT_VIEW,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.BEFORE_COMMIT_VIEW,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, catalogName)
+                      .put(EventAttributes.VIEW_IDENTIFIER, identifier)
+                      .put(EventAttributes.VIEW_METADATA_BEFORE, base)
+                      .put(EventAttributes.VIEW_METADATA_AFTER, metadata)));
 
       // TODO: Maybe avoid writing metadata if there's definitely a transaction conflict
       LOGGER.debug(
@@ -1941,14 +1951,16 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       }
 
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_COMMIT_VIEW,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, catalogName)
-                  .put(EventAttributes.VIEW_IDENTIFIER, identifier)
-                  .put(EventAttributes.VIEW_METADATA_BEFORE, base)
-                  .put(EventAttributes.VIEW_METADATA_AFTER, metadata)));
+          PolarisEventType.AFTER_COMMIT_VIEW,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_COMMIT_VIEW,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, catalogName)
+                      .put(EventAttributes.VIEW_IDENTIFIER, identifier)
+                      .put(EventAttributes.VIEW_METADATA_BEFORE, base)
+                      .put(EventAttributes.VIEW_METADATA_AFTER, metadata)));
     }
 
     protected String writeNewMetadataIfRequired(ViewMetadata metadata) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
@@ -89,23 +89,29 @@ public class IcebergRestCatalogEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.CREATE_NAMESPACE_REQUEST, createNamespaceRequest)));
+        PolarisEventType.BEFORE_CREATE_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.CREATE_NAMESPACE_REQUEST, createNamespaceRequest)));
     Response resp =
         delegate.createNamespace(prefix, createNamespaceRequest, realmContext, securityContext);
     CreateNamespaceResponse createNamespaceResponse = (CreateNamespaceResponse) resp.getEntity();
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, createNamespaceResponse.namespace())
-                .put(EventAttributes.NAMESPACE_PROPERTIES, createNamespaceResponse.properties())));
+        PolarisEventType.AFTER_CREATE_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, createNamespaceResponse.namespace())
+                    .put(
+                        EventAttributes.NAMESPACE_PROPERTIES,
+                        createNamespaceResponse.properties())));
     return resp;
   }
 
@@ -119,21 +125,25 @@ public class IcebergRestCatalogEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_NAMESPACES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.PARENT_NAMESPACE_FQN, parent)));
+        PolarisEventType.BEFORE_LIST_NAMESPACES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_NAMESPACES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.PARENT_NAMESPACE_FQN, parent)));
     Response resp =
         delegate.listNamespaces(prefix, pageToken, pageSize, parent, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_NAMESPACES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.PARENT_NAMESPACE_FQN, parent)));
+        PolarisEventType.AFTER_LIST_NAMESPACES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_NAMESPACES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.PARENT_NAMESPACE_FQN, parent)));
     return resp;
   }
 
@@ -142,23 +152,27 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_NAMESPACE_METADATA,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
+        PolarisEventType.BEFORE_LOAD_NAMESPACE_METADATA,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_NAMESPACE_METADATA,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
     Response resp =
         delegate.loadNamespaceMetadata(prefix, namespace, realmContext, securityContext);
     GetNamespaceResponse getNamespaceResponse = (GetNamespaceResponse) resp.getEntity();
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_NAMESPACE_METADATA,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, getNamespaceResponse.namespace())
-                .put(EventAttributes.NAMESPACE_PROPERTIES, getNamespaceResponse.properties())));
+        PolarisEventType.AFTER_LOAD_NAMESPACE_METADATA,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_NAMESPACE_METADATA,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, getNamespaceResponse.namespace())
+                    .put(EventAttributes.NAMESPACE_PROPERTIES, getNamespaceResponse.properties())));
     return resp;
   }
 
@@ -168,20 +182,24 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CHECK_EXISTS_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.BEFORE_CHECK_EXISTS_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CHECK_EXISTS_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     Response resp = delegate.namespaceExists(prefix, namespace, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CHECK_EXISTS_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.AFTER_CHECK_EXISTS_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CHECK_EXISTS_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     return resp;
   }
 
@@ -190,20 +208,24 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DROP_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
+        PolarisEventType.BEFORE_DROP_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DROP_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
     Response resp = delegate.dropNamespace(prefix, namespace, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DROP_NAMESPACE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_FQN, namespace)));
+        PolarisEventType.AFTER_DROP_NAMESPACE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DROP_NAMESPACE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_FQN, namespace)));
     return resp;
   }
 
@@ -217,28 +239,32 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_NAMESPACE_PROPERTIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(
-                    EventAttributes.UPDATE_NAMESPACE_PROPERTIES_REQUEST,
-                    updateNamespacePropertiesRequest)));
+        PolarisEventType.BEFORE_UPDATE_NAMESPACE_PROPERTIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_NAMESPACE_PROPERTIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(
+                        EventAttributes.UPDATE_NAMESPACE_PROPERTIES_REQUEST,
+                        updateNamespacePropertiesRequest)));
     Response resp =
         delegate.updateProperties(
             prefix, namespace, updateNamespacePropertiesRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_NAMESPACE_PROPERTIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(
-                    EventAttributes.UPDATE_NAMESPACE_PROPERTIES_RESPONSE,
-                    (UpdateNamespacePropertiesResponse) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_NAMESPACE_PROPERTIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_NAMESPACE_PROPERTIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(
+                        EventAttributes.UPDATE_NAMESPACE_PROPERTIES_RESPONSE,
+                        (UpdateNamespacePropertiesResponse) resp.getEntity())));
     return resp;
   }
 
@@ -253,14 +279,16 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.CREATE_TABLE_REQUEST, createTableRequest)
-                .put(EventAttributes.ACCESS_DELEGATION_MODE, accessDelegationMode)));
+        PolarisEventType.BEFORE_CREATE_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.CREATE_TABLE_REQUEST, createTableRequest)
+                    .put(EventAttributes.ACCESS_DELEGATION_MODE, accessDelegationMode)));
     Response resp =
         delegate.createTable(
             prefix,
@@ -271,14 +299,18 @@ public class IcebergRestCatalogEventServiceDelegator
             securityContext);
     if (!createTableRequest.stageCreate()) {
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_CREATE_TABLE,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, catalogName)
-                  .put(EventAttributes.NAMESPACE, namespaceObj)
-                  .put(EventAttributes.TABLE_NAME, createTableRequest.name())
-                  .put(EventAttributes.LOAD_TABLE_RESPONSE, (LoadTableResponse) resp.getEntity())));
+          PolarisEventType.AFTER_CREATE_TABLE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_CREATE_TABLE,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, catalogName)
+                      .put(EventAttributes.NAMESPACE, namespaceObj)
+                      .put(EventAttributes.TABLE_NAME, createTableRequest.name())
+                      .put(
+                          EventAttributes.LOAD_TABLE_RESPONSE,
+                          (LoadTableResponse) resp.getEntity())));
     }
     return resp;
   }
@@ -294,21 +326,25 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_TABLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.BEFORE_LIST_TABLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_TABLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     Response resp =
         delegate.listTables(prefix, namespace, pageToken, pageSize, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_TABLES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.AFTER_LIST_TABLES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_TABLES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     return resp;
   }
 
@@ -325,16 +361,18 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.ACCESS_DELEGATION_MODE, accessDelegationMode)
-                .put(EventAttributes.IF_NONE_MATCH_STRING, ifNoneMatchString)
-                .put(EventAttributes.SNAPSHOTS, snapshots)));
+        PolarisEventType.BEFORE_LOAD_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.ACCESS_DELEGATION_MODE, accessDelegationMode)
+                    .put(EventAttributes.IF_NONE_MATCH_STRING, ifNoneMatchString)
+                    .put(EventAttributes.SNAPSHOTS, snapshots)));
     Response resp =
         delegate.loadTable(
             prefix,
@@ -346,14 +384,18 @@ public class IcebergRestCatalogEventServiceDelegator
             realmContext,
             securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.LOAD_TABLE_RESPONSE, (LoadTableResponse) resp.getEntity())));
+        PolarisEventType.AFTER_LOAD_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(
+                        EventAttributes.LOAD_TABLE_RESPONSE,
+                        (LoadTableResponse) resp.getEntity())));
     return resp;
   }
 
@@ -367,22 +409,26 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CHECK_EXISTS_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)));
+        PolarisEventType.BEFORE_CHECK_EXISTS_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CHECK_EXISTS_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)));
     Response resp = delegate.tableExists(prefix, namespace, table, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CHECK_EXISTS_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)));
+        PolarisEventType.AFTER_CHECK_EXISTS_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CHECK_EXISTS_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)));
     return resp;
   }
 
@@ -397,25 +443,29 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DROP_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.PURGE_REQUESTED, purgeRequested)));
+        PolarisEventType.BEFORE_DROP_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DROP_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.PURGE_REQUESTED, purgeRequested)));
     Response resp =
         delegate.dropTable(prefix, namespace, table, purgeRequested, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DROP_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.PURGE_REQUESTED, purgeRequested)));
+        PolarisEventType.AFTER_DROP_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DROP_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.PURGE_REQUESTED, purgeRequested)));
     return resp;
   }
 
@@ -429,25 +479,31 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_REGISTER_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.REGISTER_TABLE_REQUEST, registerTableRequest)));
+        PolarisEventType.BEFORE_REGISTER_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_REGISTER_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.REGISTER_TABLE_REQUEST, registerTableRequest)));
     Response resp =
         delegate.registerTable(
             prefix, namespace, registerTableRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_REGISTER_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, registerTableRequest.name())
-                .put(EventAttributes.LOAD_TABLE_RESPONSE, (LoadTableResponse) resp.getEntity())));
+        PolarisEventType.AFTER_REGISTER_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_REGISTER_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, registerTableRequest.name())
+                    .put(
+                        EventAttributes.LOAD_TABLE_RESPONSE,
+                        (LoadTableResponse) resp.getEntity())));
     return resp;
   }
 
@@ -459,20 +515,24 @@ public class IcebergRestCatalogEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_RENAME_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
+        PolarisEventType.BEFORE_RENAME_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_RENAME_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     Response resp = delegate.renameTable(prefix, renameTableRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_RENAME_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
+        PolarisEventType.AFTER_RENAME_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_RENAME_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     return resp;
   }
 
@@ -487,27 +547,33 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.UPDATE_TABLE_REQUEST, commitTableRequest)));
+        PolarisEventType.BEFORE_UPDATE_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.UPDATE_TABLE_REQUEST, commitTableRequest)));
     Response resp =
         delegate.updateTable(
             prefix, namespace, table, commitTableRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_TABLE,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.UPDATE_TABLE_REQUEST, commitTableRequest)
-                .put(EventAttributes.LOAD_TABLE_RESPONSE, (LoadTableResponse) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_TABLE,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_TABLE,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.UPDATE_TABLE_REQUEST, commitTableRequest)
+                    .put(
+                        EventAttributes.LOAD_TABLE_RESPONSE,
+                        (LoadTableResponse) resp.getEntity())));
     return resp;
   }
 
@@ -521,24 +587,28 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.CREATE_VIEW_REQUEST, createViewRequest)));
+        PolarisEventType.BEFORE_CREATE_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.CREATE_VIEW_REQUEST, createViewRequest)));
     Response resp =
         delegate.createView(prefix, namespace, createViewRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, createViewRequest.name())
-                .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
+        PolarisEventType.AFTER_CREATE_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, createViewRequest.name())
+                    .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
     return resp;
   }
 
@@ -553,21 +623,25 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_VIEWS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.BEFORE_LIST_VIEWS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_VIEWS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     Response resp =
         delegate.listViews(prefix, namespace, pageToken, pageSize, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_VIEWS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)));
+        PolarisEventType.AFTER_LIST_VIEWS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_VIEWS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)));
     return resp;
   }
 
@@ -581,23 +655,27 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)));
+        PolarisEventType.BEFORE_LOAD_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)));
     Response resp =
         delegate.loadCredentials(prefix, namespace, table, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_CREDENTIALS,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)));
+        PolarisEventType.AFTER_LOAD_CREDENTIALS,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_CREDENTIALS,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)));
     return resp;
   }
 
@@ -611,23 +689,27 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)));
+        PolarisEventType.BEFORE_LOAD_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)));
     Response resp = delegate.loadView(prefix, namespace, view, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)
-                .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
+        PolarisEventType.AFTER_LOAD_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)
+                    .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
     return resp;
   }
 
@@ -641,22 +723,26 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CHECK_EXISTS_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)));
+        PolarisEventType.BEFORE_CHECK_EXISTS_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CHECK_EXISTS_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)));
     Response resp = delegate.viewExists(prefix, namespace, view, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CHECK_EXISTS_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)));
+        PolarisEventType.AFTER_CHECK_EXISTS_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CHECK_EXISTS_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)));
     return resp;
   }
 
@@ -670,22 +756,26 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DROP_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)));
+        PolarisEventType.BEFORE_DROP_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DROP_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)));
     Response resp = delegate.dropView(prefix, namespace, view, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DROP_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)));
+        PolarisEventType.AFTER_DROP_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DROP_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)));
     return resp;
   }
 
@@ -697,20 +787,24 @@ public class IcebergRestCatalogEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_RENAME_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
+        PolarisEventType.BEFORE_RENAME_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_RENAME_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     Response resp = delegate.renameView(prefix, renameTableRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_RENAME_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
+        PolarisEventType.AFTER_RENAME_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_RENAME_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     return resp;
   }
 
@@ -725,27 +819,31 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_REPLACE_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)
-                .put(EventAttributes.COMMIT_VIEW_REQUEST, commitViewRequest)));
+        PolarisEventType.BEFORE_REPLACE_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_REPLACE_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)
+                    .put(EventAttributes.COMMIT_VIEW_REQUEST, commitViewRequest)));
     Response resp =
         delegate.replaceView(
             prefix, namespace, view, commitViewRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_REPLACE_VIEW,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.VIEW_NAME, view)
-                .put(EventAttributes.COMMIT_VIEW_REQUEST, commitViewRequest)
-                .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
+        PolarisEventType.AFTER_REPLACE_VIEW,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_REPLACE_VIEW,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.VIEW_NAME, view)
+                    .put(EventAttributes.COMMIT_VIEW_REQUEST, commitViewRequest)
+                    .put(EventAttributes.LOAD_VIEW_RESPONSE, (LoadViewResponse) resp.getEntity())));
     return resp;
   }
 
@@ -757,42 +855,50 @@ public class IcebergRestCatalogEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_COMMIT_TRANSACTION,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.COMMIT_TRANSACTION_REQUEST, commitTransactionRequest)));
+        PolarisEventType.BEFORE_COMMIT_TRANSACTION,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_COMMIT_TRANSACTION,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.COMMIT_TRANSACTION_REQUEST, commitTransactionRequest)));
     for (UpdateTableRequest req : commitTransactionRequest.tableChanges()) {
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.BEFORE_UPDATE_TABLE,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, catalogName)
-                  .put(EventAttributes.NAMESPACE, req.identifier().namespace())
-                  .put(EventAttributes.TABLE_NAME, req.identifier().name())
-                  .put(EventAttributes.UPDATE_TABLE_REQUEST, req)));
+          PolarisEventType.BEFORE_UPDATE_TABLE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.BEFORE_UPDATE_TABLE,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, catalogName)
+                      .put(EventAttributes.NAMESPACE, req.identifier().namespace())
+                      .put(EventAttributes.TABLE_NAME, req.identifier().name())
+                      .put(EventAttributes.UPDATE_TABLE_REQUEST, req)));
     }
     Response resp =
         delegate.commitTransaction(prefix, commitTransactionRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_COMMIT_TRANSACTION,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.COMMIT_TRANSACTION_REQUEST, commitTransactionRequest)));
+        PolarisEventType.AFTER_COMMIT_TRANSACTION,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_COMMIT_TRANSACTION,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.COMMIT_TRANSACTION_REQUEST, commitTransactionRequest)));
     for (UpdateTableRequest req : commitTransactionRequest.tableChanges()) {
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_UPDATE_TABLE,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, catalogName)
-                  .put(EventAttributes.NAMESPACE, req.identifier().namespace())
-                  .put(EventAttributes.TABLE_NAME, req.identifier().name())
-                  .put(EventAttributes.UPDATE_TABLE_REQUEST, req)));
+          PolarisEventType.AFTER_UPDATE_TABLE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_UPDATE_TABLE,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, catalogName)
+                      .put(EventAttributes.NAMESPACE, req.identifier().namespace())
+                      .put(EventAttributes.TABLE_NAME, req.identifier().name())
+                      .put(EventAttributes.UPDATE_TABLE_REQUEST, req)));
     }
     return resp;
   }
@@ -820,25 +926,29 @@ public class IcebergRestCatalogEventServiceDelegator
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_SEND_NOTIFICATION,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)
-                .put(EventAttributes.NOTIFICATION_REQUEST, notificationRequest)));
+        PolarisEventType.BEFORE_SEND_NOTIFICATION,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_SEND_NOTIFICATION,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)
+                    .put(EventAttributes.NOTIFICATION_REQUEST, notificationRequest)));
     Response resp =
         delegate.sendNotification(
             prefix, namespace, table, notificationRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_SEND_NOTIFICATION,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, namespaceObj)
-                .put(EventAttributes.TABLE_NAME, table)));
+        PolarisEventType.AFTER_SEND_NOTIFICATION,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_SEND_NOTIFICATION,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE, namespaceObj)
+                    .put(EventAttributes.TABLE_NAME, table)));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestConfigurationEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestConfigurationEventServiceDelegator.java
@@ -61,17 +61,21 @@ public class IcebergRestConfigurationEventServiceDelegator
   public Response getConfig(
       String warehouse, RealmContext realmContext, SecurityContext securityContext) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_CONFIG,
-            eventMetadataFactory.create(),
-            new AttributeMap().put(EventAttributes.WAREHOUSE, warehouse)));
+        PolarisEventType.BEFORE_GET_CONFIG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_CONFIG,
+                eventMetadataFactory.create(),
+                new AttributeMap().put(EventAttributes.WAREHOUSE, warehouse)));
     Response resp = delegate.getConfig(warehouse, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_CONFIG,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CONFIG_RESPONSE, (ConfigResponse) resp.getEntity())));
+        PolarisEventType.AFTER_GET_CONFIG,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_CONFIG,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CONFIG_RESPONSE, (ConfigResponse) resp.getEntity())));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/CatalogPolicyEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/CatalogPolicyEventServiceDelegator.java
@@ -61,24 +61,30 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_CREATE_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.CREATE_POLICY_REQUEST, createPolicyRequest)));
+        PolarisEventType.BEFORE_CREATE_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_CREATE_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.CREATE_POLICY_REQUEST, createPolicyRequest)));
     Response resp =
         delegate.createPolicy(
             prefix, namespace, createPolicyRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_CREATE_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.LOAD_POLICY_RESPONSE, (LoadPolicyResponse) resp.getEntity())));
+        PolarisEventType.AFTER_CREATE_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_CREATE_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(
+                        EventAttributes.LOAD_POLICY_RESPONSE,
+                        (LoadPolicyResponse) resp.getEntity())));
     return resp;
   }
 
@@ -93,24 +99,28 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LIST_POLICIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_TYPE, policyType)));
+        PolarisEventType.BEFORE_LIST_POLICIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LIST_POLICIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_TYPE, policyType)));
     Response resp =
         delegate.listPolicies(
             prefix, namespace, pageToken, pageSize, policyType, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LIST_POLICIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_TYPE, policyType)));
+        PolarisEventType.AFTER_LIST_POLICIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LIST_POLICIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_TYPE, policyType)));
     return resp;
   }
 
@@ -123,23 +133,29 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_LOAD_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)));
+        PolarisEventType.BEFORE_LOAD_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_LOAD_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)));
     Response resp =
         delegate.loadPolicy(prefix, namespace, policyName, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_LOAD_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.LOAD_POLICY_RESPONSE, (LoadPolicyResponse) resp.getEntity())));
+        PolarisEventType.AFTER_LOAD_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_LOAD_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(
+                        EventAttributes.LOAD_POLICY_RESPONSE,
+                        (LoadPolicyResponse) resp.getEntity())));
     return resp;
   }
 
@@ -153,25 +169,31 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_UPDATE_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.UPDATE_POLICY_REQUEST, updatePolicyRequest)));
+        PolarisEventType.BEFORE_UPDATE_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_UPDATE_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.UPDATE_POLICY_REQUEST, updatePolicyRequest)));
     Response resp =
         delegate.updatePolicy(
             prefix, namespace, policyName, updatePolicyRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_UPDATE_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.LOAD_POLICY_RESPONSE, (LoadPolicyResponse) resp.getEntity())));
+        PolarisEventType.AFTER_UPDATE_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_UPDATE_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(
+                        EventAttributes.LOAD_POLICY_RESPONSE,
+                        (LoadPolicyResponse) resp.getEntity())));
     return resp;
   }
 
@@ -185,26 +207,30 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DROP_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.DETACH_ALL, detachAll)));
+        PolarisEventType.BEFORE_DROP_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DROP_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.DETACH_ALL, detachAll)));
     Response resp =
         delegate.dropPolicy(
             prefix, namespace, policyName, detachAll, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DROP_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.DETACH_ALL, detachAll)));
+        PolarisEventType.AFTER_DROP_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DROP_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.DETACH_ALL, detachAll)));
     return resp;
   }
 
@@ -218,26 +244,30 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ATTACH_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.ATTACH_POLICY_REQUEST, attachPolicyRequest)));
+        PolarisEventType.BEFORE_ATTACH_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ATTACH_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.ATTACH_POLICY_REQUEST, attachPolicyRequest)));
     Response resp =
         delegate.attachPolicy(
             prefix, namespace, policyName, attachPolicyRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_ATTACH_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.ATTACH_POLICY_REQUEST, attachPolicyRequest)));
+        PolarisEventType.AFTER_ATTACH_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_ATTACH_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.ATTACH_POLICY_REQUEST, attachPolicyRequest)));
     return resp;
   }
 
@@ -251,26 +281,30 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_DETACH_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.DETACH_POLICY_REQUEST, detachPolicyRequest)));
+        PolarisEventType.BEFORE_DETACH_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_DETACH_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.DETACH_POLICY_REQUEST, detachPolicyRequest)));
     Response resp =
         delegate.detachPolicy(
             prefix, namespace, policyName, detachPolicyRequest, realmContext, securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_DETACH_POLICY,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.POLICY_NAME, policyName)
-                .put(EventAttributes.DETACH_POLICY_REQUEST, detachPolicyRequest)));
+        PolarisEventType.AFTER_DETACH_POLICY,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_DETACH_POLICY,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.POLICY_NAME, policyName)
+                    .put(EventAttributes.DETACH_POLICY_REQUEST, detachPolicyRequest)));
     return resp;
   }
 
@@ -286,14 +320,16 @@ public class CatalogPolicyEventServiceDelegator
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_GET_APPLICABLE_POLICIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.TARGET_NAME, targetName)
-                .put(EventAttributes.POLICY_TYPE, policyType)));
+        PolarisEventType.BEFORE_GET_APPLICABLE_POLICIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_GET_APPLICABLE_POLICIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.TARGET_NAME, targetName)
+                    .put(EventAttributes.POLICY_TYPE, policyType)));
     Response resp =
         delegate.getApplicablePolicies(
             prefix,
@@ -305,17 +341,19 @@ public class CatalogPolicyEventServiceDelegator
             realmContext,
             securityContext);
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.AFTER_GET_APPLICABLE_POLICIES,
-            eventMetadataFactory.create(),
-            new AttributeMap()
-                .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE_NAME, namespace)
-                .put(EventAttributes.TARGET_NAME, targetName)
-                .put(EventAttributes.POLICY_TYPE, policyType)
-                .put(
-                    EventAttributes.GET_APPLICABLE_POLICIES_RESPONSE,
-                    (GetApplicablePoliciesResponse) resp.getEntity())));
+        PolarisEventType.AFTER_GET_APPLICABLE_POLICIES,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.AFTER_GET_APPLICABLE_POLICIES,
+                eventMetadataFactory.create(),
+                new AttributeMap()
+                    .put(EventAttributes.CATALOG_NAME, catalogName)
+                    .put(EventAttributes.NAMESPACE_NAME, namespace)
+                    .put(EventAttributes.TARGET_NAME, targetName)
+                    .put(EventAttributes.POLICY_TYPE, policyType)
+                    .put(
+                        EventAttributes.GET_APPLICABLE_POLICIES_RESPONSE,
+                        (GetApplicablePoliciesResponse) resp.getEntity())));
     return resp;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListener.java
@@ -145,10 +145,11 @@ public class AwsCloudWatchEventListener implements PolarisEventListener {
   }
 
   @Override
-  public void onEvent(PolarisEvent event) {
-    if (event.type() != PolarisEventType.AFTER_REFRESH_TABLE) {
+  public void onEvent(PolarisEventType type, Supplier<PolarisEvent> eventSupplier) {
+    if (type != PolarisEventType.AFTER_REFRESH_TABLE) {
       return;
     }
+    PolarisEvent event = eventSupplier.get();
     HashMap<String, Object> properties = new HashMap<>();
     properties.put("event_type", event.type().name());
     event

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisEventListener.java
@@ -18,14 +18,16 @@
  */
 package org.apache.polaris.service.events.listeners;
 
+import java.util.function.Supplier;
 import org.apache.polaris.service.events.PolarisEvent;
+import org.apache.polaris.service.events.PolarisEventType;
 
 /**
- * Event listener that responds to notable moments during Polaris's execution. Implementations can
- * filter events by checking {@link PolarisEvent#type()} or by querying attributes with {@link
- * PolarisEvent#hasAttribute} and {@link PolarisEvent#attribute}.
+ * Event listener that responds to notable moments during Polaris's execution. Implementations
+ * should check the event type and only call {@code eventSupplier.get()} for types they handle,
+ * avoiding unnecessary object allocation.
  */
 public interface PolarisEventListener {
 
-  default void onEvent(PolarisEvent event) {}
+  default void onEvent(PolarisEventType type, Supplier<PolarisEvent> eventSupplier) {}
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.events.listeners;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.Namespace;
@@ -30,17 +31,16 @@ import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.service.events.EventAttributes;
 import org.apache.polaris.service.events.PolarisEvent;
+import org.apache.polaris.service.events.PolarisEventType;
 
 public abstract class PolarisPersistenceEventListener implements PolarisEventListener {
 
   @Override
-  public void onEvent(PolarisEvent event) {
-    switch (event.type()) {
-      case AFTER_CREATE_TABLE -> handleAfterCreateTable(event);
-      case AFTER_CREATE_CATALOG -> handleAfterCreateCatalog(event);
-      default -> {
-        // Other events not handled by this listener
-      }
+  public void onEvent(PolarisEventType type, Supplier<PolarisEvent> eventSupplier) {
+    switch (type) {
+      case AFTER_CREATE_TABLE -> handleAfterCreateTable(eventSupplier.get());
+      case AFTER_CREATE_CATALOG -> handleAfterCreateCatalog(eventSupplier.get());
+      default -> {}
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
@@ -64,13 +64,16 @@ public class RateLimiterFilter implements ContainerRequestFilter {
   public void filter(ContainerRequestContext ctx) throws IOException {
     if (!rateLimiter.canProceed()) {
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.BEFORE_LIMIT_REQUEST_RATE,
-              eventMetadataFactory.create(),
-              new AttributeMap()
-                  .put(EventAttributes.HTTP_METHOD, ctx.getMethod())
-                  .put(
-                      EventAttributes.REQUEST_URI, ctx.getUriInfo().getAbsolutePath().toString())));
+          PolarisEventType.BEFORE_LIMIT_REQUEST_RATE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.BEFORE_LIMIT_REQUEST_RATE,
+                  eventMetadataFactory.create(),
+                  new AttributeMap()
+                      .put(EventAttributes.HTTP_METHOD, ctx.getMethod())
+                      .put(
+                          EventAttributes.REQUEST_URI,
+                          ctx.getUriInfo().getAbsolutePath().toString())));
       ctx.abortWith(Response.status(Response.Status.TOO_MANY_REQUESTS).build());
       LOGGER.atDebug().log("Rate limiting request");
     }

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -199,12 +199,14 @@ public class TaskExecutorImpl implements TaskExecutor {
   protected void handleTask(
       long taskEntityId, CallContext ctx, PolarisEventMetadata eventMetadata, int attempt) {
     polarisEventListener.onEvent(
-        new PolarisEvent(
-            PolarisEventType.BEFORE_ATTEMPT_TASK,
-            eventMetadataFactory.copy(eventMetadata),
-            new AttributeMap()
-                .put(EventAttributes.TASK_ENTITY_ID, taskEntityId)
-                .put(EventAttributes.TASK_ATTEMPT, attempt)));
+        PolarisEventType.BEFORE_ATTEMPT_TASK,
+        () ->
+            new PolarisEvent(
+                PolarisEventType.BEFORE_ATTEMPT_TASK,
+                eventMetadataFactory.copy(eventMetadata),
+                new AttributeMap()
+                    .put(EventAttributes.TASK_ENTITY_ID, taskEntityId)
+                    .put(EventAttributes.TASK_ATTEMPT, attempt)));
 
     boolean success = false;
     try {
@@ -247,14 +249,17 @@ public class TaskExecutorImpl implements TaskExecutor {
             .log("Unable to execute async task");
       }
     } finally {
+      boolean finalSuccess = success;
       polarisEventListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_ATTEMPT_TASK,
-              eventMetadataFactory.copy(eventMetadata),
-              new AttributeMap()
-                  .put(EventAttributes.TASK_ENTITY_ID, taskEntityId)
-                  .put(EventAttributes.TASK_ATTEMPT, attempt)
-                  .put(EventAttributes.TASK_SUCCESS, success)));
+          PolarisEventType.AFTER_ATTEMPT_TASK,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_ATTEMPT_TASK,
+                  eventMetadataFactory.copy(eventMetadata),
+                  new AttributeMap()
+                      .put(EventAttributes.TASK_ENTITY_ID, taskEntityId)
+                      .put(EventAttributes.TASK_ATTEMPT, attempt)
+                      .put(EventAttributes.TASK_SUCCESS, finalSuccess)));
     }
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListenerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListenerTest.java
@@ -191,12 +191,14 @@ class AwsCloudWatchEventListenerTest {
       // Create and send a test event
       TableIdentifier testTable = TableIdentifier.of("test_namespace", "test_table");
       listener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_REFRESH_TABLE,
-              PolarisEventMetadata.builder().realmId(REALM).user(PRINCIPAL).build(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, "test_catalog")
-                  .put(EventAttributes.TABLE_IDENTIFIER, testTable)));
+          PolarisEventType.AFTER_REFRESH_TABLE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_REFRESH_TABLE,
+                  PolarisEventMetadata.builder().realmId(REALM).user(PRINCIPAL).build(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, "test_catalog")
+                      .put(EventAttributes.TABLE_IDENTIFIER, testTable)));
 
       Awaitility.await("expected amount of records should be sent to CloudWatch")
           .atMost(Duration.ofSeconds(30))
@@ -253,12 +255,14 @@ class AwsCloudWatchEventListenerTest {
       // Create and send a test event synchronously
       TableIdentifier syncTestTable = TableIdentifier.of("test_namespace", "test_table_sync");
       syncListener.onEvent(
-          new PolarisEvent(
-              PolarisEventType.AFTER_REFRESH_TABLE,
-              PolarisEventMetadata.builder().realmId(REALM).user(PRINCIPAL).build(),
-              new AttributeMap()
-                  .put(EventAttributes.CATALOG_NAME, "test_catalog")
-                  .put(EventAttributes.TABLE_IDENTIFIER, syncTestTable)));
+          PolarisEventType.AFTER_REFRESH_TABLE,
+          () ->
+              new PolarisEvent(
+                  PolarisEventType.AFTER_REFRESH_TABLE,
+                  PolarisEventMetadata.builder().realmId(REALM).user(PRINCIPAL).build(),
+                  new AttributeMap()
+                      .put(EventAttributes.CATALOG_NAME, "test_catalog")
+                      .put(EventAttributes.TABLE_IDENTIFIER, syncTestTable)));
 
       Awaitility.await("expected amount of records should be sent to CloudWatch")
           .atMost(Duration.ofSeconds(30))

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/events/listeners/TestPolarisEventListener.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/events/listeners/TestPolarisEventListener.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.events.listeners;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import org.apache.polaris.service.events.PolarisEvent;
 import org.apache.polaris.service.events.PolarisEventType;
 
@@ -28,7 +29,8 @@ public class TestPolarisEventListener implements PolarisEventListener {
   private final Map<PolarisEventType, PolarisEvent> latestEvents = new ConcurrentHashMap<>();
 
   @Override
-  public void onEvent(PolarisEvent event) {
+  public void onEvent(PolarisEventType eventType, Supplier<PolarisEvent> eventSupplier) {
+    PolarisEvent event = eventSupplier.get();
     latestEvents.put(event.type(), event);
   }
 


### PR DESCRIPTION
This PR implements @adutra's idea from his comment in #3293: https://github.com/apache/polaris/pull/3293#issuecomment-3737852429.
I used a bit different approach with Supplier instead of conditional calls to OnEvent(). Polling the listener before emitting the event does not align well with future plans to support multiple active event listeners. 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
