### PR TITLE
Refactor authz tests to use JUnit dynamic tests

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
@@ -23,7 +23,7 @@ import io.quarkus.test.junit.TestProfile;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
 import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
 import org.apache.polaris.core.admin.model.UpdateCatalogRoleRequest;
@@ -35,10 +35,9 @@ import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
-import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 @QuarkusTest
 @TestProfile(PolarisAuthzTestBase.Profile.class)
@@ -61,33 +60,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         reservedProperties);
   }
 
-  private void doTestSufficientPrivileges(
-      List<PolarisPrivilege> sufficientPrivileges,
-      Runnable action,
-      Runnable cleanupAction,
-      Function<PolarisPrivilege, PrivilegeResult> grantAction,
-      Function<PolarisPrivilege, PrivilegeResult> revokeAction) {
-    doTestSufficientPrivilegeSets(
-        sufficientPrivileges.stream().map(Set::of).toList(),
-        action,
-        cleanupAction,
-        PRINCIPAL_NAME,
-        grantAction,
-        revokeAction);
-  }
-
-  private void doTestInsufficientPrivileges(
-      List<PolarisPrivilege> insufficientPrivileges,
-      Runnable action,
-      Function<PolarisPrivilege, PrivilegeResult> grantAction,
-      Function<PolarisPrivilege, PrivilegeResult> revokeAction) {
-    doTestInsufficientPrivileges(
-        insufficientPrivileges, PRINCIPAL_NAME, action, grantAction, revokeAction);
-  }
-
-  @Test
-  public void testListCatalogsSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListCatalogsSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listCatalogs",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_LIST,
@@ -106,9 +82,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListCatalogsInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListCatalogsInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listCatalogs",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -127,8 +104,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreateCatalogSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateCatalogSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -137,7 +114,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final CreateCatalogRequest createRequest =
         new CreateCatalogRequest(newCatalog.asCatalog(serviceIdentityProvider));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createCatalog",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_CREATE,
@@ -151,13 +129,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreateCatalogInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testCreateCatalogInsufficientPrivileges() {
     final CatalogEntity newCatalog = new CatalogEntity.Builder().setName("new_catalog").build();
     final CreateCatalogRequest createRequest =
         new CreateCatalogRequest(newCatalog.asCatalog(serviceIdentityProvider));
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createCatalog",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -180,9 +159,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetCatalogSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGetCatalogSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "getCatalog",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_READ_PROPERTIES,
@@ -199,9 +179,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetCatalogInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGetCatalogInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "getCatalog",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -222,9 +203,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdateCatalogSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdateCatalogSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updateCatalog",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_WRITE_PROPERTIES,
@@ -251,9 +233,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdateCatalogInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateCatalogInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "updateCatalog",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -283,8 +266,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeleteCatalogSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDeleteCatalogSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -294,7 +277,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         new CreateCatalogRequest(newCatalog.asCatalog(serviceIdentityProvider));
     adminService.createCatalog(createRequest);
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "deleteCatalog",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_DROP,
@@ -308,14 +292,15 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeleteCatalogInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testDeleteCatalogInsufficientPrivileges() {
     final CatalogEntity newCatalog = new CatalogEntity.Builder().setName("new_catalog").build();
     final CreateCatalogRequest createRequest =
         new CreateCatalogRequest(newCatalog.asCatalog(serviceIdentityProvider));
     adminService.createCatalog(createRequest);
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "deleteCatalog",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -338,9 +323,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListPrincipalsSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListPrincipalsSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listPrincipals",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_LIST,
@@ -357,9 +343,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListPrincipalsInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListPrincipalsInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listPrincipals",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -377,8 +364,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreatePrincipalSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreatePrincipalSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -386,7 +373,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final PrincipalEntity newPrincipal =
         new PrincipalEntity.Builder().setName("new_principal").build();
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createPrincipal",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_CREATE,
@@ -400,12 +388,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreatePrincipalInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testCreatePrincipalInsufficientPrivileges() {
     final PrincipalEntity newPrincipal =
         new PrincipalEntity.Builder().setName("new_principal").build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createPrincipal",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -425,9 +414,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetPrincipalSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGetPrincipalSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "getPrincipal",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_READ_PROPERTIES,
@@ -442,9 +432,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetPrincipalInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGetPrincipalInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "getPrincipal",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -464,9 +455,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdatePrincipalSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdatePrincipalSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updatePrincipal",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_WRITE_PROPERTIES,
@@ -491,9 +483,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdatePrincipalInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdatePrincipalInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "updatePrincipal",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -522,8 +515,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeletePrincipalSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDeletePrincipalSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -532,7 +525,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         new PrincipalEntity.Builder().setName("new_principal").build();
     adminService.createPrincipal(newPrincipal);
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "deletePrincipal",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_DROP,
@@ -546,13 +540,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeletePrincipalInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testDeletePrincipalInsufficientPrivileges() {
     final PrincipalEntity newPrincipal =
         new PrincipalEntity.Builder().setName("new_principal").build();
     adminService.createPrincipal(newPrincipal);
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "deletePrincipal",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -572,9 +567,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListPrincipalRolesSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListPrincipalRolesSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listPrincipalRoles",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_LIST,
@@ -591,9 +587,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListPrincipalRolesInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListPrincipalRolesInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listPrincipalRoles",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -611,8 +608,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreatePrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreatePrincipalRoleSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -620,7 +617,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final PrincipalRoleEntity newPrincipalRole =
         new PrincipalRoleEntity.Builder().setName("new_principal_role").build();
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createPrincipalRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_CREATE,
@@ -636,12 +634,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testCreatePrincipalRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testCreatePrincipalRoleInsufficientPrivileges() {
     final PrincipalRoleEntity newPrincipalRole =
         new PrincipalRoleEntity.Builder().setName("new_principal_role").build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createPrincipalRole",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -661,9 +660,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetPrincipalRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGetPrincipalRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "getPrincipalRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_READ_PROPERTIES,
@@ -678,9 +678,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGetPrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGetPrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "getPrincipalRole",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -700,9 +701,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdatePrincipalRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdatePrincipalRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updatePrincipalRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_WRITE_PROPERTIES,
@@ -727,9 +729,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testUpdatePrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdatePrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "updatePrincipalRole",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -758,8 +761,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeletePrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDeletePrincipalRoleSufficientPrivileges() {
     // Cleanup with PRINCIPAL_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnRootContainerToPrincipalRole(
@@ -768,7 +771,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         new PrincipalRoleEntity.Builder().setName("new_principal_role").build();
     adminService.createPrincipalRole(newPrincipalRole);
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "deletePrincipalRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_DROP,
@@ -784,13 +788,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testDeletePrincipalRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testDeletePrincipalRoleInsufficientPrivileges() {
     final PrincipalRoleEntity newPrincipalRole =
         new PrincipalRoleEntity.Builder().setName("new_principal_role").build();
     adminService.createPrincipalRole(newPrincipalRole);
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "deletePrincipalRole",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -812,9 +817,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListCatalogRolesSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListCatalogRolesSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listCatalogRoles",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_LIST,
@@ -823,16 +829,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.CATALOG_ROLE_CREATE,
             PolarisPrivilege.CATALOG_ROLE_FULL_METADATA),
         () -> newTestAdminService().listCatalogRoles(CATALOG_NAME),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testListCatalogRolesInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListCatalogRolesInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listCatalogRoles",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -843,15 +847,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.PRINCIPAL_FULL_METADATA,
             PolarisPrivilege.CATALOG_ROLE_DROP,
             PolarisPrivilege.PRINCIPAL_ROLE_FULL_METADATA),
-        () -> newTestAdminService().listCatalogRoles(CATALOG_NAME),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        () -> newTestAdminService().listCatalogRoles(CATALOG_NAME));
   }
 
-  @Test
-  public void testCreateCatalogRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateCatalogRoleSufficientPrivileges() {
     // Cleanup with CATALOG_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
@@ -859,7 +859,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
     final CatalogRoleEntity newCatalogRole =
         new CatalogRoleEntity.Builder().setName("new_catalog_role").build();
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_CREATE,
@@ -869,19 +870,16 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 .createCatalogRole(CATALOG_NAME, newCatalogRole),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE2))
-                .deleteCatalogRole(CATALOG_NAME, newCatalogRole.getName()),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                .deleteCatalogRole(CATALOG_NAME, newCatalogRole.getName()));
   }
 
-  @Test
-  public void testCreateCatalogRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testCreateCatalogRoleInsufficientPrivileges() {
     final CatalogRoleEntity newCatalogRole =
         new CatalogRoleEntity.Builder().setName("new_catalog_role").build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -896,32 +894,27 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.CATALOG_ROLE_WRITE_PROPERTIES),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
-                .createCatalogRole(CATALOG_NAME, newCatalogRole),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                .createCatalogRole(CATALOG_NAME, newCatalogRole));
   }
 
-  @Test
-  public void testGetCatalogRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGetCatalogRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "getCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_READ_PROPERTIES,
             PolarisPrivilege.CATALOG_ROLE_WRITE_PROPERTIES,
             PolarisPrivilege.CATALOG_ROLE_FULL_METADATA),
         () -> newTestAdminService().getCatalogRole(CATALOG_NAME, CATALOG_ROLE2),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testGetCatalogRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGetCatalogRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "getCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -934,16 +927,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.CATALOG_ROLE_CREATE,
             PolarisPrivilege.CATALOG_ROLE_DROP,
             PolarisPrivilege.PRINCIPAL_ROLE_FULL_METADATA),
-        () -> newTestAdminService().getCatalogRole(CATALOG_NAME, CATALOG_ROLE2),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        () -> newTestAdminService().getCatalogRole(CATALOG_NAME, CATALOG_ROLE2));
   }
 
