### PR TITLE
Releasey: adjust workflwo for Apache org level secrets

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Log in to Docker Hub
         if: env.DRY_RUN == '0'
         run: |
-          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.DOCKERHUB_USER }}" --password-stdin
 
       - name: Publish Polaris Server Docker image to Docker Hub
         run: |


### PR DESCRIPTION
See reference [INFRA-27430](https://issues.apache.org/jira/browse/INFRA-27430), requiring us to use `DOCKERHUB_USER` + `DOCKERHUB_TOKEN` instead of `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN`.
