### PR TITLE
Versioned-docs: do not index old versioned docs

### DIFF
--- a/0.9.0/_index.md
+++ b/0.9.0/_index.md
@@ -29,6 +29,8 @@ cascade:
   params:
     show_page_toc: true
 # This file will NOT be copied into a new release's versioned docs folder.
+robots: noindex
+exclude_search: true
 ---
 
 Check out the [Quick Start]({{% ref "quickstart" %}}) page to get started.

--- a/0.9.0/access-control.md
+++ b/0.9.0/access-control.md
@@ -20,6 +20,8 @@
 Title: Access Control
 type: docs
 weight: 500
+robots: noindex
+exclude_search: true
 ---
 
 This section provides information about how access control works for Apache Polaris (Incubating).

--- a/0.9.0/command-line-interface.md
+++ b/0.9.0/command-line-interface.md
@@ -21,6 +21,8 @@ linkTitle: Command Line Interface
 title: Apache Polaris (Incubating) CLI
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 In order to help administrators quickly set up and manage their Polaris server, Polaris provides a simple command-line interface (CLI) for common tasks.

--- a/0.9.0/configuring-polaris-for-production.md
+++ b/0.9.0/configuring-polaris-for-production.md
@@ -21,6 +21,8 @@ title: Configuring Apache Polaris (Incubating) for Production
 linkTitle: Deploying In Production
 type: docs
 weight: 600
+robots: noindex
+exclude_search: true
 ---
 
 The default `polaris-server.yml` configuration is intended for development and testing. When deploying Polaris in production, there are several best practices to keep in mind.

--- a/0.9.0/entities.md
+++ b/0.9.0/entities.md
@@ -20,6 +20,8 @@
 Title: Entities
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 This page documents various entities that can be managed in Apache Polaris (Incubating).

--- a/0.9.0/metastores.md
+++ b/0.9.0/metastores.md
@@ -21,6 +21,8 @@ title: Metastores
 linkTitle: Metastores
 type: docs
 weight: 700
