### PR TITLE
Guides: use `sql` code block

### DIFF
--- a/getting-started/ceph/README.md
+++ b/getting-started/ceph/README.md
@@ -125,20 +125,17 @@ since Ceph does not require a specific region.
 
 Run inside the Spark SQL shell:
 
+```sql
+USE polaris;
+
+CREATE NAMESPACE ns;
+
+CREATE TABLE ns.t1 AS SELECT 'abc';
+
+SELECT * FROM ns.t1;
+-- abc
 ```
-spark-sql (default)> use polaris;
-Time taken: 0.837 seconds
 
-spark-sql ()> create namespace ns;
-Time taken: 0.374 seconds
-
-spark-sql ()> create table ns.t1 as select 'abc';
-Time taken: 2.192 seconds
-
-spark-sql ()> select * from ns.t1;
-abc
-Time taken: 0.579 seconds, Fetched 1 row(s)
-```
 ## Lack of Credential Vending
 
 Notice that the Spark configuration does not contain a `X-Iceberg-Access-Delegation` header.

--- a/getting-started/minio/README.md
+++ b/getting-started/minio/README.md
@@ -72,19 +72,15 @@ since MinIO does not require a specific region.
 
 Run inside the Spark SQL shell:
 
-```
-spark-sql (default)> use polaris;
-Time taken: 0.837 seconds
+```sql
+USE polaris;
 
-spark-sql ()> create namespace ns;
-Time taken: 0.374 seconds
+CREATE NAMESPACE ns;
 
-spark-sql ()> create table ns.t1 as select 'abc';
-Time taken: 2.192 seconds
+CREATE TABLE ns.t1 AS SELECT 'abc';
 
-spark-sql ()> select * from ns.t1;
-abc
-Time taken: 0.579 seconds, Fetched 1 row(s)
+SELECT * FROM ns.t1;
+-- abc
 ```
 
 ## MinIO Endpoints

--- a/getting-started/ozone/README.md
+++ b/getting-started/ozone/README.md
@@ -64,19 +64,15 @@ when securing S3 is not enabled.
 
 Run inside the Spark SQL shell:
 
-```
-spark-sql (default)> use polaris;
-Time taken: 0.837 seconds
+```sql
+USE polaris;
 
-spark-sql ()> create namespace ns;
-Time taken: 0.374 seconds
+CREATE NAMESPACE ns;
 
-spark-sql ()> create table ns.t1 as select 'abc';
-Time taken: 2.192 seconds
+CREATE TABLE ns.t1 AS SELECT 'abc';
 
-spark-sql ()> select * from ns.t1;
-abc
-Time taken: 0.579 seconds, Fetched 1 row(s)
+SELECT * FROM ns.t1;
+-- abc
 ```
 
 ## Lack of Credential Vending

--- a/getting-started/rustfs/README.md
+++ b/getting-started/rustfs/README.md
@@ -70,19 +70,15 @@ since RustFS does not require a specific region.
 
 Run inside the Spark SQL shell:
 
-```
-spark-sql (default)> use polaris;
-Time taken: 0.837 seconds
+```sql
+USE polaris;
 
-spark-sql ()> create namespace ns;
-Time taken: 0.374 seconds
+CREATE NAMESPACE ns;
 
-spark-sql ()> create table ns.t1 as select 'abc';
-Time taken: 2.192 seconds
+CREATE TABLE ns.t1 AS SELECT 'abc';
 
-spark-sql ()> select * from ns.t1;
-abc
-Time taken: 0.579 seconds, Fetched 1 row(s)
+SELECT * FROM ns.t1;
+-- abc
 ```
 
 ## RustFS Endpoints


### PR DESCRIPTION
Replaces the "anonymous" code blocks with `sql` code blocks, which is easier to "copy + paste" for users.
