### PR TITLE
Quarkus: replace `quarkus-junit5*` with `quarkus-junit*`

### DIFF
--- a/extensions/auth/opa/tests/build.gradle.kts
+++ b/extensions/auth/opa/tests/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   testImplementation(project(":polaris-runtime-test-common"))
 
   // Test dependencies
-  intTestImplementation("io.quarkus:quarkus-junit5")
+  intTestImplementation("io.quarkus:quarkus-junit")
   intTestImplementation("io.rest-assured:rest-assured")
   intTestImplementation(project(":polaris-api-management-model"))
   intTestImplementation(platform(libs.iceberg.bom))

--- a/plugins/spark/v3.5/integration/build.gradle.kts
+++ b/plugins/spark/v3.5/integration/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
   testImplementation(testFixtures(project(":polaris-runtime-service")))
 
   testImplementation(platform(libs.quarkus.bom))
-  testImplementation("io.quarkus:quarkus-junit5")
+  testImplementation("io.quarkus:quarkus-junit")
   testImplementation("io.quarkus:quarkus-rest-client")
   testImplementation("io.quarkus:quarkus-rest-client-jackson")
 

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   testFixturesApi(project(":polaris-core"))
 
   testFixturesApi(enforcedPlatform(libs.quarkus.bom))
-  testFixturesApi("io.quarkus:quarkus-junit5")
+  testFixturesApi("io.quarkus:quarkus-junit")
 
   testFixturesApi(project(":polaris-container-spec-helper"))
   testFixturesApi(platform(libs.testcontainers.bom))

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -133,8 +133,8 @@ dependencies {
   testImplementation("software.amazon.awssdk:dynamodb")
 
   testImplementation(enforcedPlatform(libs.quarkus.bom))
-  testImplementation("io.quarkus:quarkus-junit5")
-  testImplementation("io.quarkus:quarkus-junit5-mockito")
+  testImplementation("io.quarkus:quarkus-junit")
+  testImplementation("io.quarkus:quarkus-junit-mockito")
   testImplementation("io.quarkus:quarkus-rest-client")
   testImplementation("io.quarkus:quarkus-rest-client-jackson")
   testImplementation("io.quarkus:quarkus-jdbc-h2")

--- a/runtime/spark-tests/build.gradle.kts
+++ b/runtime/spark-tests/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   testImplementation(project(":polaris-runtime-test-common"))
 
   testImplementation(platform(libs.quarkus.bom))
-  testImplementation("io.quarkus:quarkus-junit5")
+  testImplementation("io.quarkus:quarkus-junit")
   testImplementation("io.quarkus:quarkus-rest-client")
   testImplementation("io.quarkus:quarkus-rest-client-jackson")
 

--- a/runtime/test-common/build.gradle.kts
+++ b/runtime/test-common/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
   implementation(project(":polaris-core"))
   implementation(libs.jakarta.ws.rs.api)
   implementation(enforcedPlatform(libs.quarkus.bom))
-  implementation("io.quarkus:quarkus-junit5")
+  implementation("io.quarkus:quarkus-junit")
 
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")


### PR DESCRIPTION
Since Quarkus 3.31, all quarkus-junit5 artifacts are relocations to quarkus-junit.