### PR TITLE
fix: production readiness check doesn't take every credential vendor into account

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Startup;
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import java.nio.charset.Charset;
@@ -327,7 +328,7 @@ public class ProductionReadinessChecks {
   @Produces
   @SuppressWarnings("unchecked")
   public ProductionReadinessCheck checkConnectionCredentialVendors(
-      Instance<ConnectionCredentialVendor> credentialVendors,
+      @Any Instance<ConnectionCredentialVendor> credentialVendors,
       FeaturesConfiguration featureConfiguration) {
     var mapper = JsonMapper.builder().build();
     var defaults = featureConfiguration.parseDefaults(mapper);


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR fixes the production readiness check when SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES feature is used. The `checkConnectionCredentialVendors` method doesn't inject every credential vendor, but only a single one, which is the `DefaultPolarisCredentialManager`. When the external catalog authentication feature is used `polaris.features."SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES"=["OAUTH"]` then the production readiness check will fail, as it won't find the selected OAUTH provider.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
