### PR TITLE
Correct build instruction, project properties require org.gradle.project prefix

### DIFF
--- a/extensions/federation/hive/README.md
+++ b/extensions/federation/hive/README.md
@@ -25,7 +25,7 @@ NonRESTCatalogs=HIVE,<alternates>
 
 The other option is to pass it as an argument to the gradle JVM as follows: 
 ```
-./gradlew build -Dorg.gradle.project.NonRESTCatalogs=HIVE
+./gradlew build -PNonRESTCatalogs=HIVE
 ```
 
 Without this flag, the Hive factory won't be compiled into Polaris and therefore Polaris will not load the class at runtime, throwing an unsupported exception for federated catalog calls.

--- a/site/content/in-dev/unreleased/federation/hive-metastore-federation.md
+++ b/site/content/in-dev/unreleased/federation/hive-metastore-federation.md
@@ -34,7 +34,7 @@ property to include `HIVE` (and any other non-REST backends you need):
 
 ```bash
 ./gradlew :polaris-server:assemble :polaris-server:quarkusAppPartsBuild --rerun \
-  -Dorg.gradle.project.NonRESTCatalogs=HIVE -Dquarkus.container-image.build=true
+  -PNonRESTCatalogs=HIVE -Dquarkus.container-image.build=true
 ```
 
 `runtime/server/build.gradle.kts` wires the extension in only when this flag is present, so binaries


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This is a minor doc fix for the build command in the federated metastore instructions: it appears project properties neer the 'org.gradle.project' prefix to work correctly.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
