### PR TITLE
(feat) Tool: Make python version configuration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 ## Variables
+PYTHON ?= python3
 BUILD_IMAGE ?= true
 DOCKER ?= docker
 MINIKUBE_PROFILE ?= minikube
@@ -109,7 +110,7 @@ spotless-apply: check-dependencies ## Apply code formatting using Spotless Gradl
 # Target to create the virtual environment directory
 $(VENV_DIR):
 	@echo "Setting up Python virtual environment at $(VENV_DIR)..."
-	@python3 -m venv $(VENV_DIR)
+	@$(PYTHON) -m venv $(VENV_DIR)
 	@echo "Virtual environment created."
 
 .PHONY: client-install-dependencies
@@ -134,7 +135,7 @@ client-lint: client-setup-env ## Run linting checks for Polaris client
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code
 	@echo "--- Regenerating client code ---"
-	@$(ACTIVATE_AND_CD) && python3 -B generate_clients.py
+	@$(ACTIVATE_AND_CD) && $(PYTHON) -B generate_clients.py
 	@echo "--- Client code regeneration complete ---"
 
 .PHONY: client-unit-test
@@ -219,7 +220,7 @@ helm-doc-generate: DEPENDENCIES := helm-docs
 helm-doc-generate: check-dependencies ## Generate Helm chart documentation
 	@echo "--- Generating Helm documentation ---"
 	@helm-docs --chart-search-root=helm
-	@python3 helm/polaris/tools/prepare_helm_readme.py helm/polaris/README.md site/content/in-dev/unreleased/helm.md
+	@$(PYTHON) helm/polaris/tools/prepare_helm_readme.py helm/polaris/README.md site/content/in-dev/unreleased/helm.md
 	@echo "--- Helm documentation generated and copied ---"
 
 helm-unittest: DEPENDENCIES := helm


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently the Makefile is default to `python3` (which can be any python3 version users may had set on their setup), to allow user to use a specific version of Python for building as well testing, we should consider make python version configurable without modifying symbolic link for python3 or modify Makefile. Here is a sample use-case I tried earlier to validate if we can actually use python3.14 for polaris:
```
➜  polaris git:(makefile_custom_python) ✗ PYTHON=python3.14 make client-regenerate
Setting up Python virtual environment at .venv...
Virtual environment created.
Installing UV and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.14/site-packages (25.3)
Collecting uv>=0.9.0
  Using cached uv-0.9.26-py3-none-macosx_11_0_arm64.whl.metadata (11 kB)
Using cached uv-0.9.26-py3-none-macosx_11_0_arm64.whl (20.2 MB)
Installing collected packages: uv
Successfully installed uv-0.9.26
Resolved 63 packages in 8ms
Resolved 63 packages in 4ms
  × Failed to build `pyroaring==1.0.3`
...
  help: `pyroaring` (v1.0.3) was included because `apache-polaris:dev` (v1.4.0) depends on `pyiceberg` (v0.10.0) which depends on `pyroaring`
``` 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
