### PR TITLE
Compile client modules with Java 17 compatibility

### DIFF
--- a/api/iceberg-service/src/main/java/org/apache/polaris/service/types/NotificationRequest.java
+++ b/api/iceberg-service/src/main/java/org/apache/polaris/service/types/NotificationRequest.java
@@ -54,10 +54,9 @@ public class NotificationRequest {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof NotificationRequest)) {
+    if (!(o instanceof NotificationRequest notificationRequest)) {
       return false;
     }
-    NotificationRequest notificationRequest = (NotificationRequest) o;
     return Objects.equals(this.notificationType, notificationRequest.notificationType)
         && Objects.equals(this.payload, notificationRequest.payload);
   }

--- a/api/iceberg-service/src/main/java/org/apache/polaris/service/types/TableUpdateNotification.java
+++ b/api/iceberg-service/src/main/java/org/apache/polaris/service/types/TableUpdateNotification.java
@@ -106,10 +106,9 @@ public class TableUpdateNotification {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof TableUpdateNotification)) {
+    if (!(o instanceof TableUpdateNotification tableUpdateNotification)) {
       return false;
     }
-    TableUpdateNotification tableUpdateNotification = (TableUpdateNotification) o;
     return Objects.equals(this.tableName, tableUpdateNotification.tableName)
         && Objects.equals(this.timestamp, tableUpdateNotification.timestamp)
         && Objects.equals(this.tableUuid, tableUpdateNotification.tableUuid)

--- a/api/polaris-catalog-service/src/main/java/org/apache/polaris/service/types/PolicyIdentifier.java
+++ b/api/polaris-catalog-service/src/main/java/org/apache/polaris/service/types/PolicyIdentifier.java
@@ -104,10 +104,9 @@ public class PolicyIdentifier {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof PolicyIdentifier)) {
+    if (!(o instanceof PolicyIdentifier policyIdentifier)) {
       return false;
     }
-    PolicyIdentifier policyIdentifier = (PolicyIdentifier) o;
     return Objects.equals(this.namespace, policyIdentifier.namespace)
         && Objects.equals(this.name, policyIdentifier.name);
   }

--- a/codestyle/errorprone-rules.properties
+++ b/codestyle/errorprone-rules.properties
@@ -184,7 +184,7 @@ OrphanedFormatString=ERROR
 Overrides=ERROR
 # Varargs doesn't agree for overridden method
 