+robots: noindex
+exclude_search: true
 ---
 
 This page documents important configurations for connecting to production database through [EclipseLink](https://eclipse.dev/eclipselink/).

--- a/0.9.0/overview.md
+++ b/0.9.0/overview.md
@@ -20,6 +20,8 @@
 Title: Overview
 type: docs
 weight: 200
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris (Incubating) is a catalog implementation for Apache Iceberg&trade; tables and is built on the open source Apache Iceberg&trade; REST protocol.

--- a/0.9.0/polaris-management-service.md
+++ b/0.9.0/polaris-management-service.md
@@ -22,6 +22,8 @@ linkTitle: 'Management OpenAPI'
 weight: 800
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 <meta http-equiv="refresh" content="0; url=http://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-0.9.0-incubating/spec/polaris-management-service.yml" />

--- a/0.9.0/quickstart.md
+++ b/0.9.0/quickstart.md
@@ -20,6 +20,8 @@
 Title: Quick Start
 type: docs
 weight: 100
+robots: noindex
+exclude_search: true
 ---
 
 This guide serves as a introduction to several key entities that can be managed with Apache Polaris (Incubating), describes how to build and deploy Polaris locally, and finally includes examples of how to use Polaris with Apache Spark&trade;.

--- a/0.9.0/rest-catalog-open-api.md
+++ b/0.9.0/rest-catalog-open-api.md
@@ -22,6 +22,8 @@ linkTitle: 'Iceberg OpenAPI'
 weight: 900
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 <meta http-equiv="refresh" content="0; url=http://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-0.9.0-incubating/spec/rest-catalog-open-api.yaml" />

--- a/1.0.0/_index.md
+++ b/1.0.0/_index.md
@@ -29,6 +29,8 @@ cascade:
   params:
     show_page_toc: true
 # This file will NOT be copied into a new release's versioned docs folder.
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris (Incubating) is a catalog implementation for Apache Iceberg&trade; tables and is built on the open source Apache Iceberg&trade; REST protocol.

--- a/1.0.0/access-control.md
+++ b/1.0.0/access-control.md
@@ -20,6 +20,8 @@
 Title: Access Control
 type: docs
 weight: 500
+robots: noindex
+exclude_search: true
 ---
 
 This section provides information about how access control works for Apache Polaris (Incubating).

--- a/1.0.0/admin-tool.md
+++ b/1.0.0/admin-tool.md
@@ -20,6 +20,8 @@
 title: Admin Tool
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 Polaris includes a tool for administrators to manage the metastore.

--- a/1.0.0/command-line-interface.md
+++ b/1.0.0/command-line-interface.md
@@ -20,6 +20,8 @@
 title: Command Line Interface
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 In order to help administrators quickly set up and manage their Polaris server, Polaris provides a simple command-line interface (CLI) for common tasks.

--- a/1.0.0/configuration.md
+++ b/1.0.0/configuration.md
@@ -20,6 +20,8 @@
 title: Configuring Polaris
 type: docs
 weight: 550
+robots: noindex
+exclude_search: true
 ---
 
 ## Overview

--- a/1.0.0/configuring-polaris-for-production.md
+++ b/1.0.0/configuring-polaris-for-production.md
@@ -21,6 +21,8 @@ title: Configuring Polaris for Production
 linkTitle: Production Configuration
 type: docs
 weight: 600
+robots: noindex
+exclude_search: true
 ---
 
 The default server configuration is intended for development and testing. When you deploy Polaris in production,

--- a/1.0.0/entities.md
+++ b/1.0.0/entities.md
@@ -20,6 +20,8 @@
 Title: Entities
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 This page documents various entities that can be managed in Apache Polaris (Incubating).

--- a/1.0.0/evolution.md
+++ b/1.0.0/evolution.md
@@ -20,6 +20,8 @@
 title: Polaris Evolution
 type: docs
 weight: 1000
+robots: noindex
+exclude_search: true
 ---
 
 This page discusses what can be expected from Apache Polaris as the project evolves.

--- a/1.0.0/generic-table.md
+++ b/1.0.0/generic-table.md
@@ -20,6 +20,8 @@
 title: Generic Table (Beta)
 type: docs
 weight: 435
+robots: noindex
+exclude_search: true
 ---
 
 The Generic Table in Apache Polaris is designed to provide support for non-Iceberg tables across different table formats includes delta, csv etc. It currently provides the following capabilities:

--- a/1.0.0/getting-started/_index.md
+++ b/1.0.0/getting-started/_index.md
@@ -20,4 +20,6 @@
 title: 'Getting Started'
 type: docs
 weight: 101
+robots: noindex
+exclude_search: true
 ---

--- a/1.0.0/getting-started/deploying-polaris/_index.md
+++ b/1.0.0/getting-started/deploying-polaris/_index.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Cloud Providers
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 We will now demonstrate how to deploy Polaris locally, as well as with all supported Cloud Providers: Amazon Web Services (AWS), Azure, and Google Cloud Platform (GCP).

--- a/1.0.0/getting-started/deploying-polaris/quickstart-deploy-aws.md
+++ b/1.0.0/getting-started/deploying-polaris/quickstart-deploy-aws.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Amazon Web Services (AWS)
 type: docs
 weight: 310
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.0/getting-started/deploying-polaris/quickstart-deploy-azure.md
+++ b/1.0.0/getting-started/deploying-polaris/quickstart-deploy-azure.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Azure
 type: docs
 weight: 320
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Azure Database for PostgreSQL - Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.0/getting-started/deploying-polaris/quickstart-deploy-gcp.md
+++ b/1.0.0/getting-started/deploying-polaris/quickstart-deploy-gcp.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Google Cloud Platform (GCP)
 type: docs
 weight: 330
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start a [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.0/getting-started/install-dependencies.md
+++ b/1.0.0/getting-started/install-dependencies.md
@@ -20,6 +20,8 @@
 Title: Installing Dependencies
 type: docs
 weight: 100
+robots: noindex
+exclude_search: true
 ---
 
 This guide serves as an introduction to several key entities that can be managed with Apache Polaris (Incubating), describes how to build and deploy Polaris locally, and finally includes examples of how to use Polaris with Apache Spark&trade;.

--- a/1.0.0/getting-started/quickstart.md
+++ b/1.0.0/getting-started/quickstart.md
@@ -20,6 +20,8 @@
 Title: Quickstart
 type: docs
 weight: 200
+robots: noindex
+exclude_search: true
 ---
 
 Polaris can be deployed via a docker image or as a standalone process. Before starting, be sure that you've satisfied the relevant prerequisites detailed in the previous page.

--- a/1.0.0/getting-started/using-polaris.md
+++ b/1.0.0/getting-started/using-polaris.md
@@ -20,6 +20,8 @@
 Title: Using Polaris
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 ## Setup

--- a/1.0.0/metastores.md
+++ b/1.0.0/metastores.md
@@ -20,6 +20,8 @@
 title: Metastores
 type: docs
 weight: 700
+robots: noindex
+exclude_search: true
 ---
 
 This page explains how to configure and use Polaris metastores with either the recommended Relational JDBC or the

--- a/1.0.0/polaris-catalog-service.md
+++ b/1.0.0/polaris-catalog-service.md
@@ -21,6 +21,8 @@ linkTitle: 'Catalog API Spec'
 weight: 900
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}

--- a/1.0.0/polaris-management-service.md
+++ b/1.0.0/polaris-management-service.md
@@ -22,6 +22,8 @@ linkTitle: 'Management OpenAPI'
 weight: 800
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "polaris-management-service.yml" >}}