-  @Test
-  public void testUpdateCatalogRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdateCatalogRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updateCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_WRITE_PROPERTIES,
@@ -962,16 +952,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                   .build();
           newTestAdminService().updateCatalogRole(CATALOG_NAME, CATALOG_ROLE2, updateRequest);
         },
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testUpdateCatalogRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateCatalogRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "updateCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -995,15 +983,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                   .setProperties(Map.of("foo", Long.toString(System.currentTimeMillis())))
                   .build();
           newTestAdminService().updateCatalogRole(CATALOG_NAME, CATALOG_ROLE2, updateRequest);
-        },
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        });
   }
 
-  @Test
-  public void testDeleteCatalogRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDeleteCatalogRoleSufficientPrivileges() {
     // Cleanup with CATALOG_ROLE2
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
@@ -1012,7 +996,8 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         new CatalogRoleEntity.Builder().setName("new_catalog_role").build();
     adminService.createCatalogRole(CATALOG_NAME, newCatalogRole);
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "deleteCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_DROP,
@@ -1022,20 +1007,17 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 .deleteCatalogRole(CATALOG_NAME, newCatalogRole.getName()),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE2))
-                .createCatalogRole(CATALOG_NAME, newCatalogRole),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                .createCatalogRole(CATALOG_NAME, newCatalogRole));
   }
 
-  @Test
-  public void testDeleteCatalogRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testDeleteCatalogRoleInsufficientPrivileges() {
     final CatalogRoleEntity newCatalogRole =
         new CatalogRoleEntity.Builder().setName("new_catalog_role").build();
     adminService.createCatalogRole(CATALOG_NAME, newCatalogRole);
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "deleteCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -1050,19 +1032,16 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             PolarisPrivilege.CATALOG_ROLE_WRITE_PROPERTIES),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
-                .deleteCatalogRole(CATALOG_NAME, newCatalogRole.getName()),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                .deleteCatalogRole(CATALOG_NAME, newCatalogRole.getName()));
   }
 
-  @Test
-  public void testAssignPrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testAssignPrincipalRoleSufficientPrivileges() {
     adminService.createPrincipal(new PrincipalEntity.Builder().setName("newprincipal").build());
 
     // Assign only requires privileges on the securable.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "assignPrincipalRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.PRINCIPAL_ROLE_MANAGE_GRANTS_ON_SECURABLE),
@@ -1077,10 +1056,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testAssignPrincipalRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testAssignPrincipalRoleInsufficientPrivileges() {
     adminService.createPrincipal(new PrincipalEntity.Builder().setName("newprincipal").build());
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "assignPrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1113,13 +1093,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokePrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testRevokePrincipalRoleSufficientPrivileges() {
     adminService.createPrincipal(new PrincipalEntity.Builder().setName("newprincipal").build());
 
     // Revoke requires privileges both on the "securable" (PrincipalRole) as well as the "grantee"
     // (Principal).
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "revokePrincipalRole",
         List.of(
             Set.of(PolarisPrivilege.SERVICE_MANAGE_ACCESS),
             Set.of(
@@ -1129,7 +1110,6 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokePrincipalRole("newprincipal", PRINCIPAL_ROLE2),
         null, // cleanupAction
-        PRINCIPAL_NAME,
         (privilege) ->
             adminService.grantPrivilegeOnRootContainerToPrincipalRole(PRINCIPAL_ROLE1, privilege),
         (privilege) ->
@@ -1137,10 +1117,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokePrincipalRoleInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testRevokePrincipalRoleInsufficientPrivileges() {
     adminService.createPrincipal(new PrincipalEntity.Builder().setName("newprincipal").build());
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "revokePrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1174,10 +1155,11 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testAssignCatalogRoleToPrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testAssignCatalogRoleToPrincipalRoleSufficientPrivileges() {
     // Assign only requires privileges on the securable.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "assignCatalogRoleToPrincipalRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE),
@@ -1192,9 +1174,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testAssignCatalogRoleToPrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testAssignCatalogRoleToPrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "assignCatalogRoleToPrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1227,12 +1210,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokeCatalogRoleFromPrincipalRoleSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testRevokeCatalogRoleFromPrincipalRoleSufficientPrivileges() {
     // Revoke requires privileges both on the "securable" (CatalogRole) as well as the "grantee"
     // (PrincipalRole); neither CATALOG_MANAGE_ACCESS nor SERVICE_MANAGE_ACCESS alone are
     // sufficient.
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "revokeCatalogRoleFromPrincipalRole",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_ACCESS, PolarisPrivilege.SERVICE_MANAGE_ACCESS),
             Set.of(
@@ -1245,7 +1229,6 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokeCatalogRoleFromPrincipalRole(PRINCIPAL_ROLE2, CATALOG_NAME, CATALOG_ROLE1),
         null, // cleanupAction
-        PRINCIPAL_NAME,
         (privilege) ->
             adminService.grantPrivilegeOnRootContainerToPrincipalRole(PRINCIPAL_ROLE1, privilege),
         (privilege) ->
@@ -1253,9 +1236,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokeCatalogRoleFromPrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokeCatalogRoleFromPrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokeCatalogRoleFromPrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1290,9 +1274,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testListAssigneePrincipalRolesForCatalogRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListAssigneePrincipalRolesForCatalogRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listAssigneePrincipalRolesForCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_ROLE_LIST_GRANTS,
             PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE,
@@ -1308,9 +1293,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
   }
 
-  @Test
-  public void testListAssigneePrincipalRolesForCatalogRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListAssigneePrincipalRolesForCatalogRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listAssigneePrincipalRolesForCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_LIST,
@@ -1332,9 +1318,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
   }
 
-  @Test
-  public void testListGrantsForCatalogRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListGrantsForCatalogRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listGrantsForCatalogRole",
         List.of(
             PolarisPrivilege.CATALOG_ROLE_LIST_GRANTS,
             PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE,
@@ -1350,9 +1337,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
   }
 
-  @Test
-  public void testListGrantsForCatalogRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListGrantsForCatalogRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listGrantsForCatalogRole",
         List.of(
             PolarisPrivilege.SERVICE_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_ROLE_LIST,
@@ -1374,9 +1362,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
   }
 
-  @Test
-  public void testGrantPrivilegeOnRootContainerToPrincipalRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnRootContainerToPrincipalRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "grantPrivilegeOnRootContainerToPrincipalRole",
         List.of(PolarisPrivilege.SERVICE_MANAGE_ACCESS),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
@@ -1390,9 +1379,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGrantPrivilegeOnRootContainerToPrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnRootContainerToPrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "grantPrivilegeOnRootContainerToPrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1427,9 +1417,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokePrivilegeOnRootContainerFromPrincipalRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testRevokePrivilegeOnRootContainerFromPrincipalRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "revokePrivilegeOnRootContainerFromPrincipalRole",
         List.of(PolarisPrivilege.SERVICE_MANAGE_ACCESS),
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
@@ -1443,9 +1434,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testRevokePrivilegeOnRootContainerFromPrincipalRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokePrivilegeOnRootContainerFromPrincipalRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokePrivilegeOnRootContainerFromPrincipalRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1480,9 +1472,10 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 PRINCIPAL_ROLE1, privilege));
   }
 
