### PR TITLE
Explicitly set build-time property `quarkus.datasource.db-kind`

### DIFF
--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -43,6 +43,7 @@ quarkus.oidc.enabled=true
 quarkus.otel.enabled=true
 #quarkus.mongodb.metrics.enabled=true
 #quarkus.mongodb.connection-string=mongodb://localhost:27017
+quarkus.datasource.db-kind=postgresql
 
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.


### PR DESCRIPTION
The property is set for the Polaris admin tool, but not for Polaris server. This causes a startup error with Quarkus 3.31.

Error message:
```
ERROR: Failed to start application
java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:116)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:119)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:79)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:50)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:143)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:86)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:37)
Caused by: java.lang.IllegalStateException: Build time property cannot be changed at runtime:
 - quarkus.datasource.db-kind is set to 'postgresql' but it is build time fixed to 'null'. Did you change the property quarkus.datasource.db-kind after building the application?
	at io.quarkus.runtime.configuration.ConfigRecorder.handleConfigChange(ConfigRecorder.java:72)
	at io.quarkus.runner.recorded.ConfigGenerationBuildStep$checkForBuildTimeConfigChange1532146938.deploy_6(Unknown Source)
	at io.quarkus.runner.recorded.ConfigGenerationBuildStep$checkForBuildTimeConfigChange1532146938.deploy(Unknown Source)
	... 9 more
```
