### PR TITLE
fix(site): Bump the binary distribution version.

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/binary-distribution.md
+++ b/site/content/in-dev/unreleased/getting-started/binary-distribution.md
@@ -32,8 +32,8 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.2.0-incubating/polaris-bin-1.2.0-incubating.tgz | tar xz
-cd polaris-distribution-1.2.0-incubating
+curl -L https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz | tar xz
+cd polaris-distribution-1.3.0-incubating
 ```
 
 Start the Polaris server:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Bump the binary distribution version in `getting-started` page as `1.3.0` is the available release version on https://downloads.apache.org/incubator/polaris/

The current command will return `no such file or directory: polaris-distribution-1.2.0-incubating`

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
