### PR TITLE
Ozone guide: add missing `X-Iceberg-Access-Delegation` header

### DIFF
--- a/getting-started/ozone/README.md
+++ b/getting-started/ozone/README.md
@@ -48,6 +48,7 @@ bin/spark-sql \
     --conf spark.sql.catalog.polaris.token-refresh-enabled=false \
     --conf spark.sql.catalog.polaris.warehouse=quickstart_catalog \
     --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
+    --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation="" \
     --conf spark.sql.catalog.polaris.credential=root:s3cr3t \
     --conf spark.sql.catalog.polaris.client.region=us-west-2 \
     --conf spark.sql.catalog.polaris.s3.access-key-id=polaris_root \


### PR DESCRIPTION
This aligns the Ozone guide with the other object storages guides.