### PR TITLE
Helm: Ingress paths missing pathType in values.yaml

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -331,7 +331,7 @@ ct install --namespace polaris --charts ./helm/polaris
 | ingress.annotations | object | `{}` | Annotations to add to the ingress. |
 | ingress.className | string | `""` | Specifies the ingressClassName; leave empty if you don't want to customize it |
 | ingress.enabled | bool | `false` | Specifies whether an ingress should be created. |
-| ingress.hosts | list | `[{"host":"chart-example.local","paths":[]}]` | A list of host paths used to configure the ingress. |
+| ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | A list of host paths used to configure the ingress. |
 | ingress.tls | list | `[]` | A list of TLS certificates; each entry has a list of hosts in the certificate, along with the secret name used to terminate TLS traffic on port 443. |
 | livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"terminationGracePeriodSeconds":30,"timeoutSeconds":10}` | Configures the liveness probe for polaris pods. |
 | livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1. |

--- a/helm/polaris/tests/ingress_test.yaml
+++ b/helm/polaris/tests/ingress_test.yaml
@@ -151,15 +151,10 @@ tests:
                 - "chart-example2.local"
               secretName: secret1
 
-  # spec.rules (with ingress enabled)
-  - it: should set ingress TLS
+  # spec.rules (with ingress enabled - default values)
+  - it: should set ingress with default values
     set:
       ingress.enabled: true
-      ingress.hosts:
-        - host: chart-example.local
-          paths:
-            - path: /
-              pathType:  Prefix
     asserts:
       - equal:
           path: spec.rules
@@ -168,6 +163,30 @@ tests:
               http:
                 paths:
                   - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: polaris-release
+                        port:
+                          number: 8181
+
+  # spec.rules (with ingress enabled - custom paths)
+  - it: should set ingress with custom paths
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: chart-example.local
+          paths:
+            - path: /api
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules
+          value:
+            - host: chart-example.local
+              http:
+                paths:
+                  - path: /api
                     pathType: Prefix
                     backend:
                       service:

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -233,7 +233,9 @@ ingress:
   # -- A list of host paths used to configure the ingress.
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+        - path: /
+          pathType: Prefix
   # -- A list of TLS certificates; each entry has a list of hosts in the certificate,
   # along with the secret name used to terminate TLS traffic on port 443.
   tls: []

--- a/site/content/in-dev/unreleased/helm.md
+++ b/site/content/in-dev/unreleased/helm.md
@@ -318,7 +318,7 @@ ct install --namespace polaris --charts ./helm/polaris
 | ingress.annotations | object | `{}` | Annotations to add to the ingress. |
 | ingress.className | string | `""` | Specifies the ingressClassName; leave empty if you don't want to customize it |
 | ingress.enabled | bool | `false` | Specifies whether an ingress should be created. |
-| ingress.hosts | list | `[{"host":"chart-example.local","paths":[]}]` | A list of host paths used to configure the ingress. |
+| ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | A list of host paths used to configure the ingress. |
 | ingress.tls | list | `[]` | A list of TLS certificates; each entry has a list of hosts in the certificate, along with the secret name used to terminate TLS traffic on port 443. |
 | livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"terminationGracePeriodSeconds":30,"timeoutSeconds":10}` | Configures the liveness probe for polaris pods. |
 | livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1. |


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

In current `values.yaml`, we are providing list of paths to end-users:
```
  hosts:
    - host: chart-example.local
      paths: []
```

However, in the chart template, we are looking for `pathType`:
```
    {{- range .Values.ingress.hosts }}
    - host: {{ .host | quote }}
      http:
        paths:
          {{- range .paths }}
          - path: {{ .path }}
            pathType: {{ .pathType }}
            backend:
              service:
                name: {{ $fullName }}
                port:
                  number: {{ $svcPort }}
          {{- end }}
```

This PR makes this clear on the `values.yaml` on the expected values and format.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
