### PR TITLE
CI: Fix site workflow concurrency

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,7 +31,7 @@ on:
 # Ensure that no two site publications happen concurrently.
 # 1 job per reference can run concurrently, no cancellation
 concurrency:
-  group: site-publishing
+  group: site-publishing-${{ case(github.event_name == 'push', 'main', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
The change #3520 added a concurrency group, accidentally a _static_ concurrency group which applies to both pushed to "main" and all PRs, which is wrong.
