### PR TITLE
Remove unnecessary header X-Iceberg-Access-Delegation for Ceph

### DIFF
--- a/getting-started/ceph/README.md
+++ b/getting-started/ceph/README.md
@@ -86,7 +86,7 @@ bin/spark-sql \
     --conf spark.sql.catalog.polaris.warehouse=quickstart_catalog \
     --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
     --conf spark.sql.catalog.polaris.credential=root:s3cr3t \
-    --conf spark.sql.catalog.polaris.client.region=us-west-2 \
+    --conf spark.sql.catalog.polaris.client.region=irrelevant \
     --conf spark.sql.catalog.polaris.s3.access-key-id=POLARIS123ACCESS \
     --conf spark.sql.catalog.polaris.s3.secret-access-key=POLARIS456SECRET
 ```


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Same discussed in https://github.com/apache/polaris/pull/3591, having empty value for `X-Iceberg-Access-Delegation` is kind misleading and we don't need this for the getting start example to work.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
