### PR TITLE
Fix Helm repository update after release vote

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -231,7 +231,6 @@ jobs:
 
           exec_process cd "${release_helm_dir}"
           exec_process helm repo index .
-          exec_process svn add index.yaml
           exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Update Helm index for ${version_without_rc} release"
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The Github workflow included a `svn add index.yaml` command which would be correct if it was a Git repository.  But in SVN, this results in an error when the file is already under version control.  This line is unnecessary and a simple `svn commit` results in pushing the changes to the SVN server.
