### PR TITLE
Fix the Keycloak getting-started example for 26.5+

### DIFF
--- a/getting-started/assets/keycloak/iceberg-realm.json
+++ b/getting-started/assets/keycloak/iceberg-realm.json
@@ -356,9 +356,9 @@
         "acr.loa.map": "{}",
         "display.on.consent.screen": "false",
         "client.offline.session.max.lifespan": "86400",
-        "client.session.max.lifespan": "86400",
+        "client.session.max.lifespan": "36000",
         "token.response.type.bearer.lower-case": "false",
-        "client.session.idle.timeout": "86400"
+        "client.session.idle.timeout": "1800"
       },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,


### PR DESCRIPTION
The example was failing because Keycloak 26.5 introduced stricter validation rules for session lifespan and timeout.

Fixes #3567

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
