### PR TITLE
Synchronize on PolarisConfiguration.registerConfiguration()

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ReservedProperties.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ReservedProperties.java
@@ -67,7 +67,7 @@ public interface ReservedProperties {
    * prefix
    */
   default Set<String> allowlist() {
-    return AllowlistHolder.INSTANCE;
+    return PolarisConfiguration.getAllCatalogConfigs();
   }
 
   /** If true, attempts to modify a reserved property should throw an exception. */
@@ -154,24 +154,5 @@ public interface ReservedProperties {
       }
       default -> update;
     };
-  }
-
-  class AllowlistHolder {
-    static final Set<String> INSTANCE = computeAllowlist();
-
-    private static Set<String> computeAllowlist() {
-      Set<String> allowlist = new HashSet<>();
-      PolarisConfiguration.getAllConfigurations()
-          .forEach(
-              c -> {
-                if (c.hasCatalogConfig()) {
-                  allowlist.add(c.catalogConfig());
-                }
-                if (c.hasCatalogConfigUnsafe()) {
-                  allowlist.add(c.catalogConfigUnsafe());
-                }
-              });
-      return allowlist;
-    }
   }
 }


### PR DESCRIPTION
The `ALL_CONFIGURATIONS` field is using `ArrayList` which is not thread-safe.

The field is only accessed via `registerConfiguration()`, and all configurations are currently registered during static initialization.

But we have two subclasses, `FeatureConfiguration` and `BehaviorChangeConfiguration`, that both call that method.

Consider this scenario:

1. Thread A triggers loading of `FeatureConfiguration`;
2. Thread B triggers loading of `BehaviorChangeConfiguration`;
3. Both classes' static initializers run in parallel;
4. Both call `registerConfiguration()` on the shared list concurrently.

In order to avoid this, this PR <strike>changes the list to `CopyOnWriteArrayList`</strike> makes the `registerConfiguration` method synchronized.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
