### PR TITLE
(feat) Add example for rustfs integration

### DIFF
--- a/getting-started/rustfs/README.md
+++ b/getting-started/rustfs/README.md
@@ -19,9 +19,12 @@
 
 # Getting Started with Apache Polaris and RustFS
 
+> [!WARNING]
+> Disclaimer: This getting-started example uses mc from MinIO OSS for local testing only. MinIO OSS is in maintenance mode, and MinIO container images may no longer receive updates or security fixes. For production setups, [rc](https://github.com/rustfs/cli) should be used.
+
 ## Overview
 
-This example uses RustFS as a storage provider with Polaris.
+This example uses [RustFS](https://rustfs.com/) as a storage provider with Polaris.
 
 Spark is used as a query engine. This example assumes a local Spark installation.
 See the [Spark Notebooks Example](../spark/README.md) for a more advanced Spark setup.

--- a/getting-started/rustfs/docker-compose.yml
+++ b/getting-started/rustfs/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       start_period: 40s
 
   polaris:
-    image: apache/polaris:1.3.0-incubating
+    image: apache/polaris:latest
     ports:
       # API port
       - "8181:8181"


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Per discussion in https://lists.apache.org/thread/8o31ly7cd8ov70opjbtg630qlhrfl5yh, we would want to add support for RustFS integration. I follow the same layout as MinIO example for easy readability. If we do want to move forward with RustFS, I can then add more advance features such as assume role integration.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
