### PR TITLE
Use Weld-BOM for better dependency management

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,7 @@ testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version
 testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "4.1.1" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
 weld-junit5 = { module = "org.jboss.weld:weld-junit5", version = "5.0.3.Final" }
-weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "6.0.4.Final" }
+weld-core-bom = { module = "org.jboss.weld:weld-core-bom", version = "6.0.4.Final" }
 
 [plugins]
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.9.0" }

--- a/persistence/nosql/async/api/build.gradle.kts
+++ b/persistence/nosql/async/api/build.gradle.kts
@@ -50,7 +50,8 @@ dependencies {
 
   testFixturesApi(project(":polaris-idgen-api"))
 
-  testFixturesImplementation(libs.weld.se.core)
+  testFixturesImplementation(platform(libs.weld.core.bom))
+  testFixturesImplementation("org.jboss.weld.se:weld-se-core")
   testFixturesImplementation(libs.weld.junit5)
   testFixturesImplementation(libs.guava)
   testFixturesRuntimeOnly(libs.smallrye.jandex)

--- a/persistence/nosql/authz/impl/build.gradle.kts
+++ b/persistence/nosql/authz/impl/build.gradle.kts
@@ -51,7 +51,8 @@ dependencies {
   testFixturesImplementation(project(":polaris-persistence-nosql-authz-api"))
   testFixturesImplementation(project(":polaris-persistence-nosql-authz-spi"))
 
-  testImplementation(libs.weld.se.core)
+  testImplementation(platform(libs.weld.core.bom))
+  testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 

--- a/persistence/nosql/authz/store-nosql/build.gradle.kts
+++ b/persistence/nosql/authz/store-nosql/build.gradle.kts
@@ -45,7 +45,8 @@ dependencies {
   compileOnly(libs.jakarta.inject.api)
   compileOnly(libs.jakarta.enterprise.cdi.api)
 
-  testFixturesApi(libs.weld.se.core)
+  testFixturesApi(platform(libs.weld.core.bom))
+  testFixturesApi("org.jboss.weld.se:weld-se-core")
   testFixturesApi(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 

--- a/persistence/nosql/nodes/store-nosql/build.gradle.kts
+++ b/persistence/nosql/nodes/store-nosql/build.gradle.kts
@@ -53,7 +53,8 @@ dependencies {
   testFixturesRuntimeOnly(project(":polaris-persistence-nosql-cdi-weld"))
   testFixturesApi(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
 
-  testFixturesApi(libs.weld.se.core)
+  testFixturesApi(platform(libs.weld.core.bom))
+  testFixturesApi("org.jboss.weld.se:weld-se-core")
   testFixturesApi(libs.weld.junit5)
   testFixturesRuntimeOnly(libs.smallrye.jandex)
 

--- a/persistence/nosql/persistence/cdi/weld/build.gradle.kts
+++ b/persistence/nosql/persistence/cdi/weld/build.gradle.kts
@@ -66,7 +66,8 @@ dependencies {
   testFixturesApi(project(":polaris-nodes-api"))
   testFixturesRuntimeOnly(libs.smallrye.config.core)
 
-  testImplementation(libs.weld.se.core)
+  testImplementation(platform(libs.weld.core.bom))
+  testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 }

--- a/persistence/nosql/persistence/maintenance/impl/build.gradle.kts
+++ b/persistence/nosql/persistence/maintenance/impl/build.gradle.kts
@@ -72,7 +72,8 @@ dependencies {
 
   testImplementation(project(":polaris-idgen-mocks"))
   testRuntimeOnly(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
-  testImplementation(libs.weld.se.core)
+  testImplementation(platform(libs.weld.core.bom))
+  testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 

--- a/persistence/nosql/persistence/metastore-maintenance/build.gradle.kts
+++ b/persistence/nosql/persistence/metastore-maintenance/build.gradle.kts
@@ -74,7 +74,8 @@ dependencies {
   testImplementation(project(":polaris-persistence-nosql-impl"))
 
   testRuntimeOnly(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
-  testImplementation(libs.weld.se.core)
+  testImplementation(platform(libs.weld.core.bom))
+  testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 }

--- a/persistence/nosql/persistence/metastore/build.gradle.kts
+++ b/persistence/nosql/persistence/metastore/build.gradle.kts
@@ -60,7 +60,8 @@ dependencies {
   testRuntimeOnly(project(":polaris-persistence-nosql-authz-impl"))
   testRuntimeOnly(project(":polaris-persistence-nosql-authz-store-nosql"))
   testRuntimeOnly(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
-  testImplementation(libs.weld.se.core)
+  testImplementation(platform(libs.weld.core.bom))
+  testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
 

--- a/persistence/nosql/realms/store-nosql/build.gradle.kts
+++ b/persistence/nosql/realms/store-nosql/build.gradle.kts
@@ -52,7 +52,8 @@ dependencies {
   testFixturesRuntimeOnly(project(":polaris-persistence-nosql-cdi-weld"))
   testFixturesApi(testFixtures(project(":polaris-persistence-nosql-cdi-weld")))
 
-  testFixturesApi(libs.weld.se.core)
+  testFixturesApi(platform(libs.weld.core.bom))
+  testFixturesApi("org.jboss.weld.se:weld-se-core")
   testFixturesApi(libs.weld.junit5)
   testFixturesRuntimeOnly(libs.smallrye.jandex)
 


### PR DESCRIPTION
... to ensure that other Weld dependencies are also aligned, in case other dependencies bring Weld stuff as well.

No functional change.