### PR TITLE
Remove code duplication in PolicyCatalog

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -26,13 +26,14 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
-import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 
 public class PolicyCatalogUtils {
+  private PolicyCatalogUtils() {}
 
   public static PolarisResolvedPathWrapper getResolvedPathWrapper(
-      @Nonnull PolarisResolutionManifest resolutionManifest,
+      @Nonnull PolarisResolutionManifestCatalogView resolutionManifest,
       @Nonnull PolicyAttachmentTarget target) {
     return switch (target.getType()) {
       // get the current catalog entity, since policy cannot apply across catalog at this moment


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR removes a duplicated code block from PolicyCatalog.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
