### PR TITLE
Unify exception construction in utility class

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/ExceptionUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/ExceptionUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.common;
+
+import java.util.List;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+
+public class ExceptionUtils {
+  private ExceptionUtils() {}
+
+  /**
+   * Helper function for when a TABLE_LIKE entity is not found, so we want to throw the appropriate
+   * exception. Used in Iceberg APIs, so the Iceberg messages cannot be changed.
+   *
+   * @param subTypes The subtypes of the entity that the exception should report as non-existing
+   */
+  public static RuntimeException notFoundExceptionForTableLikeEntity(
+      TableIdentifier identifier, List<PolarisEntitySubType> subTypes) {
+
+    // In this case, we assume it's a table
+    if (subTypes.size() > 1) {
+      return new NoSuchTableException("Table does not exist: %s", identifier);
+    } else {
+      return notFoundExceptionForTableLikeEntity(identifier, subTypes.getFirst());
+    }
+  }
+
+  public static RuntimeException notFoundExceptionForTableLikeEntity(
+      TableIdentifier identifier, PolarisEntitySubType subType) {
+    return notFoundExceptionForTableLikeEntity(identifier.toString(), subType);
+  }
+
+  public static RuntimeException notFoundExceptionForTableLikeEntity(
+      String identifier, PolarisEntitySubType subType) {
+    return subType == PolarisEntitySubType.ICEBERG_VIEW
+        ? new NoSuchViewException(
+            "%s does not exist: %s", entityNameForSubType(subType), identifier)
+        : new NoSuchTableException(
+            "%s does not exist: %s", entityNameForSubType(subType), identifier);
+  }
+
+  public static RuntimeException alreadyExistsExceptionForTableLikeEntity(
+      TableIdentifier identifier, PolarisEntitySubType subType) {
+    return alreadyExistsExceptionForTableLikeEntity(identifier.toString(), subType);
+  }
+
+  public static RuntimeException alreadyExistsExceptionForTableLikeEntity(
+      String identifier, PolarisEntitySubType subType) {
+    return new AlreadyExistsException(
+        "%s already exists: %s", entityNameForSubType(subType), identifier);
+  }
+
+  public static RuntimeException alreadyExistsExceptionWithSameNameForTableLikeEntity(
+      TableIdentifier identifier, PolarisEntitySubType subType) {
+    return new AlreadyExistsException(
+        "%s with same name already exists: %s", entityNameForSubType(subType), identifier);
+  }
+
+  public static String entityNameForSubType(PolarisEntitySubType subType) {
+    if (subType == null) {
+      return "Object";
+    }
+    return switch (subType) {
+      case ICEBERG_VIEW -> "View";
+      case GENERIC_TABLE -> "Generic table";
+      default -> "Table";
+    };
+  }
+
+  public static NoSuchNamespaceException noSuchNamespaceException(TableIdentifier identifier) {
+    return noSuchNamespaceException(identifier.namespace());
+  }
+
+  public static NoSuchNamespaceException noSuchNamespaceException(Namespace namespace) {
+    // tests assert this
+    var ns = namespace.isEmpty() ? "''" : namespace.toString();
+    return new NoSuchNamespaceException("Namespace does not exist: %s", ns);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -21,6 +21,8 @@ package org.apache.polaris.service.catalog.iceberg;
 import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_FEDERATED_CATALOGS_CREDENTIAL_VENDING;
 import static org.apache.polaris.core.config.FeatureConfiguration.LIST_PAGINATION_ENABLED;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.alreadyExistsExceptionForTableLikeEntity;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -63,7 +65,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.rest.Endpoint;
@@ -478,7 +479,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, request.name());
     if (baseCatalog.tableExists(tableIdentifier)) {
-      throw new AlreadyExistsException("Table already exists: %s", tableIdentifier);
+      throw alreadyExistsExceptionForTableLikeEntity(
+          tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
     }
 
     Map<String, String> properties = Maps.newHashMap();
@@ -508,7 +510,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
           .build();
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
-      throw new NoSuchTableException("Table does not exist: %s", tableIdentifier.toString());
+      throw notFoundExceptionForTableLikeEntity(
+          tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
     }
 
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
@@ -519,7 +522,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     TableIdentifier ident = TableIdentifier.of(namespace, request.name());
     if (baseCatalog.tableExists(ident)) {
-      throw new AlreadyExistsException("Table already exists: %s", ident);
+      throw alreadyExistsExceptionForTableLikeEntity(ident, PolarisEntitySubType.ICEBERG_TABLE);
     }
 
     Map<String, String> properties = Maps.newHashMap();
@@ -828,7 +831,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       return Optional.of(filterResponseToSnapshots(response, snapshots));
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
-      throw new NoSuchTableException("Table does not exist: %s", tableIdentifier.toString());
+      throw notFoundExceptionForTableLikeEntity(
+          tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
     }
 
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -20,6 +20,8 @@ package org.apache.polaris.service.catalog.policy;
 
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 import static org.apache.polaris.service.types.PolicyAttachmentTarget.TypeEnum.CATALOG;
 
 import com.google.common.base.Strings;
@@ -38,8 +40,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -448,7 +448,7 @@ public class PolicyCatalog {
       // namespace
       var resolvedTargetEntity = resolvedEntityView.getResolvedPath(namespace);
       if (resolvedTargetEntity == null) {
-        throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+        throw noSuchNamespaceException(namespace);
       }
       return resolvedTargetEntity.getRawFullPath();
     } else {
@@ -459,7 +459,8 @@ public class PolicyCatalog {
           resolvedEntityView.getResolvedPath(
               tableIdentifier, PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ICEBERG_TABLE);
       if (resolvedTableEntity == null) {
-        throw new NoSuchTableException("Iceberg Table does not exist: %s", tableIdentifier);
+        throw notFoundExceptionForTableLikeEntity(
+            tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
       }
       return resolvedTableEntity.getRawFullPath();
     }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.service.catalog.policy;
 
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
+
 import com.google.common.base.Strings;
 import jakarta.annotation.Nullable;
 import java.util.Arrays;
@@ -25,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
@@ -296,8 +297,7 @@ public abstract class PolicyCatalogHandler extends CatalogHandler {
                 PolarisCatalogHelpers.listToTableIdentifier(
                     status.getFailedToResolvePath().entityNames()));
         case PolarisEntityType.NAMESPACE ->
-            throw new NoSuchNamespaceException(
-                "Namespace does not exist: %s",
+            throw noSuchNamespaceException(
                 Namespace.of(status.getFailedToResolvePath().entityNames().toArray(new String[0])));
         case PolarisEntityType.POLICY ->
             throw new NoSuchPolicyException(String.format("Policy does not exist: %s", identifier));

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -18,11 +18,12 @@
  */
 package org.apache.polaris.service.catalog.policy;
 
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
+
 import jakarta.annotation.Nonnull;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
@@ -41,7 +42,7 @@ public class PolicyCatalogUtils {
         var namespace = Namespace.of(target.getPath().toArray(new String[0]));
         var resolvedTargetEntity = resolutionManifest.getResolvedPath(namespace);
         if (resolvedTargetEntity == null) {
-          throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+          throw noSuchNamespaceException(namespace);
         }
         yield resolvedTargetEntity;
       }
@@ -52,7 +53,8 @@ public class PolicyCatalogUtils {
             resolutionManifest.getResolvedPath(
                 tableIdentifier, PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ICEBERG_TABLE);
         if (resolvedTableEntity == null) {
-          throw new NoSuchTableException("Iceberg Table does not exist: %s", tableIdentifier);
+          throw notFoundExceptionForTableLikeEntity(
+              tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
         }
         yield resolvedTableEntity;
       }


### PR DESCRIPTION
There are many places that construct `NoSuchNamespaceException`s and `NotFoundException`s. This change unifies this in common utility functions. No functional changes.