### PR TITLE
Fix CI required checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,7 +53,9 @@ github:
         # Contexts are the names of checks that must pass. This is the value
         # of the job's `name` property if it's present.
         contexts:
-          - "Required Checks"
+          # "CI/PR" is the name of the workflow _job_ (jobs.ci-pr.name in ci-pr.yml),
+          # "Required Checks" is the name of the workflow _job_ in ci.yml.
+          - "CI/PR / Required Checks"
 
   features:
     wiki: false

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,5 +30,7 @@ concurrency:
 
 jobs:
   ci-pr:
-    name: PR#${{ github.event.number }} ${{ github.event.pull_request.title }}
+    # The 'name' MUST BE CONSTANT, as it becomes a part of the required_checks in .asf.yaml !!
+    # Do not rename this job, this is referenced in .asf.yaml!
+    name: CI/PR
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,8 @@ jobs:
         with:
           ref: "versioned-docs"
           path: site/content/releases
+        # Do not let this step fail when the versioned-docs branch does not exist, as on most forks
+        continue-on-error: true
       - name: Setup test environment
         uses: ./.github/actions/setup-test-env
       - name: Install docker-compose
@@ -369,6 +371,7 @@ jobs:
           cache-read-only: false
 
   required-checks:
+    # Do not rename this job, this is referenced in .asf.yaml!
     name: "Required Checks"
     needs:
       - build-checks


### PR DESCRIPTION
Github required checks are a bit "picky" about the names of the referenced workflow jobs.
The referenced name is the value of the `name:` property of a workflow jobs, or a `" / "` joined sequence in case of workflow-calls.

This means, those job names *must* be constant to be referenced as required checks.