### PR TITLE
fix(JDBC): Add retry condition for acquisition timeout error

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -312,7 +312,8 @@ public class DatasourceOperations {
 
     // Additionally, one might check for specific error messages or other conditions
     return e.getMessage().toLowerCase(Locale.ROOT).contains("connection refused")
-        || e.getMessage().toLowerCase(Locale.ROOT).contains("connection reset");
+        || e.getMessage().toLowerCase(Locale.ROOT).contains("connection reset")
+        || e.getMessage().toLowerCase(Locale.ROOT).contains("acquisition timeout");
   }
 
   // TODO: consider refactoring to use a retry library, inorder to have fair retries

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -291,4 +291,18 @@ public class DatasourceOperationsTest {
     assertThrows(SQLException.class, () -> datasourceOperations.withRetries(mockOperation));
     verify(mockOperation, times(1)).execute();
   }
+
+  @Test
+  void testAcquisitionTimeoutIsRetryable() throws SQLException {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(2000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockOperation.execute())
+        .thenThrow(new SQLException("Acquisition timeout while waiting for new connection"))
+        .thenReturn("Success!");
+
+    String result = datasourceOperations.withRetries(mockOperation);
+    assertEquals("Success!", result);
+    verify(mockOperation, times(2)).execute();
+  }
 }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
### Description
When the Agroal connection pool is exhausted, requests fail with "Acquisition timeout while waiting for new connection". This error is often transient during traffic spikes and should be retried.

Added "acquisition timeout" to the list of retryable error conditions in DatasourceOperations.isRetryable() method.

#### Stack trace: 
`Caused by: java.sql.SQLException: Failed due to 'Acquisition timeout while waiting for new connection' (error code 0, sql-state 'null'), after 1 attempts and 5000 milliseconds
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.withRetries(DatasourceOperations.java:300)
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.executeSelectOverStream(DatasourceOperations.java:153)
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.executeSelect(DatasourceOperations.java:134)
	at org.apache.polaris.persistence.relational.jdbc.JdbcBasePersistenceImpl.lookupEntities(JdbcBasePersistenceImpl.java:399)
	... 68 more
Caused by: java.sql.SQLException: Acquisition timeout while waiting for new connection
	at io.agroal.pool.ConnectionPool.handlerFromSharedCache(ConnectionPool.java:367)
	at io.agroal.pool.ConnectionPool.getConnection(ConnectionPool.java:293)
	at io.agroal.pool.DataSource.getConnection(DataSource.java:86)
	at io.agroal.api.AgroalDataSource_sqqLi56D50iCdXmOjyjPSAxbLu0_Synthetic_ClientProxy.getConnection(Unknown Source)
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.borrowConnection(DatasourceOperations.java:339)
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.lambda$executeSelectOverStream$2(DatasourceOperations.java:156)
	at org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.withRetries(DatasourceOperations.java:271)
	... 71 more
Caused by: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:204)
	at io.agroal.pool.ConnectionPool.handlerFromSharedCache(ConnectionPool.java:344)
	... 77 more`

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
