### PR TITLE
Add cleanup step of SVN dist release repo

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -207,6 +207,59 @@ jobs:
           Artifacts and Helm chart moved from dist dev to dist release
           EOT
 
+      - name: Clean up old releases from dist release repository
+        env:
+          SVN_USERNAME: ${{ secrets.POLARIS_SVN_DEV_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.POLARIS_SVN_DEV_PASSWORD }}
+        run: |
+          echo "::add-mask::$SVN_PASSWORD"
+
+          source "${LIBS_DIR}/_constants.sh"
+          source "${LIBS_DIR}/_exec.sh"
+
+          release_artifacts_url="${APACHE_DIST_URL}/release/incubator/polaris"
+          release_helm_url="${APACHE_DIST_URL}/release/incubator/polaris/helm-chart"
+
+          # List and remove old release artifact versions
+          old_versions=$(svn list --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_artifacts_url}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+-incubating/$' | sed 's|/$||' | grep -v "^${version_without_rc}$" || true)
+
+          if [[ -n "${old_versions}" ]]; then
+            echo "## Old Releases Cleanup" >> $GITHUB_STEP_SUMMARY
+            echo "Removing old release versions:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${old_versions}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+
+            for old_version in ${old_versions}; do
+              exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+                "${release_artifacts_url}/${old_version}" \
+                -m "Remove old release ${old_version} (superseded by ${version_without_rc})"
+            done
+          else
+            echo "## Old Releases Cleanup" >> $GITHUB_STEP_SUMMARY
+            echo "No old release versions found to remove" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # List and remove old Helm chart versions
+          old_helm_versions=$(svn list --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_helm_url}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+-incubating/$' | sed 's|/$||' | grep -v "^${version_without_rc}$" || true)
+
+          if [[ -n "${old_helm_versions}" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Removing old Helm chart versions:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${old_helm_versions}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+
+            for old_helm_version in ${old_helm_versions}; do
+              exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+                "${release_helm_url}/${old_helm_version}" \
+                -m "Remove old Helm chart ${old_helm_version} (superseded by ${version_without_rc})"
+            done
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No old Helm chart versions found to remove" >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Transfer Helm index from dev to release
         env:
           SVN_USERNAME: ${{ secrets.POLARIS_SVN_DEV_USERNAME }}
@@ -376,6 +429,7 @@ jobs:
           | --- | --- |
           | Distribution artifacts | ✅ Moved to release space |
           | Helm chart and index | ✅ Updated in release space |
+          | Old releases cleanup | ✅ Removed from dist release |
           | Git release tag | ✅ Created and pushed |
           | GitHub release | ✅ Created with artifacts attached |
           | Docker images | ✅ Published to Docker Hub |


### PR DESCRIPTION
Follow-up of #3474.

This PR adds some cleanup step in the fourth release automation workflow (publish artifacts after a vote succeeds).  The cleanup step delete previously released artifacts (binaries and helm charts) **after** the artifacts from the current release have been published.  This cleanup happens before the `helm repo index .` step so that deleted helm charts are not indexed anymore.

I tested this by removing previous released versions (before 1.3.0-incubating) from the Apache dist release SVN repository.  I did this operation manually from my machine, but reused the bash commands that would have been executed by the workflow.  See below for the console output.

**Question for reviewers**.
This logic removes all previous versions, given that we do not currently cut minor releases for any major version.  This fact is strictly required for any sort of automated cleanup.  Otherwise we would need to maintain some memory of the currently supported releases, so that the logic does not delete artifacts from a previous-but-supported release.

Is this PR good-enough for now or should we abandon it and instead keep this as a manual step?


```

bash-5.2$             for old_helm_version in ${old_helm_versions}; do               exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive                 "${release_helm_url}/${old_helm_version}"                 -m "Remove old Helm chart ${old_helm_version} (superseded by ${version_without_rc})";             done
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/helm-chart/1.0.0-incubating -m Remove old Helm chart 1.0.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81990 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/helm-chart/1.0.1-incubating -m Remove old Helm chart 1.0.1-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81991 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/helm-chart/1.1.0-incubating -m Remove old Helm chart 1.1.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81992 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/helm-chart/1.2.0-incubating -m Remove old Helm chart 1.2.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81993 propagée.


bash-5.2$             for old_version in ${old_versions}; do               exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive                 "${release_artifacts_url}/${old_version}"                 -m "Remove old release ${old_version} (superseded by ${version_without_rc})";             done
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/0.9.0-incubating -m Remove old release 0.9.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81994 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/1.0.0-incubating -m Remove old release 1.0.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81995 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/1.0.1-incubating -m Remove old release 1.0.1-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81996 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/1.1.0-incubating -m Remove old release 1.1.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81997 propagée.
DEBUG: Executing 'svn rm --username ... --password ... --non-interactive https://dist.apache.org/repos/dist/release/incubator/polaris/1.2.0-incubating -m Remove old release 1.2.0-incubating (superseded by 1.3.0-incubating)'
Transaction de propagation...
Révision 81998 propagée.

bash-5.2$           exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Update Helm index for ${version_without_rc} release"
DEBUG: Executing 'svn commit --username ... --password ... --non-interactive -m Update Helm index for 1.3.0-incubating release'
```