### PR TITLE
Replace deprecated Quarkus log configs

### DIFF
--- a/client/python/docker-compose.yml
+++ b/client/python/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
       POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
       polaris.realm-context.realms: POLARIS
-      quarkus.log.file.enable: "false"
+      quarkus.log.file.enabled: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."DROP_WITH_PURGE_ENABLED": "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"

--- a/helm/polaris/templates/configmap.yaml
+++ b/helm/polaris/templates/configmap.yaml
@@ -132,7 +132,7 @@ data:
     {{- /* Logging */ -}}
     {{- $_ = set $map "quarkus.log.level" .Values.logging.level -}}
     {{- if .Values.logging.console.enabled -}}
-    {{- $_ = set $map "quarkus.log.console.enable" "true" -}}
+    {{- $_ = set $map "quarkus.log.console.enabled" "true" -}}
     {{- $_ = set $map "quarkus.log.console.level" .Values.logging.console.threshold -}}
     {{- if .Values.logging.console.json -}}
     {{- $_ = set $map "quarkus.log.console.json.enabled" "true" -}}
@@ -140,10 +140,10 @@ data:
     {{- $_ = set $map "quarkus.log.console.format" .Values.logging.console.format -}}
     {{- end -}}
     {{- else -}}
-    {{- $_ = set $map "quarkus.log.console.enable" "false" -}}
+    {{- $_ = set $map "quarkus.log.console.enabled" "false" -}}
     {{- end -}}
     {{- if .Values.logging.file.enabled -}}
-    {{- $_ = set $map "quarkus.log.file.enable" "true" -}}
+    {{- $_ = set $map "quarkus.log.file.enabled" "true" -}}
     {{- $_ = set $map "quarkus.log.file.level" .Values.logging.file.threshold -}}
     {{- $_ = set $map "quarkus.log.file.path" (printf "%s/%s" .Values.logging.file.logsDir .Values.logging.file.fileName) -}}
     {{- $_ = set $map "quarkus.log.file.rotation.max-file-size" (include "polaris.quantity" .Values.logging.file.rotation.maxFileSize) -}}
@@ -157,7 +157,7 @@ data:
     {{- $_ = set $map "quarkus.log.file.format" .Values.logging.file.format -}}
     {{- end -}}
     {{- else -}}
-    {{- $_ = set $map "quarkus.log.file.enable" "false" -}}
+    {{- $_ = set $map "quarkus.log.file.enabled" "false" -}}
     {{- end -}}
     {{- $categories := dict -}}
     {{- list .Values.logging.categories "" $categories | include "polaris.mergeConfigTree" -}}

--- a/helm/polaris/tests/configmap_test.yaml
+++ b/helm/polaris/tests/configmap_test.yaml
@@ -233,7 +233,7 @@ tests:
       logging: { level: DEBUG, console: { enabled: true, threshold: INFO, format: custom } }
     asserts:
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.level=DEBUG" }
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enable=true" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enabled=true" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.level=INFO" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.format=custom" }
 
@@ -241,7 +241,7 @@ tests:
     set:
       logging: { file: { enabled: true, threshold: DEBUG, format: custom, logsDir: /mnt/logs, fileName: custom.log, rotation: { maxFileSize: 50Mi, maxBackupIndex: 2, fileSuffix: .yyyy-MM-dd } } }
     asserts:
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enable=true" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enabled=true" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.level=DEBUG" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.path=/mnt/logs/custom.log" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.rotation.max-file-size=52428800" }
@@ -252,15 +252,15 @@ tests:
     set:
       logging: { file: { enabled: false }, console: { enabled: false } }
     asserts:
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enable=false" }
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enable=false" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enabled=false" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enabled=false" }
 
   - it: should enable JSON logging
     set:
       logging: { file: { enabled: true, json: true }, console: { enabled: true, json: true } }
     asserts:
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enable=true" }
-      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enable=true" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.enabled=true" }
+      - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.enabled=true" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.file.json.enabled=true" }
       - matchRegex: { path: 'data["application.properties"]', pattern: "quarkus.log.console.json.enabled=true" }
 

--- a/plugins/spark/v3.5/regtests/docker-compose.yml
+++ b/plugins/spark/v3.5/regtests/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       AWS_REGION: us-west-2
       POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
-      quarkus.log.file.enable: "false"
+      quarkus.log.file.enabled: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"
       polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES": "[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]"

--- a/regtests/docker-compose.yml
+++ b/regtests/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       AZURE_CLIENT_ID: $AZURE_CLIENT_ID
       AZURE_CLIENT_SECRET: $AZURE_CLIENT_SECRET
       POLARIS_BOOTSTRAP_CREDENTIALS: POLARIS,root,s3cr3t
-      quarkus.log.file.enable: "false"
+      quarkus.log.file.enabled: "false"
       quarkus.otel.sdk.disabled: "true"
       polaris.features."DROP_WITH_PURGE_ENABLED": "true"
       polaris.features."ALLOW_INSECURE_STORAGE_TYPES": "true"

--- a/runtime/defaults/src/main/resources/application-test.properties
+++ b/runtime/defaults/src/main/resources/application-test.properties
@@ -25,7 +25,7 @@ quarkus.keycloak.devservices.enabled=false
 quarkus.mongodb.devservices.enabled=false
 
 quarkus.log.level=ERROR
-quarkus.log.file.enable=false
+quarkus.log.file.enabled=false
 quarkus.console.color=true
 
 # Useful loggers for debugging purposes.

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -68,11 +68,11 @@ quarkus.http.port=8181
 quarkus.http.test-port=0
 
 quarkus.log.level=INFO
-quarkus.log.console.enable=true
+quarkus.log.console.enabled=true
 quarkus.log.console.level=ALL
 quarkus.log.console.json.enabled=false
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] [%X{requestId},%X{realmId}] [%X{traceId},%X{parentId},%X{spanId},%X{sampled}] (%t) %s%e%n
-quarkus.log.file.enable=true
+quarkus.log.file.enabled=true
 quarkus.log.file.level=ALL
 quarkus.log.file.json.enabled=false
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] [%X{requestId},%X{realmId}] [%X{traceId},%X{parentId},%X{spanId},%X{sampled}] (%t) %s%e%n


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Two Quarkus log config properties are now deprecated, replacing them to the new configs (enable -> enable**d** as per https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.26)

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
