### PR TITLE
feat: pass ExternalCatalog properties into federated catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The (Before/After)CommitViewEvent has been removed.
 - The (Before/After)CommitTableEvent has been removed.
 - The `PolarisMetricsReporter.reportMetric()` method signature has been extended to include a `receivedTimestamp` parameter of type `java.time.Instant`.
+- The `ExternalCatalogFactory.createCatalog()` and `createGenericCatalog()` method signatures have been extended to include a `catalogProperties` parameter of type `Map<String, String>` for passing through proxy and timeout settings to federated catalog HTTP clients.
 
 ### New Features
 

--- a/extensions/federation/hive/src/main/java/org/apache/polaris/extensions/federation/hive/HiveFederatedCatalogFactory.java
+++ b/extensions/federation/hive/src/main/java/org/apache/polaris/extensions/federation/hive/HiveFederatedCatalogFactory.java
@@ -20,8 +20,10 @@ package org.apache.polaris.extensions.federation.hive;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.catalog.ExternalCatalogFactory;
 import org.apache.polaris.core.catalog.GenericTableCatalog;
 import org.apache.polaris.core.connection.AuthenticationParametersDpo;
@@ -30,19 +32,17 @@ import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
 import org.apache.polaris.core.connection.ConnectionType;
 import org.apache.polaris.core.connection.hive.HiveConnectionConfigInfoDpo;
 import org.apache.polaris.core.credentials.PolarisCredentialManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Factory class for creating a Hive catalog handle based on connection configuration. */
 @ApplicationScoped
 @Identifier(ConnectionType.HIVE_FACTORY_IDENTIFIER)
 public class HiveFederatedCatalogFactory implements ExternalCatalogFactory {
-  private static final Logger LOGGER = LoggerFactory.getLogger(HiveFederatedCatalogFactory.class);
 
   @Override
   public Catalog createCatalog(
       ConnectionConfigInfoDpo connectionConfigInfoDpo,
-      PolarisCredentialManager polarisCredentialManager) {
+      PolarisCredentialManager polarisCredentialManager,
+      Map<String, String> catalogProperties) {
     // Currently, Polaris supports Hive federation only via IMPLICIT authentication.
     // Hence, prior to initializing the configuration, ensure that the catalog uses
     // IMPLICIT authentication.
@@ -69,14 +69,19 @@ public class HiveFederatedCatalogFactory implements ExternalCatalogFactory {
     // Polaris could support federating to multiple LDAP based Hive metastores. Multiple
     // Kerberos instances are not suitable because Kerberos ties a single identity to the server.
     HiveCatalog hiveCatalog = new HiveCatalog();
-    hiveCatalog.initialize(
-        warehouse, connectionConfigInfoDpo.asIcebergCatalogProperties(polarisCredentialManager));
+    Map<String, String> mergedProperties =
+        RESTUtil.merge(
+            catalogProperties != null ? catalogProperties : Map.of(),
+            connectionConfigInfoDpo.asIcebergCatalogProperties(polarisCredentialManager));
+    hiveCatalog.initialize(warehouse, mergedProperties);
     return hiveCatalog;
   }
 
   @Override
   public GenericTableCatalog createGenericCatalog(
-      ConnectionConfigInfoDpo connectionConfig, PolarisCredentialManager polarisCredentialManager) {
+      ConnectionConfigInfoDpo connectionConfig,
+      PolarisCredentialManager polarisCredentialManager,
+      Map<String, String> catalogProperties) {
     // TODO implement
     throw new UnsupportedOperationException(
         "Generic table federation to this catalog is not supported.");

--- a/polaris-core/src/main/java/org/apache/polaris/core/catalog/ExternalCatalogFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/catalog/ExternalCatalogFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.catalog;
 
+import java.util.Map;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
 import org.apache.polaris.core.credentials.PolarisCredentialManager;
@@ -36,11 +37,16 @@ public interface ExternalCatalogFactory {
    * @param connectionConfig the connection configuration
    * @param polarisCredentialManager the credential manager for generating connection credentials
    *     that Polaris uses to access external systems
+   * @param catalogProperties additional properties from the ExternalCatalog entity that should be
+   *     passed through to the underlying catalog (e.g., rest.client.proxy.*, timeout settings).
+   *     These are merged with lower precedence than connection config properties.
    * @return the initialized catalog
    * @throws IllegalStateException if the connection configuration is invalid
    */
   Catalog createCatalog(
-      ConnectionConfigInfoDpo connectionConfig, PolarisCredentialManager polarisCredentialManager);
+      ConnectionConfigInfoDpo connectionConfig,
+      PolarisCredentialManager polarisCredentialManager,
+      Map<String, String> catalogProperties);
 
   /**
    * Creates a generic table catalog for the given connection configuration.
@@ -48,9 +54,13 @@ public interface ExternalCatalogFactory {
    * @param connectionConfig the connection configuration
    * @param polarisCredentialManager the credential manager for generating connection credentials
    *     that Polaris uses to access external systems
+   * @param catalogProperties additional properties from the ExternalCatalog entity that should be
+   *     passed through to the underlying catalog
    * @return the initialized catalog
    * @throws IllegalStateException if the connection configuration is invalid
    */
   GenericTableCatalog createGenericCatalog(
-      ConnectionConfigInfoDpo connectionConfig, PolarisCredentialManager polarisCredentialManager);
+      ConnectionConfigInfoDpo connectionConfig,
+      PolarisCredentialManager polarisCredentialManager,
+      Map<String, String> catalogProperties);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -98,10 +98,13 @@ public class GenericTableCatalogHandler extends CatalogHandler {
           externalCatalogFactories.select(
               Identifier.Literal.of(connectionType.getFactoryIdentifier()));
       if (externalCatalogFactory.isResolvable()) {
+        // Pass through catalog properties (e.g., rest.client.proxy.*, timeout settings)
+        Map<String, String> catalogProperties = resolvedCatalogEntity.getPropertiesAsMap();
         federatedCatalog =
             externalCatalogFactory
                 .get()
-                .createGenericCatalog(connectionConfigInfoDpo, getPolarisCredentialManager());
+                .createGenericCatalog(
+                    connectionConfigInfoDpo, getPolarisCredentialManager(), catalogProperties);
       } else {
         throw new UnsupportedOperationException(
             "External catalog factory for type '" + connectionType + "' is unavailable.");

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -302,10 +302,14 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
           externalCatalogFactories.select(
               Identifier.Literal.of(connectionType.getFactoryIdentifier()));
       if (externalCatalogFactory.isResolvable()) {
+        // Pass through catalog properties (e.g., rest.client.proxy.*, timeout settings)
+        // to the external catalog factory for configuration of the underlying HTTP client
+        Map<String, String> catalogProperties = resolvedCatalogEntity.getPropertiesAsMap();
         federatedCatalog =
             externalCatalogFactory
                 .get()
-                .createCatalog(connectionConfigInfoDpo, getPolarisCredentialManager());
+                .createCatalog(
+                    connectionConfigInfoDpo, getPolarisCredentialManager(), catalogProperties);
       } else {
         throw new UnsupportedOperationException(
             "External catalog factory for type '" + connectionType + "' is unavailable.");

--- a/site/content/in-dev/unreleased/federation/iceberg-rest-federation.md
+++ b/site/content/in-dev/unreleased/federation/iceberg-rest-federation.md
@@ -61,6 +61,33 @@ Refer to the [CLI documentation](../command-line-interface.md#catalogs) for deta
 Grant catalog roles to principal roles the same way you do for internal catalogs so compute engines
 receive tokens with access to the federated namespace.
 
+## Outbound HTTP settings
+
+Iceberg REST federation uses Iceberg's HTTP client. You can pass through HTTP settings by adding
+catalog properties when creating or updating the external catalog (via `--property` or
+`--set-property`).
+
+Common settings include:
+
+- `rest.client.proxy.hostname`
+- `rest.client.proxy.port`
+- `rest.client.proxy.username`
+- `rest.client.proxy.password`
+- `rest.client.connection-timeout-ms`
+- `rest.client.socket-timeout-ms`
+
+Example:
+
+```bash
+polaris catalogs update analytics_rest \
+    --set-property rest.client.proxy.hostname=proxy.example.com \
+    --set-property rest.client.proxy.port=3128 \
+    --set-property rest.client.connection-timeout-ms=30000 \
+    --set-property rest.client.socket-timeout-ms=120000
+```
+
+Connection config properties (URI and authentication) take precedence if the same keys are present.
+
 ## Operational notes
 
 - **Connectivity checks:** Polaris does not lazily probe the remote service; catalog creation fails if


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Summary
- pass `ExternalCatalog.properties` through federation factories (Iceberg REST, Hive, Hadoop)
- merge catalog properties with connection config, with connection config taking precedence
- document proxy/timeout settings for Iceberg REST federation
- add tests that exercise production merge logic

## Context
External catalog properties such as `rest.client.proxy.*` and REST client timeout settings were not reaching the Iceberg REST HTTP client. This blocks federation in controlled egress environments where outbound traffic must go through an allowlisted forward proxy.

## Changes
 - Add a shared merge helper in IcebergRESTExternalCatalogFactory and use it for REST catalog initialization
 - Honor ExternalCatalog.properties for Hive/Hadoop federation as well
 - Update docs with supported proxy/timeout keys and CLI examples

## Tests
- `./gradlew format compileAll` ✅ 
- `./gradlew rat` ✅ 
- `./gradlew :polaris-core:test` ✅ 
- `./gradlew :polaris-extensions-federation-hadoop:test` (NO-SOURCE) ✅ 
- `./gradlew :polaris-extensions-federation-hive:test` (NO-SOURCE) ✅ 
- `./gradlew :polaris-runtime-service:test` **fails** with 4 failures in `AwsCloudWatchEventListenerTest` (Testcontainers/Docker initialization issue; unrelated)

###  Manual integration test (EKS + Squid forward proxy + External Iceberg REST catalog)

I validated this PR end to end in a real AWS EKS environment with an external Iceberg REST catalog behind a Squid forward proxy. Federation requests succeeded and proxy usage was confirmed via Squid access logs.

Setup
- Polaris built from this PR branch (1.4.0-incubating-SNAPSHOT)
- AWS EKS cluster
- Squid deployed as a Kubernetes service (domain allowlist for the external catalog)
- External catalog: Iceberg REST
- Proxy configured via external catalog properties (rest.client.proxy.hostname, rest.client.proxy.port)

```
{
  "type": "EXTERNAL",
  "name": "test-external-catalog",
  "properties": {
    "rest.client.proxy.hostname": "squid.egress-proxy.svc.cluster.local",
    "rest.client.proxy.port": "3128",
    "rest.client.connection-timeout-ms": "30000",
    "rest.client.socket-timeout-ms": "120000"
  },
  "connectionConfigInfo": {
    "connectionType": "ICEBERG_REST",
    "uri": "https://<external-catalog-host>/polaris/api/catalog",
    "remoteCatalogName": "<remote-catalog>",
    "authenticationParameters": {
      "authenticationType": "OAUTH",
      "tokenUri": "https://<external-catalog-host>/polaris/api/catalog/v1/oauth/tokens",
      "clientId": "<redacted>",
      "clientSecret": "<redacted>",
      "scopes": ["<scope>"]
    }
  }
}
```

### Evidence  (Squid access logs)
When calling the federation API (example: `GET /api/catalog/v1/<catalog>/namespaces`), Squid showed a successful HTTPS tunnel:
```
<timestamp> <duration> <polaris-pod-ip> TCP_TUNNEL/200 <bytes> CONNECT <external-catalog-host>:443 - HIER_DIRECT/<external-ip> -
```
This indicates traffic originated from the Polaris pod and went through the proxy via CONNECT to the external catalog host.

### Before vs After

| Behavior | Before PR #3480 | After PR #3480 |
|---|---|---|
| Proxy properties in external catalog config | Proxy settings were not propagated to the Iceberg REST HTTP client | Proxy settings are passed through and applied by the REST client |
| Squid access logs for external catalog traffic | No `CONNECT <external-catalog-host>:443` entries observed | `TCP_TUNNEL/200 CONNECT <external-catalog-host>:443` entries observed |
| Network path from Polaris to external catalog | Direct egress (proxy bypass) | Routed via the configured Squid forward proxy |
| Federation API calls (namespaces/tables) | Failed or could not complete in proxy-only egress environments | Succeeded; namespaces and tables retrieved from the remote catalog |


### Federation API Results
- List namespaces: returned <x> namespaces from the remote catalog. ✅ 
- List tables: returned <xx> tables from the remote catalog ✅ . 
All requests were observed going through Squid. 

### Note
- This changes an external extension point (ExternalCatalogFactory). Per CONTRIBUTING guidance, I plan to discuss this on the dev mailing list before marking the PR ready for review.

Related to #3465 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #3465
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
