### PR TITLE
Guides: compose dependencies / long-option

### DIFF
--- a/getting-started/ceph/docker-compose.yml
+++ b/getting-started/ceph/docker-compose.yml
@@ -61,7 +61,8 @@ services:
     volumes:
       - ./ceph-conf:/etc/ceph
     depends_on:
-      - mon1
+      mon1:
+        condition: service_started
     ports:
       - ${DASHBOARD_PORT}:${INTERNAL_DASHBOARD_PORT}
 
@@ -93,7 +94,8 @@ services:
       - ./ceph-conf:/etc/ceph
       - ./bootstrap-osd:/var/lib/ceph/bootstrap-osd
     depends_on:
-      - mon1
+      mon1:
+        condition: service_started
 
   rgw1:
     image: quay.io/ceph/ceph:v20.2.0
@@ -125,7 +127,8 @@ services:
     volumes:
       - ./ceph-conf:/etc/ceph
     depends_on:
-      - osd1
+      osd1:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7480"]
       interval: 2s
@@ -161,7 +164,8 @@ services:
       # Optional, allows attaching a debugger to the Polaris JVM
       - "5005:5005"
     depends_on:
-      - rgw1
+      rgw1:
+        condition: service_started
     environment:
       JAVA_DEBUG: true
       JAVA_DEBUG_PORT: "*:5005"

--- a/getting-started/minio/docker-compose.yml
+++ b/getting-started/minio/docker-compose.yml
@@ -89,6 +89,8 @@ services:
     depends_on:
       polaris:
         condition: service_healthy
+      setup_bucket:
+        condition: service_completed_successfully
     environment:
       - CLIENT_ID=root
       - CLIENT_SECRET=s3cr3t

--- a/getting-started/quickstart/docker-compose.yml
+++ b/getting-started/quickstart/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     depends_on:
       rustfs:
         condition: service_healthy
+      bucket-setup:
+        condition: service_completed_successfully
     environment:
       JAVA_DEBUG: true
       JAVA_DEBUG_PORT: "*:5005"

--- a/getting-started/telemetry/docker-compose.yml
+++ b/getting-started/telemetry/docker-compose.yml
@@ -78,6 +78,8 @@ services:
     depends_on:
       polaris:
         condition: service_healthy
+      polaris-setup:
+        condition: service_completed_successfully
     volumes:
       - ../assets/prometheus/:/etc/prometheus/
     command:


### PR DESCRIPTION
Docker compose's "short" `depends_on` syntax (just mentioning the dependent service) does not assert on the expected condition (`service_healthy` or `service_completed_successfully`). This can lead to services being started too early, although their dependencies are not in the expected state.

This change updates the affected parts to use the "long" syntax.