### PR TITLE
[doc] Bump k8s min version to 1.33 and helm support to include 4.x

### DIFF
--- a/helm/polaris/README.md
+++ b/helm/polaris/README.md
@@ -27,8 +27,8 @@ including Apache Doris™, Apache Flink®, Apache Spark™, Dremio® OSS, StarRo
 
 ## Requirements
 
-- Kubernetes 1.32+ cluster
-- Helm 3.0+
+- Kubernetes 1.33+ cluster
+- Helm 3.x or 4.x
 
 ## Features
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Matching to https://github.com/apache/polaris/pull/3812, where k8s 1.32 will be EOL at 2026-02-28 (https://kubernetes.io/releases/#release-v1-32) and our chart does work on helm 4.x as well.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
