### PR TITLE
change rs.getObject to specific types like getLong, getString, getInt

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
@@ -219,23 +219,21 @@ public class ModelEntity implements Converter<PolarisBaseEntity> {
 
     var modelEntity =
         ModelEntity.builder()
-            .catalogId(r.getObject("catalog_id", Long.class))
-            .id(r.getObject("id", Long.class))
-            .parentId(r.getObject("parent_id", Long.class))
-            .typeCode(r.getObject("type_code", Integer.class))
-            .name(r.getObject("name", String.class))
-            .entityVersion(r.getObject("entity_version", Integer.class))
-            .subTypeCode(r.getObject("sub_type_code", Integer.class))
-            .createTimestamp(r.getObject("create_timestamp", Long.class))
-            .dropTimestamp(r.getObject("drop_timestamp", Long.class))
-            .purgeTimestamp(r.getObject("purge_timestamp", Long.class))
-            .toPurgeTimestamp(r.getObject("to_purge_timestamp", Long.class))
-            .lastUpdateTimestamp(r.getObject("last_update_timestamp", Long.class))
-            // JSONB: use getString(), not getObject().
+            .catalogId(r.getLong("catalog_id"))
+            .id(r.getLong("id"))
+            .parentId(r.getLong("parent_id"))
+            .typeCode(r.getInt("type_code"))
+            .name(r.getString("name"))
+            .entityVersion(r.getInt("entity_version"))
+            .subTypeCode(r.getInt("sub_type_code"))
+            .createTimestamp(r.getLong("create_timestamp"))
+            .dropTimestamp(r.getLong("drop_timestamp"))
+            .purgeTimestamp(r.getLong("purge_timestamp"))
+            .toPurgeTimestamp(r.getLong("to_purge_timestamp"))
+            .lastUpdateTimestamp(r.getLong("last_update_timestamp"))
             .properties(r.getString("properties"))
-            // JSONB: use getString(), not getObject().
             .internalProperties(r.getString("internal_properties"))
-            .grantRecordsVersion(r.getObject("grant_records_version", Integer.class))
+            .grantRecordsVersion(r.getInt("grant_records_version"))
             .locationWithoutScheme(
                 this.schemaVersion >= 2 ? r.getString("location_without_scheme") : null)
             .build();

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelGrantRecord.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelGrantRecord.java
@@ -82,11 +82,11 @@ public class ModelGrantRecord implements Converter<PolarisGrantRecord> {
   public PolarisGrantRecord fromResultSet(ResultSet rs) throws SQLException {
     var modelGrantRecord =
         ModelGrantRecord.builder()
-            .securableCatalogId(rs.getObject("securable_catalog_id", Long.class))
-            .securableId(rs.getObject("securable_id", Long.class))
-            .granteeCatalogId(rs.getObject("grantee_catalog_id", Long.class))
-            .granteeId(rs.getObject("grantee_id", Long.class))
-            .privilegeCode(rs.getObject("privilege_code", Integer.class))
+            .securableCatalogId(rs.getLong("securable_catalog_id"))
+            .securableId(rs.getLong("securable_id"))
+            .granteeCatalogId(rs.getLong("grantee_catalog_id"))
+            .granteeId(rs.getLong("grantee_id"))
+            .privilegeCode(rs.getInt("privilege_code"))
             .build();
 
     return toGrantRecord(modelGrantRecord);

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
@@ -156,11 +156,11 @@ public class ModelPolicyMappingRecord implements Converter<PolarisPolicyMappingR
   public PolarisPolicyMappingRecord fromResultSet(ResultSet rs) throws SQLException {
     var modelRecord =
         ModelPolicyMappingRecord.builder()
-            .targetCatalogId(rs.getObject("target_catalog_id", Long.class))
-            .targetId(rs.getObject("target_id", Long.class))
-            .policyTypeCode(rs.getObject("policy_type_code", Integer.class))
-            .policyCatalogId(rs.getObject("policy_catalog_id", Long.class))
-            .policyId(rs.getObject("policy_id", Long.class))
+            .targetCatalogId(rs.getLong("target_catalog_id"))
+            .targetId(rs.getLong("target_id"))
+            .policyTypeCode(rs.getInt("policy_type_code"))
+            .policyCatalogId(rs.getLong("policy_catalog_id"))
+            .policyId(rs.getLong("policy_id"))
             .parameters(rs.getString("parameters"))
             .build();
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPrincipalAuthenticationData.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPrincipalAuthenticationData.java
@@ -79,11 +79,11 @@ public class ModelPrincipalAuthenticationData implements Converter<PolarisPrinci
   public PolarisPrincipalSecrets fromResultSet(ResultSet rs) throws SQLException {
     var modelRecord =
         ModelPrincipalAuthenticationData.builder()
-            .principalId(rs.getObject("principal_id", Long.class))
-            .principalClientId(rs.getObject("principal_client_id", String.class))
-            .mainSecretHash(rs.getObject("main_secret_hash", String.class))
-            .secondarySecretHash(rs.getObject("secondary_secret_hash", String.class))
-            .secretSalt(rs.getObject("secret_salt", String.class))
+            .principalId(rs.getLong("principal_id"))
+            .principalClientId(rs.getString("principal_client_id"))
+            .mainSecretHash(rs.getString("main_secret_hash"))
+            .secondarySecretHash(rs.getString("secondary_secret_hash"))
+            .secretSalt(rs.getString("secret_salt"))
             .build();
 
     return toPrincipalAuthenticationData(modelRecord);


### PR DESCRIPTION
Certain jdbc drivers (e.g. [vitess driver](https://github.com/vitessio/vitess/blob/main/java/jdbc/src/main/java/io/vitess/jdbc/VitessResultSet.java#L1570)) don't implement `ResultSet.getObject(String columnLabel, Class<T> type)` and throws `SQLFeatureNotSupportedException`. Consolidating the method to be specific to each type in line with other uses in Polaris like:

https://github.com/apache/polaris/blob/main/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java#L109

https://github.com/apache/polaris/blob/main/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelIdempotencyRecord.java#L143

https://github.com/apache/polaris/blob/main/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/EntityNameLookupRecordConverter.java

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
