### PR TITLE
Add NoSQL persistence and MongoDB extension to the admin tool

### DIFF
--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -35,6 +35,14 @@ dependencies {
   runtimeOnly(project(":polaris-relational-jdbc"))
   runtimeOnly("org.postgresql:postgresql")
 
+  runtimeOnly(project(":polaris-persistence-nosql-metastore"))
+  runtimeOnly(project(":polaris-persistence-nosql-cdi-quarkus"))
+  runtimeOnly(project(":polaris-persistence-nosql-cdi-quarkus-distcache"))
+  runtimeOnly(project(":polaris-persistence-nosql-maintenance-impl"))
+  runtimeOnly(project(":polaris-persistence-nosql-metastore-maintenance"))
+
+  runtimeOnly("io.quarkus:quarkus-mongodb-client")
+
   implementation("io.quarkus:quarkus-jdbc-postgresql")
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-picocli")


### PR DESCRIPTION
The admin tool binary distribution and Docker image do not contain the NoSQL persistence + MongoDB extension.

Because of that, it's impossible to bootstrap a realm using NoSQL:

```
2026-02-18 14:41:05,478 WARN  [io.quarkus.config] (main) Unrecognized configuration key "quarkus.mongodb.connection-string" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2026-02-18 14:41:05,478 WARN  [io.quarkus.config] (main) Unrecognized configuration key "quarkus.mongodb.database" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2026-02-18 14:41:05,582 ERROR [io.quarkus.runtime.Application] (main) Failed to start application: java.lang.RuntimeException: Error injecting org.apache.polaris.core.persistence.MetaStoreManagerFactory org.apache.polaris.admintool.BaseMetaStoreCommand.metaStoreManagerFactory
...
Caused by: jakarta.enterprise.inject.UnsatisfiedResolutionException: No bean found for required type [interface org.apache.polaris.core.persistence.MetaStoreManagerFactory] and qualifiers [[@jakarta.enterprise.inject.Any(), @io.smallrye.common.annotation.Identifier(value="nosql")]]      
```

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
