### PR TITLE
Helm chart: use the chart version as default image tag

### DIFF
--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -26,8 +26,8 @@ image:
   repository: apache/polaris
   # -- The image pull policy.
   pullPolicy: IfNotPresent
-  # -- The image tag.
-  tag: "latest"
+  # -- The image tag. If not set, the chart version is used.
+  tag: ""
   # -- The path to the directory where the application.properties file, and other configuration
   # files, if any, should be mounted.
   configDir: /deployments/config

--- a/site/content/in-dev/unreleased/helm.md
+++ b/site/content/in-dev/unreleased/helm.md
@@ -313,7 +313,7 @@ ct install --namespace polaris --charts ./helm/polaris
 | image.configDir | string | `"/deployments/config"` | The path to the directory where the application.properties file, and other configuration files, if any, should be mounted. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | image.repository | string | `"apache/polaris"` | The image repository to pull from. |
-| image.tag | string | `"latest"` | The image tag. |
+| image.tag | string | `""` | The image tag. If not set, the chart version is used. |
 | imagePullSecrets | list | `[]` | References to secrets in the same namespace to use for pulling any of the images used by this chart. Each entry is a LocalObjectReference to an existing secret in the namespace. The secret must contain a .dockerconfigjson key with a base64-encoded Docker configuration file. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ for more information. |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress. |
 | ingress.className | string | `""` | Specifies the ingressClassName; leave empty if you don't want to customize it |


### PR DESCRIPTION
Since the chart release cycle is tied to the server's it makes sense to default the image tag to the chart version, which is also the Polaris server version.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
