### PR TITLE
Move lookup and cast logic to PolarisConfiguration

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/core/config/PolarisConfigurationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/config/PolarisConfigurationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PolarisConfigurationTest {
+
+  private <T> PolarisConfiguration<T> cfg(T value) {
+    return PolarisConfiguration.<T>builder()
+        .key("TEST-CONFIG-" + UUID.randomUUID())
+        .description("test")
+        .defaultValue(value)
+        .buildFeatureConfiguration();
+  }
+
+  private <T> T resolve(T value, PolarisConfiguration<T> cfg) {
+    return cfg.resolveValue(name -> value, name -> value);
+  }
+
+  private <T> T resolve(PolarisConfiguration<T> cfg) {
+    return cfg.resolveValue(name -> null, name -> null);
+  }
+
+  private <T> T resolveString(String value, PolarisConfiguration<T> cfg) {
+    return cfg.resolveValue(name -> value, name -> value);
+  }
+
+  @Test
+  void typeCastSameType() {
+    assertThat(resolve("str", cfg("test"))).isEqualTo("str");
+    assertThat(resolve(1, cfg(2))).isEqualTo(1);
+    assertThat(resolve(2L, cfg(1L))).isEqualTo(2L);
+    assertThat(resolve(true, cfg(false))).isEqualTo(true);
+    assertThat(resolve(1.2f, cfg(0.0f))).isEqualTo(1.2f);
+    assertThat(resolve(3.4d, cfg(0.1d))).isEqualTo(3.4d);
+    assertThat(resolve(List.of("1", "2"), cfg(List.of("3")))).isEqualTo(List.of("1", "2"));
+  }
+
+  @Test
+  void typeCastFromString() {
+    assertThat(resolveString("str", cfg("test"))).isEqualTo("str");
+    assertThat(resolveString("1", cfg(2))).isEqualTo(1);
+    assertThat(resolveString("2", cfg(1L))).isEqualTo(2L);
+    assertThat(resolveString("true", cfg(false))).isEqualTo(true);
+    assertThat(resolveString("1.2", cfg(0.0f))).isEqualTo(1.2f);
+    assertThat(resolveString("3.4", cfg(0.1d))).isEqualTo(3.4d);
+  }
+
+  @Test
+  public void testInvalidCast() {
+    assertThatThrownBy(() -> resolveString("str", cfg(1)))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> resolveString("str", cfg(2L)))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> resolveString("str", cfg(0.1f)))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> resolveString("str", cfg(0.2d)))
+        .isInstanceOf(NumberFormatException.class);
+
+    assertThatThrownBy(() -> resolveString("str", cfg(List.of("1", "2"))))
+        .isInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void typedDefaults() {
+    assertThat(resolve(cfg("test"))).isEqualTo("test");
+    assertThat(resolve(cfg(1))).isEqualTo(1);
+    assertThat(resolve(cfg(2L))).isEqualTo(2L);
+    assertThat(resolve(cfg(true))).isEqualTo(true);
+    assertThat(resolve(cfg(1.2f))).isEqualTo(1.2f);
+    assertThat(resolve(cfg(3.4d))).isEqualTo(3.4d);
+    assertThat(resolve(cfg(List.of("3", "4")))).isEqualTo(List.of("3", "4"));
+  }
+
+  @Test
+  void catalogConfigUnsafe() {
+    @SuppressWarnings("removal")
+    FeatureConfiguration<String> cfg =
+        PolarisConfiguration.<String>builder()
+            .key("TEST-catalogConfigUnsafe-" + UUID.randomUUID())
+            .description("test")
+            .defaultValue("def1")
+            .catalogConfigUnsafe("unsafe1")
+            .buildFeatureConfiguration();
+
+    assertThat(cfg.resolveValue(name -> null, name -> null)).isEqualTo("def1");
+    assertThat(cfg.resolveValue(name -> null, Map.of("unsafe1", "old2")::get)).isEqualTo("old2");
+  }
+
+  @Test
+  void lookupPrecedence() {
+    String key = "TEST-PRECEDENCE-" + UUID.randomUUID();
+    FeatureConfiguration<String> cfg =
+        PolarisConfiguration.<String>builder()
+            .key(key)
+            .description("test")
+            .defaultValue("def1")
+            .catalogConfig("polaris.config.test1")
+            .legacyCatalogConfig("legacy2")
+            .buildFeatureConfiguration();
+
+    assertThat(cfg.resolveValue(name -> "glob", name -> "cat123")).isEqualTo("cat123");
+    assertThat(cfg.resolveValue(name -> "glob", name -> null)).isEqualTo("glob");
+    assertThat(cfg.resolveValue(name -> null, name -> null)).isEqualTo("def1");
+    assertThat(cfg.resolveValue(Map.of(key, "glob")::get, name -> null)).isEqualTo("glob");
+    assertThat(
+            cfg.resolveValue(
+                Map.of(key, "glob0")::get, Map.of("polaris.config.test1", "cat1")::get))
+        .isEqualTo("cat1");
+    assertThat(cfg.resolveValue(name -> null, Map.of("legacy2", "old2")::get)).isEqualTo("old2");
+    assertThat(
+            cfg.resolveValue(
+                name -> null, Map.of("polaris.config.test1", "cat1", "legacy2", "old2")::get))
+        .isEqualTo("cat1");
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/config/RealmConfigImplTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/config/RealmConfigImplTest.java
@@ -22,9 +22,7 @@ package org.apache.polaris.core.config;
 import static org.apache.polaris.core.config.RealmConfigurationSource.EMPTY_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +35,6 @@ class RealmConfigImplTest {
     return new RealmConfigImpl(stringsSource, () -> realmName);
   }
 
-  private RealmConfig fixed(Object value) {
-    return new RealmConfigImpl((rc, name) -> value, () -> "test-realm");
-  }
-
   private RealmConfig empty() {
     return new RealmConfigImpl(EMPTY_CONFIG, () -> "test-realm");
   }
@@ -51,61 +45,6 @@ class RealmConfigImplTest {
     assertThat((Object) strings("rc1").getConfig("c1")).isEqualTo("value-rc1-c1");
     assertThat((Object) strings("rc2").getConfig("c1", "default1")).isEqualTo("value-rc2-c1");
     assertThat((Object) empty().getConfig("c1", "default1")).isEqualTo("default1");
-  }
-
-  @Test
-  void configPropertyOrder() {
-    @SuppressWarnings("deprecation")
-    FeatureConfiguration<String> cfg1 =
-        PolarisConfiguration.<String>builder()
-            .key("TEST-KEY1")
-            .catalogConfig("polaris.config.cat-prop")
-            .catalogConfigUnsafe("legacy-prop")
-            .description("test")
-            .defaultValue("default2")
-            .buildFeatureConfiguration();
-    assertThat(strings("rc1").getConfig(cfg1)).isEqualTo("value-rc1-TEST-KEY1");
-    assertThat(strings("rc2").getConfig(cfg1, Map.of())).isEqualTo("value-rc2-TEST-KEY1");
-    assertThat(strings("rc3").getConfig(cfg1, Map.of("polaris.config.cat-prop", "cat1")))
-        .isEqualTo("cat1");
-    assertThat(strings("rc3").getConfig(cfg1, Map.of("legacy-prop", "old2"))).isEqualTo("old2");
-    assertThat(empty().getConfig(cfg1)).isEqualTo("default2");
-
-    @SuppressWarnings("deprecation")
-    FeatureConfiguration<String> cfg2 =
-        PolarisConfiguration.<String>builder()
-            .key("TEST-KEY2")
-            .catalogConfigUnsafe("legacy-prop2")
-            .description("test")
-            .defaultValue("default2")
-            .buildFeatureConfiguration();
-    assertThat(strings("rc1").getConfig(cfg2)).isEqualTo("value-rc1-TEST-KEY2");
-    assertThat(strings("rc2").getConfig(cfg2, Map.of())).isEqualTo("value-rc2-TEST-KEY2");
-    assertThat(strings("rc3").getConfig(cfg2, Map.of("legacy-prop2", "old2"))).isEqualTo("old2");
-    assertThat(empty().getConfig(cfg2)).isEqualTo("default2");
-
-    FeatureConfiguration<String> cfg3 =
-        PolarisConfiguration.<String>builder()
-            .key("TEST-KEY3")
-            .catalogConfig("polaris.config.cat-prop2")
-            .description("test")
-            .defaultValue("default2")
-            .buildFeatureConfiguration();
-    assertThat(strings("rc1").getConfig(cfg3)).isEqualTo("value-rc1-TEST-KEY3");
-    assertThat(strings("rc2").getConfig(cfg3, Map.of())).isEqualTo("value-rc2-TEST-KEY3");
-    assertThat(strings("rc3").getConfig(cfg3, Map.of("polaris.config.cat-prop2", "cat2")))
-        .isEqualTo("cat2");
-    assertThat(empty().getConfig(cfg3)).isEqualTo("default2");
-
-    FeatureConfiguration<String> cfg4 =
-        PolarisConfiguration.<String>builder()
-            .key("TEST-KEY4")
-            .description("test")
-            .defaultValue("default2")
-            .buildFeatureConfiguration();
-    assertThat(strings("rc1").getConfig(cfg4)).isEqualTo("value-rc1-TEST-KEY4");
-    assertThat(strings("rc2").getConfig(cfg4, Map.of())).isEqualTo("value-rc2-TEST-KEY4");
-    assertThat(empty().getConfig(cfg4)).isEqualTo("default2");
   }
 
   @Test
@@ -125,35 +64,5 @@ class RealmConfigImplTest {
 
     assertThat(strings("rc1").getConfig(cfg)).isEqualTo("value-rc1-TEST-ENTITY1");
     assertThat(strings("rc2").getConfig(cfg, entity)).isEqualTo("entity2");
-  }
-
-  private <T> PolarisConfiguration<T> cfg(T value) {
-    return PolarisConfiguration.<T>builder()
-        .key("TEST-CAST-" + UUID.randomUUID().toString())
-        .description("test")
-        .defaultValue(value)
-        .buildFeatureConfiguration();
-  }
-
-  @Test
-  void typeCast() {
-    assertThat(fixed("str").getConfig(cfg("test"))).isEqualTo("str");
-    assertThat(fixed(1).getConfig(cfg(2))).isEqualTo(1);
-    assertThat(fixed(2L).getConfig(cfg(1L))).isEqualTo(2L);
-    assertThat(fixed(true).getConfig(cfg(false))).isEqualTo(true);
-    assertThat(fixed(1.2f).getConfig(cfg(0.0f))).isEqualTo(1.2f);
-    assertThat(fixed(3.4d).getConfig(cfg(0.1d))).isEqualTo(3.4d);
-    assertThat(fixed(List.of("1", "2")).getConfig(cfg(List.of()))).isEqualTo(List.of("1", "2"));
-  }
-
-  @Test
-  void typedDefaults() {
-    assertThat(empty().getConfig(cfg("test"))).isEqualTo("test");
-    assertThat(empty().getConfig(cfg(2))).isEqualTo(2);
-    assertThat(empty().getConfig(cfg(1L))).isEqualTo(1L);
-    assertThat(empty().getConfig(cfg(false))).isEqualTo(false);
-    assertThat(empty().getConfig(cfg(0.1f))).isEqualTo(0.1f);
-    assertThat(empty().getConfig(cfg(2.3d))).isEqualTo(2.3d);
-    assertThat(empty().getConfig(cfg(List.of("3", "4")))).isEqualTo(List.of("3", "4"));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
@@ -194,34 +194,9 @@ public class DefaultConfigurationStoreTest {
             .description(prefix)
             .buildFeatureConfiguration();
 
-    @SuppressWarnings({"deprecation", "removal"})
-    FeatureConfiguration<Boolean> unsafeConfig =
-        FeatureConfiguration.<Boolean>builder()
-            .key(String.format("%s_unsafe", prefix))
-            .catalogConfigUnsafe(String.format("%s.unsafe", prefix))
-            .defaultValue(true)
-            .description(prefix)
-            .buildFeatureConfiguration();
-
-    @SuppressWarnings({"deprecation", "removal"})
-    FeatureConfiguration<Boolean> bothConfig =
-        FeatureConfiguration.<Boolean>builder()
-            .key(String.format("%s_both", prefix))
-            .catalogConfig(String.format("polaris.config.%s.both", prefix))
-            .catalogConfigUnsafe(String.format("%s.both", prefix))
-            .defaultValue(true)
-            .description(prefix)
-            .buildFeatureConfiguration();
-
     CatalogEntity catalog = new CatalogEntity.Builder().build();
 
     Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, safeConfig))
-        .isTrue();
-
-    Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, unsafeConfig))
-        .isTrue();
-
-    Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, bothConfig))
         .isTrue();
   }
 }


### PR DESCRIPTION
Following up on #3735

* Consolidate property lookup (preference) logic in PolarisConfiguration

* Consolidate property type cast logic in PolarisConfiguration (add case for `Float`)

* Improve test coverage in PolarisConfigurationTest and RealmConfigImplTest

* Remove irrelevant tests from PolarisConfigurationStoreTest and DefaultConfigurationStoreTest (covered by the above tests)

This change does not affect configuration lookup behaviour aside from failures related to incorrect config for `Float` types... However, that case is apparently not invoked by existing `PolarisConfiguration` constants.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
