### PR TITLE
Optimize configuration value casts (#3688)

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/PolarisConfiguration.java
@@ -177,17 +177,24 @@ public abstract class PolarisConfiguration<T> {
       return defaultValue();
     }
 
-    if (defaultValue() instanceof Boolean) {
+    Object defaultValue = defaultValue();
+
+    // If value is already the same type as the default, no conversion needed
+    if (defaultValue.getClass().isInstance(value)) {
+      return cast(value);
+    }
+
+    if (defaultValue instanceof Boolean) {
       return cast(Boolean.valueOf(String.valueOf(value)));
-    } else if (defaultValue() instanceof Integer) {
+    } else if (defaultValue instanceof Integer) {
       return cast(Integer.valueOf(String.valueOf(value)));
-    } else if (defaultValue() instanceof Long) {
+    } else if (defaultValue instanceof Long) {
       return cast(Long.valueOf(String.valueOf(value)));
-    } else if (defaultValue() instanceof Double) {
+    } else if (defaultValue instanceof Double) {
       return cast(Double.valueOf(String.valueOf(value)));
-    } else if (defaultValue() instanceof Float) {
+    } else if (defaultValue instanceof Float) {
       return cast(Float.valueOf(String.valueOf(value)));
-    } else if (defaultValue() instanceof List<?>) {
+    } else if (defaultValue instanceof List<?>) {
       return cast(new ArrayList<>((List<?>) value));
     } else {
       return cast(value);


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
Optimizes `tryCast` to avoid unnecessary string conversions when configuration values are already the correct type.

The method was converting every value to string and parsing it back, even when the value already matched the expected type (Boolean, Integer, Long, Double). This adds type checks before string conversion to eliminate unnecessary overhead.

Fixes #3688

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #3688
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
