### PR TITLE
Minio guide: fix service dependencies

### DIFF
--- a/getting-started/minio/docker-compose.yml
+++ b/getting-started/minio/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     depends_on:
       minio:
         condition: service_healthy
+      setup_bucket:
+        condition: service_completed_successfully
     environment:
       JAVA_DEBUG: true
       JAVA_DEBUG_PORT: "*:5005"
@@ -67,6 +69,7 @@ services:
 
   setup_bucket:
     image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    restart: "no"
     depends_on:
       minio:
         condition: service_healthy
@@ -82,6 +85,7 @@ services:
 
   polaris-setup:
     image: alpine/curl:8.17.0
+    restart: "no"
     depends_on:
       polaris:
         condition: service_healthy


### PR DESCRIPTION
Use the "long" options for compose service dependencies, and adds the explicit option `restart: no` option for setup tasks, which is necessary to let docker-compose correctly interpret the termination of such tasks.