### PR TITLE
Site: Change Security link to local security reporting page

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -227,11 +227,8 @@ menu:
         external: true
     - name: "Security"
       parent: "asf"
-      url: "https://github.com/apache/polaris/blob/main/SECURITY.md"
+      url: "/community/security-report"
       weight: 46
-      params:
-        rel: "external"
-        external: true
     - name: "Sponsorship"
       parent: "asf"
       url: "https://www.apache.org/foundation/sponsorship.html"


### PR DESCRIPTION
Changes the link to use a relative path to our Security Reporting instructions rather than a link to the github.md file which Whimsy does not enjoy.
