### PR TITLE
Use typed config for `POLARIS_TASK_TIMEOUT_MILLIS`

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -555,9 +556,7 @@ record NoSqlMetaStoreManager(
               long taskAgeTimeout =
                   callCtx
                       .getRealmConfig()
-                      .getConfig(
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
+                      .getConfig(FeatureConfiguration.POLARIS_TASK_TIMEOUT_MILLIS);
               return taskState == null
                   || taskState.executor == null
                   || clock.millis() - taskState.lastAttemptStartTime > taskAgeTimeout;

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -249,6 +249,14 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(true)
           .buildFeatureConfiguration();
 
+  public static final FeatureConfiguration<Long> POLARIS_TASK_TIMEOUT_MILLIS =
+      PolarisConfiguration.<Long>builder()
+          .key("POLARIS_TASK_TIMEOUT_MILLIS")
+          .description(
+              "Polaris task expiry timeout (milliseconds). Older unfinished tasks may not be processed.")
+          .defaultValue(300_000L)
+          .buildFeatureConfiguration();
+
   public static final FeatureConfiguration<Integer> STORAGE_CREDENTIAL_DURATION_SECONDS =
       PolarisConfiguration.<Integer>builder()
           .key("STORAGE_CREDENTIAL_DURATION_SECONDS")

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisTaskConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisTaskConstants.java
@@ -18,10 +18,22 @@
  */
 package org.apache.polaris.core.entity;
 
+import org.apache.polaris.core.config.FeatureConfiguration;
+
 /** Constants used to store task properties and configuration parameters */
 public class PolarisTaskConstants {
+  /**
+   * @deprecated Use {@link FeatureConfiguration#POLARIS_TASK_TIMEOUT_MILLIS}
+   */
+  @Deprecated(forRemoval = true)
   public static final long TASK_TIMEOUT_MILLIS = 300000;
+
+  /**
+   * @deprecated Use {@link FeatureConfiguration#POLARIS_TASK_TIMEOUT_MILLIS}
+   */
+  @Deprecated(forRemoval = true)
   public static final String TASK_TIMEOUT_MILLIS_CONFIG = "POLARIS_TASK_TIMEOUT_MILLIS";
+
   public static final String LAST_ATTEMPT_EXECUTOR_ID = "lastAttemptExecutorId";
   public static final String LAST_ATTEMPT_START_TIME = "lastAttemptStartTime";
   public static final String ATTEMPT_COUNT = "attemptCount";

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1536,9 +1536,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
               long taskAgeTimeout =
                   callCtx
                       .getRealmConfig()
-                      .getConfig(
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
+                      .getConfig(FeatureConfiguration.POLARIS_TASK_TIMEOUT_MILLIS);
               return taskState == null
                   || taskState.executor == null
                   || clock.millis() - taskState.lastAttemptStartTime > taskAgeTimeout;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -2033,9 +2033,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
               long taskAgeTimeout =
                   callCtx
                       .getRealmConfig()
-                      .getConfig(
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS_CONFIG,
-                          PolarisTaskConstants.TASK_TIMEOUT_MILLIS);
+                      .getConfig(FeatureConfiguration.POLARIS_TASK_TIMEOUT_MILLIS);
               return taskState == null
                   || taskState.executor == null
                   || clock.millis() - taskState.lastAttemptStartTime > taskAgeTimeout;


### PR DESCRIPTION
Add a typed `FeatureConfiguration` with the same config name and default value.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
