### PR TITLE
Fix: Preserve federated field when creating PrincipalRole (#2966)

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -954,6 +954,10 @@ public class PolarisManagementServiceIntegrationTest {
             .request("v1/principal-roles")
             .post(Entity.json(new CreatePrincipalRoleRequest(federatedPrincipalRole)))) {
       assertThat(createResponse).returns(CREATED.getStatusCode(), Response::getStatus);
+
+      // Verify that the returned principal role has federated=true
+      PrincipalRole createdRole = createResponse.readEntity(PrincipalRole.class);
+      assertThat(createdRole.getFederated()).isTrue();
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -350,6 +350,7 @@ public class PolarisServiceImpl
             .setProperties(
                 reservedProperties.removeReservedProperties(
                     request.getPrincipalRole().getProperties()))
+            .setFederated(request.getPrincipalRole().getFederated())
             .build();
     PrincipalRole newPrincipalRole =
         new PrincipalRoleEntity(adminService.createPrincipalRole(entity)).asPrincipalRole();


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
## Summary

Fixes the bug where the `federated` field was being ignored when creating a PrincipalRole via the API, causing all principal roles to be created as non-federated regardless of the input value.

## Changes

- **Bug Fix**: Added `.setFederated(request.getPrincipalRole().getFederated())` to `PolarisServiceImpl.createPrincipalRole()` to properly preserve the federated flag from the request
- **Test Enhancement**: Updated `testCreateFederatedPrincipalRoleSucceeds` to actually verify the `federated` field value in the response, not just the HTTP 201 status code

## Testing

### Manual Testing
Verified the fix by running a Polaris server and executing API calls:
1. Created a principal role with `federated: true` → correctly returned `federated: true` ✅
2. Created a principal role with `federated: false` → correctly returned `federated: false` ✅
3. Verified federated roles cannot be assigned to principals (correct validation behavior) ✅


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #2966
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
