### PR TITLE
Update renovate to include docker file with suffix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,7 @@
   docker: {
     fileMatch: [
       "(^|/)Dockerfile$",
+      "(^|/)Dockerfile\\.[^/]*$",
       "(^|/)Dockerfile-[^/]*$"
     ]
   },


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

We have couple docker files which are using suffix and these are not getting tracked by renovate bot:
```
➜  polaris git:(renovate_docker) find . -name "Dockerfile*"
./tools/minio-testcontainer/build/resources/main/org/apache/polaris/test/minio/Dockerfile-minio-version
./tools/minio-testcontainer/src/main/resources/org/apache/polaris/test/minio/Dockerfile-minio-version
./plugins/spark/v3.5/regtests/Dockerfile
./plugins/spark/v3.5/getting-started/notebooks/Dockerfile
./runtime/admin/build/resources/testFixtures/org/apache/polaris/admintool/Dockerfile-postgres-version
./runtime/admin/src/testFixtures/resources/org/apache/polaris/admintool/Dockerfile-postgres-version
./runtime/admin/src/main/docker/Dockerfile.jvm
./runtime/server/src/main/docker/Dockerfile.jvm
./runtime/test-common/build/resources/main/org/apache/polaris/test/commons/s3mock/Dockerfile-s3mock-version
./runtime/test-common/build/resources/main/org/apache/polaris/test/commons/Dockerfile-postgres-version
./runtime/test-common/build/resources/main/org/apache/polaris/test/commons/keycloak/Dockerfile-keycloak-version
./runtime/test-common/src/main/resources/org/apache/polaris/test/commons/s3mock/Dockerfile-s3mock-version
./runtime/test-common/src/main/resources/org/apache/polaris/test/commons/Dockerfile-postgres-version
./runtime/test-common/src/main/resources/org/apache/polaris/test/commons/keycloak/Dockerfile-keycloak-version
./runtime/service/build/resources/test/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/Dockerfile-localstack-version
./runtime/service/src/test/resources/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/Dockerfile-localstack-version
./regtests/Dockerfile
./extensions/auth/opa/tests/build/resources/intTest/org/apache/polaris/extension/auth/opa/test/Dockerfile-opa-version
./extensions/auth/opa/tests/src/intTest/resources/org/apache/polaris/extension/auth/opa/test/Dockerfile-opa-version
./getting-started/spark/notebooks/Dockerfile
./persistence/nosql/persistence/db/mongodb/build/resources/testFixtures/org/apache/polaris/persistence/nosql/mongodb/Dockerfile-mongodb-version
./persistence/nosql/persistence/db/mongodb/src/testFixtures/resources/org/apache/polaris/persistence/nosql/mongodb/Dockerfile-mongodb-version
./site/docker/Dockerfile
./site/build/hugo-cache/modules/filecache/modules/pkg/mod/github.com/google/docsy@v0.10.0/Dockerfile
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
