### PR TITLE
[doc] Fix wrong directory path in binary distribution doc

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/binary-distribution.md
+++ b/site/content/in-dev/unreleased/getting-started/binary-distribution.md
@@ -33,7 +33,7 @@ Download and extract the binary distribution:
 
 ```bash
 curl -L https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz | tar xz
-cd polaris-distribution-1.3.0-incubating
+cd polaris-bin-1.3.0-incubating
 ```
 
 Start the Polaris server:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The current path is not correct as the target directory after uncompress is `polaris-bin-1.3.0-incubating`.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