--- a/1.0.0/polaris-spark-client.md
+++ b/1.0.0/polaris-spark-client.md
@@ -20,6 +20,8 @@
 Title: Polaris Spark Client
 type: docs
 weight: 650
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris now provides Catalog support for Generic Tables (non-Iceberg tables), please check out 

--- a/1.0.0/policy.md
+++ b/1.0.0/policy.md
@@ -20,6 +20,8 @@
 title: Policy
 type: docs
 weight: 425 
+robots: noindex
+exclude_search: true
 ---
 
 The Polaris Policy framework empowers organizations to centrally define, manage, and enforce fine-grained governance, lifecycle, and operational rules across all data resources in the catalog. 

--- a/1.0.0/realm.md
+++ b/1.0.0/realm.md
@@ -20,6 +20,8 @@
 Title: Realm
 type: docs
 weight: 350
+robots: noindex
+exclude_search: true
 ---
 
 This page explains what a realm is and what it is used for in Polaris.

--- a/1.0.0/telemetry.md
+++ b/1.0.0/telemetry.md
@@ -20,6 +20,8 @@
 title: Telemetry
 type: docs
 weight: 450
+robots: noindex
+exclude_search: true
 ---
 
 ## Metrics

--- a/1.0.1/_index.md
+++ b/1.0.1/_index.md
@@ -29,6 +29,8 @@ cascade:
   params:
     show_page_toc: true
 # This file will NOT be copied into a new release's versioned docs folder.
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris (Incubating) is a catalog implementation for Apache Iceberg&trade; tables and is built on the open source Apache Iceberg&trade; REST protocol.

--- a/1.0.1/access-control.md
+++ b/1.0.1/access-control.md
@@ -20,6 +20,8 @@
 Title: Access Control
 type: docs
 weight: 500
+robots: noindex
+exclude_search: true
 ---
 
 This section provides information about how access control works for Apache Polaris (Incubating).

--- a/1.0.1/admin-tool.md
+++ b/1.0.1/admin-tool.md
@@ -20,6 +20,8 @@
 title: Admin Tool
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 Polaris includes a tool for administrators to manage the metastore.