-  @Test
-  public void testGrantPrivilegeOnCatalogToRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnCatalogToRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "grantPrivilegeOnCatalogToRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.CATALOG_MANAGE_GRANTS_ON_SECURABLE),
@@ -1490,16 +1483,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .grantPrivilegeOnCatalogToRole(
                     CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testGrantPrivilegeOnCatalogToRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnCatalogToRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "grantPrivilegeOnCatalogToRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1525,16 +1516,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .grantPrivilegeOnCatalogToRole(
-                    CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @Test
-  public void testRevokePrivilegeOnCatalogFromRoleSufficientPrivileges() {
-    doTestSufficientPrivilegeSets(
+  @TestFactory
+  Stream<DynamicNode> testRevokePrivilegeOnCatalogFromRoleSufficientPrivileges() {
+    return doTestSufficientPrivilegeSets(
+        "revokePrivilegeOnCatalogFromRole",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_ACCESS),
             Set.of(
@@ -1544,17 +1532,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokePrivilegeOnCatalogFromRole(
                     CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        PRINCIPAL_NAME,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testRevokePrivilegeOnCatalogFromRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokePrivilegeOnCatalogFromRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokePrivilegeOnCatalogFromRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1581,34 +1566,40 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokePrivilegeOnCatalogFromRole(
-                    CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @ParameterizedTest(name = "{displayName}({0})")
-  @ValueSource(strings = {CATALOG_NAME, FEDERATED_CATALOG_NAME})
-  public void testGrantPrivilegeOnNamespaceToRoleSufficientPrivileges(String catalogName) {
-    doTestSufficientPrivileges(
-        List.of(
-            PolarisPrivilege.CATALOG_MANAGE_ACCESS,
-            PolarisPrivilege.NAMESPACE_MANAGE_GRANTS_ON_SECURABLE),
-        () ->
-            newTestAdminService(Set.of(PRINCIPAL_ROLE1))
-                .grantPrivilegeOnNamespaceToRole(
-                    catalogName, CATALOG_ROLE2, NS1, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(catalogName, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(catalogName, CATALOG_ROLE1, privilege));
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnNamespaceToRoleSufficientPrivileges() {
+    return Stream.of(CATALOG_NAME, FEDERATED_CATALOG_NAME)
+        .flatMap(
+            catalogName ->
+                doTestSufficientPrivileges(
+                    "grantPrivilegeOnNamespaceToRole[" + catalogName + "]",
+                    List.of(
+                        PolarisPrivilege.CATALOG_MANAGE_ACCESS,
+                        PolarisPrivilege.NAMESPACE_MANAGE_GRANTS_ON_SECURABLE),
+                    () ->
+                        newTestAdminService(Set.of(PRINCIPAL_ROLE1))
+                            .grantPrivilegeOnNamespaceToRole(
+                                catalogName,
+                                CATALOG_ROLE2,
+                                NS1,
+                                PolarisPrivilege.CATALOG_MANAGE_ACCESS),
+                    null, // cleanupAction
+                    (privilege) ->
+                        adminService.grantPrivilegeOnCatalogToRole(
+                            catalogName, CATALOG_ROLE1, privilege),
+                    (privilege) ->
+                        adminService.revokePrivilegeOnCatalogFromRole(
+                            catalogName, CATALOG_ROLE1, privilege)));
   }
 
-  @Test
-  public void testGrantPrivilegeOnNamespaceToRoleSufficientPrivileges_FederationNestedNamespace() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode>
+      testGrantPrivilegeOnNamespaceToRoleSufficientPrivileges_FederationNestedNamespace() {
+    return doTestSufficientPrivileges(
+        "grantPrivilegeOnNamespaceToRole_FederationNestedNamespace",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.NAMESPACE_MANAGE_GRANTS_ON_SECURABLE),
@@ -1628,45 +1619,54 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                 FEDERATED_CATALOG_NAME, CATALOG_ROLE1, privilege));
   }
 
-  @ParameterizedTest(name = "{displayName}({0})")
-  @ValueSource(strings = {CATALOG_NAME, FEDERATED_CATALOG_NAME})
-  public void testGrantPrivilegeOnNamespaceToRoleInsufficientPrivileges(String catalogName) {
-    doTestInsufficientPrivileges(
-        List.of(
-            PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
-            PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.PRINCIPAL_LIST_GRANTS,
-            PolarisPrivilege.PRINCIPAL_ROLE_MANAGE_GRANTS_FOR_GRANTEE,
-            PolarisPrivilege.PRINCIPAL_ROLE_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.PRINCIPAL_ROLE_LIST_GRANTS,
-            PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_FOR_GRANTEE,
-            PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.CATALOG_ROLE_LIST_GRANTS,
-            PolarisPrivilege.CATALOG_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.CATALOG_LIST_GRANTS,
-            PolarisPrivilege.NAMESPACE_LIST_GRANTS,
-            PolarisPrivilege.TABLE_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.TABLE_LIST_GRANTS,
-            PolarisPrivilege.VIEW_MANAGE_GRANTS_ON_SECURABLE,
-            PolarisPrivilege.VIEW_LIST_GRANTS,
-            PolarisPrivilege.PRINCIPAL_FULL_METADATA,
-            PolarisPrivilege.PRINCIPAL_ROLE_FULL_METADATA,
-            PolarisPrivilege.CATALOG_FULL_METADATA,
-            PolarisPrivilege.CATALOG_MANAGE_CONTENT,
-            PolarisPrivilege.SERVICE_MANAGE_ACCESS),
-        () ->
-            newTestAdminService(Set.of(PRINCIPAL_ROLE1))
-                .grantPrivilegeOnNamespaceToRole(
-                    catalogName, CATALOG_ROLE2, NS1, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(catalogName, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(catalogName, CATALOG_ROLE1, privilege));
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnNamespaceToRoleInsufficientPrivileges() {
+    return Stream.of(CATALOG_NAME, FEDERATED_CATALOG_NAME)
+        .flatMap(
+            catalogName ->
+                doTestInsufficientPrivileges(
+                    "grantPrivilegeOnNamespaceToRole[" + catalogName + "]",
+                    List.of(
+                        PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
+                        PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.PRINCIPAL_LIST_GRANTS,
+                        PolarisPrivilege.PRINCIPAL_ROLE_MANAGE_GRANTS_FOR_GRANTEE,
+                        PolarisPrivilege.PRINCIPAL_ROLE_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.PRINCIPAL_ROLE_LIST_GRANTS,
+                        PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_FOR_GRANTEE,
+                        PolarisPrivilege.CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.CATALOG_ROLE_LIST_GRANTS,
+                        PolarisPrivilege.CATALOG_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.CATALOG_LIST_GRANTS,
+                        PolarisPrivilege.NAMESPACE_LIST_GRANTS,
+                        PolarisPrivilege.TABLE_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.TABLE_LIST_GRANTS,
+                        PolarisPrivilege.VIEW_MANAGE_GRANTS_ON_SECURABLE,
+                        PolarisPrivilege.VIEW_LIST_GRANTS,
+                        PolarisPrivilege.PRINCIPAL_FULL_METADATA,
+                        PolarisPrivilege.PRINCIPAL_ROLE_FULL_METADATA,
+                        PolarisPrivilege.CATALOG_FULL_METADATA,
+                        PolarisPrivilege.CATALOG_MANAGE_CONTENT,
+                        PolarisPrivilege.SERVICE_MANAGE_ACCESS),
+                    () ->
+                        newTestAdminService(Set.of(PRINCIPAL_ROLE1))
+                            .grantPrivilegeOnNamespaceToRole(
+                                catalogName,
+                                CATALOG_ROLE2,
+                                NS1,
+                                PolarisPrivilege.CATALOG_MANAGE_ACCESS),
+                    (privilege) ->
+                        adminService.grantPrivilegeOnCatalogToRole(
+                            catalogName, CATALOG_ROLE1, privilege),
+                    (privilege) ->
+                        adminService.revokePrivilegeOnCatalogFromRole(
+                            catalogName, CATALOG_ROLE1, privilege)));
   }
 
-  @Test
-  public void testRevokePrivilegeOnNamespaceFromRoleSufficientPrivileges() {
-    doTestSufficientPrivilegeSets(
+  @TestFactory
+  Stream<DynamicNode> testRevokePrivilegeOnNamespaceFromRoleSufficientPrivileges() {
+    return doTestSufficientPrivilegeSets(
+        "revokePrivilegeOnNamespaceFromRole",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_ACCESS),
             Set.of(
@@ -1676,17 +1676,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokePrivilegeOnNamespaceFromRole(
                     CATALOG_NAME, CATALOG_ROLE2, NS1, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        PRINCIPAL_NAME,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testRevokePrivilegeOnNamespaceFromRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokePrivilegeOnNamespaceFromRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokePrivilegeOnNamespaceFromRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1713,37 +1710,39 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
         () ->
             newTestAdminService(Set.of(PRINCIPAL_ROLE1))
                 .revokePrivilegeOnNamespaceFromRole(
-                    CATALOG_NAME, CATALOG_ROLE2, NS1, PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    CATALOG_NAME, CATALOG_ROLE2, NS1, PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @ParameterizedTest(name = "{displayName}({0})")
-  @ValueSource(strings = {CATALOG_NAME, FEDERATED_CATALOG_NAME})
-  public void testGrantPrivilegeOnTableToRoleSufficientPrivileges(String catalogName) {
-    doTestSufficientPrivileges(
-        List.of(
-            PolarisPrivilege.CATALOG_MANAGE_ACCESS,
-            PolarisPrivilege.TABLE_MANAGE_GRANTS_ON_SECURABLE),
-        () ->
-            newTestAdminService(Set.of(PRINCIPAL_ROLE1))
-                .grantPrivilegeOnTableToRole(
-                    catalogName,
-                    CATALOG_ROLE2,
-                    TABLE_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(catalogName, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(catalogName, CATALOG_ROLE1, privilege));
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnTableToRoleSufficientPrivileges() {
+    return Stream.of(CATALOG_NAME, FEDERATED_CATALOG_NAME)
+        .flatMap(
+            catalogName ->
+                doTestSufficientPrivileges(
+                    "grantPrivilegeOnTableToRole[" + catalogName + "]",
+                    List.of(
+                        PolarisPrivilege.CATALOG_MANAGE_ACCESS,
+                        PolarisPrivilege.TABLE_MANAGE_GRANTS_ON_SECURABLE),
+                    () ->
+                        newTestAdminService(Set.of(PRINCIPAL_ROLE1))
+                            .grantPrivilegeOnTableToRole(
+                                catalogName,
+                                CATALOG_ROLE2,
+                                TABLE_NS1_1,
+                                PolarisPrivilege.CATALOG_MANAGE_ACCESS),
+                    null, // cleanupAction
+                    (privilege) ->
+                        adminService.grantPrivilegeOnCatalogToRole(
+                            catalogName, CATALOG_ROLE1, privilege),
+                    (privilege) ->
+                        adminService.revokePrivilegeOnCatalogFromRole(
+                            catalogName, CATALOG_ROLE1, privilege)));
   }
 
-  @Test
-  public void testGrantPrivilegeOnTableToRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnTableToRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "grantPrivilegeOnTableToRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1772,16 +1771,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_NAME,
                     CATALOG_ROLE2,
                     TABLE_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @Test
-  public void testRevokePrivilegeOnTableFromRoleSufficientPrivileges() {
-    doTestSufficientPrivilegeSets(
+  @TestFactory
+  Stream<DynamicNode> testRevokePrivilegeOnTableFromRoleSufficientPrivileges() {
+    return doTestSufficientPrivilegeSets(
+        "revokePrivilegeOnTableFromRole",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_ACCESS),
             Set.of(
@@ -1794,17 +1790,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_ROLE2,
                     TABLE_NS1_1,
                     PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        PRINCIPAL_NAME,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testRevokePrivilegeOnTableFromRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokePrivilegeOnTableFromRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokePrivilegeOnTableFromRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1834,16 +1827,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_NAME,
                     CATALOG_ROLE2,
                     TABLE_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @Test
-  public void testGrantPrivilegeOnViewToRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnViewToRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "grantPrivilegeOnViewToRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.VIEW_MANAGE_GRANTS_ON_SECURABLE),
@@ -1854,16 +1844,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_ROLE2,
                     VIEW_NS1_1,
                     PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testGrantPrivilegeOnViewToRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnViewToRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "grantPrivilegeOnViewToRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1892,16 +1880,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_NAME,
                     CATALOG_ROLE2,
                     VIEW_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @Test
-  public void testRevokePrivilegeOnViewFromRoleSufficientPrivileges() {
-    doTestSufficientPrivilegeSets(
+  @TestFactory
+  Stream<DynamicNode> testRevokePrivilegeOnViewFromRoleSufficientPrivileges() {
+    return doTestSufficientPrivilegeSets(
+        "revokePrivilegeOnViewFromRole",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_ACCESS),
             Set.of(
@@ -1914,17 +1899,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_ROLE2,
                     VIEW_NS1_1,
                     PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        PRINCIPAL_NAME,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testRevokePrivilegeOnViewFromRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testRevokePrivilegeOnViewFromRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "revokePrivilegeOnViewFromRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -1954,16 +1936,13 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_NAME,
                     CATALOG_ROLE2,
                     VIEW_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 
-  @Test
-  public void testGrantPrivilegeOnPolicyToRoleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testGrantPrivilegeOnPolicyToRoleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "grantPrivilegeOnPolicyToRole",
         List.of(
             PolarisPrivilege.CATALOG_MANAGE_ACCESS,
             PolarisPrivilege.POLICY_MANAGE_GRANTS_ON_SECURABLE),
@@ -1974,16 +1953,14 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_ROLE2,
                     POLICY_NS1_1,
                     PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        null, // cleanupAction
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        null // cleanupAction
+        );
   }
 
-  @Test
-  public void testGrantPrivilegeOnPolicyToRoleInsufficientPrivileges() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testGrantPrivilegeOnPolicyToRoleInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "grantPrivilegeOnPolicyToRole",
         List.of(
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_FOR_GRANTEE,
             PolarisPrivilege.PRINCIPAL_MANAGE_GRANTS_ON_SECURABLE,
@@ -2013,10 +1990,6 @@ public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
                     CATALOG_NAME,
                     CATALOG_ROLE2,
                     POLICY_NS1_1,
-                    PolarisPrivilege.CATALOG_MANAGE_ACCESS),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+                    PolarisPrivilege.CATALOG_MANAGE_ACCESS));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.MetadataUpdate;
@@ -81,7 +82,10 @@ import org.apache.polaris.service.types.NotificationRequest;
 import org.apache.polaris.service.types.NotificationType;
 import org.apache.polaris.service.types.TableUpdateNotification;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.mockito.Mockito;
 
 /**
@@ -122,91 +126,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     return ImmutableIcebergCatalogHandler.builder().from(handler).catalogFactory(factory).build();
   }
 
-  protected void doTestInsufficientPrivileges(
-      List<PolarisPrivilege> insufficientPrivileges, Runnable action) {
-    doTestInsufficientPrivileges(insufficientPrivileges, PRINCIPAL_NAME, action);
-  }
-
-  /**
-   * Tests each "insufficient" privilege individually using CATALOG_ROLE1 by granting at the
-   * CATALOG_NAME level, ensuring the action fails, then revoking after each test case.
-   */
-  private void doTestInsufficientPrivileges(
-      List<PolarisPrivilege> insufficientPrivileges, String principalName, Runnable action) {
-    doTestInsufficientPrivileges(
-        insufficientPrivileges,
-        principalName,
-        action,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
-  }
-
-  /**
-   * Tests each "sufficient" privilege individually using CATALOG_ROLE1 by granting at the
-   * CATALOG_NAME level, revoking after each test, and also ensuring that the request fails after
-   * revocation.
-   *
-   * @param sufficientPrivileges List of privileges that should be sufficient each in isolation for
-   *     {@code action} to succeed.
-   * @param action The operation being tested; could also be multiple operations that should all
-   *     succeed with the sufficient privilege
-   * @param cleanupAction If non-null, additional action to run to "undo" a previous success action
-   *     in case the action has side effects. Called before revoking the sufficient privilege;
-   *     either the cleanup privileges must be latent, or the cleanup action could be run with
-   *     PRINCIPAL_ROLE2 while running {@code action} with PRINCIPAL_ROLE1.
-   */
-  protected void doTestSufficientPrivileges(
-      List<PolarisPrivilege> sufficientPrivileges, Runnable action, Runnable cleanupAction) {
-    doTestSufficientPrivilegeSets(
-        sufficientPrivileges.stream().map(Set::of).toList(), action, cleanupAction, PRINCIPAL_NAME);
-  }
-
-  /**
-   * @param sufficientPrivileges each set of concurrent privileges expected to be sufficient
-   *     together.
-   * @param action
-   * @param cleanupAction
-   * @param principalName
-   */
-  private void doTestSufficientPrivilegeSets(
-      List<Set<PolarisPrivilege>> sufficientPrivileges,
-      Runnable action,
-      Runnable cleanupAction,
-      String principalName) {
-    doTestSufficientPrivilegeSets(
-        sufficientPrivileges, action, cleanupAction, principalName, CATALOG_NAME);
-  }
-
-  /**
-   * @param sufficientPrivileges each set of concurrent privileges expected to be sufficient
-   *     together.
-   * @param action
-   * @param cleanupAction
-   * @param principalName
-   * @param catalogName
-   */
-  protected void doTestSufficientPrivilegeSets(
-      List<Set<PolarisPrivilege>> sufficientPrivileges,
-      Runnable action,
-      Runnable cleanupAction,
-      String principalName,
-      String catalogName) {
-    doTestSufficientPrivilegeSets(
-        sufficientPrivileges,
-        action,
-        cleanupAction,
-        principalName,
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(catalogName, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(catalogName, CATALOG_ROLE1, privilege));
-  }
-
-  @Test
-  public void testListNamespacesAllSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListNamespacesSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listNamespaces",
         List.of(
             PolarisPrivilege.NAMESPACE_LIST,
             PolarisPrivilege.NAMESPACE_READ_PROPERTIES,
@@ -218,9 +141,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testListNamespacesInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListNamespacesInsufficientPrivileges() {
+    return doTestInsufficientPrivileges(
+        "listNamespaces",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -228,8 +152,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().listNamespaces(Namespace.of()));
   }
 
-  @Test
-  public void testInsufficientPermissionsPriorToSecretRotation() {
+  @TestFactory
+  Stream<DynamicNode> testInsufficientPermissionsPriorToSecretRotation() {
     String principalName = "all_the_powers";
     CreatePrincipalResult newPrincipal =
         metaStoreManager.createPrincipal(
@@ -249,17 +173,30 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         icebergCatalogHandlerFactory.createHandler(CATALOG_NAME, authenticatedPrincipal);
 
     // a variety of actions are all disallowed because the principal's credentials must be rotated
-    doTestInsufficientPrivileges(
-        List.of(PolarisPrivilege.values()),
-        principalName,
-        () -> handler.listNamespaces(Namespace.of()));
+
     Namespace ns3 = Namespace.of("ns3");
-    doTestInsufficientPrivileges(
-        List.of(PolarisPrivilege.values()),
-        principalName,
-        () -> handler.createNamespace(CreateNamespaceRequest.builder().withNamespace(ns3).build()));
-    doTestInsufficientPrivileges(
-        List.of(PolarisPrivilege.values()), principalName, () -> handler.listTables(NS1));
+    Stream<DynamicTest> beforeRotationTests =
+        Stream.of(
+                doTestInsufficientPrivileges(
+                    "listNamespaces (before rotation)",
+                    List.of(PolarisPrivilege.values()),
+                    () -> handler.listNamespaces(Namespace.of()),
+                    principalName),
+                doTestInsufficientPrivileges(
+                    "createNamespace (before rotation)",
+                    List.of(PolarisPrivilege.values()),
+                    () ->
+                        handler.createNamespace(
+                            CreateNamespaceRequest.builder().withNamespace(ns3).build()),
+                    principalName),
+                doTestInsufficientPrivileges(
+                    "listTables (before rotation)",
+                    List.of(PolarisPrivilege.values()),
+                    () -> handler.listTables(NS1),
+                    principalName))
+            .flatMap(s -> s);
+
+    // Rotate credentials and create refreshed wrapper
     PrincipalWithCredentialsCredentials credentials =
         new PrincipalWithCredentialsCredentials(
             newPrincipal.getPrincipalSecrets().getPrincipalClientId(),
@@ -277,23 +214,32 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .polarisPrincipal(authenticatedPrincipal1)
             .build();
 
-    doTestSufficientPrivilegeSets(
-        List.of(Set.of(PolarisPrivilege.NAMESPACE_LIST)),
-        () -> refreshedWrapper.listNamespaces(Namespace.of()),
-        null,
-        principalName);
-    doTestSufficientPrivilegeSets(
-        List.of(Set.of(PolarisPrivilege.NAMESPACE_CREATE)),
-        () ->
-            refreshedWrapper.createNamespace(
-                CreateNamespaceRequest.builder().withNamespace(ns3).build()),
-        null,
-        principalName);
-    doTestSufficientPrivilegeSets(
-        List.of(Set.of(PolarisPrivilege.TABLE_LIST)),
-        () -> refreshedWrapper.listTables(ns3),
-        null,
-        principalName);
+    // Tests after credential rotation - actions should succeed with proper privileges
+    Stream<DynamicNode> afterRotationTests =
+        Stream.of(
+                doTestSufficientPrivileges(
+                    "listNamespaces (after rotation)",
+                    List.of(PolarisPrivilege.NAMESPACE_LIST),
+                    () -> refreshedWrapper.listNamespaces(Namespace.of()),
+                    null,
+                    principalName),
+                doTestSufficientPrivileges(
+                    "createNamespace (after rotation)",
+                    List.of(PolarisPrivilege.NAMESPACE_CREATE),
+                    () ->
+                        refreshedWrapper.createNamespace(
+                            CreateNamespaceRequest.builder().withNamespace(ns3).build()),
+                    null,
+                    principalName),
+                doTestSufficientPrivileges(
+                    "listTables (after rotation)",
+                    List.of(PolarisPrivilege.TABLE_LIST),
+                    () -> refreshedWrapper.listTables(ns3),
+                    null,
+                    principalName))
+            .flatMap(s -> s);
+
+    return Stream.concat(beforeRotationTests, afterRotationTests);
   }
 
   @Test
@@ -348,14 +294,15 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         .containsAll(List.of(NS1AA));
   }
 
-  @Test
-  public void testCreateNamespaceAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateNamespaceAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.NAMESPACE_DROP));
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createNamespace",
         List.of(
             PolarisPrivilege.NAMESPACE_CREATE,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -376,9 +323,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateNamespacesInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testCreateNamespacesInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "createNamespace",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -392,9 +340,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     CreateNamespaceRequest.builder().withNamespace(Namespace.of("newns")).build()));
   }
 
-  @Test
-  public void testLoadNamespaceMetadataSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadNamespaceMetadataSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadNamespaceMetadata",
         List.of(
             PolarisPrivilege.NAMESPACE_READ_PROPERTIES,
             PolarisPrivilege.NAMESPACE_WRITE_PROPERTIES,
@@ -404,9 +353,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadNamespaceMetadataInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadNamespaceMetadataInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadNamespaceMetadata",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -416,13 +366,14 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().loadNamespaceMetadata(NS1A));
   }
 
-  @Test
-  public void testNamespaceExistsAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testNamespaceExistsAllSufficientPrivileges() {
     // TODO: If we change the behavior of existence-check to return 404 on unauthorized,
     // the overall test structure will need to change (other tests catching ForbiddenException
     // need to still have catalog-level "REFERENCE" equivalent privileges, and the exists()
     // tests need to expect 404 instead).
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "namespaceExists",
         List.of(
             PolarisPrivilege.NAMESPACE_LIST,
             PolarisPrivilege.NAMESPACE_READ_PROPERTIES,
@@ -434,9 +385,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testNamespaceExistsInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testNamespaceExistsInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "namespaceExists",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -444,14 +396,14 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().namespaceExists(NS1A));
   }
 
-  @Test
-  public void testDropNamespaceSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDropNamespaceSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.NAMESPACE_CREATE));
 
-    // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "dropNamespace",
         List.of(
             PolarisPrivilege.NAMESPACE_DROP,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -465,9 +417,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testDropNamespaceInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testDropNamespaceInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "dropNamespace",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -478,9 +431,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().dropNamespace(NS1AA));
   }
 
-  @Test
-  public void testUpdateNamespacePropertiesAllSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdateNamespacePropertiesAllSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updateNamespaceProperties",
         List.of(
             PolarisPrivilege.NAMESPACE_WRITE_PROPERTIES,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -496,9 +450,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateNamespacePropertiesInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateNamespacePropertiesInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "updateNamespaceProperties",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -512,9 +467,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     NS1A, UpdateNamespacePropertiesRequest.builder().update("foo", "bar").build()));
   }
 
-  @Test
-  public void testListTablesAllSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListTablesAllSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listTables",
         List.of(
             PolarisPrivilege.TABLE_LIST,
             PolarisPrivilege.TABLE_READ_PROPERTIES,
@@ -528,9 +484,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testListTablesInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListTablesInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "listTables",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -538,8 +495,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().listTables(NS1A));
   }
 
-  @Test
-  public void testCreateTableDirectAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateTableDirectAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_DROP));
@@ -552,7 +509,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         CreateTableRequest.builder().withName("newtable").withSchema(SCHEMA).build();
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createTableDirect",
         List.of(
             PolarisPrivilege.TABLE_CREATE,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -565,12 +523,13 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateTableDirectInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCreateTableDirectInsufficientPermissions() {
     final CreateTableRequest createRequest =
         CreateTableRequest.builder().withName("newtable").withSchema(SCHEMA).build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createTableDirect",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -585,8 +544,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateTableDirectWithWriteDelegationAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateTableDirectWithWriteDelegationAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_DROP));
@@ -598,7 +557,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     final CreateTableRequest createDirectWithWriteDelegationRequest =
         CreateTableRequest.builder().withName("newtable").withSchema(SCHEMA).stageCreate().build();
 
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "createTableDirectWithWriteDelegation",
         List.of(
             Set.of(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_DATA),
             Set.of(PolarisPrivilege.CATALOG_MANAGE_CONTENT)),
@@ -613,8 +573,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testCreateTableDirectWithWriteDelegationInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCreateTableDirectWithWriteDelegationInsufficientPermissions() {
     final CreateTableRequest createDirectWithWriteDelegationRequest =
         CreateTableRequest.builder()
             .withName("directtable")
@@ -622,7 +582,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .stageCreate()
             .build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createTableDirectWithWriteDelegation",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -640,8 +601,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateTableStagedAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateTableStagedAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_DROP));
@@ -654,7 +615,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .build();
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createTableStaged",
         List.of(
             PolarisPrivilege.TABLE_CREATE,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -666,8 +628,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null);
   }
 
-  @Test
-  public void testCreateTableStagedInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCreateTableStagedInsufficientPermissions() {
     final CreateTableRequest createStagedRequest =
         CreateTableRequest.builder()
             .withName("stagetable")
@@ -675,7 +637,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .stageCreate()
             .build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createTableStaged",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -690,8 +653,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateTableStagedWithWriteDelegationAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateTableStagedWithWriteDelegationAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_DROP));
@@ -703,7 +666,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .stageCreate()
             .build();
 
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "createTableStagedWithWriteDelegation",
         List.of(
             Set.of(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_DATA),
             Set.of(PolarisPrivilege.CATALOG_MANAGE_CONTENT)),
@@ -717,8 +681,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testCreateTableStagedWithWriteDelegationInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCreateTableStagedWithWriteDelegationInsufficientPermissions() {
     final CreateTableRequest createStagedWithWriteDelegationRequest =
         CreateTableRequest.builder()
             .withName("stagetable")
@@ -726,7 +690,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .stageCreate()
             .build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createTableStagedWithWriteDelegation",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -744,8 +709,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testRegisterTableAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testRegisterTableAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_DROP));
@@ -772,7 +737,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         };
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "registerTable",
         List.of(
             PolarisPrivilege.TABLE_CREATE,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -785,8 +751,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testRegisterTableInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testRegisterTableInsufficientPermissions() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_READ_PROPERTIES));
@@ -807,7 +773,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
           }
         };
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "registerTable",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -822,9 +789,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testLoadTableSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTable",
         List.of(
             PolarisPrivilege.TABLE_READ_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES,
@@ -836,9 +804,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTable",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -848,9 +817,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().loadTable(TABLE_NS1A_2, "all"));
   }
 
-  @Test
-  public void testLoadTableIfStaleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableIfStaleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTableIfStale",
         List.of(
             PolarisPrivilege.TABLE_READ_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES,
@@ -863,9 +833,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableIfStaleInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableIfStaleInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTableIfStale",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -877,9 +848,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 .loadTableIfStale(TABLE_NS1A_2, IfNoneMatch.fromHeader("W/\"0:0\""), "all"));
   }
 
-  @Test
-  public void testLoadTableWithReadAccessDelegationSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableWithReadAccessDelegationSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTableWithAccessDelegation",
         List.of(
             PolarisPrivilege.TABLE_READ_DATA,
             PolarisPrivilege.TABLE_WRITE_DATA,
@@ -888,9 +860,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableWithReadAccessDelegationInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableWithReadAccessDelegationInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTableWithAccessDelegation",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -903,9 +876,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().loadTableWithAccessDelegation(TABLE_NS1A_2, "all", Optional.empty()));
   }
 
-  @Test
-  public void testLoadTableWithWriteAccessDelegationSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableWithWriteAccessDelegationSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTableWithAccessDelegation (write)",
         List.of(
             // TODO: Once we give different creds for read/write privilege, move this
             // TABLE_READ_DATA into a special-case test; with only TABLE_READ_DATA we'd expect
@@ -917,9 +891,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableWithWriteAccessDelegationInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableWithWriteAccessDelegationInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTableWithAccessDelegation (write)",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -932,9 +907,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().loadTableWithAccessDelegation(TABLE_NS1A_2, "all", Optional.empty()));
   }
 
-  @Test
-  public void testLoadTableWithReadAccessDelegationIfStaleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableWithReadAccessDelegationIfStaleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTableWithAccessDelegationIfStale",
         List.of(
             PolarisPrivilege.TABLE_READ_DATA,
             PolarisPrivilege.TABLE_WRITE_DATA,
@@ -946,9 +922,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableWithReadAccessDelegationIfStaleInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableWithReadAccessDelegationIfStaleInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTableWithAccessDelegationIfStale",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -964,9 +941,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     TABLE_NS1A_2, IfNoneMatch.fromHeader("W/\"0:0\""), "all", Optional.empty()));
   }
 
-  @Test
-  public void testLoadTableWithWriteAccessDelegationIfStaleSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadTableWithWriteAccessDelegationIfStaleSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadTableWithAccessDelegationIfStale (write)",
         List.of(
             // TODO: Once we give different creds for read/write privilege, move this
             // TABLE_READ_DATA into a special-case test; with only TABLE_READ_DATA we'd expect
@@ -981,9 +959,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadTableWithWriteAccessDelegationIfStaleInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadTableWithWriteAccessDelegationIfStaleInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadTableWithAccessDelegationIfStale (write)",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -999,9 +978,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     TABLE_NS1A_2, IfNoneMatch.fromHeader("W/\"0:0\""), "all", Optional.empty()));
   }
 
-  @Test
-  public void testUpdateTableSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "updateTable",
         List.of(
             PolarisPrivilege.TABLE_WRITE_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_DATA,
@@ -1011,9 +991,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateTableInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "updateTable",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1025,13 +1006,14 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().updateTable(TABLE_NS1A_2, new UpdateTableRequest()));
   }
 
-  @Test
-  public void testUpdateTableForStagedCreateSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableForStagedCreateSufficientPrivileges() {
     // Note: This is kind of cheating by only leaning on the PolarisCatalogHandlerWrapper level
     // of differentiation between updateForStageCreate vs regular update so that we don't need
     // to actually set up the staged create but still test the privileges. If the underlying
     // behavior diverges, we need to change this test to actually start with a stageCreate.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTableForStagedCreate",
         List.of(
             PolarisPrivilege.TABLE_CREATE,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1040,9 +1022,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableForStagedCreateInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateTableForStagedCreateInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "updateTableForStagedCreate",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1055,8 +1038,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().updateTableForStagedCreate(TABLE_NS1A_2, new UpdateTableRequest()));
   }
 
-  @Test
-  public void testUpdateTableFallbackToCoarseGrainedWhenFeatureDisabled() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableFallbackToCoarseGrainedWhenFeatureDisabled() {
     // Test that when fine-grained authorization is disabled, it falls back to
     // TABLE_WRITE_PROPERTIES
     // This test validates that the feature flag works correctly by testing the negative case
@@ -1068,7 +1051,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
 
     // With fine-grained authorization disabled, TABLE_WRITE_PROPERTIES should work
     // even for operations that would require specific privileges when enabled
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (coarse-grained fallback)",
         List.of(
             PolarisPrivilege.TABLE_WRITE_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_DATA,
@@ -1161,8 +1145,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         .build();
   }
 
-  @Test
-  public void testDropTableWithoutPurgeAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDropTableWithoutPurgeAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_CREATE));
@@ -1171,7 +1155,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         CreateTableRequest.builder().withName(TABLE_NS1_1.name()).withSchema(SCHEMA).build();
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "dropTableWithoutPurge",
         List.of(
             PolarisPrivilege.TABLE_DROP,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1185,9 +1170,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testDropTableWithoutPurgeInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testDropTableWithoutPurgeInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "dropTableWithoutPurge",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1202,8 +1188,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testDropTableWithPurgeAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDropTableWithPurgeAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_CREATE));
@@ -1212,7 +1198,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         CreateTableRequest.builder().withName(TABLE_NS1_1.name()).withSchema(SCHEMA).build();
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "dropTableWithPurge",
         List.of(
             Set.of(PolarisPrivilege.TABLE_WRITE_DATA, PolarisPrivilege.TABLE_FULL_METADATA),
             Set.of(PolarisPrivilege.TABLE_WRITE_DATA, PolarisPrivilege.TABLE_DROP),
@@ -1227,9 +1214,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testDropTableWithPurgeInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testDropTableWithPurgeInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "dropTableWithPurge",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1246,9 +1234,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testTableExistsSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testTableExistsSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "tableExists",
         List.of(
             PolarisPrivilege.TABLE_LIST,
             PolarisPrivilege.TABLE_READ_PROPERTIES,
@@ -1262,9 +1251,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testTableExistsInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testTableExistsInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "tableExists",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1272,8 +1262,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().tableExists(TABLE_NS1A_2));
   }
 
-  @Test
-  public void testRenameTableAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testRenameTableAllSufficientPrivileges() {
     final TableIdentifier srcTable = TABLE_NS1_1;
     final TableIdentifier dstTable = TableIdentifier.of(NS1AA, "newtable");
     final RenameTableRequest rename1 =
@@ -1281,7 +1271,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     final RenameTableRequest rename2 =
         RenameTableRequest.builder().withSource(dstTable).withDestination(srcTable).build();
 
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "renameTable",
         List.of(
             Set.of(PolarisPrivilege.TABLE_FULL_METADATA),
             Set.of(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_DROP),
@@ -1295,14 +1286,15 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testRenameTableInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testRenameTableInsufficientPermissions() {
     final TableIdentifier srcTable = TABLE_NS1_1;
     final TableIdentifier dstTable = TableIdentifier.of(NS1AA, "newtable");
     final RenameTableRequest rename1 =
         RenameTableRequest.builder().withSource(srcTable).withDestination(dstTable).build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "renameTable",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1367,8 +1359,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     newWrapper().renameTable(rename2);
   }
 
-  @Test
-  public void testCommitTransactionSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCommitTransactionSufficientPrivileges() {
     CommitTransactionRequest req =
         new CommitTransactionRequest(
             List.of(
@@ -1377,19 +1369,20 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 UpdateTableRequest.create(TABLE_NS1B_1, List.of(), List.of()),
                 UpdateTableRequest.create(TABLE_NS2_1, List.of(), List.of())));
 
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "commitTransaction",
         List.of(
             Set.of(PolarisPrivilege.CATALOG_MANAGE_CONTENT),
             Set.of(PolarisPrivilege.TABLE_FULL_METADATA),
             Set.of(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_DATA),
             Set.of(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_PROPERTIES)),
         () -> newWrapper().commitTransaction(req),
-        null,
-        PRINCIPAL_NAME /* cleanupAction */);
+        null /* cleanupAction */,
+        PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testCommitTransactionInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCommitTransactionInsufficientPermissions() {
     CommitTransactionRequest req =
         new CommitTransactionRequest(
             List.of(
@@ -1398,7 +1391,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 UpdateTableRequest.create(TABLE_NS1B_1, List.of(), List.of()),
                 UpdateTableRequest.create(TABLE_NS2_1, List.of(), List.of())));
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "commitTransaction",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1467,9 +1461,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     newWrapper().commitTransaction(req);
   }
 
-  @Test
-  public void testListViewsAllSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testListViewsAllSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "listViews",
         List.of(
             PolarisPrivilege.VIEW_LIST,
             PolarisPrivilege.VIEW_READ_PROPERTIES,
@@ -1481,9 +1476,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testListViewsInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testListViewsInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "listViews",
         List.of(
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
@@ -1491,8 +1487,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().listViews(NS1A));
   }
 
-  @Test
-  public void testCreateViewAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testCreateViewAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.VIEW_DROP));
@@ -1516,8 +1512,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     .build())
             .build();
 
-    // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "createView",
         List.of(
             PolarisPrivilege.VIEW_CREATE,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1530,8 +1526,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testCreateViewInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testCreateViewInsufficientPermissions() {
     final CreateViewRequest createRequest =
         ImmutableCreateViewRequest.builder()
             .name("newview")
@@ -1550,7 +1546,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     .build())
             .build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "createView",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1563,9 +1560,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testLoadViewSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testLoadViewSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "loadView",
         List.of(
             PolarisPrivilege.VIEW_READ_PROPERTIES,
             PolarisPrivilege.VIEW_WRITE_PROPERTIES,
@@ -1575,9 +1573,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testLoadViewInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testLoadViewInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "loadView",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1587,9 +1586,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().loadView(VIEW_NS1A_2));
   }
 
-  @Test
-  public void testUpdateViewSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testUpdateViewSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "replaceView",
         List.of(
             PolarisPrivilege.VIEW_WRITE_PROPERTIES,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1598,9 +1598,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateViewInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testUpdateViewInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "replaceView",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1611,8 +1612,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().replaceView(VIEW_NS1A_2, new UpdateTableRequest()));
   }
 
-  @Test
-  public void testDropViewAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testDropViewAllSufficientPrivileges() {
     assertSuccess(
         adminService.grantPrivilegeOnCatalogToRole(
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.VIEW_CREATE));
@@ -1636,7 +1637,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .build();
 
     // Use PRINCIPAL_ROLE1 for privilege-testing, PRINCIPAL_ROLE2 for cleanup.
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "dropView",
         List.of(
             PolarisPrivilege.VIEW_DROP,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -1649,9 +1651,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testDropViewInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testDropViewInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "dropView",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1664,9 +1667,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         });
   }
 
-  @Test
-  public void testViewExistsSufficientPrivileges() {
-    doTestSufficientPrivileges(
+  @TestFactory
+  Stream<DynamicNode> testViewExistsSufficientPrivileges() {
+    return doTestSufficientPrivileges(
+        "viewExists",
         List.of(
             PolarisPrivilege.VIEW_LIST,
             PolarisPrivilege.VIEW_READ_PROPERTIES,
@@ -1678,9 +1682,10 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testViewExistsInsufficientPermissions() {
-    doTestInsufficientPrivileges(
+  @TestFactory
+  Stream<DynamicTest> testViewExistsInsufficientPermissions() {
+    return doTestInsufficientPrivileges(
+        "viewExists",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1688,8 +1693,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().viewExists(VIEW_NS1A_2));
   }
 
-  @Test
-  public void testRenameViewAllSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testRenameViewAllSufficientPrivileges() {
     final TableIdentifier srcView = VIEW_NS1_1;
     final TableIdentifier dstView = TableIdentifier.of(NS1AA, "newview");
     final RenameTableRequest rename1 =
@@ -1697,7 +1702,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     final RenameTableRequest rename2 =
         RenameTableRequest.builder().withSource(dstView).withDestination(srcView).build();
 
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "renameView",
         List.of(
             Set.of(PolarisPrivilege.VIEW_FULL_METADATA),
             Set.of(PolarisPrivilege.CATALOG_MANAGE_CONTENT),
@@ -1711,14 +1717,15 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         PRINCIPAL_NAME);
   }
 
-  @Test
-  public void testRenameViewInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testRenameViewInsufficientPermissions() {
     final TableIdentifier srcView = VIEW_NS1_1;
     final TableIdentifier dstView = TableIdentifier.of(NS1AA, "newview");
     final RenameTableRequest rename1 =
         RenameTableRequest.builder().withSource(srcView).withDestination(dstView).build();
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "renameView",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -1781,8 +1788,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     newWrapper().renameView(rename2);
   }
 
-  @Test
-  public void testSendNotificationSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testSendNotificationSufficientPrivileges() {
     String externalCatalog = "externalCatalog";
     String storageLocation =
         "file:///tmp/send_notification_sufficient_privileges_" + System.currentTimeMillis();
@@ -1914,51 +1921,86 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 PolarisPrivilege.TABLE_WRITE_PROPERTIES,
                 PolarisPrivilege.NAMESPACE_CREATE,
                 PolarisPrivilege.NAMESPACE_DROP));
-    doTestSufficientPrivilegeSets(
-        sufficientPrivilegeSets,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
-              .sendNotification(table, createRequest);
-          newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
-              .sendNotification(table, updateRequest);
-          newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
-              .sendNotification(table, dropRequest);
-          newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
-              .sendNotification(table, validateRequest);
-        },
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE2), externalCatalog, factory)
-              .dropNamespace(Namespace.of("extns1", "extns2"));
-          newWrapper(Set.of(PRINCIPAL_ROLE2), externalCatalog, factory)
-              .dropNamespace(Namespace.of("extns1"));
-        },
-        PRINCIPAL_NAME,
-        externalCatalog);
+
+    Stream<DynamicNode> allNotificationsTests =
+        doTestSufficientPrivilegeSets(
+            "sendNotification (all types)",
+            sufficientPrivilegeSets,
+            () -> {
+              newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
+                  .sendNotification(table, createRequest);
+              newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
+                  .sendNotification(table, updateRequest);
+              newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
+                  .sendNotification(table, dropRequest);
+              newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
+                  .sendNotification(table, validateRequest);
+            },
+            () -> {
+              newWrapper(Set.of(PRINCIPAL_ROLE2), externalCatalog, factory)
+                  .dropNamespace(Namespace.of("extns1", "extns2"));
+              newWrapper(Set.of(PRINCIPAL_ROLE2), externalCatalog, factory)
+                  .dropNamespace(Namespace.of("extns1"));
+            },
+            PRINCIPAL_NAME,
+            externalCatalog);
 
     // Also test VALIDATE in isolation
-    doTestSufficientPrivilegeSets(
-        sufficientPrivilegeSets,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
-              .sendNotification(table, validateRequest);
-        },
-        null /* cleanupAction */,
-        PRINCIPAL_NAME,
-        externalCatalog);
+    Stream<DynamicNode> validateOnlyTests =
+        doTestSufficientPrivilegeSets(
+            "sendNotification (VALIDATE only)",
+            sufficientPrivilegeSets,
+            () -> {
+              newWrapper(Set.of(PRINCIPAL_ROLE1), externalCatalog, factory)
+                  .sendNotification(table, validateRequest);
+            },
+            null /* cleanupAction */,
+            PRINCIPAL_NAME,
+            externalCatalog);
+
+    return Stream.concat(allNotificationsTests, validateOnlyTests);
   }
 
-  @Test
-  public void testSendNotificationInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testSendNotificationInsufficientPermissions() {
     Namespace namespace = Namespace.of("ns1", "ns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
 
-    NotificationRequest request = new NotificationRequest();
-    TableUpdateNotification update = new TableUpdateNotification();
-    update.setMetadataLocation("file:///tmp/bucket/table/metadata/v1.metadata.json");
-    update.setTableName(table.name());
-    update.setTableUuid(UUID.randomUUID().toString());
-    update.setTimestamp(230950845L);
-    request.setPayload(update);
+    NotificationRequest createRequest = new NotificationRequest();
+    createRequest.setNotificationType(NotificationType.CREATE);
+    TableUpdateNotification createUpdate = new TableUpdateNotification();
+    createUpdate.setMetadataLocation("file:///tmp/bucket/table/metadata/v1.metadata.json");
+    createUpdate.setTableName(table.name());
+    createUpdate.setTableUuid(UUID.randomUUID().toString());
+    createUpdate.setTimestamp(230950845L);
+    createRequest.setPayload(createUpdate);
+
+    NotificationRequest updateRequest = new NotificationRequest();
+    updateRequest.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification updateUpdate = new TableUpdateNotification();
+    updateUpdate.setMetadataLocation("file:///tmp/bucket/table/metadata/v1.metadata.json");
+    updateUpdate.setTableName(table.name());
+    updateUpdate.setTableUuid(UUID.randomUUID().toString());
+    updateUpdate.setTimestamp(230950845L);
+    updateRequest.setPayload(updateUpdate);
+
+    NotificationRequest dropRequest = new NotificationRequest();
+    dropRequest.setNotificationType(NotificationType.DROP);
+    TableUpdateNotification dropUpdate = new TableUpdateNotification();
+    dropUpdate.setMetadataLocation("file:///tmp/bucket/table/metadata/v1.metadata.json");
+    dropUpdate.setTableName(table.name());
+    dropUpdate.setTableUuid(UUID.randomUUID().toString());
+    dropUpdate.setTimestamp(230950845L);
+    dropRequest.setPayload(dropUpdate);
+
+    NotificationRequest validateRequest = new NotificationRequest();
+    validateRequest.setNotificationType(NotificationType.VALIDATE);
+    TableUpdateNotification validateUpdate = new TableUpdateNotification();
+    validateUpdate.setMetadataLocation("file:///tmp/bucket/table/metadata/v1.metadata.json");
+    validateUpdate.setTableName(table.name());
+    validateUpdate.setTableUuid(UUID.randomUUID().toString());
+    validateUpdate.setTimestamp(230950845L);
+    validateRequest.setPayload(validateUpdate);
 
     List<PolarisPrivilege> insufficientPrivileges =
         List.of(
@@ -1966,38 +2008,36 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             PolarisPrivilege.TABLE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA);
 
-    // Independently test insufficient privileges in isolation.
-    request.setNotificationType(NotificationType.CREATE);
-    doTestInsufficientPrivileges(
-        insufficientPrivileges,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, request);
-        });
-
-    request.setNotificationType(NotificationType.UPDATE);
-    doTestInsufficientPrivileges(
-        insufficientPrivileges,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, request);
-        });
-
-    request.setNotificationType(NotificationType.DROP);
-    doTestInsufficientPrivileges(
-        insufficientPrivileges,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, request);
-        });
-
-    request.setNotificationType(NotificationType.VALIDATE);
-    doTestInsufficientPrivileges(
-        insufficientPrivileges,
-        () -> {
-          newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, request);
-        });
+    return Stream.of(
+            doTestInsufficientPrivileges(
+                "sendNotification (CREATE)",
+                insufficientPrivileges,
+                () -> {
+                  newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, createRequest);
+                }),
+            doTestInsufficientPrivileges(
+                "sendNotification (UPDATE)",
+                insufficientPrivileges,
+                () -> {
+                  newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, updateRequest);
+                }),
+            doTestInsufficientPrivileges(
+                "sendNotification (DROP)",
+                insufficientPrivileges,
+                () -> {
+                  newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, dropRequest);
+                }),
+            doTestInsufficientPrivileges(
+                "sendNotification (VALIDATE)",
+                insufficientPrivileges,
+                () -> {
+                  newWrapper(Set.of(PRINCIPAL_ROLE1)).sendNotification(table, validateRequest);
+                }))
+        .flatMap(s -> s);
   }
 
