### PR TITLE
Update website for 1.3.0

### DIFF
--- a/site/content/downloads/_index.md
+++ b/site/content/downloads/_index.md
@@ -30,6 +30,42 @@ params:
 ## Helm Chart
 Repo: https://downloads.apache.org/incubator/polaris/helm-chart
 
+## 1.3.0
+| Artifact                                                                                                                                                                             | PGP Sig                                                                                                                                                  | SHA-512                                                                                                                                                        |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [source tar.gz](https://dlcdn.apache.org/incubator/polaris/1.3.0-incubating/apache-polaris-1.3.0-incubating.tar.gz)                                                                  | [.asc](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/apache-polaris-1.3.0-incubating.tar.gz.asc)                                       | [.sha512](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/apache-polaris-1.3.0-incubating.tar.gz.sha512)                                       |
+| [binary tgz](https://dlcdn.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz)                                                                           | [.asc](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz.asc)                                             | [.sha512](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz.sha512)                                             |
+| [binary zip](https://dlcdn.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.zip)                                                                           | [.asc](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.zip.asc)                                             | [.sha512](https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.zip.sha512)                                             |
+| [Spark 3.5 with Scala 2.12 Client Jar](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.12/1.3.0-incubating/polaris-spark-3.5_2.12-1.3.0-incubating-bundle.jar) | [.asc](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.12/1.3.0-incubating/polaris-spark-3.5_2.12-1.3.0-incubating-bundle.jar.asc) | [.sha512](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.12/1.3.0-incubating/polaris-spark-3.5_2.12-1.3.0-incubating-bundle.jar.sha512) |
+| [Spark 3.5 with Scala 2.13 Client Jar](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.13/1.3.0-incubating/polaris-spark-3.5_2.13-1.3.0-incubating-bundle.jar) | [.asc](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.13/1.3.0-incubating/polaris-spark-3.5_2.13-1.3.0-incubating-bundle.jar.asc) | [.sha512](https://repo1.maven.org/maven2/org/apache/polaris/polaris-spark-3.5_2.13/1.3.0-incubating/polaris-spark-3.5_2.13-1.3.0-incubating-bundle.jar.sha512) |
+
+Apache Polaris 1.3.0-incubating was released on January 16th, 2026.
+- **Highlights**
+  - Support for [Iceberg Metrics Reporting] has been introduced in Polaris. Out of the box, metrics can be printed to the logs by setting the `org.apache.polaris.service.reporting` logger level to `INFO` (it's set to `OFF` by default). Custom reporters can be implemented and configured to send metrics to external systems for further analysis and monitoring.
+  - Support for [Open Policy Agent (OPA)] integration has been added to Polaris. This enables delegating authorization decisions to external policy decision points, allowing organizations to centralize policy management and implement complex authorization rules. OPA integration can be enabled by setting `polaris.authorization.type=opa` in the Polaris configuration.
+
+- **Upgrade Notes**
+  - The legacy management endpoints at `/metrics` and `/healthcheck` have been removed. Please use the standard management endpoints at `/q/metrics` and `/q/health` instead.
+
+- **Breaking changes**
+  - The EclipseLink Persistence implementation has been completely removed.
+  - The default request ID header name has changed from `Polaris-Request-Id` to `X-Request-ID`.
+
+- **New Features**
+  - Added `--no-sts` flag to CLI to support S3-compatible storage systems that do not have Security Token Service available.
+  - Support credential vending for federated catalogs. `ALLOW_FEDERATED_CATALOGS_CREDENTIAL_VENDING` (default: true) was added to toggle this feature.
+  - Enhanced catalog federation with SigV4 authentication support, additional authentication types for credential vending, and location-based access restrictions to block credential vending for remote tables outside allowed location lists.
+
+- **Changes**
+  - `client.region` is no longer considered a "credential" property (related to Iceberg REST Catalog API).
+  - Relaxed the requirements for S3 storage's ARN to allow Polaris to connect to more non-AWS S3 storage appliances.
+  - Added checksum to helm deployment so that it will restart when the configmap has changed.
+  - Generic Table is no longer in beta and is generally-available.
+  - Added Windows support for Python client
+
+[Iceberg Metrics Reporting]: https://iceberg.apache.org/docs/latest/metrics-reporting/
+[Open Policy Agent (OPA)]: https://www.openpolicyagent.org/
+
 ## 1.2.0
 | Artifact                                                                                                                                                                             | PGP Sig                                                                                                                                                  | SHA-512                                                                                                                                                        |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -64,6 +64,7 @@ params:
   # at the very right in the navbar.
   active_releases:
     # Mention all active releases here, in semver descending order
+    - "1.3.0"
     - "1.2.0"
     - "1.1.0"
     - "1.0.1"
@@ -104,6 +105,10 @@ menu:
       url: "/in-dev/unreleased/"
       parent: "doc"
       weight: 1
+    - name: "1.3.0"
+      url: "/releases/1.3.0/"
+      parent: "doc"
+      weight: 995
     - name: "1.2.0"
       url: "/releases/1.2.0/"
       parent: "doc"


### PR DESCRIPTION
Note for reviewers: when I opened this PR, the Maven repository update had not been fully propagated to all CDNs so the Spark links were 404