--- a/1.0.1/command-line-interface.md
+++ b/1.0.1/command-line-interface.md
@@ -20,6 +20,8 @@
 title: Command Line Interface
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 In order to help administrators quickly set up and manage their Polaris server, Polaris provides a simple command-line interface (CLI) for common tasks.

--- a/1.0.1/configuration.md
+++ b/1.0.1/configuration.md
@@ -20,6 +20,8 @@
 title: Configuring Polaris
 type: docs
 weight: 550
+robots: noindex
+exclude_search: true
 ---
 
 ## Overview

--- a/1.0.1/configuring-polaris-for-production.md
+++ b/1.0.1/configuring-polaris-for-production.md
@@ -21,6 +21,8 @@ title: Configuring Polaris for Production
 linkTitle: Production Configuration
 type: docs
 weight: 600
+robots: noindex
+exclude_search: true
 ---
 
 The default server configuration is intended for development and testing. When you deploy Polaris in production,

--- a/1.0.1/entities.md
+++ b/1.0.1/entities.md
@@ -20,6 +20,8 @@
 Title: Entities
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 This page documents various entities that can be managed in Apache Polaris (Incubating).

--- a/1.0.1/evolution.md
+++ b/1.0.1/evolution.md
@@ -20,6 +20,8 @@
 title: Polaris Evolution
 type: docs
 weight: 1000
+robots: noindex
+exclude_search: true
 ---
 
 This page discusses what can be expected from Apache Polaris as the project evolves.

--- a/1.0.1/generic-table.md
+++ b/1.0.1/generic-table.md
@@ -20,6 +20,8 @@
 title: Generic Table (Beta)
 type: docs
 weight: 435
+robots: noindex
+exclude_search: true
 ---
 
 The Generic Table in Apache Polaris is designed to provide support for non-Iceberg tables across different table formats includes delta, csv etc. It currently provides the following capabilities:

--- a/1.0.1/getting-started/_index.md
+++ b/1.0.1/getting-started/_index.md
@@ -20,4 +20,6 @@
 title: 'Getting Started'
 type: docs
 weight: 101
+robots: noindex
+exclude_search: true
 ---

--- a/1.0.1/getting-started/deploying-polaris/_index.md
+++ b/1.0.1/getting-started/deploying-polaris/_index.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Cloud Providers
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 We will now demonstrate how to deploy Polaris locally, as well as with all supported Cloud Providers: Amazon Web Services (AWS), Azure, and Google Cloud Platform (GCP).

--- a/1.0.1/getting-started/deploying-polaris/quickstart-deploy-aws.md
+++ b/1.0.1/getting-started/deploying-polaris/quickstart-deploy-aws.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Amazon Web Services (AWS)
 type: docs
 weight: 310
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.1/getting-started/deploying-polaris/quickstart-deploy-azure.md
+++ b/1.0.1/getting-started/deploying-polaris/quickstart-deploy-azure.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Azure
 type: docs
 weight: 320
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Azure Database for PostgreSQL - Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.1/getting-started/deploying-polaris/quickstart-deploy-gcp.md
+++ b/1.0.1/getting-started/deploying-polaris/quickstart-deploy-gcp.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Google Cloud Platform (GCP)
 type: docs
 weight: 330
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start a [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.0.1/getting-started/install-dependencies.md
+++ b/1.0.1/getting-started/install-dependencies.md
@@ -20,6 +20,8 @@
 Title: Installing Dependencies
 type: docs
 weight: 100
+robots: noindex
+exclude_search: true
 ---
 
 This guide serves as an introduction to several key entities that can be managed with Apache Polaris (Incubating), describes how to build and deploy Polaris locally, and finally includes examples of how to use Polaris with Apache Spark&trade;.

--- a/1.0.1/getting-started/quickstart.md
+++ b/1.0.1/getting-started/quickstart.md
@@ -20,6 +20,8 @@
 Title: Quickstart
 type: docs
 weight: 200
+robots: noindex
+exclude_search: true
 ---
 
 Polaris can be deployed via a docker image or as a standalone process. Before starting, be sure that you've satisfied the relevant prerequisites detailed in the previous page.

--- a/1.0.1/getting-started/using-polaris.md
+++ b/1.0.1/getting-started/using-polaris.md
@@ -20,6 +20,8 @@
 Title: Using Polaris
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 ## Setup

--- a/1.0.1/metastores.md
+++ b/1.0.1/metastores.md
@@ -20,6 +20,8 @@
 title: Metastores
 type: docs
 weight: 700
+robots: noindex
+exclude_search: true
 ---
 
 This page explains how to configure and use Polaris metastores with either the recommended Relational JDBC or the

--- a/1.0.1/polaris-catalog-service.md
+++ b/1.0.1/polaris-catalog-service.md
@@ -21,6 +21,8 @@ linkTitle: 'Catalog API Spec'
 weight: 900
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}

