### PR TITLE
(NOT_READY) Fixed IcebergCatalog stale FileIO after metadata refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Fixed IcebergCatalog stale FileIO after metadata refresh, resolving AWS assumeRole permission errors.
+
 ### Commits
 
 ## [1.2.0-incubating]

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1409,6 +1409,22 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
               return TableMetadataParser.read(fileIO, metadataLocation);
             });
+
+        // After a refresh, re-load the FileIO with the new table metadata properties to
+        // ensure the right permissions are present for subsequent file system interactions.
+        if (currentMetadata != null) {
+          tableFileIO =
+              loadFileIOForTableLike(
+                  tableIdentifier,
+                  StorageUtil.getLocationsUsedByTable(currentMetadata),
+                  resolvedEntities,
+                  new HashMap<>(currentMetadata.properties()),
+                  Set.of(
+                      PolarisStorageActions.READ,
+                      PolarisStorageActions.WRITE,
+                      PolarisStorageActions.LIST));
+        }
+
         polarisEventListener.onEvent(
             new PolarisEvent(
                 PolarisEventType.AFTER_REFRESH_TABLE,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -114,6 +114,7 @@ import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.cache.EntityCache;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
@@ -124,6 +125,7 @@ import org.apache.polaris.core.persistence.resolver.Resolver;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
@@ -2502,5 +2504,67 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
         catalog.dropNamespace(Namespace.of("pagination_namespace_" + i));
       }
     }
+  }
+
+  @Test
+  public void testFileIOIsRefreshedOnTableRefresh() {
+    // Catalog use the spied provider to verify internal behavior
+    StorageAccessConfigProvider spiedProvider = spy(storageAccessConfigProvider);
+    PolarisPassthroughResolutionView passthroughView =
+        new PolarisPassthroughResolutionView(
+            resolutionManifestFactory, authenticatedRoot, CATALOG_NAME);
+    TaskExecutor taskExecutor = Mockito.mock(TaskExecutor.class);
+    IcebergCatalog catalog =
+        new IcebergCatalog(
+            diagServices,
+            resolverFactory,
+            metaStoreManager,
+            polarisContext,
+            passthroughView,
+            authenticatedRoot,
+            taskExecutor,
+            spiedProvider,
+            fileIOFactory,
+            polarisEventListener,
+            eventMetadataFactory);
+    catalog.setCatalogFileIo(new InMemoryFileIO());
+    catalog.initialize(
+        CATALOG_NAME,
+        Map.of(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+
+    // Create a table
+    TableIdentifier tableIdentifier = TableIdentifier.of(NS, "refresh_test_table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+    catalog.buildTable(tableIdentifier, SCHEMA).create();
+
+    // Get the table operations
+    IcebergCatalog.BasePolarisTableOperations operations =
+        (IcebergCatalog.BasePolarisTableOperations)
+            ((BaseTable) catalog.loadTable(tableIdentifier)).operations();
+
+    // Verify initial state
+    assertThat(operations.io()).isNotNull();
+
+    // refresh the table
+    operations.refresh();
+
+    // Verify that getStorageAccessConfig was called with WRITE permissions at least twice:
+    // 1. during table creation
+    // 2. during table refresh, to update the FileIO with WRITE permissions
+    Mockito.verify(spiedProvider, Mockito.atLeast(2))
+        .getStorageAccessConfig(
+            Mockito.eq(tableIdentifier),
+            Mockito.anySet(),
+            Mockito.argThat(
+                actions ->
+                    actions.containsAll(
+                        Set.of(
+                            PolarisStorageActions.READ,
+                            PolarisStorageActions.WRITE,
+                            PolarisStorageActions.LIST))),
+            Mockito.any(),
+            Mockito.any(PolarisResolvedPathWrapper.class));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -177,9 +177,10 @@ public class FileIOFactoryTest {
         .isInstanceOf(InMemoryFileIO.class);
 
     // 1. BasePolarisCatalog:doCommit: for writing the table during the creation
-    // 2. BasePolarisCatalog:doRefresh: for reading the table during the drop
+    // 2. BasePolarisCatalog:doRefresh: for reading the table during the drop (2 calls: 1 to read, 1
+    // to reload)
     // 3. TaskFileIOSupplier:apply: for clean up metadata files and merge files
-    Mockito.verify(testServices.fileIOFactory(), Mockito.times(3))
+    Mockito.verify(testServices.fileIOFactory(), Mockito.times(4))
         .loadFileIO(Mockito.any(), Mockito.any(), Mockito.any());
   }
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR addressed one of the issues reported in https://github.com/apache/polaris/issues/3440 where spark client is able to use STS temporary credential to create table but not using it for other S3 I/O such as insert for the following call when authed via AssumeRole. It doesn't appear we have any setup or test cases for actually validating this workflow thus the validation was done by the reporter.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
