### PR TITLE
Disable renoavte update for python version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,6 +84,11 @@
     {
       matchPackageNames: ["openapi-generator-cli"],
       enabled: false
+    },
+    // Disable update for python version
+    {
+      matchPackageNames: ["python"],
+      enabled: false
     }
   ],
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Disable renovatebot for updating python version as not all versions will work due to dependencies may not work on newer version (e.g. https://github.com/apache/polaris/pull/3539). Same reported in https://github.com/apache/polaris/pull/3491.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