-PatternMatchingInstanceof=WARN
+PatternMatchingInstanceof=ERROR
 # This code can be simplified to use a pattern-matching instanceof.
 
 StreamToIterable=ERROR

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRequest.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/CreateGenericTableRequest.java
@@ -145,10 +145,9 @@ public class CreateGenericTableRequest {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof CreateGenericTableRequest)) {
+    if (!(o instanceof CreateGenericTableRequest createGenericTableRequest)) {
       return false;
     }
-    CreateGenericTableRequest createGenericTableRequest = (CreateGenericTableRequest) o;
     return Objects.equals(this.name, createGenericTableRequest.name)
         && Objects.equals(this.format, createGenericTableRequest.format)
         && Objects.equals(this.baseLocation, createGenericTableRequest.baseLocation)

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
@@ -144,10 +144,9 @@ public class GenericTable {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof GenericTable)) {
+    if (!(o instanceof GenericTable genericTable)) {
       return false;
     }
-    GenericTable genericTable = (GenericTable) o;
     return Objects.equals(this.name, genericTable.name)
         && Objects.equals(this.format, genericTable.format)
         && Objects.equals(this.baseLocation, genericTable.baseLocation)

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/ListGenericTablesResponse.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/ListGenericTablesResponse.java
@@ -98,10 +98,9 @@ public class ListGenericTablesResponse {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ListGenericTablesResponse)) {
+    if (!(o instanceof ListGenericTablesResponse listGenericTablesResponse)) {
       return false;
     }
-    ListGenericTablesResponse listGenericTablesResponse = (ListGenericTablesResponse) o;
     return Objects.equals(this.nextPageToken, listGenericTablesResponse.nextPageToken)
         && Objects.equals(this.identifiers, listGenericTablesResponse.identifiers);
   }

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/LoadGenericTableResponse.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/LoadGenericTableResponse.java
@@ -74,10 +74,9 @@ public class LoadGenericTableResponse {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof LoadGenericTableResponse)) {
+    if (!(o instanceof LoadGenericTableResponse loadGenericTableResponse)) {
       return false;
     }
-    LoadGenericTableResponse loadGenericTableResponse = (LoadGenericTableResponse) o;
     return Objects.equals(this.table, loadGenericTableResponse.table);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -155,8 +155,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
   private StorageConfigInfo getStorageInfo(Map<String, String> internalProperties) {
     if (internalProperties.containsKey(PolarisEntityConstants.getStorageConfigInfoPropertyName())) {
       PolarisStorageConfigurationInfo configInfo = getStorageConfigurationInfo();
-      if (configInfo instanceof AwsStorageConfigurationInfo) {
-        AwsStorageConfigurationInfo awsConfig = (AwsStorageConfigurationInfo) configInfo;
+      if (configInfo instanceof AwsStorageConfigurationInfo awsConfig) {
         return AwsStorageConfigInfo.builder()
             .setRoleArn(awsConfig.getRoleARN())
             .setExternalId(awsConfig.getExternalId())
@@ -174,8 +173,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setKmsUnavailable(awsConfig.getKmsUnavailable())
             .build();
       }
-      if (configInfo instanceof AzureStorageConfigurationInfo) {
-        AzureStorageConfigurationInfo azureConfig = (AzureStorageConfigurationInfo) configInfo;
+      if (configInfo instanceof AzureStorageConfigurationInfo azureConfig) {
         return AzureStorageConfigInfo.builder()
             .setTenantId(azureConfig.getTenantId())
             .setMultiTenantAppName(azureConfig.getMultiTenantAppName())
@@ -185,16 +183,14 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setHierarchical(azureConfig.isHierarchical())
             .build();
       }
-      if (configInfo instanceof GcpStorageConfigurationInfo) {
-        GcpStorageConfigurationInfo gcpConfigModel = (GcpStorageConfigurationInfo) configInfo;
+      if (configInfo instanceof GcpStorageConfigurationInfo gcpConfigModel) {
         return GcpStorageConfigInfo.builder()
             .setGcsServiceAccount(gcpConfigModel.getGcpServiceAccount())
             .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
             .setAllowedLocations(gcpConfigModel.getAllowedLocations())
             .build();
       }
-      if (configInfo instanceof FileStorageConfigurationInfo) {
-        FileStorageConfigurationInfo fileConfigModel = (FileStorageConfigurationInfo) configInfo;
+      if (configInfo instanceof FileStorageConfigurationInfo fileConfigModel) {
         return new FileStorageConfigInfo(
             StorageConfigInfo.StorageTypeEnum.FILE, fileConfigModel.getAllowedLocations());
       }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
@@ -104,8 +104,7 @@ public class EntityNameLookupRecord implements Identifiable {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof EntityNameLookupRecord)) return false;
-    EntityNameLookupRecord that = (EntityNameLookupRecord) o;
+    if (!(o instanceof EntityNameLookupRecord that)) return false;
     return catalogId == that.catalogId
         && id == that.id
         && parentId == that.parentId

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisBaseEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisBaseEntity.java
@@ -333,10 +333,9 @@ public class PolarisBaseEntity extends PolarisEntityCore {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof PolarisBaseEntity)) {
+    if (!(o instanceof PolarisBaseEntity that)) {
       return false;
     }
-    PolarisBaseEntity that = (PolarisBaseEntity) o;
     return subTypeCode == that.subTypeCode
         && createTimestamp == that.createTimestamp
         && dropTimestamp == that.dropTimestamp

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
@@ -175,10 +175,9 @@ public class PolarisEntityCore implements Identifiable {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof PolarisEntityCore)) {
+    if (!(o instanceof PolarisEntityCore that)) {
       return false;
     }
-    PolarisEntityCore that = (PolarisEntityCore) o;
     return catalogId == that.catalogId
         && id == that.id
         && parentId == that.parentId

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityId.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityId.java
@@ -49,8 +49,7 @@ public class PolarisEntityId {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PolarisEntityId)) return false;
-    PolarisEntityId that = (PolarisEntityId) o;
+    if (!(o instanceof PolarisEntityId that)) return false;
     return catalogId == that.catalogId && id == that.id;
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisGrantRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisGrantRecord.java
@@ -139,8 +139,7 @@ public class PolarisGrantRecord {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PolarisGrantRecord)) return false;
-    PolarisGrantRecord that = (PolarisGrantRecord) o;
+    if (!(o instanceof PolarisGrantRecord that)) return false;
     return securableCatalogId == that.securableCatalogId
         && securableId == that.securableId
         && granteeCatalogId == that.granteeCatalogId

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/cache/EntityCacheByNameKey.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/cache/EntityCacheByNameKey.java
@@ -101,8 +101,7 @@ public class EntityCacheByNameKey {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof EntityCacheByNameKey)) return false;
-    EntityCacheByNameKey that = (EntityCacheByNameKey) o;
+    if (!(o instanceof EntityCacheByNameKey that)) return false;
     return parentId == that.parentId
         && typeCode == that.typeCode
         && Objects.equals(name, that.name);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -67,10 +67,9 @@ final class PageTokenUtil {
 
         @Override
         public boolean equals(Object obj) {
-          if (!(obj instanceof PageToken)) {
+          if (!(obj instanceof PageToken other)) {
             return false;
           }
-          PageToken other = (PageToken) obj;
           return other.pageSize().isEmpty() && other.value().isEmpty();
         }
 
@@ -99,10 +98,9 @@ final class PageTokenUtil {
 
       @Override
       public boolean equals(Object obj) {
-        if (!(obj instanceof PageToken)) {
+        if (!(obj instanceof PageToken other)) {
           return false;
         }
-        PageToken other = (PageToken) obj;
         return other.pageSize().equals(pageSize()) && other.value().isEmpty();
       }
 
@@ -240,8 +238,8 @@ final class PageTokenUtil {
     }
 
     private String getId(Object value) {
-      if (value instanceof Token) {
-        return ((Token) value).getT();
+      if (value instanceof Token token) {
+        return token.getT();
       }
 
       return null;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverEntityName.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/ResolverEntityName.java
@@ -54,8 +54,7 @@ public class ResolverEntityName {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ResolverEntityName)) return false;
-    ResolverEntityName that = (ResolverEntityName) o;
+    if (!(o instanceof ResolverEntityName that)) return false;
     return getEntityType() == that.getEntityType()
         && Objects.equals(getEntityName(), that.getEntityName());
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
@@ -199,8 +199,7 @@ public class PolarisPolicyMappingRecord {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PolarisPolicyMappingRecord)) return false;
-    PolarisPolicyMappingRecord that = (PolarisPolicyMappingRecord) o;
+    if (!(o instanceof PolarisPolicyMappingRecord that)) return false;
     return targetCatalogId == that.targetCatalogId
         && targetId == that.targetId
         && policyCatalogId == that.policyCatalogId

--- a/polaris-core/src/main/java/org/apache/polaris/core/secrets/SecretReference.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/secrets/SecretReference.java
@@ -202,10 +202,9 @@ public class SecretReference {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj == null || !(obj instanceof SecretReference)) {
+    if (!(obj instanceof SecretReference that)) {
       return false;
     }
-    SecretReference that = (SecretReference) obj;
     return Objects.equals(this.getUrn(), that.getUrn())
         && Objects.equals(this.getReferencePayload(), that.getReferencePayload());
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -138,8 +138,7 @@ public abstract class PolarisStorageIntegration<T extends PolarisStorageConfigur
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof ValidationResult)) return false;
-      ValidationResult that = (ValidationResult) o;
+      if (!(o instanceof ValidationResult that)) return false;
       return success == that.success;
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocation.java
@@ -95,8 +95,8 @@ public class StorageLocation {
    */
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof StorageLocation) {
-      return location.equals(((StorageLocation) obj).location);
+    if (obj instanceof StorageLocation storageLocation) {
+      return location.equals(storageLocation.location);
     } else {
       return false;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/S3Location.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/S3Location.java
@@ -49,8 +49,7 @@ public class S3Location extends StorageLocation {
 
   @Override
   public boolean isChildOf(StorageLocation potentialParent) {
-    if (potentialParent instanceof S3Location) {
-      S3Location that = (S3Location) potentialParent;
+    if (potentialParent instanceof S3Location that) {
       // Given that S3 and S3A are to be treated similarly, the parent check ignores the prefix
       String slashTerminatedObjectKey = ensureTrailingSlash(this.locationWithoutScheme);
       String slashTerminatedObjectKeyThat = ensureTrailingSlash(that.locationWithoutScheme);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -104,8 +104,7 @@ public class AzureLocation extends StorageLocation {
    */
   @Override
   public boolean isChildOf(@Nonnull StorageLocation potentialParent) {
-    if (potentialParent instanceof AzureLocation) {
-      AzureLocation potentialAzureParent = (AzureLocation) potentialParent;
+    if (potentialParent instanceof AzureLocation potentialAzureParent) {
       if (this.container.equals(potentialAzureParent.container)) {
         if (this.storageAccount.equals(potentialAzureParent.storageAccount)) {
           String formattedFilePath = ensureLeadingSlash(ensureTrailingSlash(this.filePath));

--- a/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
+++ b/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
@@ -92,17 +92,13 @@ public abstract class MemorySize {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof MemorySize)) {
-        return false;
+      if (o instanceof MemorySize that) {
+        return o instanceof MemorySizeLong l
+            ? bytes == l.bytes
+            : asBigInteger().equals(that.asBigInteger());
       }
 
-      if (o instanceof MemorySizeLong) {
-        var l = (MemorySizeLong) o;
-        return bytes == l.bytes;
-      }
-
-      var that = (MemorySize) o;
-      return asBigInteger().equals(that.asBigInteger());
+      return false;
     }
 
     @Override
@@ -145,12 +141,10 @@ public abstract class MemorySize {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof MemorySize)) {
-        return false;
+      if (o instanceof MemorySize that) {
+        return bytes.equals(that.asBigInteger());
       }
-
-      MemorySize that = (MemorySize) o;
-      return bytes.equals(that.asBigInteger());
+      return false;
     }
 
     @Override


### PR DESCRIPTION
As [agreed on the ML](https://lists.apache.org/thread/v8ghm3k5nh9xp9x0xdo2kknk5ph0rnmb), this PR upgrades Java minimum compatibility level (Javac's --release flag) to 17.

This PR also fixes the errorprone errors about `instanceof` with pattern matching..

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
