### PR TITLE
[DRAFT] feat: add RegisterTable overwrite support; preserve correct auth for overwrites

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -287,6 +287,26 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
+    return registerTable(identifier, metadataFileLocation, false);
+  }
+
+  /**
+   * Register a table with optional overwrite semantics.
+   *
+   * <p>When {@code overwrite} is false (the default) this behaves like a normal register and will
+   * fail if the table already exists. When {@code overwrite} is true and the named table already
+   * exists, this method updates the table's stored metadata-location to point at the provided
+   * metadata file. The overwrite path performs additional validation to ensure the supplied
+   * metadata file and its location are consistent with the table's resolved storage configuration.
+   *
+   * @param identifier the table identifier
+   * @param metadataFileLocation the metadata file location
+   * @param overwrite if true, update existing table metadata; if false, throw exception if table
+   *     exists
+   * @return the registered table
+   */
+  public Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean overwrite) {
     Preconditions.checkArgument(
         identifier != null && isValidIdentifier(identifier), "Invalid identifier: %s", identifier);
     Preconditions.checkArgument(
@@ -299,19 +319,26 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         "Invalid metadata file location; metadata file location must be absolute and contain a '/': %s",
         metadataFileLocation);
 
-    // Throw an exception if this table already exists in the catalog.
-    if (tableExists(identifier)) {
+    boolean tableExists = tableExists(identifier);
+    if (!overwrite && tableExists) {
       throw new AlreadyExistsException("Table already exists: %s", identifier);
     }
 
     String locationDir = metadataFileLocation.substring(0, lastSlashIndex);
+    if (!tableExists) {
+      return registerNewTable(identifier, metadataFileLocation, locationDir);
+    }
 
+    return overwriteRegisteredTable(identifier, metadataFileLocation, locationDir);
+  }
+
+  private Table registerNewTable(
+      TableIdentifier identifier, String metadataFileLocation, String locationDir) {
     TableOperations ops = newTableOps(identifier);
 
     PolarisResolvedPathWrapper resolvedParent =
         resolvedEntityView.getResolvedPath(identifier.namespace());
     if (resolvedParent == null) {
-      // Illegal state because the namespace should've already been in the static resolution set.
       throw new IllegalStateException(
           String.format("Failed to fetch resolved parent for TableIdentifier '%s'", identifier));
     }
@@ -327,6 +354,80 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     TableMetadata metadata = TableMetadataParser.read(metadataFile);
     ops.commit(null, metadata);
 
+    return new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());
+  }
+
+  private Table overwriteRegisteredTable(
+      TableIdentifier identifier, String metadataFileLocation, String locationDir) {
+    /*
+     * High-level overview:
+     * - Resolve the authorized parent for the table so we know the storage context.
+     * - Validate and read the provided metadata file using a FileIO tied to that
+     *   storage context.
+     * - Ensure the target entity exists and is the correct table-like subtype.
+     * - Replace the stored entity properties (including metadata-location) with
+     *   values derived from the parsed TableMetadata and persist the change.
+     */
+
+    // Resolve the parent namespace path that was authorized for this catalog.
+    PolarisResolvedPathWrapper resolvedParent =
+        resolvedEntityView.getResolvedPath(identifier.namespace());
+    if (resolvedParent == null) {
+      throw new IllegalStateException(
+          String.format("Failed to fetch resolved parent for TableIdentifier '%s'", identifier));
+    }
+
+    // Validate the supplied metadata file location against the resolved storage.
+    validateLocationForTableLike(identifier, metadataFileLocation, resolvedParent);
+
+    // Configure FileIO for the resolved storage and read the metadata file.
+    FileIO fileIO =
+        loadFileIOForTableLike(
+            identifier,
+            Set.of(locationDir),
+            resolvedParent,
+            new HashMap<>(tableDefaultProperties),
+            Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
+
+    TableMetadata metadata = TableMetadataParser.read(fileIO, metadataFileLocation);
+    validateLocationForTableLike(identifier, metadata.location(), resolvedParent);
+    validateMetadataFileInTableDir(identifier, metadata);
+
+    // Find the passthrough-resolved entity so we can update the stored record.
+    PolarisResolvedPathWrapper resolvedPath =
+        resolvedEntityView.getPassthroughResolvedPath(
+            identifier, PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ANY_SUBTYPE);
+    if (resolvedPath == null || resolvedPath.getRawLeafEntity() == null) {
+      throw new NoSuchTableException("Table does not exist: %s", identifier);
+    }
+
+    // Ensure the raw entity is an Iceberg table-like entity (not a view/generic table).
+    PolarisEntity rawEntity = resolvedPath.getRawLeafEntity();
+    if (rawEntity.getSubType() == PolarisEntitySubType.ICEBERG_VIEW) {
+      throw new AlreadyExistsException("View with same name already exists: %s", identifier);
+    } else if (rawEntity.getSubType() == PolarisEntitySubType.GENERIC_TABLE) {
+      throw new AlreadyExistsException(
+          "Generic table with same name already exists: %s", identifier);
+    }
+
+    IcebergTableLikeEntity existingEntity = IcebergTableLikeEntity.of(rawEntity);
+    if (existingEntity == null) {
+      throw new NoSuchTableException("Table does not exist: %s", identifier);
+    }
+
+    // Build updated entity from parsed metadata and persist the update.
+    Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+    IcebergTableLikeEntity updatedEntity =
+        new IcebergTableLikeEntity.Builder(existingEntity)
+            .setInternalProperties(storedProperties)
+            .setMetadataLocation(metadataFileLocation)
+            .build();
+
+    updateTableLike(identifier, updatedEntity);
+
+    // Refresh TableOperations so the in-memory table reflects the new metadata.
+    TableOperations ops = newTableOps(identifier);
+    ops.refresh();
     return new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/RegisterTableRequestContext.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/RegisterTableRequestContext.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+/**
+ * Thread-local context that carries additional parameters for a {@code RegisterTableRequest} which
+ * are not present on the generated Iceberg request type.
+ *
+ * <p>The current implementation only records the caller's intent to "overwrite" an existing table.
+ * Using a ThreadLocal keeps the flag local to the request lifecycle and avoids changing the
+ * generated DTOs. Callers must clear the flag (typically in a finally block) to avoid leaking state
+ * across requests.
+ */
+public class RegisterTableRequestContext {
+  private static final ThreadLocal<Boolean> SHOULD_OVERWRITE = ThreadLocal.withInitial(() -> false);
+
+  /**
+   * Record whether the current request intends to overwrite an existing table.
+   *
+   * @param overwrite true if an existing table's metadata-location should be replaced
+   */
+  public static void setOverwrite(boolean overwrite) {
+    SHOULD_OVERWRITE.set(overwrite);
+  }
+
+  /**
+   * Returns whether the current request indicated overwrite semantics. Defaults to {@code false}.
+   */
+  public static boolean getOverwrite() {
+    return SHOULD_OVERWRITE.get();
+  }
+
+  /** Clear the thread-local state for the current request. Call this in a finally block. */
+  public static void clear() {
+    SHOULD_OVERWRITE.remove();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtilsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtilsTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for CatalogHandlerUtils.registerTable overwrite support */
+public class CatalogHandlerUtilsTest {
+
+  private CatalogHandlerUtils utils;
+
+  @BeforeEach
+  public void setUp() {
+    // use defaults for retries / rollback flag; fine for these unit tests
+    utils = new CatalogHandlerUtils(3, true);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    RegisterTableRequestContext.clear();
+  }
+
+  private RegisterTableRequest sampleRequest(String name, String metadataLocation) {
+    return new RegisterTableRequest() {
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @Override
+      public String metadataLocation() {
+        return metadataLocation;
+      }
+    };
+  }
+
+  /**
+   * When a non-Polaris (non-IcebergCatalog) catalog receives an overwrite=true request and the
+   * target table already exists, the operation must be rejected. This prevents accidental
+   * replacement of an existing table pointer by catalogs that don't support overwrite semantics.
+   */
+  @Test
+  public void rejectOverwriteNonIcebergExists() {
+    Catalog mockCatalog = mock(Catalog.class);
+    Namespace ns = Namespace.of("db");
+    RegisterTableRequest req = sampleRequest("t", "s3://x/meta.json");
+    TableIdentifier ident = TableIdentifier.of(ns, req.name());
+
+    when(mockCatalog.tableExists(ident)).thenReturn(true);
+
+    RegisterTableRequestContext.setOverwrite(true);
+    try {
+      assertThrows(BadRequestException.class, () -> utils.registerTable(mockCatalog, ns, req));
+    } finally {
+      RegisterTableRequestContext.clear();
+    }
+
+    verify(mockCatalog, never()).registerTable(any(TableIdentifier.class), anyString());
+  }
+
+  /**
+   * If overwrite=true is set but the non-Polaris catalog reports the table does not exist, fall
+   * back to the normal register call (no overwrite semantics available) so the table is created as
+   * usual.
+   */
+  @Test
+  public void registerCalledWhenNonIcebergMissing() {
+    Catalog mockCatalog = mock(Catalog.class);
+    Namespace ns = Namespace.of("db");
+    RegisterTableRequest req = sampleRequest("t", "s3://x/meta.json");
+    TableIdentifier ident = TableIdentifier.of(ns, req.name());
+
+    when(mockCatalog.tableExists(ident)).thenReturn(false);
+    // return a BaseTable so the util method can wrap and return
+    BaseTable mockTable = mock(BaseTable.class);
+    TableOperations mockOps = mock(TableOperations.class);
+    TableMetadata mockMeta = mock(TableMetadata.class);
+    when(mockTable.operations()).thenReturn(mockOps);
+    when(mockOps.current()).thenReturn(mockMeta);
+    when(mockCatalog.registerTable(ident, req.metadataLocation())).thenReturn(mockTable);
+
+    RegisterTableRequestContext.setOverwrite(true);
+    try {
+      utils.registerTable(mockCatalog, ns, req);
+    } finally {
+      RegisterTableRequestContext.clear();
+    }
+
+    verify(mockCatalog, times(1)).registerTable(ident, req.metadataLocation());
+  }
+
+  /**
+   * When overwrite=true is requested against our Polaris {@link IcebergCatalog}, always route to
+   * the catalog's overwrite-capable overload so the underlying entity is updated atomically.
+   */
+  @Test
+  public void overwriteUsesIcebergRegisterWhenExists() {
+    // mock the concrete IcebergCatalog which exposes registerTable(..., overwrite)
+    IcebergCatalog iceberg = mock(IcebergCatalog.class);
+    Namespace ns = Namespace.of("db");
+    RegisterTableRequest req = sampleRequest("t", "s3://x/meta.json");
+    TableIdentifier ident = TableIdentifier.of(ns, req.name());
+
+    // Simulate that table exists in the catalog
+    when(iceberg.tableExists(ident)).thenReturn(true);
+    BaseTable mockTable = mock(BaseTable.class);
+    TableOperations mockOps = mock(TableOperations.class);
+    TableMetadata mockMeta = mock(TableMetadata.class);
+    when(mockTable.operations()).thenReturn(mockOps);
+    when(mockOps.current()).thenReturn(mockMeta);
+    when(iceberg.registerTable(ident, req.metadataLocation(), true)).thenReturn(mockTable);
+
+    RegisterTableRequestContext.setOverwrite(true);
+    try {
+      utils.registerTable(iceberg, ns, req);
+    } finally {
+      RegisterTableRequestContext.clear();
+    }
+
+    // verify that the 3-arg overload was invoked; since we mock the class we can verify the call
+    verify(iceberg, times(1)).registerTable(ident, req.metadataLocation(), true);
+  }
+
+  /**
+   * Overwrite requests against {@link IcebergCatalog} should use the three-argument register path
+   * regardless of whether the table previously existed, ensuring consistent rewrite behavior.
+   */
+  @Test
+  public void overwriteUsesIcebergRegisterWhenMissing() {
+    IcebergCatalog iceberg = mock(IcebergCatalog.class);
+    Namespace ns = Namespace.of("db");
+    RegisterTableRequest req = sampleRequest("t", "s3://x/meta.json");
+    TableIdentifier ident = TableIdentifier.of(ns, req.name());
+
+    when(iceberg.tableExists(ident)).thenReturn(false);
+    BaseTable mockTable = mock(BaseTable.class);
+    TableOperations mockOps = mock(TableOperations.class);
+    TableMetadata mockMeta = mock(TableMetadata.class);
+    when(mockTable.operations()).thenReturn(mockOps);
+    when(mockOps.current()).thenReturn(mockMeta);
+    when(iceberg.registerTable(ident, req.metadataLocation(), true)).thenReturn(mockTable);
+
+    RegisterTableRequestContext.setOverwrite(true);
+    try {
+      utils.registerTable(iceberg, ns, req);
+    } finally {
+      RegisterTableRequestContext.clear();
+    }
+
+    verify(iceberg, times(1)).registerTable(ident, req.metadataLocation(), true);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/polaris/issues/2896

Add support for the new overwrite boolean on RegisterTableRequest (default: false) so clients can register a metadata location that replaces an existing table pointer. Implement register-table overwrite semantics:
If overwrite=false (default): preserve existing behavior — attempting to register a table that already exists returns a conflict/error. If overwrite=true:
If the table does not exist: create it (normal register). If the table exists: update the table's metadata-location to the provided value (do not throw AlreadyExists). Ensure safety/backward-compatibility:
overwrite defaults to false so existing clients are unaffected. Validate provided metadata location where possible before committing to avoid corrupting catalog state.

Details / rationale:
The change implements the REST Catalog spec extension that adds an overwrite flag to RegisterTableRequest. This enables clients to atomically point an existing table identifier at a new metadata file (useful for moving or restoring table metadata). Because overwrite changes the set of operations allowed on an existing table, we had to be careful with authorization and entity resolution: When performing an overwrite against an existing table, the handler enforces the UPDATE_TABLE privilege (mapped to TABLE_WRITE_PROPERTIES) rather than REGISTER_TABLE. This prevents callers who only have create permissions from silently replacing another principal's table pointer. We fixed a subtle distinction where lack of read privileges could be mistaken for a non-existent table. The handler now distinguishes "truly not found" from "exists but unreadable" and applies the correct required privilege accordingly. Resolution manifest and passthrough-path population were adjusted so downstream overwrite logic can locate the namespace and table entries reliably. Files / components touched (high level):

Tests added/updated:
- DTO unit tests: overwrite deserialization for `RegisterTableRequest` (true/false/missing).
- Integration / behavior tests (integration-tests module):
  - Register new table with `overwrite=false` → success.
  - Register existing table with `overwrite=false` → conflict / exception as before.
  - Register existing table with `overwrite=true` → success and the table's metadata-location is updated atomically.
- Authorization tests: updated/added unit tests to assert `UPDATE_TABLE` (TABLE_WRITE_PROPERTIES) is enforced for overwrite against existing tables.
- Unit tests: added `CatalogHandlerUtilsTest` to cover handler helper logic.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
