### PR TITLE
Remove jitpack.io repository

### DIFF
--- a/gradle/banned-dependencies.txt
+++ b/gradle/banned-dependencies.txt
@@ -26,3 +26,7 @@
 
 # Contains old javax.* annotations that we do not want
 com.google.code.findbugs:jsr305
+
+# See https://github.com/RoaringBitmap/RoaringBitmap/issues/749, should only use org.roaringbitmap:RoaringBitmap
+com.github.RoaringBitmap.RoaringBitmap
+org.roaringbitmap:roaringbitmap

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,10 +121,6 @@ dependencyResolutionManagement {
   repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
   repositories {
     mavenCentral()
-    maven {
-      url = uri("https://jitpack.io")
-      content { includeModule("com.github.RoaringBitmap.RoaringBitmap", "roaringbitmap") }
-    }
     val useApacheSnapshots =
       providers.gradleProperty("useApacheSnapshots").orNull?.toBoolean() == true
     if (useApacheSnapshots) {


### PR DESCRIPTION
This change effectively reverts #3504.

RoaringBitmap now publishes to Maven Central using the original Maven coordinates `org.roaringbitmap:RoaringBitmap`. Bans for the jitpack.io published group ID `com.github.RoaringBitmap.RoaringBitmap` and experimental `org.roaringbitmap:roaringbitmap` are added.
