### PR TITLE
CI/main: re-add commit message to `run_name`

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@
 #
 
 name: CI/main
-run-name: CI/${{github.ref_name}}
+run-name: CI/${{github.ref_name}} ${{github.event.head_commit.message}}
 
 on:
   push:


### PR DESCRIPTION
The default `run_name` value is, in case of `push` events, the commit message. This change re-adds the commit message.
