### PR TITLE
[Iceberg 1.11] test. Fix test failures in SparkCatalogTest

### DIFF
--- a/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/SparkCatalogTest.java
+++ b/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/SparkCatalogTest.java
@@ -154,6 +154,7 @@ public class SparkCatalogTest {
         .thenReturn("/tmp/test-warehouse");
     Mockito.when(mockedSession.sparkContext()).thenReturn(mockedContext);
     Mockito.when(mockedContext.applicationId()).thenReturn("appId");
+    Mockito.when(mockedContext.appName()).thenReturn("test-app");
     Mockito.when(mockedContext.sparkUser()).thenReturn("test-user");
     Mockito.when(mockedContext.version()).thenReturn("3.5");
 


### PR DESCRIPTION
Simple test fix in SparkCatalogTest. We just need to initialize the app name.
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [+ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [+] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [+] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [+] 💡 Added comments for complex logic
- [+] 🧾 Updated `CHANGELOG.md` (if needed)
- [+] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
