### PR TITLE
Update OPA docker image version

### DIFF
--- a/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestResource.java
+++ b/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestResource.java
@@ -69,12 +69,12 @@ public class OpaTestResource implements QuarkusTestResourceLifecycleManager {
         default allow := false
 
         # Allow root user for all operations
-        allow {
+        allow if {
           input.actor.principal == "root"
         }
 
         # Allow admin user for all operations
-        allow {
+        allow if {
           input.actor.principal == "admin"
         }
         """;

--- a/extensions/auth/opa/tests/src/intTest/resources/org/apache/polaris/extension/auth/opa/test/Dockerfile-opa-version
+++ b/extensions/auth/opa/tests/src/intTest/resources/org/apache/polaris/extension/auth/opa/test/Dockerfile-opa-version
@@ -16,4 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM docker.io/openpolicyagent/opa:0.63.0
+FROM docker.io/openpolicyagent/opa:1.12.3


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

As reported in https://github.com/apache/polaris/issues/3447, we are using very outdated version of OPA image. This PR bump the version to the latest one and updated the rego policy to reflect v1.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
