### PR TITLE
Let `site/bin/checkout-releases.sh` pull the latest state

### DIFF
--- a/site/bin/checkout-releases.sh
+++ b/site/bin/checkout-releases.sh
@@ -30,3 +30,5 @@ if [[ -d content/releases ]] ; then
 fi
 
 git worktree add content/releases versioned-docs
+
+(cd content/releases ; git pull)


### PR DESCRIPTION
The script `site/bin/checkout-releases.sh` is a convenience to get the `versioned-docs` branch locally. It is missing a `git pull` to get the latest state of that branch though, which can be confusing.
