### PR TITLE
Helm chart: fix nodePort rendering in service.yaml

### DIFF
--- a/helm/polaris/templates/service.yaml
+++ b/helm/polaris/templates/service.yaml
@@ -39,7 +39,7 @@ spec:
       {{- if .targetPort }}
       targetPort: {{ .targetPort }}
       {{- end }}
-      {{- if and (eq $.Values.service.type "NodePort") .nodePort }}
+      {{- if .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
       protocol: {{ default "TCP" .protocol }}


### PR DESCRIPTION
The template was incorrectly testing for the NodePort type, but other service types may need a nodePort as well, e.g. LoadBalancer. Other service templates were correct (they are not checking the service type for nodePort).

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
