### PR TITLE
Site-workflow: add `workflow_call` trigger

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,7 +31,7 @@ on:
 # Ensure that no two site publications happen concurrently.
 # 1 job per reference can run concurrently, no cancellation
 concurrency:
-  group: ${{ github.ref }}
+  group: site-publishing
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
This trigger allows the Hugo Site publication workflow to be called from the `versioned-docs` branch.
    
This change also introduces a concurrency group to prevent concurrent site publications.
    
Fixes #3516