### PR TITLE
Add jitpack.io repository

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,7 +118,10 @@ dependencyResolutionManagement {
   repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
   repositories {
     mavenCentral()
-    maven { url = uri("https://jitpack.io") }
+    maven {
+      url = uri("https://jitpack.io")
+      content { includeModule("com.github.RoaringBitmap.RoaringBitmap", "roaringbitmap") }
+    }
     gradlePluginPortal()
   }
 }


### PR DESCRIPTION
The Iceberg PR https://github.com/apache/iceberg/pull/14991 bumps the https://github.com/RoaringBitmap/RoaringBitmap version, which is not published to Maven Central. We need to declare in the jitpack.io repository to prepare for the next Iceberg release.
