### PR TITLE
Fix CI

### DIFF
--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
@@ -34,6 +34,7 @@ import org.apache.polaris.test.rustfs.Rustfs;
 import org.apache.polaris.test.rustfs.RustfsAccess;
 import org.apache.polaris.test.rustfs.RustfsExtension;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @QuarkusIntegrationTest
@@ -88,5 +89,15 @@ public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBas
             .setAllowedLocations(List.of(storageBase.toString()));
 
     return storageConfig.build();
+  }
+
+  @Override
+  protected Map<String, String> extraCatalogProperties(TestInfo testInfo) {
+    return ImmutableMap.<String, String>builder()
+        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
+        .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
+        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), RUSTFS_ACCESS_KEY)
+        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), RUSTFS_SECRET_KEY)
+        .build();
   }
 }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The CI is failing after I merged https://github.com/apache/polaris/pulls?q=is%3Apr+is%3Aclosed. However, this was working fine before. Upon checking, it appears to be related to https://github.com/apache/polaris/pull/3658. This PR explicitly defining extraCatalogProperties. Reference failed test cases and traces: https://github.com/apache/polaris/issues/3697

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
