### PR TITLE
(getting-started) Avoid latest image tags for all other images except polaris

### DIFF
--- a/getting-started/ceph/docker-compose.yml
+++ b/getting-started/ceph/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       - osd1
 
   setup_bucket:
-    image: peakcom/s5cmd:latest
+    image: peakcom/s5cmd:v2.3.0
     depends_on:
       - rgw1
     environment:
@@ -174,7 +174,7 @@ services:
       start_period: 10s
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy

--- a/getting-started/jdbc/docker-compose.yml
+++ b/getting-started/jdbc/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       start_period: 10s
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy
@@ -95,7 +95,7 @@ services:
     ]
 
   trino:
-    image: trinodb/trino:latest
+    image: trinodb/trino:479
     depends_on:
       polaris-setup:
         condition: service_completed_successfully

--- a/getting-started/keycloak/docker-compose.yml
+++ b/getting-started/keycloak/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       start_period: 10s
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy

--- a/getting-started/minio/docker-compose.yml
+++ b/getting-started/minio/docker-compose.yml
@@ -20,7 +20,7 @@
 services:
 
   minio:
-    image: quay.io/minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       # API port
       - "9000:9000"
@@ -66,7 +66,7 @@ services:
       start_period: 10s
 
   setup_bucket:
-    image: quay.io/minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -81,7 +81,7 @@ services:
         echo Bucket setup complete.;
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy

--- a/getting-started/ozone/docker-compose.yml
+++ b/getting-started/ozone/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       start_period: 10s
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy

--- a/getting-started/quickstart/docker-compose.yml
+++ b/getting-started/quickstart/docker-compose.yml
@@ -20,7 +20,7 @@
 services:
 
   minio:
-    image: quay.io/minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       # API port
       - "9000:9000"
@@ -68,7 +68,7 @@ services:
       start_period: 10s
 
   setup_bucket:
-    image: quay.io/minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -83,7 +83,7 @@ services:
         echo Bucket setup complete.;
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy

--- a/getting-started/telemetry/docker-compose.yml
+++ b/getting-started/telemetry/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       retries: 10
 
   polaris-setup:
-    image: alpine/curl
+    image: alpine/curl:8.17.0
     depends_on:
       polaris:
         condition: service_healthy


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

As concluded in https://github.com/apache/polaris/pull/3482/files, it is more preferred to use implicit image tags for all images except polaris (we will keep polaris one as latest...by doing so, if we want to test thing, we can just rebuild locally and restart docker-compose deployment for testing). 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
