### PR TITLE
"Stale" job: restrict executions and adjust issue permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,7 @@
 ---
 jobs:
   stale:
+    if: github.repository == 'apache/polaris'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@d6f8a33132340b15a7006f552936e4b9b39c00ec
@@ -33,5 +34,5 @@ on:
   schedule:
     - cron: "30 1 * * *"
 permissions:
-  issues: read
+  issues: write
   pull-requests: write


### PR DESCRIPTION
The job wasn't capable of closing issues because of insufficient permissions.
This change also makes the job run only on the `apache/polaris` repo.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
