### PR TITLE
Update triggers in "Hugo Site" workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,9 +20,9 @@
 name: "Hugo Site"
 on:
   push:
-    branches: [ "main", "release/*", "versioned-docs" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "release/*" ]
+    branches: [ "main" ]
 
 jobs:
   site:


### PR DESCRIPTION
The `site.yml` workflow is currently triggered in the following scenarios:
1. A push to the `main` branch, using the state of the site and the workflow as on `main`.
2. A push to a `release/*`branch, using the state of the site and the workflow as on that release branch.

Notice that workflows get the repo state (from the checkout actions) and the workflow state as its on that particular branch. Put in other words: if we'd have a change to some old `release/1.0.x` branch, the web site would be updated as it is defined on that `release/1.0.x` branch, which is wrong and not the intended behavior.

This change updates the workflow triggers to only run for pushes to the `main` branch, plus PRs against the `main` branch and when called from another workflow.

This is part of #3516