### PR TITLE
doc: Fix Polaris CLI example, add precondition for enabling the feature flag

### DIFF
--- a/site/content/in-dev/unreleased/federation/iceberg-rest-federation.md
+++ b/site/content/in-dev/unreleased/federation/iceberg-rest-federation.md
@@ -33,6 +33,16 @@ REST implementation), enabling a Polaris service to access table and view entiti
   `ConnectionConfigInfo.AuthenticationParameters`. OAuth2 client credentials, bearer tokens, and AWS
   SigV4 are supported; choose the scheme the remote service expects.
 
+## Feature configuration
+
+The catalog federation feature is disabled by default. Enable the necessary feature flag in your application.properties
+file (or equivalent configuration mechanism such as environment variables or a Kubernetes ConfigMap):
+
+```properties
+# Enables the federation feature itself
+polaris.features."ENABLE_CATALOG_FEDERATION"=true
+```
+
 ## Creating a federated REST catalog
 
 The snippet below registers an external catalog that forwards to a remote Polaris server using OAuth2
@@ -52,7 +62,7 @@ polaris catalogs create \
     --catalog-token-uri "https://remote-polaris.example.com/catalog/v1/oauth/tokens" \
     --catalog-client-id "<remote-client-id>" \
     --catalog-client-secret "<remote-client-secret>" \
-    --catalog-client-scopes "PRINCIPAL_ROLE:ALL" \
+    --catalog-client-scope "PRINCIPAL_ROLE:ALL" \
     analytics_rest
 ```
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Improve documentation: replace `catalog-client-scopes` to the correct `catalog-client-scope` CLI parameter and mention in the doc, that catalog federation feature flag is not enabled by default.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
