### PR TITLE
CI for feature branches

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -22,7 +22,7 @@ run-name: CI/${{github.ref_name}} ${{github.event.head_commit.message}}
 
 on:
   push:
-    branches: [ "main", "release/*" ]
+    branches: [ "main", "release/*", "feature/*" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ run-name: PR#${{ github.event.number }} ${{ github.event.pull_request.title }}
 
 on:
   pull_request:
-    branches: [ "main", "release/*" ]
+    branches: [ "main", "release/*", "feature/*" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This change enables CI on branches matching the pattern `feature/*`.

This change does _not_ require PRs against `feature/*` branches to have "green" CI.