### PR TITLE
Use typed config for `TABLE_METADATA_CLEANUP_BATCH_SIZE`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -516,4 +516,11 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
                   + "Helps prevent thundering herd when multiple requests fail simultaneously.")
           .defaultValue(0.5)
           .buildFeatureConfiguration();
+
+  public static final FeatureConfiguration<Integer> TABLE_METADATA_CLEANUP_BATCH_SIZE =
+      PolarisConfiguration.<Integer>builder()
+          .key("TABLE_METADATA_CLEANUP_BATCH_SIZE")
+          .description("Metadata batch size for tasks that clean up dropped tables' files.")
+          .defaultValue(10)
+          .buildFeatureConfiguration();
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.service.task;
 
+import static org.apache.polaris.core.config.FeatureConfiguration.TABLE_METADATA_CLEANUP_BATCH_SIZE;
+
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +58,6 @@ public class TableCleanupTaskHandler implements TaskHandler {
   private final Clock clock;
   private final MetaStoreManagerFactory metaStoreManagerFactory;
   private final TaskFileIOSupplier fileIOSupplier;
-  private static final String BATCH_SIZE_CONFIG_KEY = "TABLE_METADATA_CLEANUP_BATCH_SIZE";
 
   public TableCleanupTaskHandler(
       TaskExecutor taskExecutor,
@@ -208,7 +209,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext) {
     PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
-    int batchSize = callContext.getRealmConfig().getConfig(BATCH_SIZE_CONFIG_KEY, 10);
+    int batchSize = callContext.getRealmConfig().getConfig(TABLE_METADATA_CLEANUP_BATCH_SIZE);
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {


### PR DESCRIPTION
Add a typed `FeatureConfiguration` with the same config name and default value.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
