### PR TITLE
deduplicate storage requests when loading views.

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1838,7 +1838,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
-                      
+
               return ViewMetadataParser.read(fileIO.newInputFile(metadataLocation));
             });
         polarisEventListener.onEvent(


### PR DESCRIPTION

The PR addresses issue #3061 where loadview makes multiple requests for the same file.
This PR has two main changes to avoid making too many storage requests when loading tables and views. 
The first change is aimed at reusing ```fileIO``` in case ```refreshFromMetadataLocation``` is retried. this is done for both tables and views.

The second change is related to ```loadView``` only it overrides ```loadView``` in ```BaseMetastoreViewCatalog```  to reuse viewOps instead of creating them twice.



## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
