### PR TITLE
Add JSON Schema for Helm chart values validation

### DIFF
--- a/helm/polaris/tests/configmap_test.yaml
+++ b/helm/polaris/tests/configmap_test.yaml
@@ -152,12 +152,6 @@ tests:
     asserts:
       - matchRegex: { path: 'data["application.properties"]', pattern: "polaris.authentication.type=mixed" }
 
-  - it: should fail on invalid authentication type
-    set: { authentication: { type: invalid } }
-    asserts:
-      - failedTemplate:
-          errorMessage: "authentication.type: invalid authentication type"
-
   - it: should configure default authenticator
     set: { authentication: { authenticator: { type: default } } }
     asserts:
@@ -222,8 +216,8 @@ tests:
 
   - it: should derive HTTP ports from service configuration
     set:
-      service: { ports: [ { port: 8080 } ] }
-      managementService: { ports: [ { port: 8081 } ] }
+      service: { ports: [ { name: polaris-http, port: 8080 } ] }
+      managementService: { ports: [ { name: polaris-mgmt, port: 8081 } ] }
     asserts:
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.http.port=8080" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.management.port=8081" }

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -120,7 +120,7 @@ tests:
   - it: should not set revisionHistoryLimit with quote empty string
     template: deployment.yaml
     set:
-      revisionHistoryLimit: ""
+      revisionHistoryLimit: ~
     asserts:
       - notExists:
           path: spec.revisionHistoryLimit