--- a/1.0.1/polaris-management-service.md
+++ b/1.0.1/polaris-management-service.md
@@ -22,6 +22,8 @@ linkTitle: 'Management OpenAPI'
 weight: 800
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "polaris-management-service.yml" >}}

--- a/1.0.1/polaris-spark-client.md
+++ b/1.0.1/polaris-spark-client.md
@@ -20,6 +20,8 @@
 Title: Polaris Spark Client
 type: docs
 weight: 650
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris now provides Catalog support for Generic Tables (non-Iceberg tables), please check out 

--- a/1.0.1/policy.md
+++ b/1.0.1/policy.md
@@ -20,6 +20,8 @@
 title: Policy
 type: docs
 weight: 425 
+robots: noindex
+exclude_search: true
 ---
 
 The Polaris Policy framework empowers organizations to centrally define, manage, and enforce fine-grained governance, lifecycle, and operational rules across all data resources in the catalog. 

--- a/1.0.1/realm.md
+++ b/1.0.1/realm.md
@@ -20,6 +20,8 @@
 Title: Realm
 type: docs
 weight: 350
+robots: noindex
+exclude_search: true
 ---
 
 This page explains what a realm is and what it is used for in Polaris.

--- a/1.0.1/telemetry.md
+++ b/1.0.1/telemetry.md
@@ -20,6 +20,8 @@
 title: Telemetry
 type: docs
 weight: 450
+robots: noindex
+exclude_search: true
 ---
 
 ## Metrics

--- a/1.1.0/_index.md
+++ b/1.1.0/_index.md
@@ -29,6 +29,8 @@ cascade:
   params:
     show_page_toc: true
 # This file will NOT be copied into a new release's versioned docs folder.
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris (Incubating) is a catalog implementation for Apache Iceberg&trade; tables and is built on the open source Apache Iceberg&trade; REST protocol.

--- a/1.1.0/access-control.md
+++ b/1.1.0/access-control.md
@@ -20,6 +20,8 @@
 Title: Access Control
 type: docs
 weight: 500
+robots: noindex
+exclude_search: true
 ---
 
 This section provides information about how access control works for Apache Polaris (Incubating).

--- a/1.1.0/admin-tool.md
+++ b/1.1.0/admin-tool.md
@@ -20,6 +20,8 @@
 title: Admin Tool
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 Polaris includes a tool for administrators to manage the metastore.

--- a/1.1.0/command-line-interface.md
+++ b/1.1.0/command-line-interface.md
@@ -20,6 +20,8 @@
 title: Command Line Interface
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 In order to help administrators quickly set up and manage their Polaris server, Polaris provides a simple command-line interface (CLI) for common tasks.

--- a/1.1.0/configuration.md
+++ b/1.1.0/configuration.md
@@ -20,6 +20,8 @@
 title: Configuring Polaris
 type: docs
 weight: 550
