### PR TITLE
CI: fix missing Gradle build scans

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -32,3 +32,5 @@ jobs:
   ci-main:
     name: CI/${{ github.ref_name }}
     uses: ./.github/workflows/ci.yml
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ name: CI
 on:
   workflow_call:
     # Called from ci-main.yml and ci-pr.yml, which define different concurrency groups.
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        required: false
 
 jobs:
   build-checks:


### PR DESCRIPTION
Publishing the Gradle build scans requires the `DEVELOCITY_ACCESS_KEY` secret. For workflow-calls, each secret to be propagated to a called workflow must be explicitly defined.

This change propagates the secrets from `ci-main.yml` to the called `ci.yml`.