--- a/helm/polaris/values.schema.json
+++ b/helm/polaris/values.schema.json
@@ -1,0 +1,1211 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The number of replicas to deploy (horizontal scaling). Beware that replicas are stateless; don't set this number > 1 when using in-memory meta store manager."
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration.",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "The image repository to pull from."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "The image pull policy."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The image tag."
+        },
+        "configDir": {
+          "type": "string",
+          "description": "The path to the directory where the application.properties file, and other configuration files, if any, should be mounted."
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "References to secrets in the same namespace to use for pulling any of the images used by this chart.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "Service account configuration.",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template."
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to apply to polaris pods.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional Labels to apply to polaris pods.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "configMapLabels": {
+      "type": "object",
+      "description": "Additional Labels to apply to polaris configmap.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "Pod disruption budget settings.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether a pod disruption budget should be created."
+        },
+        "minAvailable": {
+          "type": ["integer", "string", "null"],
+          "description": "The minimum number of pods that should remain available during disruptions. Can be an absolute number or a percentage."
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string", "null"],
+          "description": "The maximum number of pods that can be unavailable during disruptions. Can be an absolute number or a percentage."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the pod disruption budget.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "revisionHistoryLimit": {
+      "type": ["integer", "null"],
+      "description": "The number of old ReplicaSets to retain to allow rollback."
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the polaris pod. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podsecuritycontext-v1-core"
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "description": "Security context for the polaris container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#securitycontext-v1-core"
+    },
+    "service": {
+      "type": "object",
+      "description": "Polaris main service settings.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ExternalName", "ClusterIP", "NodePort", "LoadBalancer"],
+          "description": "The type of service to create."
+        },
+        "ports": {
+          "type": "array",
+          "description": "The ports the service will listen on. At least one port is required.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the port. Required.",
+                "maxLength": 15
+              },
+              "port": {
+                "type": "integer",
+                "description": "The port the service listens on."
+              },
+              "targetPort": {
+                "type": ["integer", "string", "null"],
+                "description": "Number or name of the port to access on the pods."
+              },
+              "nodePort": {
+                "type": ["integer", "null"],
+                "description": "The port on each node when type is NodePort or LoadBalancer."
+              },
+              "protocol": {
+                "oneOf": [
+                  { "type": "string", "enum": ["TCP", "UDP", "SCTP"] },
+                  { "type": "null" }
+                ],
+                "description": "The IP protocol for this port."
+              }
+            },
+            "required": ["name", "port"]
+          }
+        },
+        "sessionAffinity": {
+          "oneOf": [
+            { "type": "string", "enum": ["None", "ClientIP"] },
+            { "type": "null" }
+          ],
+          "description": "The session affinity for the service."
+        },
+        "clusterIP": {
+          "type": ["string", "null"],
+          "description": "You can specify your own cluster IP address."
+        },
+        "internalTrafficPolicy": {
+          "oneOf": [
+            { "type": "string", "enum": ["Cluster", "Local"] },
+            { "type": "null" }
+          ],
+          "description": "Controls how traffic from internal sources is routed."
+        },
+        "externalTrafficPolicy": {
+          "oneOf": [
+            { "type": "string", "enum": ["Cluster", "Local"] },
+            { "type": "null" }
+          ],
+          "description": "Controls how traffic from external sources is routed."
+        },
+        "trafficDistribution": {
+          "type": ["string", "null"],
+          "description": "The traffic distribution field for routing preferences."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "managementService": {
+      "type": "object",
+      "description": "Management service settings for liveness/readiness probes and metrics.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ExternalName", "ClusterIP", "NodePort", "LoadBalancer"],
+          "description": "The type of service to create."
+        },
+        "ports": {
+          "type": "array",
+          "description": "The ports the management service will listen on. At least one port is required.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the management port. Required.",
+                "maxLength": 15
+              },
+              "port": {
+                "type": "integer",
+                "description": "The port the management service listens on."
+              },
+              "targetPort": {
+                "type": ["integer", "string", "null"],
+                "description": "Number or name of the port to access on the pods."
+              },
+              "nodePort": {
+                "type": ["integer", "null"],
+                "description": "The port on each node when type is NodePort or LoadBalancer."
+              },
+              "protocol": {
+                "oneOf": [
+                  { "type": "string", "enum": ["TCP", "UDP", "SCTP"] },
+                  { "type": "null" }
+                ],
+                "description": "The IP protocol for this port."
+              }
+            },
+            "required": ["name", "port"]
+          }
+        },
+        "clusterIP": {
+          "type": ["string", "null"],
+          "description": "By default, the management service is headless (None)."
+        },
+        "sessionAffinity": {
+          "oneOf": [
+            { "type": "string", "enum": ["None", "ClientIP"] },
+            { "type": "null" }
+          ],
+          "description": "The session affinity for the service."
+        },
+        "internalTrafficPolicy": {
+          "oneOf": [
+            { "type": "string", "enum": ["Cluster", "Local"] },
+            { "type": "null" }
+          ],
+          "description": "Controls how traffic from internal sources is routed."
+        },
+        "externalTrafficPolicy": {
+          "oneOf": [
+            { "type": "string", "enum": ["Cluster", "Local"] },
+            { "type": "null" }
+          ],
+          "description": "Controls how traffic from external sources is routed."
+        },
+        "trafficDistribution": {
+          "type": ["string", "null"],
+          "description": "The traffic distribution field for routing preferences."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "extraServices": {
+      "type": "array",
+      "description": "Additional service definitions. All service definitions always select all Polaris pods.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "nameSuffix": {
+            "type": "string",
+            "description": "The suffix to append to the service name. Required. It must be unique."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["ExternalName", "ClusterIP", "NodePort", "LoadBalancer"],
+            "description": "The type of service to create."
+          },
+          "ports": {
+            "type": "array",
+            "description": "The ports the service will listen on.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "maxLength": 15
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "targetPort": {
+                  "type": ["integer", "string", "null"]
+                },
+                "nodePort": {
+                  "type": ["integer", "null"]
+                },
+                "protocol": {
+                  "oneOf": [
+                    { "type": "string", "enum": ["TCP", "UDP", "SCTP"] },
+                    { "type": "null" }
+                  ]
+                }
+              }
+            }
+          },
+          "sessionAffinity": {
+            "oneOf": [
+              { "type": "string", "enum": ["None", "ClientIP"] },
+              { "type": "null" }
+            ]
+          },
+          "clusterIP": {
+            "type": ["string", "null"]
+          },
+          "internalTrafficPolicy": {
+            "oneOf": [
+              { "type": "string", "enum": ["Cluster", "Local"] },
+              { "type": "null" }
+            ]
+          },
+          "externalTrafficPolicy": {
+            "oneOf": [
+              { "type": "string", "enum": ["Cluster", "Local"] },
+              { "type": "null" }
+            ]
+          },
+          "trafficDistribution": {
+            "type": ["string", "null"]
+          },
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["nameSuffix"]
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "description": "Polaris Ingress settings.",
+      "properties": {
+        "className": {
+          "type": "string",
+          "description": "Specifies the ingressClassName."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether an ingress should be created."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the ingress.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "hosts": {
+          "type": "array",
+          "description": "A list of host paths used to configure the ingress.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "The hostname."
+              },
+              "paths": {
+                "type": "array",
+                "description": "The paths for this host.",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "description": "A list of TLS certificates.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Polaris Gateway settings for Gateway API-based routing.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether a Gateway should be created."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the Gateway.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "className": {
+          "type": "string",
+          "description": "The name of the GatewayClass to use."
+        },
+        "listeners": {
+          "type": "array",
+          "description": "Gateway listeners configuration. See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Listener",
+          "items": {
+            "type": "object"
+          }
+        },
+        "addresses": {
+          "type": "array",
+          "description": "Addresses requested for this Gateway. See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayAddress",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "httproute": {
+      "type": "object",
+      "description": "Polaris HTTPRoute settings for Gateway API-based routing.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether an HTTPRoute should be created."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the HTTPRoute.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "gatewayName": {
+          "type": "string",
+          "description": "Name of the Gateway resource to attach to."
+        },
+        "gatewayNamespace": {
+          "type": "string",
+          "description": "Namespace where the Gateway is deployed."
+        },
+        "sectionName": {
+          "type": "string",
+          "description": "Section name within the gateway to use (optional)."
+        },
+        "hosts": {
+          "type": "array",
+          "description": "A list of hostnames that the HTTPRoute should match.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Configures the resources requests and limits for polaris pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core"
+    },
+    "autoscaling": {
+      "type": "object",
+      "description": "Horizontal pod autoscaling configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether automatic horizontal scaling should be enabled."
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The minimum number of replicas to maintain."
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum number of replicas to maintain."
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Target CPU utilization percentage."
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Target memory utilization percentage."
+        }
+      }
+    },
+    "priorityClassName": {
+      "type": ["string", "null"],
+      "description": "Priority class name for polaris pods."
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node labels which must match for the polaris pod to be scheduled on that node.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "A list of tolerations to apply to polaris pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#toleration-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity and anti-affinity for polaris pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#affinity-v1-core"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology spread constraints for polaris pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#topologyspreadconstraint-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Configures the liveness probe for polaris pods.",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of seconds after the container has started before liveness probes are initiated."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "How often (in seconds) to perform the probe."
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of seconds after which the probe times out."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure."
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Configures the readiness probe for polaris pods.",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of seconds after the container has started before readiness probes are initiated."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "How often (in seconds) to perform the probe."
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of seconds after which the probe times out."
+        }
+      }
+    },
+    "advancedConfig": {
+      "type": "object",
+      "description": "Advanced configuration. You can pass here any valid Polaris or Quarkus configuration property."
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Extra environment variables to add to the Polaris server container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra volumes to add to the polaris pod. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volume-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Extra volume mounts to add to the polaris container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volumemount-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Add additional init containers to the polaris pod(s). See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#container-v1-core",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tracing": {
+      "type": "object",
+      "description": "Tracing configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether tracing for the polaris server should be enabled."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "The collector endpoint URL to connect to (required when tracing is enabled). Must have http:// or https:// scheme.",
+          "pattern": "^https?://.+"
+        },
+        "sample": {
+          "type": "string",
+          "description": "Which requests should be sampled. Valid values are: all, none, or a ratio between 0.0 and 1.0d."
+        },
+        "attributes": {
+          "type": "object",
+          "description": "Resource attributes to identify the polaris service among other tracing sources.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "enabled": { "const": true }
+        },
+        "required": ["enabled"]
+      },
+      "then": {
+        "required": ["endpoint"]
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Metrics configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether metrics for the polaris server should be enabled."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Additional tags (dimensional labels) to add to the metrics.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "description": "ServiceMonitor for Prometheus operator configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether a ServiceMonitor for Prometheus operator should be created."
+        },
+        "interval": {
+          "type": "string",
+          "description": "The scrape interval; leave empty to let Prometheus decide."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Labels for the created ServiceMonitor.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "metricRelabelings": {
+          "type": "array",
+          "description": "Relabeling rules to apply to metrics.",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "logging": {
+      "type": "object",
+      "description": "Logging configuration.",
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "The log level of the root category, which is used as the default log level for all categories."
+        },
+        "requestIdHeaderName": {
+          "type": "string",
+          "description": "The header name to use for the request ID."
+        },
+        "console": {
+          "type": "object",
+          "description": "Configuration for the console appender.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to enable the console appender."
+            },
+            "threshold": {
+              "type": "string",
+              "description": "The log level of the console appender."
+            },
+            "json": {
+              "type": "boolean",
+              "description": "Whether to log in JSON format."
+            },
+            "format": {
+              "type": "string",
+              "description": "The log format to use. Ignored if JSON format is enabled. See https://quarkus.io/guides/logging#logging-format for details."
+            }
+          }
+        },
+        "file": {
+          "type": "object",
+          "description": "Configuration for the file appender.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to enable the file appender."
+            },
+            "threshold": {
+              "type": "string",
+              "description": "The log level of the file appender."
+            },
+            "json": {
+              "type": "boolean",
+              "description": "Whether to log in JSON format."
+            },
+            "format": {
+              "type": "string",
+              "description": "The log format to use. Ignored if JSON format is enabled. See https://quarkus.io/guides/logging#logging-format for details."
+            },
+            "logsDir": {
+              "type": "string",
+              "description": "The local directory where log files are stored. The persistent volume claim will be mounted here."
+            },
+            "fileName": {
+              "type": "string",
+              "description": "The log file name."
+            },
+            "rotation": {
+              "type": "object",
+              "description": "Log rotation configuration.",
+              "properties": {
+                "maxFileSize": {
+                  "type": "string",
+                  "description": "The maximum size of the log file before it is rotated. Should be expressed as a Kubernetes quantity."
+                },
+                "maxBackupIndex": {
+                  "type": "integer",
+                  "description": "The maximum number of backup files to keep.",
+                  "minimum": 0
+                },
+                "fileSuffix": {
+                  "type": ["string", "null"],
+                  "description": "An optional suffix to append to the rotated log files. The suffix must be in a date-time format understood by DateTimeFormatter. If the suffix ends with .gz or .zip, the rotated files will also be compressed."
+                }
+              }
+            },
+            "storage": {
+              "type": "object",
+              "description": "The log storage configuration. A persistent volume claim will be created using these settings.",
+              "properties": {
+                "className": {
+                  "type": "string",
+                  "description": "The storage class name of the persistent volume claim to create."
+                },
+                "size": {
+                  "type": "string",
+                  "description": "The size of the persistent volume claim to create."
+                },
+                "selectorLabels": {
+                  "type": "object",
+                  "description": "Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist. Leave empty if using dynamic provisioning.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "categories": {
+          "type": "object",
+          "description": "Configuration for specific log categories. Keys are category names (e.g., org.apache.polaris), values are log levels.",
+          "additionalProperties": {
+            "type": ["string", "object"]
+          }
+        },
+        "mdc": {
+          "type": "object",
+          "description": "Configuration for MDC (Mapped Diagnostic Context). Values specified here will be added to the log context of all incoming requests and can be used in log patterns.",
+          "additionalProperties": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    },
+    "realmContext": {
+      "type": "object",
+      "description": "Realm context resolver configuration.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of realm context resolver to use."
+        },
+        "realms": {
+          "type": "array",
+          "description": "List of valid realms. The first realm in the list is the default realm. Realms not in this list will be rejected.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "description": "Polaris features configuration."
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Polaris persistence configuration.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of persistence to use."
+        },
+        "relationalJdbc": {
+          "type": "object",
+          "description": "The configuration for the relational-jdbc persistence manager.",
+          "properties": {
+            "secret": {
+              "type": "object",
+              "description": "The secret to pull the database connection properties from.",
+              "properties": {
+                "name": {
+                  "type": ["string", "null"],
+                  "description": "The secret name to pull database connection properties from."
+                },
+                "username": {
+                  "type": "string",
+                  "description": "The secret key holding the database username for authentication."
+                },
+                "password": {
+                  "type": "string",
+                  "description": "The secret key holding the database password for authentication."
+                },
+                "jdbcUrl": {
+                  "type": "string",
+                  "description": "The secret key holding the database JDBC connection URL."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fileIo": {
+      "type": "object",
+      "description": "Polaris FileIO configuration.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of file IO to use."
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "description": "Storage credentials for the server. If the following properties are unset, default credentials will be used, in which case the pod must have the necessary permissions to access the storage.",
+      "properties": {
+        "secret": {
+          "type": "object",
+          "description": "The secret to pull storage credentials from.",
+          "properties": {
+            "name": {
+              "type": ["string", "null"],
+              "description": "The name of the secret to pull storage credentials from."
+            },
+            "awsAccessKeyId": {
+              "type": ["string", "null"],
+              "description": "The key in the secret to pull the AWS access key ID from. Only required when using AWS."
+            },
+            "awsSecretAccessKey": {
+              "type": ["string", "null"],
+              "description": "The key in the secret to pull the AWS secret access key from. Only required when using AWS."
+            },
+            "gcpToken": {
+              "type": ["string", "null"],
+              "description": "The key in the secret to pull the GCP token from. Only required when using GCP."
+            },
+            "gcpTokenLifespan": {
+              "type": ["string", "null"],
+              "description": "The key in the secret to pull the GCP token expiration time from. Only required when using GCP. Must be a valid ISO 8601 duration. The default is PT1H (1 hour)."
+            }
+          }
+        }
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "description": "Polaris authentication configuration.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["internal", "external", "mixed"],
+          "description": "The type of authentication to use."
+        },
+        "authenticator": {
+          "type": "object",
+          "description": "The Authenticator implementation to use. Only one built-in type is supported: default.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of authenticator to use."
+            }
+          }
+        },
+        "tokenService": {
+          "type": "object",
+          "description": "The token service (IcebergRestOAuth2ApiService) implementation to use. Two built-in types are supported: default and disabled. Only relevant when using internal (or mixed) authentication.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of token service to use."
+            }
+          }
+        },
+        "tokenBroker": {
+          "type": "object",
+          "description": "The TokenBroker implementation to use. Two built-in types are supported: rsa-key-pair and symmetric-key. Only relevant when using internal (or mixed) authentication.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of token broker to use."
+            },
+            "maxTokenGeneration": {
+              "type": "string",
+              "description": "Maximum token generation duration (e.g., PT1H for 1 hour)."
+            },
+            "secret": {
+              "type": "object",
+              "description": "The secret name to pull the public and private keys, or the symmetric key secret from.",
+              "properties": {
+                "name": {
+                  "type": ["string", "null"],
+                  "description": "The name of the secret to pull the keys from. If not provided, a key pair will be generated. This is not recommended for production."
+                },
+                "publicKey": {
+                  "type": "string",
+                  "description": "DEPRECATED: Use authentication.tokenBroker.secret.rsaKeyPair.publicKey instead. Key name inside the secret for the public key."
+                },
+                "privateKey": {
+                  "type": "string",
+                  "description": "DEPRECATED: Use authentication.tokenBroker.secret.rsaKeyPair.privateKey instead. Key name inside the secret for the private key."
+                },
+                "secretKey": {
+                  "type": "string",
+                  "description": "DEPRECATED: Use authentication.tokenBroker.secret.symmetricKey.secretKey instead. Key name inside the secret for the symmetric key."
+                },
+                "rsaKeyPair": {
+                  "type": "object",
+                  "description": "Configuration specific to RSA key pair secret.",
+                  "properties": {
+                    "publicKey": {
+                      "type": "string",
+                      "description": "Key name inside the secret for the public key."
+                    },
+                    "privateKey": {
+                      "type": "string",
+                      "description": "Key name inside the secret for the private key."
+                    }
+                  }
+                },
+                "symmetricKey": {
+                  "type": "object",
+                  "description": "Configuration specific to symmetric key secret.",
+                  "properties": {
+                    "secretKey": {
+                      "type": "string",
+                      "description": "Key name inside the secret for the symmetric key."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "realmOverrides": {
+          "type": "object",
+          "description": "Authentication configuration overrides per realm.",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "oidc": {
+      "type": "object",
+      "description": "Polaris OIDC configuration. Only relevant when at least one realm is configured for external (or mixed) authentication.",
+      "properties": {
+        "authServerUrl": {
+          "type": ["string", "null"],
+          "description": "The authentication server URL. Must be provided if at least one realm is configured for external authentication."
+        },
+        "client": {
+          "type": "object",
+          "description": "The client to use when authenticating with the authentication server.",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The client ID to use when contacting the authentication server's introspection endpoint."
+            },
+            "secret": {
+              "type": "object",
+              "description": "The secret to pull the client secret from.",
+              "properties": {
+                "name": {
+                  "type": ["string", "null"],
+                  "description": "The name of the secret to pull the client secret from."
+                },
+                "key": {
+                  "type": "string",
+                  "description": "The key name inside the secret to pull the client secret from."
+                }
+              }
+            }
+          }
+        },
+        "principalMapper": {
+          "type": "object",
+          "description": "Principal mapping configuration.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The PrincipalMapper implementation to use."
+            },
+            "idClaimPath": {
+              "type": ["string", "null"],
+              "description": "The path to the claim that contains the principal ID."
+            },
+            "nameClaimPath": {
+              "type": ["string", "null"],
+              "description": "The claim that contains the principal name."
+            }
+          }
+        },
+        "principalRolesMapper": {
+          "type": "object",
+          "description": "Principal roles mapping configuration.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The PrincipalRolesMapper implementation to use."
+            },
+            "rolesClaimPath": {
+              "type": ["string", "null"],
+              "description": "The path to the claim that contains the principal roles."
+            },
+            "filter": {
+              "type": ["string", "null"],
+              "description": "A regular expression that matches the role names in the identity."
+            },
+            "mappings": {
+              "type": "array",
+              "description": "A list of regex mappings to transform role names.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "regex": {
+                    "type": "string"
+                  },
+                  "replacement": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cors": {
+      "type": "object",
+      "description": "Polaris CORS configuration.",
+      "properties": {
+        "allowedOrigins": {
+          "type": "array",
+          "description": "Origins allowed for CORS.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedMethods": {
+          "type": "array",
+          "description": "HTTP methods allowed for CORS.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedHeaders": {
+          "type": "array",
+          "description": "HTTP headers allowed for CORS.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exposedHeaders": {
+          "type": "array",
+          "description": "HTTP headers exposed to the client.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accessControlMaxAge": {
+          "type": ["string", "null"],
+          "description": "The Access-Control-Max-Age response header value."
+        },
+        "accessControlAllowCredentials": {
+          "type": ["boolean", "null"],
+          "description": "The Access-Control-Allow-Credentials response header."
+        }
+      }
+    },
+    "rateLimiter": {
+      "type": "object",
+      "description": "Polaris rate limiter configuration.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of rate limiter filter to use."
+        },
+        "tokenBucket": {
+          "type": "object",
+          "description": "The configuration for the default rate limiter."
+        }
+      }
+    },
+    "tasks": {
+      "type": "object",
+      "description": "Polaris asynchronous task executor configuration.",
+      "properties": {
+        "maxConcurrentTasks": {
+          "type": ["integer", "null"],
+          "description": "The maximum number of concurrent tasks that can be executed at the same time."
+        },
+        "maxQueuedTasks": {
+          "type": ["integer", "null"],
+          "description": "The maximum number of tasks that can be queued up for execution."
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This PR adds a `values.schema.json` file to the Helm chart to enable automatic validation of `values.yaml` during chart rendering.

Benefits of a schema file:

- Configuration errors can be caught early before deployment
- IDE autocompletion and validation support

The schema file uses JSON Schema draft-07 for broad tooling compatibility. A comprehensive schema covering all configuration sections is provided; however, Kubernetes API types (e.g. `EnvVar`) are declared as "object" to avoid referencing external schemas, and to avoid Kubernetes API versioning issues.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