+robots: noindex
+exclude_search: true
 ---
 
 ## Overview

--- a/1.1.0/configuring-polaris-for-production.md
+++ b/1.1.0/configuring-polaris-for-production.md
@@ -21,6 +21,8 @@ title: Configuring Polaris for Production
 linkTitle: Production Configuration
 type: docs
 weight: 600
+robots: noindex
+exclude_search: true
 ---
 
 The default server configuration is intended for development and testing. When you deploy Polaris in production,

--- a/1.1.0/entities.md
+++ b/1.1.0/entities.md
@@ -20,6 +20,8 @@
 Title: Entities
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 This page documents various entities that can be managed in Apache Polaris (Incubating).

--- a/1.1.0/evolution.md
+++ b/1.1.0/evolution.md
@@ -20,6 +20,8 @@
 title: Polaris Evolution
 type: docs
 weight: 1000
+robots: noindex
+exclude_search: true
 ---
 
 This page discusses what can be expected from Apache Polaris as the project evolves.

--- a/1.1.0/external-idp.md
+++ b/1.1.0/external-idp.md
@@ -20,6 +20,8 @@
 title: External Identity Providers 
 type: docs
 weight: 550
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris supports authentication via external identity providers (IdPs) using OpenID Connect (OIDC) in addition to the internal authentication system. This feature enables flexible identity federation with enterprise IdPs and allows gradual migration or hybrid authentication strategies across realms in Polaris. 

--- a/1.1.0/generic-table.md
+++ b/1.1.0/generic-table.md
@@ -20,6 +20,8 @@
 title: Generic Table (Beta)
 type: docs
 weight: 435
+robots: noindex
+exclude_search: true
 ---
 
 The Generic Table in Apache Polaris is designed to provide support for non-Iceberg tables across different table formats includes delta, csv etc. It currently provides the following capabilities:

--- a/1.1.0/getting-started/_index.md
+++ b/1.1.0/getting-started/_index.md
@@ -20,4 +20,6 @@
 title: 'Getting Started'
 type: docs
 weight: 101
+robots: noindex
+exclude_search: true
 ---

--- a/1.1.0/getting-started/deploying-polaris/_index.md
+++ b/1.1.0/getting-started/deploying-polaris/_index.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Cloud Providers
 type: docs
 weight: 300
+robots: noindex
+exclude_search: true
 ---
 
 We will now demonstrate how to deploy Polaris locally, as well as with all supported Cloud Providers: Amazon Web Services (AWS), Azure, and Google Cloud Platform (GCP).

