### PR TITLE
[doc] Update CLI docs to use $HOME instead of quoted tilde

### DIFF
--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -97,7 +97,7 @@ Read [here]({{% ref "./configuration.md" %}}) more about configuring polaris ser
 These examples assume the Polaris CLI is on the PATH and so can be invoked just by the command `polaris`. You can add the CLI to your PATH environment variable with a command like the following:
 
 ```
-export PATH="~/polaris:$PATH"
+export PATH="$HOME/polaris:$PATH"
 ```
 
 Alternatively, you can run the CLI by providing a path to it, such as with the following invocation:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The [CLI docs](https://github.com/apache/polaris/blob/main/site/content/in-dev/unreleased/command-line-interface.md#path) currently recommend adding Polaris to PATH using `export PATH="~/polaris:$PATH"`.

In zsh (default in mac), ~ is not reliably expanded when quoted, which can leave a literal `~/polaris` entry in PATH. This causes polaris to not be found even after following the docs.
- Many mac users like myself will follow these instructions as-is, so using `$HOME` avoids a common footgun.
```
❯ docker run --rm -it zshusers/zsh:latest
4ea452cea1fc# mkdir -p ~/polaris
4ea452cea1fc# print 'echo POLARIS\n' > ~/polaris/polaris
4ea452cea1fc# chmod +x ~/polaris/polaris

4ea452cea1fc# export PATH="~/polaris:$PATH"
4ea452cea1fc# command -v polaris || echo "not found"

not found

4ea452cea1fc# export PATH="$HOME/polaris:$PATH"
4ea452cea1fc# command -v polaris

/root/polaris/polaris
```

Although the docs use bash-style examples, `$HOME` works reliably across both bash and zsh, especially in quoted PATH exports.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
