### PR TITLE
Site: Adds the copyright message to all site pages

### DIFF
--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -54,7 +54,6 @@ For announcement and discussions about the project.
 Apache Polaris™ is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 </p>
 <p>
-Copyright © 2026 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.
-Apache®, Apache Polaris™, Apache Iceberg™, Apache Spark™, Apache, the Apache logo, and the Apache Polaris project logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+Apache®, Apache Polaris™, Apache Iceberg™, Apache Spark™ are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
 </p>
 {{< /blocks/section >}}

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -21,6 +21,7 @@ baseURL: 'https://polaris.apache.org/'
 languageCode: 'en-us'
 title: 'Apache Polaris'
 enableRobotsTXT: true
+copyright: '<a href="https://www.apache.org/">Copyright © 2026 The Apache Software Foundation</a>.<br>Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.'
 
 permalinks:
   blog: "/:section/:year/:month/:day/:slug/"


### PR DESCRIPTION

Removes the bespoke copyright message on the index page and replaces it with a copyright in the footer on every page.

Examples
<img width="1507" height="309" alt="image" src="https://github.com/user-attachments/assets/3ea22e37-5a4b-4da2-acca-597206ac428a" />

<img width="1507" height="471" alt="image" src="https://github.com/user-attachments/assets/5c17b35c-9916-4f34-935d-04f30f12c968" />
