### PR TITLE
Guides: add mandatory `curl` `--fail` option

### DIFF
--- a/getting-started/assets/polaris/create-catalog.sh
+++ b/getting-started/assets/polaris/create-catalog.sh
@@ -77,7 +77,9 @@ PAYLOAD='{
 
 echo $PAYLOAD
 
-curl -s -H "Authorization: Bearer ${TOKEN}" \
+curl --fail-with-body \
+   -s \
+   -H "Authorization: Bearer ${TOKEN}" \
    -H 'Accept: application/json' \
    -H 'Content-Type: application/json' \
    -H "Polaris-Realm: $realm" \

--- a/getting-started/assets/polaris/obtain-token.sh
+++ b/getting-started/assets/polaris/obtain-token.sh
@@ -23,7 +23,10 @@ apk add --no-cache jq
 
 realm=${1:-"POLARIS"}
 
-TOKEN=$(curl -s http://polaris:8181/api/catalog/v1/oauth/tokens \
+TOKEN=$(curl \
+  --fail-with-body \
+  -s \
+  http://polaris:8181/api/catalog/v1/oauth/tokens \
   --user ${CLIENT_ID}:${CLIENT_SECRET} \
   -H "Polaris-Realm: $realm" \
   -d grant_type=client_credentials \

--- a/getting-started/ceph/docker-compose.yml
+++ b/getting-started/ceph/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     depends_on:
       - osd1
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7480"]
+      test: ["CMD", "curl", "--fail", "http://localhost:7480"]
       interval: 2s
       timeout: 10s
       retries: 10
@@ -172,7 +172,7 @@ services:
       polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10

--- a/getting-started/jdbc/docker-compose.yml
+++ b/getting-started/jdbc/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"
       polaris.readiness.ignore-severe-issues: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10
@@ -76,7 +76,7 @@ services:
     ports:
       - "4040-4045:4040-4045"
     healthcheck:
-      test: "curl localhost:4040"
+      test: ["CMD", "curl", "--fail", "http://localhost:4040"]
       interval: 5s
       retries: 15
     command: [

--- a/getting-started/keycloak/docker-compose.yml
+++ b/getting-started/keycloak/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"
       polaris.readiness.ignore-severe-issues: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10

--- a/getting-started/minio/docker-compose.yml
+++ b/getting-started/minio/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "--console-address"
       - ":9001"
     healthcheck:
-      test: ["CMD", "curl", "http://127.0.0.1:9000/minio/health/live"]
+      test: ["CMD", "curl", "--fail", "http://127.0.0.1:9000/minio/health/live"]
       interval: 1s
       timeout: 10s
 
@@ -61,7 +61,7 @@ services:
       polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10

--- a/getting-started/ozone/docker-compose.yml
+++ b/getting-started/ozone/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       ozone-datanode:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:9888"]
+      test: ["CMD", "curl", "--fail", "http://localhost:9888"]
       interval: 1s
       timeout: 10s
       retries: 60
@@ -91,7 +91,9 @@ services:
       <<: *ozone-common-config
       WAITFOR: ozone-om:9874
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:9878"]
+      test: ["CMD", "curl", "--fail", "http://localhost:19878"]
+      # Should ideally use the following, but the curl version in ozone image is too old (7.76.1) to support --aws-sigv4
+      # test: ["CMD", "curl", "--fail", "--user", "root:s3cr3t", "--aws-sigv4", "aws:amz:us-west-1:s3", "http://localhost:9878"]
       interval: 1s
       timeout: 10s
       retries: 60
@@ -118,7 +120,7 @@ services:
       polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 60

--- a/getting-started/quickstart/docker-compose.yml
+++ b/getting-started/quickstart/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"]
+      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:9000/health && curl --fail http://127.0.0.1:9001/rustfs/console/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -62,7 +62,7 @@ services:
       polaris.realm-context.realms: ${POLARIS_REALM:-POLARIS}
       quarkus.otel.sdk.disabled: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10

--- a/getting-started/rustfs/docker-compose.yml
+++ b/getting-started/rustfs/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"]
+      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:9000/health && curl --fail http://127.0.0.1:9001/rustfs/console/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -60,7 +60,7 @@ services:
       polaris.realm-context.realms: POLARIS
       quarkus.otel.sdk.disabled: "true"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10

--- a/getting-started/spark/docker-compose.yml
+++ b/getting-started/spark/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"
       polaris.readiness.ignore-severe-issues: "true"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/healthcheck"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/getting-started/telemetry/docker-compose.yml
+++ b/getting-started/telemetry/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       quarkus.log.file.format:    "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] [%X{app},%X{env}] [%X{realmId},%X{requestId}] [%X{traceId},%X{spanId}] (%t) %s%e%n"
       polaris.realm-context.realms: POLARIS
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8182/q/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8182/q/health"]
       interval: 2s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
`curl` does _not_ return an error code when the URL can be retrieved but returns an error HTTP status code, for example 404, 403, 401. This means that the health checks are yieldíng "OK" too early.

This change adds the missing `--fail` option.