### PR TITLE
Getting-Started: Jaeger upgraded from V1 to V2

### DIFF
--- a/getting-started/telemetry/docker-compose.yml
+++ b/getting-started/telemetry/docker-compose.yml
@@ -92,8 +92,6 @@ services:
       - "4317:4317"
       # Jaeger UI
       - "16686:16686"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:13133/status"]
       interval: 5s


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

As reported by @snazy in https://github.com/apache/polaris/issues/3579, the Jaeger all-in-one image is EOL. Switched to V2 and use the new health check endpoint (https://docs.google.com/document/d/1z4QrNtB9dMgT5SHNx-7Vc38XPLqnjmM2jFIupvkAEHo/view?tab=t.0#heading=h.jnv1rg1hltk)

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
