### PR TITLE
ensure sts is cached regardless of the refresh endpoint

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheKey.java
@@ -51,9 +51,6 @@ public interface StorageCredentialCacheKey {
   Set<String> allowedWriteLocations();
 
   @Value.Parameter(order = 7)
-  Optional<String> refreshCredentialsEndpoint();
-
-  @Value.Parameter(order = 8)
   Optional<String> principalName();
 
   /**
@@ -61,7 +58,7 @@ public interface StorageCredentialCacheKey {
    * the catalog, namespace, table, and roles information. When session tags are disabled, this
    * should be {@link CredentialVendingContext#empty()} to ensure consistent cache key behavior.
    */
-  @Value.Parameter(order = 9)
+  @Value.Parameter(order = 8)
   CredentialVendingContext credentialVendingContext();
 
   static StorageCredentialCacheKey of(
@@ -84,7 +81,6 @@ public interface StorageCredentialCacheKey {
         allowedListAction,
         allowedReadLocations,
         allowedWriteLocations,
-        refreshCredentialsEndpoint,
         polarisPrincipal.map(PolarisPrincipal::getName),
         credentialVendingContext);
   }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

### Summary 
This change addresses issue #3292 
One load table API request was resulting in two STS AssumeRole requests because refreshCredentialsEndpoint was part of the cache key in  StorageCredentialCacheKey.java. During a loadTable operation, credentials were fetched twice:                                                                                  
  1. First call with refreshCredentialsEndpoint=Optional.empty() (server-side metadata read)                                                                 
  2. Second call with refreshCredentialsEndpoint=Optional.of(url) (building client response) 
Since refreshCredentialsEndpoint was part of the cache key, these two calls resulted in cache misses, causing duplicate STS calls. 

So the fix is to remove refreshCredentialsEndpoint as cache key. I did not find any evidence that we wanted an STS per refresh endpoint. 
### Test
Added unit test to show previous behavior, the test passed after the change was updated. 
- I setup an aws backend to see that the sts request was not called twice.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
