### PR TITLE
Releasey: update check for required-checks

### DIFF
--- a/releasey/libs/_github.sh
+++ b/releasey/libs/_github.sh
@@ -43,7 +43,11 @@ function check_github_checks_passed() {
   local repo_info="$GITHUB_REPOSITORY"
 
   local num_invalid_checks
-  local num_invalid_checks_retrieval_command="gh api repos/${repo_info}/commits/${commit_sha}/check-runs --jq '[.check_runs[] | select(.conclusion != \"success\" and .conclusion != \"skipped\" and (.name | startswith(\"Release - \") | not) and (.name != \"markdown-link-check\"))] | length'"
+  # Look for checks with names ending with ` / Required Checks`.
+  # The full names follow the pattern `CI/<branch-name> / Required Checks`, for example
+  # `CI/main / Required Checks` or `CI/release/abc / Required Checks`.
+  # Refer to the `ci-main` job name attribute in yi-main.yml.
+  local num_invalid_checks_retrieval_command="gh api repos/${repo_info}/commits/${commit_sha}/check-runs --jq '[.check_runs[] | select(.conclusion != \"success\" and .conclusion != \"skipped\" and (.name | endswith(\" / Required Checks\")))] | length'"
   if [ ${DRY_RUN} -eq 1 ]; then
     print_info "DRY_RUN is enabled, skipping GitHub check verification"
     print_command "${num_invalid_checks_retrieval_command}"


### PR DESCRIPTION
After #3625 the `jq` select to look for required checks can be simplified to select only the `Required Checks` check/job.