--- a/1.1.0/getting-started/deploying-polaris/quickstart-deploy-aws.md
+++ b/1.1.0/getting-started/deploying-polaris/quickstart-deploy-aws.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Amazon Web Services (AWS)
 type: docs
 weight: 310
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.1.0/getting-started/deploying-polaris/quickstart-deploy-azure.md
+++ b/1.1.0/getting-started/deploying-polaris/quickstart-deploy-azure.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Azure
 type: docs
 weight: 320
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start an [Azure Database for PostgreSQL - Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.1.0/getting-started/deploying-polaris/quickstart-deploy-gcp.md
+++ b/1.1.0/getting-started/deploying-polaris/quickstart-deploy-gcp.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on Google Cloud Platform (GCP)
 type: docs
 weight: 330
+robots: noindex
+exclude_search: true
 ---
 
 Build and launch Polaris using the AWS Startup Script at the location provided in the command below. This script will start a [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres) instance, which will be used as the backend Postgres instance holding all Polaris data.

--- a/1.1.0/getting-started/install-dependencies.md
+++ b/1.1.0/getting-started/install-dependencies.md
@@ -20,6 +20,8 @@
 Title: Installing Dependencies
 type: docs
 weight: 100
+robots: noindex
+exclude_search: true
 ---
 
 This guide serves as an introduction to several key entities that can be managed with Apache Polaris (Incubating), describes how to build and deploy Polaris locally, and finally includes examples of how to use Polaris with Apache Spark&trade;.

--- a/1.1.0/getting-started/minio.md
+++ b/1.1.0/getting-started/minio.md
@@ -20,6 +20,8 @@
 Title: Deploying Polaris on MinIO
 type: docs
 weight: 350
+robots: noindex
+exclude_search: true
 ---
 
 In this guide we walk through setting up a simple Polaris Server with local [MinIO](https://www.min.io/) storage.

--- a/1.1.0/getting-started/quickstart.md
+++ b/1.1.0/getting-started/quickstart.md
@@ -20,6 +20,8 @@
 Title: Quickstart
 type: docs
 weight: 200
+robots: noindex
+exclude_search: true
 ---
 
 Polaris can be deployed via a docker image or as a standalone process. Before starting, be sure that you've satisfied the relevant prerequisites detailed in the previous page.

--- a/1.1.0/getting-started/using-polaris.md
+++ b/1.1.0/getting-started/using-polaris.md
@@ -20,6 +20,8 @@
 Title: Using Polaris
 type: docs
 weight: 400
+robots: noindex
+exclude_search: true
 ---
 
 ## Setup

--- a/1.1.0/helm.md
+++ b/1.1.0/helm.md
@@ -20,6 +20,8 @@
 Title: Polaris Helm Chart
 type: docs
 weight: 675
+robots: noindex
+exclude_search: true
 ---
 
 <!---

--- a/1.1.0/metastores.md
+++ b/1.1.0/metastores.md
@@ -20,6 +20,8 @@
 title: Metastores
 type: docs
 weight: 700
+robots: noindex
+exclude_search: true
 ---
 
 This page explains how to configure and use Polaris metastores with either the recommended Relational JDBC or the

--- a/1.1.0/polaris-catalog-service.md
+++ b/1.1.0/polaris-catalog-service.md
@@ -21,6 +21,8 @@ linkTitle: 'Catalog API Spec'
 weight: 900
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "generated/bundled-polaris-catalog-service.yaml" >}}

--- a/1.1.0/polaris-management-service.md
+++ b/1.1.0/polaris-management-service.md
@@ -22,6 +22,8 @@ linkTitle: 'Management OpenAPI'
 weight: 800
 params:
   show_page_toc: false
+robots: noindex
+exclude_search: true
 ---
 
 {{< redoc-polaris "polaris-management-service.yml" >}}

--- a/1.1.0/polaris-spark-client.md
+++ b/1.1.0/polaris-spark-client.md
@@ -20,6 +20,8 @@
 Title: Polaris Spark Client
 type: docs
 weight: 650
+robots: noindex
+exclude_search: true
 ---
 
 Apache Polaris now provides Catalog support for Generic Tables (non-Iceberg tables), please check out

--- a/1.1.0/policy.md
+++ b/1.1.0/policy.md
@@ -20,6 +20,8 @@
 title: Policy
 type: docs
 weight: 425
+robots: noindex
+exclude_search: true
 ---
 
 The Polaris Policy framework empowers organizations to centrally define, manage, and enforce fine-grained governance, lifecycle, and operational rules across all data resources in the catalog.

--- a/1.1.0/realm.md
+++ b/1.1.0/realm.md
@@ -20,6 +20,8 @@
 Title: Realm
 type: docs
 weight: 350
+robots: noindex
+exclude_search: true
 ---
 
 This page explains what a realm is and what it is used for in Polaris.

--- a/1.1.0/telemetry.md
+++ b/1.1.0/telemetry.md
@@ -20,6 +20,8 @@
 title: Telemetry
 type: docs
 weight: 450
+robots: noindex
+exclude_search: true
 ---
 
 ## Metrics


### PR DESCRIPTION
Adds the front-matter tags `robots: noindex` (HTML META tag) and `exclude_search: true` (local site search) for old released versions, aka all except 1.3.0. The change was created using the script from #3485.
