### PR TITLE
Telemetry guide: fix setup-polaris service

### DIFF
--- a/getting-started/telemetry/docker-compose.yml
+++ b/getting-started/telemetry/docker-compose.yml
@@ -69,7 +69,6 @@ services:
     command:
       - "-c"
       - >-
-        chmod +x /polaris/create-catalog.sh;
         /polaris/create-catalog.sh;
 
   prometheus:


### PR DESCRIPTION
Fixes the polaris-setup service to use the "working" way/syntax, in alignment to other guides.