### PR TITLE
Versioned-docs: trigger site publication

### DIFF
--- a/.github/workflows/trigger-site.yml
+++ b/.github/workflows/trigger-site.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Tigger Site Publishing"
+name: "Trigger Site Publishing"
 on:
   push:
     branches: [ "versioned_docs" ]


### PR DESCRIPTION
A workflow triggered on a `push` to the `versioned-docs` branch and calls the "Hugo Site" publication workflow on the `main` branch.

Part of #3516