### PR TITLE
fix: HMS federation doesn't build due to outdated depdency

### DIFF
--- a/extensions/federation/hive/build.gradle.kts
+++ b/extensions/federation/hive/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     exclude("ch.qos.reload4j", "reload4j")
     exclude("log4j", "log4j")
     exclude("org.apache.zookeeper", "zookeeper")
+    exclude("org.ow2.asm", "asm-all")
   }
 
   // Hadoop dependencies


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Fix the broken HMS federation build (`-PNonRESTCatalogs=HIVE`). It seems that there's an outdated, very old asm dependency which isn't compatible with Java 21, that's why the build is failing. This PR excludes the problematic dependency, which is brought in by Hive 3.1.3.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