-  @Test
-  public void testUpdateTableWith_AssignUuid_Privilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_AssignUuid_Privilege() {
     // Test that TABLE_ASSIGN_UUID privilege is required for AssignUUID MetadataUpdate
     UpdateTableRequest request =
         UpdateTableRequest.create(
@@ -2005,7 +2045,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             List.of(), // no requirements
             List.of(new MetadataUpdate.AssignUUID(UUID.randomUUID().toString())));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (AssignUUID)",
         List.of(
             PolarisPrivilege.TABLE_ASSIGN_UUID,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES, // Should also work with broader privilege
@@ -2015,15 +2056,16 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableWith_AssignUuidInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testUpdateTableWith_AssignUuidInsufficientPermissions() {
     UpdateTableRequest request =
         UpdateTableRequest.create(
             TABLE_NS1A_2,
             List.of(), // no requirements
             List.of(new MetadataUpdate.AssignUUID(UUID.randomUUID().toString())));
 
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "updateTable (AssignUUID)",
         List.of(
             PolarisPrivilege.NAMESPACE_FULL_METADATA,
             PolarisPrivilege.VIEW_FULL_METADATA,
@@ -2038,8 +2080,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().updateTable(TABLE_NS1A_2, request));
   }
 
-  @Test
-  public void testUpdateTableWith_UpgradeFormatVersionPrivilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_UpgradeFormatVersionPrivilege() {
     // Test that TABLE_UPGRADE_FORMAT_VERSION privilege is required for UpgradeFormatVersion
     // MetadataUpdate
     UpdateTableRequest request =
@@ -2048,7 +2090,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             List.of(), // no requirements
             List.of(new MetadataUpdate.UpgradeFormatVersion(2)));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (UpgradeFormatVersion)",
         List.of(
             PolarisPrivilege.TABLE_UPGRADE_FORMAT_VERSION,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES, // Should also work with broader privilege
@@ -2058,8 +2101,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableWith_SetPropertiesPrivilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_SetPropertiesPrivilege() {
     // Test that TABLE_SET_PROPERTIES privilege is required for SetProperties MetadataUpdate
     UpdateTableRequest request =
         UpdateTableRequest.create(
@@ -2067,7 +2110,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             List.of(), // no requirements
             List.of(new MetadataUpdate.SetProperties(Map.of("test.property", "test.value"))));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (SetProperties)",
         List.of(
             PolarisPrivilege.TABLE_SET_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES, // Should also work with broader privilege
@@ -2077,8 +2121,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableWith_RemoveProperties_Privilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_RemoveProperties_Privilege() {
     // Test that TABLE_REMOVE_PROPERTIES privilege is required for RemoveProperties MetadataUpdate
     UpdateTableRequest request =
         UpdateTableRequest.create(
@@ -2086,7 +2130,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             List.of(), // no requirements
             List.of(new MetadataUpdate.RemoveProperties(Set.of("property.to.remove"))));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (RemoveProperties)",
         List.of(
             PolarisPrivilege.TABLE_REMOVE_PROPERTIES,
             PolarisPrivilege.TABLE_WRITE_PROPERTIES, // Should also work with broader privilege
@@ -2096,8 +2141,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableWith_MultipleUpdates_Privilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_MultipleUpdates_Privilege() {
     // Test that multiple MetadataUpdate types require multiple specific privileges
     UpdateTableRequest request =
         UpdateTableRequest.create(
@@ -2107,8 +2152,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 new MetadataUpdate.UpgradeFormatVersion(2),
                 new MetadataUpdate.SetProperties(Map.of("test.prop", "test.val"))));
 
-    // Test that having both specific privileges works
-    doTestSufficientPrivilegeSets(
+    return doTestSufficientPrivilegeSets(
+        "updateTable (multiple updates)",
         List.of(
             Set.of(
                 PolarisPrivilege.TABLE_UPGRADE_FORMAT_VERSION,
@@ -2122,8 +2167,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         CATALOG_NAME);
   }
 
-  @Test
-  public void testUpdateTableWith_MultipleUpdatesInsufficientPermissions() {
+  @TestFactory
+  Stream<DynamicTest> testUpdateTableWith_MultipleUpdatesInsufficientPermissions() {
     // Test that having only one of the required privileges fails
     UpdateTableRequest request =
         UpdateTableRequest.create(
@@ -2134,7 +2179,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 new MetadataUpdate.SetProperties(Map.of("test.prop", "test.val"))));
 
     // Test that having only one specific privilege fails (need both)
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "updateTable (multiple updates)",
         List.of(
             PolarisPrivilege.TABLE_UPGRADE_FORMAT_VERSION, // Only one of the two needed
             PolarisPrivilege.TABLE_SET_PROPERTIES, // Only one of the two needed
@@ -2144,8 +2190,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().updateTable(TABLE_NS1A_2, request));
   }
 
-  @Test
-  public void testUpdateTableWith_TableManageStructureSuperPrivilege() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_TableManageStructureSuperPrivilege() {
     // Test that TABLE_MANAGE_STRUCTURE works as a super privilege for structural operations
     // (but NOT for snapshot operations like TABLE_ADD_SNAPSHOT)
 
@@ -2160,7 +2206,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 new MetadataUpdate.SetProperties(Map.of("test.property", "test.value")),
                 new MetadataUpdate.RemoveProperties(Set.of("property.to.remove"))));
 
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "updateTable (TABLE_MANAGE_STRUCTURE super privilege)",
         List.of(
             PolarisPrivilege.TABLE_MANAGE_STRUCTURE, // Should work for all structural operations
             PolarisPrivilege.TABLE_WRITE_PROPERTIES, // Should also work with broader privilege
@@ -2170,8 +2217,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testUpdateTableWith_TableManageStructureDoesNotIncludeSnapshots() {
+  @TestFactory
+  Stream<DynamicNode> testUpdateTableWith_TableManageStructureDoesNotIncludeSnapshots() {
     // Verify that TABLE_MANAGE_STRUCTURE does NOT grant access to snapshot operations
     // This test verifies that TABLE_ADD_SNAPSHOT and TABLE_SET_SNAPSHOT_REF were correctly
     // excluded from the TABLE_MANAGE_STRUCTURE super privilege mapping
@@ -2185,22 +2232,28 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 new MetadataUpdate.AssignUUID(UUID.randomUUID().toString()),
                 new MetadataUpdate.SetProperties(Map.of("structure.test", "value"))));
 
-    doTestSufficientPrivileges(
-        List.of(PolarisPrivilege.TABLE_MANAGE_STRUCTURE),
-        () -> newWrapper().updateTable(TABLE_NS1A_2, nonSnapshotRequest),
-        null /* cleanupAction */);
+    Stream<DynamicNode> sufficientTests =
+        doTestSufficientPrivileges(
+            "updateTable (TABLE_MANAGE_STRUCTURE for non-snapshot ops)",
+            List.of(PolarisPrivilege.TABLE_MANAGE_STRUCTURE),
+            () -> newWrapper().updateTable(TABLE_NS1A_2, nonSnapshotRequest),
+            null /* cleanupAction */);
 
     // Test that TABLE_MANAGE_STRUCTURE is insufficient for operations that require
     // different privilege categories (like read operations)
-    doTestInsufficientPrivileges(
-        List.of(PolarisPrivilege.TABLE_MANAGE_STRUCTURE),
-        () ->
-            newWrapper()
-                .loadTable(TABLE_NS1A_2, "all")); // Load table requires different privileges
+    Stream<DynamicTest> insufficientTests =
+        doTestInsufficientPrivileges(
+            "loadTable (TABLE_MANAGE_STRUCTURE insufficient)",
+            List.of(PolarisPrivilege.TABLE_MANAGE_STRUCTURE),
+            () ->
+                newWrapper()
+                    .loadTable(TABLE_NS1A_2, "all")); // Load table requires different privileges
+
+    return Stream.concat(sufficientTests, insufficientTests);
   }
 
-  @Test
-  public void testReportReadMetricsSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testReportReadMetricsSufficientPrivileges() {
     ImmutableScanReport report =
         ImmutableScanReport.builder()
             .tableName(TABLE_NS1A_1.name())
@@ -2212,14 +2265,15 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
             .build();
     ReportMetricsRequest request = ReportMetricsRequest.of(report);
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "reportMetrics (read)",
         List.of(PolarisPrivilege.TABLE_READ_DATA, PolarisPrivilege.CATALOG_MANAGE_CONTENT),
         () -> newWrapper().reportMetrics(TABLE_NS1A_1, request),
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testReportReadMetricsInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testReportReadMetricsInsufficientPrivileges() {
     ImmutableScanReport report =
         ImmutableScanReport.builder()
             .tableName(TABLE_NS1A_1.name())
@@ -2231,7 +2285,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
             .build();
     ReportMetricsRequest request = ReportMetricsRequest.of(report);
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "reportMetrics (read)",
         List.of(
             PolarisPrivilege.TABLE_READ_PROPERTIES,
             PolarisPrivilege.TABLE_FULL_METADATA,
@@ -2241,8 +2296,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         () -> newWrapper().reportMetrics(TABLE_NS1A_1, request));
   }
 
-  @Test
-  public void testReportWriteMetricsSufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicNode> testReportWriteMetricsSufficientPrivileges() {
     CommitReport commitReport =
         ImmutableCommitReport.builder()
             .tableName(TABLE_NS1A_1.name())
@@ -2252,14 +2307,15 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
             .build();
     ReportMetricsRequest request = ReportMetricsRequest.of(commitReport);
-    doTestSufficientPrivileges(
+    return doTestSufficientPrivileges(
+        "reportMetrics (write)",
         List.of(PolarisPrivilege.TABLE_WRITE_DATA, PolarisPrivilege.CATALOG_MANAGE_CONTENT),
         () -> newWrapper().reportMetrics(TABLE_NS1A_1, request),
         null /* cleanupAction */);
   }
 
-  @Test
-  public void testReportWriteMetricsInsufficientPrivileges() {
+  @TestFactory
+  Stream<DynamicTest> testReportWriteMetricsInsufficientPrivileges() {
     CommitReport commitReport =
         ImmutableCommitReport.builder()
             .tableName(TABLE_NS1A_1.name())
@@ -2269,7 +2325,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
             .build();
     ReportMetricsRequest request = ReportMetricsRequest.of(commitReport);
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "reportMetrics (write)",
         List.of(
             PolarisPrivilege.TABLE_READ_PROPERTIES,
             PolarisPrivilege.TABLE_FULL_METADATA,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
@@ -26,12 +26,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.service.admin.PolarisAuthzTestBase;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 /**
  * Test class specifically for testing fine-grained authorization when the feature is DISABLED. This
@@ -58,8 +60,8 @@ public class IcebergCatalogHandlerFineGrainedDisabledTest extends PolarisAuthzTe
     }
   }
 
-  @Test
-  public void testUpdateTableFineGrainedPrivilegesIgnoredWhenFeatureDisabled() {
+  @TestFactory
+  Stream<DynamicTest> testUpdateTableFineGrainedPrivilegesIgnoredWhenFeatureDisabled() {
     // Test that when fine-grained authorization is disabled, fine-grained privileges alone are
     // insufficient
     // This ensures the feature flag properly controls behavior and fine-grained privileges don't
@@ -72,7 +74,8 @@ public class IcebergCatalogHandlerFineGrainedDisabledTest extends PolarisAuthzTe
 
     // With fine-grained authorization disabled, even having the specific fine-grained privilege
     // should be insufficient - the system should require the broader privileges
-    doTestInsufficientPrivileges(
+    return doTestInsufficientPrivileges(
+        "updateTable",
         List.of(
             PolarisPrivilege
                 .TABLE_ASSIGN_UUID, // This alone should be insufficient when feature disabled
@@ -86,11 +89,6 @@ public class IcebergCatalogHandlerFineGrainedDisabledTest extends PolarisAuthzTe
             PolarisPrivilege.TABLE_CREATE,
             PolarisPrivilege.TABLE_LIST,
             PolarisPrivilege.TABLE_DROP),
-        PRINCIPAL_NAME,
-        () -> newWrapper().updateTable(TABLE_NS1A_2, request),
-        (privilege) ->
-            adminService.grantPrivilegeOnCatalogToRole(CATALOG_NAME, CATALOG_ROLE1, privilege),
-        (privilege) ->
-            adminService.revokePrivilegeOnCatalogFromRole(CATALOG_NAME, CATALOG_ROLE1, privilege));
+        () -> newWrapper().updateTable(TABLE_NS1A_2, request));
   }
 }


### PR DESCRIPTION
This PR refactors the authorization tests to use JUnit 5's dynamic test feature (`@TestFactory`).

**There is no functional change, just a refactoring.**

* Better test organization: tests are now organized into hierarchies, grouping related privilege tests together.
* Clearer test naming: Each dynamic test has a descriptive name that includes:
  * The operation being tested (e.g., `listNamespaces`, `createCatalog`)
  * The privilege(s) being tested
  * Whether the test expects success or failure
* Improved test output: the dynamic test structure provides better visibility into which specific privilege combinations are being tested and which ones pass or fail. This greatly facilitates debugging failing tests.
* Simplified test methods: the base class `PolarisAuthzTestBase` now provides many overloaded methods with sensible defaults. Child classes don't need to declare such methods anymore.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
