### PR TITLE
Unify keycloak docker tags

### DIFF
--- a/runtime/test-common/src/main/resources/org/apache/polaris/test/commons/keycloak/Dockerfile-keycloak-version
+++ b/runtime/test-common/src/main/resources/org/apache/polaris/test/commons/keycloak/Dockerfile-keycloak-version
@@ -19,4 +19,4 @@
 
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM keycloak/keycloak:26.5.3
+FROM quay.io/keycloak/keycloak:26.5.3


### PR DESCRIPTION
This aligns with `getting-started/keycloak/docker-compose.yml`, prevent duplicate Renovate PRs against the different tags.
