### PR TITLE
Simplify CatalogPrefixParser API

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/CatalogPrefixParser.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/CatalogPrefixParser.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.service.catalog;
 
-import org.apache.polaris.core.context.RealmContext;
-
 /** An extension point for converting Iceberg REST API "prefix" values to Polaris Catalog names. */
 public interface CatalogPrefixParser {
 
@@ -27,19 +25,17 @@ public interface CatalogPrefixParser {
    * Produces the name of a Polaris catalog from the given Iceberg Catalog REST API "prefix" for the
    * specified realm.
    *
-   * @param realm identifies the realm where the API request is to be served.
    * @param prefix the "prefix" according to the Iceberg REST Catalog API specification.
    * @return Polaris Catalog name
    */
-  String prefixToCatalogName(RealmContext realm, String prefix);
+  String prefixToCatalogName(String prefix);
 
   /**
    * Produces the "prefix" according to the Iceberg REST Catalog API specification for the given
    * Polaris catalog name in the specified realm.
    *
-   * @param realm identifies the realm owning the catalog
    * @param catalogName name of a Polaris catalog.
    * @return the "prefix" for the Iceberg REST client to be used for requests to the given catalog.
    */
-  String catalogNameToPrefix(RealmContext realm, String catalogName);
+  String catalogNameToPrefix(String catalogName);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/DefaultCatalogPrefixParser.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/DefaultCatalogPrefixParser.java
@@ -19,17 +19,16 @@
 package org.apache.polaris.service.catalog;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.polaris.core.context.RealmContext;
 
 @ApplicationScoped
 public class DefaultCatalogPrefixParser implements CatalogPrefixParser {
   @Override
-  public String prefixToCatalogName(RealmContext realm, String prefix) {
+  public String prefixToCatalogName(String prefix) {
     return prefix;
   }
 
   @Override
-  public String catalogNameToPrefix(RealmContext realm, String catalogName) {
+  public String catalogNameToPrefix(String catalogName) {
     return catalogName;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
@@ -55,7 +55,7 @@ public class CatalogGenericTableEventServiceDelegator
       CreateGenericTableRequest createGenericTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_CREATE_GENERIC_TABLE,
@@ -87,7 +87,7 @@ public class CatalogGenericTableEventServiceDelegator
       String genericTable,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
@@ -117,7 +117,7 @@ public class CatalogGenericTableEventServiceDelegator
       Integer pageSize,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LIST_GENERIC_TABLES,
@@ -145,7 +145,7 @@ public class CatalogGenericTableEventServiceDelegator
       String genericTable,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_GENERIC_TABLE,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -101,7 +101,7 @@ public class GenericTableCatalogAdapter
         resolutionManifestFactory,
         metaStoreManager,
         principal,
-        prefixParser.prefixToCatalogName(realmContext, prefix),
+        prefixParser.prefixToCatalogName(prefix),
         polarisAuthorizer,
         polarisCredentialManager,
         externalCatalogFactories);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -157,7 +157,7 @@ public class IcebergCatalogAdapter
       SecurityContext securityContext,
       String prefix,
       Function<IcebergCatalogHandler, Response> action) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     return withCatalogByName(securityContext, catalogName, action);
   }
 
@@ -727,7 +727,7 @@ public class IcebergCatalogAdapter
       ReportMetricsRequest reportMetricsRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace ns = decodeNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1344,7 +1344,7 @@ public class IcebergCatalogHandler extends CatalogHandler implements AutoCloseab
     Map<String, String> properties =
         PolarisEntity.of(resolvedReferenceCatalog.getEntity()).getPropertiesAsMap();
 
-    String prefix = prefixParser.catalogNameToPrefix(callContext.getRealmContext(), catalogName);
+    String prefix = prefixParser.catalogNameToPrefix(catalogName);
     return ConfigResponse.builder()
         .withDefaults(properties) // catalog properties are defaults
         .withOverrides(ImmutableMap.of("prefix", prefix))

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
@@ -92,7 +92,7 @@ public class IcebergRestCatalogEventServiceDelegator
       CreateNamespaceRequest createNamespaceRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_CREATE_NAMESPACE,
@@ -122,7 +122,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String parent,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LIST_NAMESPACES,
@@ -145,7 +145,7 @@ public class IcebergRestCatalogEventServiceDelegator
   @Override
   public Response loadNamespaceMetadata(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_NAMESPACE_METADATA,
@@ -170,7 +170,7 @@ public class IcebergRestCatalogEventServiceDelegator
   @Override
   public Response namespaceExists(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -193,7 +193,7 @@ public class IcebergRestCatalogEventServiceDelegator
   @Override
   public Response dropNamespace(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_DROP_NAMESPACE,
@@ -219,7 +219,7 @@ public class IcebergRestCatalogEventServiceDelegator
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -255,7 +255,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String accessDelegationMode,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -296,7 +296,7 @@ public class IcebergRestCatalogEventServiceDelegator
       Integer pageSize,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -327,7 +327,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String snapshots,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -370,7 +370,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String table,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -400,7 +400,7 @@ public class IcebergRestCatalogEventServiceDelegator
       Boolean purgeRequested,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -432,7 +432,7 @@ public class IcebergRestCatalogEventServiceDelegator
       RegisterTableRequest registerTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -463,7 +463,7 @@ public class IcebergRestCatalogEventServiceDelegator
       RenameTableRequest renameTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_RENAME_TABLE,
@@ -490,7 +490,7 @@ public class IcebergRestCatalogEventServiceDelegator
       CommitTableRequest commitTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -526,7 +526,7 @@ public class IcebergRestCatalogEventServiceDelegator
       CreateViewRequest createViewRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -558,7 +558,7 @@ public class IcebergRestCatalogEventServiceDelegator
       Integer pageSize,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -586,7 +586,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String table,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -616,7 +616,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -646,7 +646,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -675,7 +675,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -703,7 +703,7 @@ public class IcebergRestCatalogEventServiceDelegator
       RenameTableRequest renameTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_RENAME_VIEW,
@@ -730,7 +730,7 @@ public class IcebergRestCatalogEventServiceDelegator
       CommitViewRequest commitViewRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(
@@ -763,7 +763,7 @@ public class IcebergRestCatalogEventServiceDelegator
       CommitTransactionRequest commitTransactionRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_COMMIT_TRANSACTION,
@@ -833,7 +833,7 @@ public class IcebergRestCatalogEventServiceDelegator
       NotificationRequest notificationRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     Namespace namespaceObj = decodeNamespace(namespace);
     polarisEventListener.onEvent(
         new PolarisEvent(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/CatalogPolicyEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/CatalogPolicyEventServiceDelegator.java
@@ -59,7 +59,7 @@ public class CatalogPolicyEventServiceDelegator
       CreatePolicyRequest createPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_CREATE_POLICY,
@@ -91,7 +91,7 @@ public class CatalogPolicyEventServiceDelegator
       String policyType,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LIST_POLICIES,
@@ -121,7 +121,7 @@ public class CatalogPolicyEventServiceDelegator
       String policyName,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_POLICY,
@@ -151,7 +151,7 @@ public class CatalogPolicyEventServiceDelegator
       UpdatePolicyRequest updatePolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_UPDATE_POLICY,
@@ -183,7 +183,7 @@ public class CatalogPolicyEventServiceDelegator
       Boolean detachAll,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_DROP_POLICY,
@@ -216,7 +216,7 @@ public class CatalogPolicyEventServiceDelegator
       AttachPolicyRequest attachPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_ATTACH_POLICY,
@@ -249,7 +249,7 @@ public class CatalogPolicyEventServiceDelegator
       DetachPolicyRequest detachPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_DETACH_POLICY,
@@ -284,7 +284,7 @@ public class CatalogPolicyEventServiceDelegator
       String policyType,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    String catalogName = prefixParser.prefixToCatalogName(realmContext, prefix);
+    String catalogName = prefixParser.prefixToCatalogName(prefix);
     polarisEventListener.onEvent(
         new PolarisEvent(
             PolarisEventType.BEFORE_GET_APPLICABLE_POLICIES,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -101,7 +101,7 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
         resolutionManifestFactory,
         metaStoreManager,
         principal,
-        prefixParser.prefixToCatalogName(realmContext, prefix),
+        prefixParser.prefixToCatalogName(prefix),
         polarisAuthorizer,
         polarisCredentialManager,
         externalCatalogFactories);


### PR DESCRIPTION
This component's methods do not need to have a `RealmContext` parameter: either the implementation is application-scoped, in which case the realm is irrelevant; or the implementation is request-scoped, in which case it can have the `RealmContext` injected. (FWIW, the default implementation is application-scoped.)

This refactor will further simplify the remote request signing implementation.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
