### PR TITLE
fix: Correct schema version number in schema-v4.sql files

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -50,7 +50,7 @@ public enum DatabaseType {
    */
   public InputStream openInitScriptResource(int schemaVersion) {
     // Preconditions check is simpler and more direct than a switch default
-    if (schemaVersion <= 0 || schemaVersion > 3) {
+    if (schemaVersion <= 0 || schemaVersion > 4) {
       throw new IllegalArgumentException("Unknown or invalid schema version " + schemaVersion);
     }
 

--- a/persistence/relational-jdbc/src/main/resources/h2/schema-v4.sql
+++ b/persistence/relational-jdbc/src/main/resources/h2/schema-v4.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS version (
 
 MERGE INTO version (version_key, version_value)
     KEY (version_key)
-    VALUES ('version', 3);
+    VALUES ('version', 4);
 
 -- H2 supports COMMENT, but some modes may ignore it
 COMMENT ON TABLE version IS 'the version of the JDBC schema in use';

--- a/persistence/relational-jdbc/src/main/resources/postgres/schema-v4.sql
+++ b/persistence/relational-jdbc/src/main/resources/postgres/schema-v4.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS version (
     version_value INTEGER NOT NULL
 );
 INSERT INTO version (version_key, version_value)
-VALUES ('version', 3)
+VALUES ('version', 4)
 ON CONFLICT (version_key) DO UPDATE
 SET version_value = EXCLUDED.version_value;
 COMMENT ON TABLE version IS 'the version of the JDBC schema in use';


### PR DESCRIPTION
- Update DatabaseType.java to allow schemaVersion up to 4
- Fix h2/schema-v4.sql to set version to 4 instead of 3
- Fix postgres/schema-v4.sql to set version to 4 instead of 3

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
