### PR TITLE
Allow CatalogAdmin to list Principal Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added setup options to Polaris CLI.
 - Added CockroachDB as a supported database for the relational JDBC persistence backend. Set `polaris.persistence.relational.jdbc.database-type` to `cockroachdb` to get started.
 - Added summarize subcommand to Polaris CLI.
+- Added automatic `catalog_role_manager` principal role that allows principals with `catalog_admin` privileges to list principal roles. When a principal role is granted `catalog_admin` on any catalog, all principals assigned to that role are automatically granted the `catalog_role_manager` role, which provides read-only access to list principal roles.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added setup options to Polaris CLI.
 - Added CockroachDB as a supported database for the relational JDBC persistence backend. Set `polaris.persistence.relational.jdbc.database-type` to `cockroachdb` to get started.
 - Added summarize subcommand to Polaris CLI.
-- Added automatic `catalog_role_manager` principal role that allows principals with `catalog_admin` privileges to list principal roles. When a principal role is granted `catalog_admin` on any catalog, all principals assigned to that role are automatically granted the `catalog_role_manager` role, which provides read-only access to list principal roles.
+- Added automatic `principal_role_viewer` role that allows principals with `catalog_admin` privileges to list principal roles. When a principal role is granted `catalog_admin` on any catalog, all principals assigned to that role are automatically granted the `principal_role_viewer` role, which provides read-only access to list principal roles.
 
 ### Changes
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1985,7 +1985,7 @@ public class PolarisManagementServiceIntegrationTest {
     // Assign principal to principal role
     managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
 
-    // Verify principal does not have catalog_role_manager yet by checking activated roles
+    // Verify principal does not have principal_role_viewer yet by checking activated roles
     Principal principalBefore = managementApi.getPrincipal(principal.getPrincipal().getName());
     assertThat(principalBefore).isNotNull();
 
@@ -1995,7 +1995,7 @@ public class PolarisManagementServiceIntegrationTest {
             catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
 
-    // Verify principal now has catalog_role_manager (auto-granted)
+    // Verify principal now has principal_role_viewer (auto-granted)
     try (Response response =
         managementApi
             .request(
@@ -2006,7 +2006,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
     // Verify catalog_admin can list principal roles
@@ -2024,7 +2024,7 @@ public class PolarisManagementServiceIntegrationTest {
       assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
     }
 
-    // Verify catalog_role_manager is auto-revoked
+    // Verify principal_role_viewer is auto-revoked
     try (Response response =
         managementApi
             .request(
@@ -2035,7 +2035,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .doesNotContain(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
   }
 
@@ -2061,13 +2061,13 @@ public class PolarisManagementServiceIntegrationTest {
     // Assign principal to principal role
     managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
 
-    // Grant catalog_admin to the principal role (should auto-grant catalog_role_manager)
+    // Grant catalog_admin to the principal role (should auto-grant principal_role_viewer)
     CatalogRole catalogAdminRole =
         managementApi.getCatalogRole(
             catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
 
-    // Verify principal has catalog_role_manager
+    // Verify principal has principal_role_viewer
     try (Response response =
         managementApi
             .request(
@@ -2078,10 +2078,10 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
-    // Revoke the principal role from the principal (this should auto-revoke catalog_role_manager)
+    // Revoke the principal role from the principal (this should auto-revoke principal_role_viewer)
     try (Response response =
         managementApi
             .request(
@@ -2091,7 +2091,7 @@ public class PolarisManagementServiceIntegrationTest {
       assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
     }
 
-    // Verify catalog_role_manager is auto-revoked
+    // Verify principal_role_viewer is auto-revoked
     try (Response response =
         managementApi
             .request(
@@ -2102,7 +2102,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .doesNotContain(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
   }
 
@@ -2138,14 +2138,14 @@ public class PolarisManagementServiceIntegrationTest {
     // Assign principal to principal role
     managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
 
-    // Grant catalog_admin on catalog1 (should auto-grant catalog_role_manager)
+    // Grant catalog_admin on catalog1 (should auto-grant principal_role_viewer)
     CatalogRole catalogAdminRole1 =
         managementApi.getCatalogRole(
             catalog1Name, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(
         principalRoleName, catalog1Name, catalogAdminRole1);
 
-    // Verify principal has catalog_role_manager
+    // Verify principal has principal_role_viewer
     try (Response response =
         managementApi
             .request(
@@ -2156,10 +2156,10 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
-    // Drop catalog1 (principal should still have catalog_role_manager - no catalog_admin anywhere
+    // Drop catalog1 (principal should still have principal_role_viewer - no catalog_admin anywhere
     // now)
     // First revoke catalog_admin to allow deletion
     try (Response response =
@@ -2173,7 +2173,7 @@ public class PolarisManagementServiceIntegrationTest {
 
     managementApi.deleteCatalog(catalog1Name);
 
-    // Verify catalog_role_manager is auto-revoked after catalog drop (no catalog_admin on any
+    // Verify principal_role_viewer is auto-revoked after catalog drop (no catalog_admin on any
     // catalog)
     try (Response response =
         managementApi
@@ -2185,17 +2185,17 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .doesNotContain(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
-    // Now grant catalog_admin on catalog2 and verify catalog_role_manager is granted again
+    // Now grant catalog_admin on catalog2 and verify principal_role_viewer is granted again
     CatalogRole catalogAdminRole2 =
         managementApi.getCatalogRole(
             catalog2Name, PolarisEntityConstants.getNameOfCatalogAdminRole());
     managementApi.grantCatalogRoleToPrincipalRole(
         principalRoleName, catalog2Name, catalogAdminRole2);
 
-    // Verify principal has catalog_role_manager again
+    // Verify principal has principal_role_viewer again
     try (Response response =
         managementApi
             .request(
@@ -2206,10 +2206,10 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
-    // Drop catalog2 (should revoke catalog_role_manager again)
+    // Drop catalog2 (should revoke principal_role_viewer again)
     try (Response response =
         managementApi
             .request(
@@ -2221,7 +2221,7 @@ public class PolarisManagementServiceIntegrationTest {
 
     managementApi.deleteCatalog(catalog2Name);
 
-    // Final check - catalog_role_manager should be revoked
+    // Final check - principal_role_viewer should be revoked
     try (Response response =
         managementApi
             .request(
@@ -2232,18 +2232,18 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .doesNotContain(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
   }
 
   @Test
   public void testCatalogRoleManagerCannotBeDeleted() {
-    // Try to delete catalog_role_manager system role - should fail
+    // Try to delete principal_role_viewer system role - should fail
     try (Response response =
         managementApi
             .request(
                 "v1/principal-roles/{pr}",
-                Map.of("pr", PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole()))
+                Map.of("pr", PolarisEntityConstants.getNameOfPrincipalRoleViewerRole()))
             .delete()) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
       ErrorResponse error = response.readEntity(ErrorResponse.class);
@@ -2254,13 +2254,13 @@ public class PolarisManagementServiceIntegrationTest {
     List<PrincipalRole> allRoles = managementApi.listPrincipalRoles();
     assertThat(allRoles)
         .extracting(PrincipalRole::getName)
-        .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+        .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
   }
 
   @Test
   public void testCatalogRoleManagerGrantedWhenPrincipalAssignedToRoleWithCatalogAdmin() {
     // This tests the reverse order: grant catalog_admin to role FIRST,
-    // then assign principal to that role - principal should still get catalog_role_manager
+    // then assign principal to that role - principal should still get principal_role_viewer
 
     // Create a catalog
     String catalogName = client.newEntityName("catalog_reverse_order_test");
@@ -2288,7 +2288,7 @@ public class PolarisManagementServiceIntegrationTest {
         managementApi.createPrincipal(client.newEntityName("test_principal_reverse"));
     managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
 
-    // Verify the principal automatically got catalog_role_manager
+    // Verify the principal automatically got principal_role_viewer
     try (Response response =
         managementApi
             .request(
@@ -2299,7 +2299,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
     // Verify the principal can list principal roles
@@ -2311,7 +2311,7 @@ public class PolarisManagementServiceIntegrationTest {
   @Test
   public void testCatalogRoleManagerRevokedWhenPrincipalRoleDeleted() {
     // This tests the privilege leak scenario where deleting a PrincipalRole
-    // with catalog_admin should revoke catalog_role_manager from affected principals
+    // with catalog_admin should revoke principal_role_viewer from affected principals
 
     // Create a catalog
     String catalogName = client.newEntityName("catalog_role_delete_test");
@@ -2353,7 +2353,7 @@ public class PolarisManagementServiceIntegrationTest {
     managementApi.grantCatalogRoleToPrincipalRole(
         principalRoleName2, catalogName, catalogAdminRole);
 
-    // Verify both principals have catalog_role_manager
+    // Verify both principals have principal_role_viewer
     try (Response response =
         managementApi
             .request(
@@ -2364,7 +2364,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
     try (Response response =
@@ -2377,7 +2377,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
     // Delete principalRole1
@@ -2388,7 +2388,7 @@ public class PolarisManagementServiceIntegrationTest {
       assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
     }
 
-    // Verify principal1 no longer has catalog_role_manager (lost only source of catalog_admin)
+    // Verify principal1 no longer has principal_role_viewer (lost only source of catalog_admin)
     try (Response response =
         managementApi
             .request(
@@ -2399,10 +2399,10 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .doesNotContain(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
 
-    // Verify principal2 STILL has catalog_role_manager (still has role2 with catalog_admin)
+    // Verify principal2 STILL has principal_role_viewer (still has role2 with catalog_admin)
     try (Response response =
         managementApi
             .request(
@@ -2413,7 +2413,7 @@ public class PolarisManagementServiceIntegrationTest {
       PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
       assertThat(roles.getRoles())
           .extracting(PrincipalRole::getName)
-          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+          .contains(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
     }
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -2040,6 +2040,224 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCatalogRoleManagerRevokedWhenPrincipalRoleRevoked() {
+    // Create a catalog
+    String catalogName = client.newEntityName("catalog_principal_revoke_test");
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    managementApi.createCatalog(catalog);
+
+    // Create a principal and principal role
+    PrincipalWithCredentials principal =
+        managementApi.createPrincipal(client.newEntityName("test_principal_revoke"));
+    String principalRoleName = client.newEntityName("test_role_revoke");
+    managementApi.createPrincipalRole(principalRoleName);
+
+    // Assign principal to principal role
+    managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
+
+    // Grant catalog_admin to the principal role (should auto-grant catalog_role_manager)
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
+
+    // Verify principal has catalog_role_manager
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Revoke the principal role from the principal (this should auto-revoke catalog_role_manager)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles/{pr}",
+                Map.of("p", principal.getPrincipal().getName(), "pr", principalRoleName))
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+
+    // Verify catalog_role_manager is auto-revoked
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+  }
+
+  @Test
+  public void testCatalogRoleManagerRevokedWhenCatalogDropped() {
+    // Create two catalogs
+    String catalog1Name = client.newEntityName("catalog_drop_test1");
+    Catalog catalog1 =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalog1Name)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    managementApi.createCatalog(catalog1);
+
+    String catalog2Name = client.newEntityName("catalog_drop_test2");
+    Catalog catalog2 =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalog2Name)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket2/"))
+            .build();
+    managementApi.createCatalog(catalog2);
+
+    // Create a principal and principal role
+    PrincipalWithCredentials principal =
+        managementApi.createPrincipal(client.newEntityName("test_principal_drop"));
+    String principalRoleName = client.newEntityName("test_role_drop");
+    managementApi.createPrincipalRole(principalRoleName);
+
+    // Assign principal to principal role
+    managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
+
+    // Grant catalog_admin on catalog1 (should auto-grant catalog_role_manager)
+    CatalogRole catalogAdminRole1 =
+        managementApi.getCatalogRole(
+            catalog1Name, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(
+        principalRoleName, catalog1Name, catalogAdminRole1);
+
+    // Verify principal has catalog_role_manager
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Drop catalog1 (principal should still have catalog_role_manager - no catalog_admin anywhere
+    // now)
+    // First revoke catalog_admin to allow deletion
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principal-roles/{pr}/catalog-roles/{cat}/catalog_admin",
+                Map.of("pr", principalRoleName, "cat", catalog1Name))
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+
+    managementApi.deleteCatalog(catalog1Name);
+
+    // Verify catalog_role_manager is auto-revoked after catalog drop (no catalog_admin on any
+    // catalog)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Now grant catalog_admin on catalog2 and verify catalog_role_manager is granted again
+    CatalogRole catalogAdminRole2 =
+        managementApi.getCatalogRole(
+            catalog2Name, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(
+        principalRoleName, catalog2Name, catalogAdminRole2);
+
+    // Verify principal has catalog_role_manager again
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Drop catalog2 (should revoke catalog_role_manager again)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principal-roles/{pr}/catalog-roles/{cat}/catalog_admin",
+                Map.of("pr", principalRoleName, "cat", catalog2Name))
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+
+    managementApi.deleteCatalog(catalog2Name);
+
+    // Final check - catalog_role_manager should be revoked
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+  }
+
+  @Test
+  public void testCatalogRoleManagerCannotBeDeleted() {
+    // Try to delete catalog_role_manager system role - should fail
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principal-roles/{pr}",
+                Map.of("pr", PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole()))
+            .delete()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+      ErrorResponse error = response.readEntity(ErrorResponse.class);
+      assertThat(error.message()).contains("cannot be dropped");
+    }
+
+    // Verify it still exists by listing all principal roles
+    List<PrincipalRole> allRoles = managementApi.listPrincipalRoles();
+    assertThat(allRoles)
+        .extracting(PrincipalRole::getName)
+        .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+  }
+
+  @Test
   public void testTableManageAccessCanGrantAndRevokeFromCatalogRoles() {
     // Create a PrincipalRole and a new catalog.
     String principalRoleName = client.newEntityName("mypr_table_manage");

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -2309,6 +2309,115 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCatalogRoleManagerRevokedWhenPrincipalRoleDeleted() {
+    // This tests the privilege leak scenario where deleting a PrincipalRole
+    // with catalog_admin should revoke catalog_role_manager from affected principals
+
+    // Create a catalog
+    String catalogName = client.newEntityName("catalog_role_delete_test");
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    managementApi.createCatalog(catalog);
+
+    // Create two principal roles: one will be deleted, one will remain
+    String principalRoleName1 = client.newEntityName("test_role_to_delete");
+    managementApi.createPrincipalRole(principalRoleName1);
+
+    String principalRoleName2 = client.newEntityName("test_role_to_keep");
+    managementApi.createPrincipalRole(principalRoleName2);
+
+    // Create two principals
+    PrincipalWithCredentials principal1 =
+        managementApi.createPrincipal(client.newEntityName("test_principal_role_delete1"));
+    PrincipalWithCredentials principal2 =
+        managementApi.createPrincipal(client.newEntityName("test_principal_role_delete2"));
+
+    // Assign principals to roles
+    managementApi.assignPrincipalRole(principal1.getPrincipal().getName(), principalRoleName1);
+    managementApi.assignPrincipalRole(
+        principal2.getPrincipal().getName(), principalRoleName1); // both principals in role1
+    managementApi.assignPrincipalRole(
+        principal2.getPrincipal().getName(), principalRoleName2); // principal2 also in role2
+
+    // Grant catalog_admin to both roles
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(
+        principalRoleName1, catalogName, catalogAdminRole);
+    managementApi.grantCatalogRoleToPrincipalRole(
+        principalRoleName2, catalogName, catalogAdminRole);
+
+    // Verify both principals have catalog_role_manager
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal1.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal2.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Delete principalRole1
+    try (Response response =
+        managementApi
+            .request("v1/principal-roles/{pr}", Map.of("pr", principalRoleName1))
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+
+    // Verify principal1 no longer has catalog_role_manager (lost only source of catalog_admin)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal1.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Verify principal2 STILL has catalog_role_manager (still has role2 with catalog_admin)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal2.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+  }
+
+  @Test
   public void testTableManageAccessCanGrantAndRevokeFromCatalogRoles() {
     // Create a PrincipalRole and a new catalog.
     String principalRoleName = client.newEntityName("mypr_table_manage");

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1964,6 +1964,82 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCatalogRoleManagerAutoGrantAndRevoke() {
+    // Create a catalog
+    String catalogName = client.newEntityName("catalog_role_mgr_test");
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    managementApi.createCatalog(catalog);
+
+    // Create a principal and principal role
+    PrincipalWithCredentials principal =
+        managementApi.createPrincipal(client.newEntityName("test_principal"));
+    String principalRoleName = client.newEntityName("test_role");
+    managementApi.createPrincipalRole(principalRoleName);
+
+    // Assign principal to principal role
+    managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
+
+    // Verify principal does not have catalog_role_manager yet by checking activated roles
+    Principal principalBefore = managementApi.getPrincipal(principal.getPrincipal().getName());
+    assertThat(principalBefore).isNotNull();
+
+    // Grant catalog_admin to the principal role
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
+
+    // Verify principal now has catalog_role_manager (auto-granted)
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Verify catalog_admin can list principal roles
+    String catalogAdminToken = client.obtainToken(principal);
+    List<PrincipalRole> listedRoles = client.managementApi(catalogAdminToken).listPrincipalRoles();
+    assertThat(listedRoles).isNotEmpty();
+
+    // Revoke catalog_admin from the principal role
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principal-roles/{pr}/catalog-roles/{cat}/catalog_admin",
+                Map.of("pr", principalRoleName, "cat", catalogName))
+            .delete()) {
+      assertThat(response).returns(Response.Status.NO_CONTENT.getStatusCode(), Response::getStatus);
+    }
+
+    // Verify catalog_role_manager is auto-revoked
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .doesNotContain(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+  }
+
+  @Test
   public void testTableManageAccessCanGrantAndRevokeFromCatalogRoles() {
     // Create a PrincipalRole and a new catalog.
     String principalRoleName = client.newEntityName("mypr_table_manage");

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -2258,6 +2258,57 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCatalogRoleManagerGrantedWhenPrincipalAssignedToRoleWithCatalogAdmin() {
+    // This tests the reverse order: grant catalog_admin to role FIRST,
+    // then assign principal to that role - principal should still get catalog_role_manager
+
+    // Create a catalog
+    String catalogName = client.newEntityName("catalog_reverse_order_test");
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+    managementApi.createCatalog(catalog);
+
+    // Create a principal role
+    String principalRoleName = client.newEntityName("test_role_reverse");
+    managementApi.createPrincipalRole(principalRoleName);
+
+    // Grant catalog_admin to the principal role FIRST (before assigning any principals)
+    CatalogRole catalogAdminRole =
+        managementApi.getCatalogRole(
+            catalogName, PolarisEntityConstants.getNameOfCatalogAdminRole());
+    managementApi.grantCatalogRoleToPrincipalRole(principalRoleName, catalogName, catalogAdminRole);
+
+    // Now create and assign a principal to this role
+    PrincipalWithCredentials principal =
+        managementApi.createPrincipal(client.newEntityName("test_principal_reverse"));
+    managementApi.assignPrincipalRole(principal.getPrincipal().getName(), principalRoleName);
+
+    // Verify the principal automatically got catalog_role_manager
+    try (Response response =
+        managementApi
+            .request(
+                "v1/principals/{p}/principal-roles",
+                Map.of("p", principal.getPrincipal().getName()))
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      PrincipalRoles roles = response.readEntity(PrincipalRoles.class);
+      assertThat(roles.getRoles())
+          .extracting(PrincipalRole::getName)
+          .contains(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+    }
+
+    // Verify the principal can list principal roles
+    String principalToken = client.obtainToken(principal);
+    List<PrincipalRole> listedRoles = client.managementApi(principalToken).listPrincipalRoles();
+    assertThat(listedRoles).isNotEmpty();
+  }
+
+  @Test
   public void testTableManageAccessCanGrantAndRevokeFromCatalogRoles() {
     // Create a PrincipalRole and a new catalog.
     String principalRoleName = client.newEntityName("mypr_table_manage");

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
@@ -245,15 +245,15 @@ public class TestCatalogMaintenance {
             true,
             OptionalInt.of(0),
             Optional.of(0L),
-            // 8 stale objects:
+            // 11 stale objects:
             // - 1 namespace (catalog state)
             // - 1 table (catalog state)
-            // - 2 grants (realm setup) - including 2 ACLs
+            // - 3 grants - including 3 ACLs
             // - 1 principal
-            // - 1 principal role
+            // - 2 principal roles
             // - 1 catalog role
             // - 1 catalog
-            Optional.of(10L));
+            Optional.of(13L));
 
     checkEntities("real state after grace", entities);
   }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -186,9 +186,21 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
         PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
-        PrincipalSecretsResult secretsResult =
-            createPolarisPrincipalForRealm(metaStoreManager, polarisContext);
-        results.put(realm, secretsResult);
+        // Check if the realm is already bootstrapped by looking for the root principal in the
+        // database
+        Optional<PrincipalEntity> existingRootPrincipal =
+            metaStoreManager.findRootPrincipal(polarisContext);
+
+        if (existingRootPrincipal.isPresent()) {
+          // Realm is already bootstrapped, skip principal creation
+          LOGGER.info(
+              "Realm '{}' is already fully bootstrapped, skipping principal creation", realm);
+        } else {
+          // Realm needs bootstrap, create principals
+          PrincipalSecretsResult secretsResult =
+              createPolarisPrincipalForRealm(metaStoreManager, polarisContext);
+          results.put(realm, secretsResult);
+        }
       }
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
@@ -104,6 +104,23 @@ public class AuthBootstrapUtil {
         rootContainer,
         PolarisPrivilege.SERVICE_MANAGE_ACCESS);
 
+    // create the catalog_role_manager principal role for catalog admins to list principal roles
+    PrincipalRoleEntity catalogRoleManagerPrincipalRole =
+        new PrincipalRoleEntity.Builder()
+            .setId(generateId(metaStoreManager, ctx))
+            .setName(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole())
+            .setCreateTimestamp(System.currentTimeMillis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(ctx, null, catalogRoleManagerPrincipalRole);
+
+    // grant PRINCIPAL_ROLE_LIST on the rootContainer to the catalogRoleManagerPrincipalRole
+    metaStoreManager.grantPrivilegeOnSecurableToRole(
+        ctx,
+        catalogRoleManagerPrincipalRole,
+        null,
+        rootContainer,
+        PolarisPrivilege.PRINCIPAL_ROLE_LIST);
+
     return metaStoreManager.loadPrincipalSecrets(ctx, rootPrincipal.getClientId());
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
@@ -121,6 +121,67 @@ public class AuthBootstrapUtil {
     return metaStoreManager.loadPrincipalSecrets(ctx, rootPrincipal.getClientId());
   }
 
+  /**
+   * Ensures the principal_role_viewer role exists in an already-bootstrapped realm. This is used
+   * for upgrade migrations to add the role to realms that were bootstrapped before this role was
+   * introduced.
+   *
+   * <p>This method is idempotent - it checks if the role already exists and only creates it if
+   * missing.
+   *
+   * @param metaStoreManager the metastore manager for the realm
+   * @param ctx the call context for the realm
+   */
+  public static void ensurePrincipalRoleViewerExists(
+      PolarisMetaStoreManager metaStoreManager, PolarisCallContext ctx) {
+    // Check if the role already exists
+    EntityResult existingRoleResult =
+        metaStoreManager.readEntityByName(
+            ctx,
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
+
+    if (existingRoleResult.isSuccess() && existingRoleResult.getEntity() != null) {
+      // Role already exists, nothing to do
+      LOGGER.info("principal_role_viewer role already exists, skipping creation");
+      return;
+    }
+
+    LOGGER.info(
+        "principal_role_viewer role not found. Creating it for existing installation upgrade.");
+
+    // Load the root container for granting privileges
+    EntityResult rootContainerResult =
+        metaStoreManager.readEntityByName(
+            ctx,
+            null,
+            PolarisEntityType.ROOT,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootContainerName());
+
+    Preconditions.checkState(
+        rootContainerResult.isSuccess() && rootContainerResult.getEntity() != null,
+        "Root container not found - realm may not be bootstrapped");
+    PolarisBaseEntity rootContainer = rootContainerResult.getEntity();
+
+    // Create the principal_role_viewer role
+    PrincipalRoleEntity principalRoleViewer =
+        new PrincipalRoleEntity.Builder()
+            .setId(generateId(metaStoreManager, ctx))
+            .setName(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())
+            .setCreateTimestamp(System.currentTimeMillis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(ctx, null, principalRoleViewer);
+
+    // Grant PRINCIPAL_ROLE_LIST privilege on the root container
+    metaStoreManager.grantPrivilegeOnSecurableToRole(
+        ctx, principalRoleViewer, null, rootContainer, PolarisPrivilege.PRINCIPAL_ROLE_LIST);
+
+    LOGGER.info("Successfully created principal_role_viewer role for upgrade migration");
+  }
+
   private static long generateId(PolarisMetaStoreManager metaStoreManager, PolarisCallContext ctx) {
     GenerateEntityIdResult res = metaStoreManager.generateNewEntityId(ctx);
     Preconditions.checkState(res.isSuccess(), "Unable to generate id for polaris entity");

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
@@ -33,6 +33,7 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.slf4j.Logger;
@@ -104,22 +105,18 @@ public class AuthBootstrapUtil {
         rootContainer,
         PolarisPrivilege.SERVICE_MANAGE_ACCESS);
 
-    // create the catalog_role_manager principal role for catalog admins to list principal roles
-    PrincipalRoleEntity catalogRoleManagerPrincipalRole =
+    // create the principal_role_viewer role for catalog admins to list principal roles
+    PrincipalRoleEntity principalRoleViewer =
         new PrincipalRoleEntity.Builder()
             .setId(generateId(metaStoreManager, ctx))
-            .setName(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole())
+            .setName(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())
             .setCreateTimestamp(System.currentTimeMillis())
             .build();
-    metaStoreManager.createEntityIfNotExists(ctx, null, catalogRoleManagerPrincipalRole);
+    metaStoreManager.createEntityIfNotExists(ctx, null, principalRoleViewer);
 
-    // grant PRINCIPAL_ROLE_LIST on the rootContainer to the catalogRoleManagerPrincipalRole
+    // grant PRINCIPAL_ROLE_LIST on the rootContainer to the principalRoleViewer
     metaStoreManager.grantPrivilegeOnSecurableToRole(
-        ctx,
-        catalogRoleManagerPrincipalRole,
-        null,
-        rootContainer,
-        PolarisPrivilege.PRINCIPAL_ROLE_LIST);
+        ctx, principalRoleViewer, null, rootContainer, PolarisPrivilege.PRINCIPAL_ROLE_LIST);
 
     return metaStoreManager.loadPrincipalSecrets(ctx, rootPrincipal.getClientId());
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
@@ -43,6 +43,9 @@ public class PolarisEntityConstants {
   // the name of the principal role we create to manage the entire Polaris service
   private static final String ADMIN_PRINCIPAL_ROLE_NAME = "service_admin";
 
+  // the name of the principal role for catalog admins to list principal roles
+  private static final String CATALOG_ROLE_MANAGER_PRINCIPAL_ROLE_NAME = "catalog_role_manager";
+
   // 24 hours retention before purging. This should be a config
   private static final long RETENTION_TIME_IN_MS = 24 * 3600_000;
 
@@ -89,6 +92,10 @@ public class PolarisEntityConstants {
 
   public static String getNameOfPrincipalServiceAdminRole() {
     return ADMIN_PRINCIPAL_ROLE_NAME;
+  }
+
+  public static String getNameOfCatalogRoleManagerPrincipalRole() {
+    return CATALOG_ROLE_MANAGER_PRINCIPAL_ROLE_NAME;
   }
 
   public static long getRetentionTimeInMs() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
@@ -44,7 +44,7 @@ public class PolarisEntityConstants {
   private static final String ADMIN_PRINCIPAL_ROLE_NAME = "service_admin";
 
   // the name of the principal role for catalog admins to list principal roles
-  private static final String CATALOG_ROLE_MANAGER_PRINCIPAL_ROLE_NAME = "catalog_role_manager";
+  private static final String PRINCIPAL_ROLE_VIEWER_ROLE_NAME = "principal_role_viewer";
 
   // 24 hours retention before purging. This should be a config
   private static final long RETENTION_TIME_IN_MS = 24 * 3600_000;
@@ -94,8 +94,8 @@ public class PolarisEntityConstants {
     return ADMIN_PRINCIPAL_ROLE_NAME;
   }
 
-  public static String getNameOfCatalogRoleManagerPrincipalRole() {
-    return CATALOG_ROLE_MANAGER_PRINCIPAL_ROLE_NAME;
+  public static String getNameOfPrincipalRoleViewerRole() {
+    return PRINCIPAL_ROLE_VIEWER_ROLE_NAME;
   }
 
   public static long getRetentionTimeInMs() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
@@ -159,7 +159,9 @@ public class PolarisEntityCore implements Identifiable {
     return (this.typeCode == PolarisEntityType.CATALOG_ROLE.getCode()
             && this.name.equals(PolarisEntityConstants.getNameOfCatalogAdminRole()))
         || (this.typeCode == PolarisEntityType.PRINCIPAL_ROLE.getCode()
-            && this.name.equals(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole()));
+            && (this.name.equals(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole())
+                || this.name.equals(
+                    PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole())));
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityCore.java
@@ -160,8 +160,7 @@ public class PolarisEntityCore implements Identifiable {
             && this.name.equals(PolarisEntityConstants.getNameOfCatalogAdminRole()))
         || (this.typeCode == PolarisEntityType.PRINCIPAL_ROLE.getCode()
             && (this.name.equals(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole())
-                || this.name.equals(
-                    PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole())));
+                || this.name.equals(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())));
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthBootstrapUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthBootstrapUtilTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
+import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AuthBootstrapUtilTest {
+
+  @Mock private PolarisMetaStoreManager metaStoreManager;
+  @Mock private PolarisCallContext callContext;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testEnsurePrincipalRoleViewerExists_WhenRoleAlreadyExists() {
+    // Given: principal_role_viewer role already exists
+    PrincipalRoleEntity existingRole =
+        new PrincipalRoleEntity.Builder()
+            .setId(100L)
+            .setName(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())
+            .build();
+    EntityResult existingRoleResult = new EntityResult(existingRole);
+
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.PRINCIPAL_ROLE),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())))
+        .thenReturn(existingRoleResult);
+
+    // When: we ensure the role exists
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+
+    // Then: role creation should be skipped
+    verify(metaStoreManager, never()).createEntityIfNotExists(any(), any(), any());
+    verify(metaStoreManager, never())
+        .grantPrivilegeOnSecurableToRole(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void testEnsurePrincipalRoleViewerExists_WhenRoleDoesNotExist() {
+    // Given: principal_role_viewer role does not exist
+    EntityResult notFoundResult =
+        new EntityResult(EntityResult.ReturnStatus.ENTITY_NOT_FOUND, null);
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.PRINCIPAL_ROLE),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())))
+        .thenReturn(notFoundResult);
+
+    // Root container exists
+    PolarisBaseEntity rootContainer =
+        new PolarisBaseEntity(
+            0L,
+            1L,
+            PolarisEntityType.ROOT,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            1L,
+            PolarisEntityConstants.getRootContainerName());
+    EntityResult rootContainerResult = new EntityResult(rootContainer);
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.ROOT),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getRootContainerName())))
+        .thenReturn(rootContainerResult);
+
+    // ID generation works
+    when(metaStoreManager.generateNewEntityId(eq(callContext)))
+        .thenReturn(new GenerateEntityIdResult(200L));
+
+    // When: we ensure the role exists
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+
+    // Then: role should be created and privilege granted
+    verify(metaStoreManager, times(1))
+        .createEntityIfNotExists(eq(callContext), isNull(), any(PrincipalRoleEntity.class));
+    verify(metaStoreManager, times(1))
+        .grantPrivilegeOnSecurableToRole(
+            eq(callContext),
+            any(PrincipalRoleEntity.class),
+            isNull(),
+            eq(rootContainer),
+            eq(PolarisPrivilege.PRINCIPAL_ROLE_LIST));
+  }
+
+  @Test
+  void testEnsurePrincipalRoleViewerExists_IsIdempotent() {
+    // Given: role exists on first call, then doesn't exist on second call (hypothetical)
+    PrincipalRoleEntity existingRole =
+        new PrincipalRoleEntity.Builder()
+            .setId(100L)
+            .setName(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())
+            .build();
+    EntityResult existingRoleResult = new EntityResult(existingRole);
+
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.PRINCIPAL_ROLE),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())))
+        .thenReturn(existingRoleResult);
+
+    // When: we call it multiple times
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+
+    // Then: role creation should never happen
+    verify(metaStoreManager, never()).createEntityIfNotExists(any(), any(), any());
+  }
+
+  @Test
+  void testEnsurePrincipalRoleViewerExists_UsesCorrectRoleName() {
+    // Given: role doesn't exist
+    EntityResult notFoundResult =
+        new EntityResult(EntityResult.ReturnStatus.ENTITY_NOT_FOUND, null);
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.PRINCIPAL_ROLE),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())))
+        .thenReturn(notFoundResult);
+
+    // Root container exists
+    PolarisBaseEntity rootContainer =
+        new PolarisBaseEntity(
+            0L,
+            1L,
+            PolarisEntityType.ROOT,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            1L,
+            PolarisEntityConstants.getRootContainerName());
+    EntityResult rootContainerResult = new EntityResult(rootContainer);
+    when(metaStoreManager.readEntityByName(
+            eq(callContext),
+            isNull(),
+            eq(PolarisEntityType.ROOT),
+            eq(PolarisEntitySubType.NULL_SUBTYPE),
+            eq(PolarisEntityConstants.getRootContainerName())))
+        .thenReturn(rootContainerResult);
+
+    when(metaStoreManager.generateNewEntityId(eq(callContext)))
+        .thenReturn(new GenerateEntityIdResult(200L));
+
+    // When: we ensure the role exists
+    AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+
+    // Then: verify correct role name is used
+    verify(metaStoreManager)
+        .createEntityIfNotExists(
+            eq(callContext),
+            isNull(),
+            argThat(
+                entity ->
+                    entity instanceof PrincipalRoleEntity
+                        && entity
+                            .getName()
+                            .equals(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())));
+  }
+}

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -1906,7 +1906,7 @@ public class PolarisTestMetaStoreManager {
                 PageToken.readEverything())
             .getEntities();
 
-    // ensure not null, two elements (service_admin and catalog_role_manager)
+    // ensure not null, two elements (service_admin and principal_role_viewer)
     Assertions.assertThat(principalRoles).isNotNull().hasSize(2);
 
     // validate service_admin principal role
@@ -1924,8 +1924,7 @@ public class PolarisTestMetaStoreManager {
 
       if (role.getName().equals(PolarisEntityConstants.getNameOfPrincipalServiceAdminRole())) {
         serviceAdminRole = role;
-      } else if (role.getName()
-          .equals(PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole())) {
+      } else if (role.getName().equals(PolarisEntityConstants.getNameOfPrincipalRoleViewerRole())) {
         catalogRoleManagerRole = role;
       }
     }
@@ -2084,7 +2083,7 @@ public class PolarisTestMetaStoreManager {
             ImmutablePair.of("P1", PolarisEntitySubType.NULL_SUBTYPE),
             ImmutablePair.of("P2", PolarisEntitySubType.NULL_SUBTYPE)));
 
-    // 4 principal roles with the bootstrap service_admin and catalog_role_manager
+    // 4 principal roles with the bootstrap service_admin and principal_role_viewer
     this.validateListReturn(
         null,
         PolarisEntityType.PRINCIPAL_ROLE,
@@ -2095,7 +2094,7 @@ public class PolarisTestMetaStoreManager {
                 PolarisEntityConstants.getNameOfPrincipalServiceAdminRole(),
                 PolarisEntitySubType.NULL_SUBTYPE),
             ImmutablePair.of(
-                PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole(),
+                PolarisEntityConstants.getNameOfPrincipalRoleViewerRole(),
                 PolarisEntitySubType.NULL_SUBTYPE)));
 
     // three namespaces under top-level namespace N1
@@ -2164,7 +2163,7 @@ public class PolarisTestMetaStoreManager {
                 PolarisEntityConstants.getNameOfPrincipalServiceAdminRole(),
                 PolarisEntitySubType.NULL_SUBTYPE),
             ImmutablePair.of(
-                PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole(),
+                PolarisEntityConstants.getNameOfPrincipalRoleViewerRole(),
                 PolarisEntitySubType.NULL_SUBTYPE),
             ImmutablePair.of("PR1", PolarisEntitySubType.NULL_SUBTYPE),
             ImmutablePair.of("PR2", PolarisEntitySubType.NULL_SUBTYPE)));

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -2389,12 +2389,29 @@ public class PolarisAdminService {
                   PolarisEntityType.PRINCIPAL);
 
           if (principalResult.isSuccess() && principalResult.getEntity() != null) {
-            // Grant catalog_role_manager to this principal
-            metaStoreManager.grantUsageOnRoleToGrantee(
-                getCurrentPolarisContext(),
-                null,
-                catalogRoleManagerEntity,
-                PrincipalEntity.of(principalResult.getEntity()));
+            PrincipalEntity principal = PrincipalEntity.of(principalResult.getEntity());
+
+            // Check if the principal already has catalog_role_manager
+            LoadGrantsResult principalGrantsResult =
+                metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principal);
+
+            boolean alreadyHasCatalogRoleManager = false;
+            if (principalGrantsResult.isSuccess()) {
+              for (PolarisGrantRecord existingGrant : principalGrantsResult.getGrantRecords()) {
+                if (existingGrant.getSecurableId() == catalogRoleManagerEntity.getId()
+                    && existingGrant.getPrivilegeCode()
+                        == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+                  alreadyHasCatalogRoleManager = true;
+                  break;
+                }
+              }
+            }
+
+            // Only grant if not already granted
+            if (!alreadyHasCatalogRoleManager) {
+              metaStoreManager.grantUsageOnRoleToGrantee(
+                  getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
+            }
           }
         }
       }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1464,8 +1464,17 @@ public class PolarisAdminService {
     if (FederatedEntities.isFederated(principalRoleEntity)) {
       throw new ValidationException("Cannot assign a federated role to a principal");
     }
-    return metaStoreManager.grantUsageOnRoleToGrantee(
-        getCurrentPolarisContext(), null, principalRoleEntity, principalEntity);
+    PrivilegeResult result =
+        metaStoreManager.grantUsageOnRoleToGrantee(
+            getCurrentPolarisContext(), null, principalRoleEntity, principalEntity);
+
+    // If the principal role already has catalog_admin on any catalog,
+    // grant catalog_role_manager to this principal
+    if (result.isSuccess() && hasCatalogAdminOnAnyCatalog(principalRoleEntity)) {
+      grantCatalogRoleManagerToPrincipalIfNeeded(principalEntity);
+    }
+
+    return result;
   }
 
   public PrivilegeResult revokePrincipalRole(String principalName, String principalRoleName) {
@@ -2645,6 +2654,53 @@ public class PolarisAdminService {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Grants catalog_role_manager to a specific principal if they don't already have it. This is
+   * called when a principal is assigned to a principal role that already has catalog_admin.
+   */
+  private void grantCatalogRoleManagerToPrincipalIfNeeded(PrincipalEntity principal) {
+    // Load catalog_role_manager directly from metastore
+    EntityResult catalogRoleManagerResult =
+        metaStoreManager.readEntityByName(
+            getCurrentPolarisContext(),
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+
+    if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      LOGGER.warn(
+          "catalog_role_manager role not found. This role should be created during bootstrap. "
+              + "Existing deployments may need to re-bootstrap to enable this feature.");
+      return;
+    }
+
+    PrincipalRoleEntity catalogRoleManagerEntity =
+        PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
+
+    // Check if the principal already has catalog_role_manager
+    LoadGrantsResult principalGrantsResult =
+        metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principal);
+
+    boolean alreadyHasCatalogRoleManager = false;
+    if (principalGrantsResult.isSuccess()) {
+      for (PolarisGrantRecord existingGrant : principalGrantsResult.getGrantRecords()) {
+        if (existingGrant.getSecurableId() == catalogRoleManagerEntity.getId()
+            && existingGrant.getPrivilegeCode()
+                == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+          alreadyHasCatalogRoleManager = true;
+          break;
+        }
+      }
+    }
+
+    // Only grant if not already granted
+    if (!alreadyHasCatalogRoleManager) {
+      metaStoreManager.grantUsageOnRoleToGrantee(
+          getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -2618,7 +2618,8 @@ public class PolarisAdminService {
 
     // Find all principals that have catalog_role_manager
     LoadGrantsResult grantsResult =
-        metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), catalogRoleManagerEntity);
+        metaStoreManager.loadGrantsOnSecurable(
+            getCurrentPolarisContext(), catalogRoleManagerEntity);
 
     if (grantsResult.isSuccess()) {
       for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -820,7 +820,7 @@ public class PolarisAdminService {
     }
 
     // After successfully dropping the catalog, check if any principals should lose
-    // catalog_role_manager because they no longer have catalog_admin on any catalog
+    // principal_role_viewer because they no longer have catalog_admin on any catalog
     revokeCatalogRoleManagerAfterCatalogDrop(entity);
   }
 
@@ -1248,7 +1248,7 @@ public class PolarisAdminService {
     PrincipalRoleEntity entity = getPrincipalRoleByName(resolutionManifest, name);
 
     // Before deleting the principal role, collect all principals that have this role
-    // We need to check them after deletion to revoke catalog_role_manager if needed
+    // We need to check them after deletion to revoke principal_role_viewer if needed
     List<PrincipalEntity> principalsWithRole = new java.util.ArrayList<>();
     LoadGrantsResult grantsResult =
         metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), entity);
@@ -1286,7 +1286,7 @@ public class PolarisAdminService {
     }
 
     // After successfully deleting the principal role, check if any principals
-    // should lose catalog_role_manager because they no longer have catalog_admin
+    // should lose principal_role_viewer because they no longer have catalog_admin
     for (PrincipalEntity principal : principalsWithRole) {
       revokeCatalogRoleManagerFromPrincipalIfNeeded(principal);
     }
@@ -1498,7 +1498,7 @@ public class PolarisAdminService {
             getCurrentPolarisContext(), null, principalRoleEntity, principalEntity);
 
     // If the principal role already has catalog_admin on any catalog,
-    // grant catalog_role_manager to this principal
+    // grant principal_role_viewer to this principal
     if (result.isSuccess() && hasCatalogAdminOnAnyCatalog(principalRoleEntity)) {
       grantCatalogRoleManagerToPrincipalIfNeeded(principalEntity);
     }
@@ -1563,7 +1563,7 @@ public class PolarisAdminService {
         metaStoreManager.grantUsageOnRoleToGrantee(
             getCurrentPolarisContext(), catalogEntity, catalogRoleEntity, principalRoleEntity);
 
-    // if granting catalog_admin, also grant catalog_role_manager to allow listing principal roles
+    // if granting catalog_admin, also grant principal_role_viewer to allow listing principal roles
     if (result.isSuccess()
         && PolarisEntityConstants.getNameOfCatalogAdminRole().equals(catalogRoleName)) {
       grantCatalogRoleManagerIfNeeded(principalRoleEntity);
@@ -2402,22 +2402,22 @@ public class PolarisAdminService {
   }
 
   /**
-   * Grants the catalog_role_manager principal role to all principals assigned to the specified
+   * Grants the principal_role_viewer principal role to all principals assigned to the specified
    * principal role. This allows catalog admins to list principal roles.
    */
   private void grantCatalogRoleManagerIfNeeded(PrincipalRoleEntity principalRoleEntity) {
-    // Load catalog_role_manager directly from metastore
+    // Load principal_role_viewer directly from metastore
     EntityResult catalogRoleManagerResult =
         metaStoreManager.readEntityByName(
             getCurrentPolarisContext(),
             null,
             PolarisEntityType.PRINCIPAL_ROLE,
             PolarisEntitySubType.NULL_SUBTYPE,
-            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
       LOGGER.warn(
-          "catalog_role_manager role not found. This role should be created during bootstrap. "
+          "principal_role_viewer role not found. This role should be created during bootstrap. "
               + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
@@ -2425,7 +2425,7 @@ public class PolarisAdminService {
     PrincipalRoleEntity catalogRoleManagerEntity =
         PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
 
-    // Find all principals that have this principal role and grant catalog_role_manager to them
+    // Find all principals that have this principal role and grant principal_role_viewer to them
     LoadGrantsResult grantsResult =
         metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), principalRoleEntity);
 
@@ -2444,7 +2444,7 @@ public class PolarisAdminService {
           if (principalResult.isSuccess() && principalResult.getEntity() != null) {
             PrincipalEntity principal = PrincipalEntity.of(principalResult.getEntity());
 
-            // Check if the principal already has catalog_role_manager
+            // Check if the principal already has principal_role_viewer
             LoadGrantsResult principalGrantsResult =
                 metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principal);
 
@@ -2472,22 +2472,22 @@ public class PolarisAdminService {
   }
 
   /**
-   * Revokes the catalog_role_manager principal role from all principals assigned to the specified
+   * Revokes the principal_role_viewer principal role from all principals assigned to the specified
    * principal role if they no longer have any catalog_admin grants.
    */
   private void revokeCatalogRoleManagerIfNeeded(PrincipalRoleEntity principalRoleEntity) {
-    // Load catalog_role_manager directly from metastore
+    // Load principal_role_viewer directly from metastore
     EntityResult catalogRoleManagerResult =
         metaStoreManager.readEntityByName(
             getCurrentPolarisContext(),
             null,
             PolarisEntityType.PRINCIPAL_ROLE,
             PolarisEntitySubType.NULL_SUBTYPE,
-            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
       LOGGER.warn(
-          "catalog_role_manager role not found. This role should be created during bootstrap. "
+          "principal_role_viewer role not found. This role should be created during bootstrap. "
               + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
@@ -2516,7 +2516,7 @@ public class PolarisAdminService {
 
             // Check if this principal still has catalog_admin on any other catalog
             if (!hasCatalogAdminOnAnyCatalog(principal)) {
-              // Revoke catalog_role_manager from this principal
+              // Revoke principal_role_viewer from this principal
               metaStoreManager.revokeUsageOnRoleFromGrantee(
                   getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
             }
@@ -2599,22 +2599,22 @@ public class PolarisAdminService {
   }
 
   /**
-   * Revokes catalog_role_manager from a principal if they no longer have catalog_admin on any
+   * Revokes principal_role_viewer from a principal if they no longer have catalog_admin on any
    * catalog. This is called when a principal role is revoked from a principal.
    */
   private void revokeCatalogRoleManagerFromPrincipalIfNeeded(PrincipalEntity principal) {
-    // Load catalog_role_manager directly from metastore
+    // Load principal_role_viewer directly from metastore
     EntityResult catalogRoleManagerResult =
         metaStoreManager.readEntityByName(
             getCurrentPolarisContext(),
             null,
             PolarisEntityType.PRINCIPAL_ROLE,
             PolarisEntitySubType.NULL_SUBTYPE,
-            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
       LOGGER.warn(
-          "catalog_role_manager role not found. This role should be created during bootstrap. "
+          "principal_role_viewer role not found. This role should be created during bootstrap. "
               + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
@@ -2624,29 +2624,29 @@ public class PolarisAdminService {
 
     // Check if this principal still has catalog_admin on any catalog
     if (!hasCatalogAdminOnAnyCatalog(principal)) {
-      // Revoke catalog_role_manager from this principal
+      // Revoke principal_role_viewer from this principal
       metaStoreManager.revokeUsageOnRoleFromGrantee(
           getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
     }
   }
 
   /**
-   * Revokes catalog_role_manager from all principals who had catalog_admin only on the dropped
+   * Revokes principal_role_viewer from all principals who had catalog_admin only on the dropped
    * catalog. This is called after a catalog is successfully deleted.
    */
   private void revokeCatalogRoleManagerAfterCatalogDrop(CatalogEntity droppedCatalog) {
-    // Load catalog_role_manager directly from metastore
+    // Load principal_role_viewer directly from metastore
     EntityResult catalogRoleManagerResult =
         metaStoreManager.readEntityByName(
             getCurrentPolarisContext(),
             null,
             PolarisEntityType.PRINCIPAL_ROLE,
             PolarisEntitySubType.NULL_SUBTYPE,
-            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
       LOGGER.warn(
-          "catalog_role_manager role not found. This role should be created during bootstrap. "
+          "principal_role_viewer role not found. This role should be created during bootstrap. "
               + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
@@ -2654,14 +2654,14 @@ public class PolarisAdminService {
     PrincipalRoleEntity catalogRoleManagerEntity =
         PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
 
-    // Find all principals that have catalog_role_manager
+    // Find all principals that have principal_role_viewer
     LoadGrantsResult grantsResult =
         metaStoreManager.loadGrantsOnSecurable(
             getCurrentPolarisContext(), catalogRoleManagerEntity);
 
     if (grantsResult.isSuccess()) {
       for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {
-        // Check if this is a PRINCIPAL_ROLE_USAGE grant (principal using catalog_role_manager)
+        // Check if this is a PRINCIPAL_ROLE_USAGE grant (principal using principal_role_viewer)
         if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
           // Load the principal
           EntityResult principalResult =
@@ -2676,7 +2676,7 @@ public class PolarisAdminService {
 
             // Check if this principal still has catalog_admin on any remaining catalog
             if (!hasCatalogAdminOnAnyCatalog(principal)) {
-              // Revoke catalog_role_manager from this principal
+              // Revoke principal_role_viewer from this principal
               metaStoreManager.revokeUsageOnRoleFromGrantee(
                   getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
             }
@@ -2687,22 +2687,22 @@ public class PolarisAdminService {
   }
 
   /**
-   * Grants catalog_role_manager to a specific principal if they don't already have it. This is
+   * Grants principal_role_viewer to a specific principal if they don't already have it. This is
    * called when a principal is assigned to a principal role that already has catalog_admin.
    */
   private void grantCatalogRoleManagerToPrincipalIfNeeded(PrincipalEntity principal) {
-    // Load catalog_role_manager directly from metastore
+    // Load principal_role_viewer directly from metastore
     EntityResult catalogRoleManagerResult =
         metaStoreManager.readEntityByName(
             getCurrentPolarisContext(),
             null,
             PolarisEntityType.PRINCIPAL_ROLE,
             PolarisEntitySubType.NULL_SUBTYPE,
-            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+            PolarisEntityConstants.getNameOfPrincipalRoleViewerRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
       LOGGER.warn(
-          "catalog_role_manager role not found. This role should be created during bootstrap. "
+          "principal_role_viewer role not found. This role should be created during bootstrap. "
               + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
@@ -2710,7 +2710,7 @@ public class PolarisAdminService {
     PrincipalRoleEntity catalogRoleManagerEntity =
         PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
 
-    // Check if the principal already has catalog_role_manager
+    // Check if the principal already has principal_role_viewer
     LoadGrantsResult principalGrantsResult =
         metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principal);
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -88,6 +88,7 @@ import org.apache.polaris.core.entity.CatalogRoleEntity;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -1508,8 +1509,17 @@ public class PolarisAdminService {
     CatalogEntity catalogEntity = getCatalogByName(resolutionManifest, catalogName);
     CatalogRoleEntity catalogRoleEntity = getCatalogRoleByName(resolutionManifest, catalogRoleName);
 
-    return metaStoreManager.grantUsageOnRoleToGrantee(
-        getCurrentPolarisContext(), catalogEntity, catalogRoleEntity, principalRoleEntity);
+    PrivilegeResult result =
+        metaStoreManager.grantUsageOnRoleToGrantee(
+            getCurrentPolarisContext(), catalogEntity, catalogRoleEntity, principalRoleEntity);
+
+    // if granting catalog_admin, also grant catalog_role_manager to allow listing principal roles
+    if (result.isSuccess()
+        && PolarisEntityConstants.getNameOfCatalogAdminRole().equals(catalogRoleName)) {
+      grantCatalogRoleManagerIfNeeded(principalRoleEntity);
+    }
+
+    return result;
   }
 
   public PrivilegeResult revokeCatalogRoleFromPrincipalRole(
@@ -1524,8 +1534,17 @@ public class PolarisAdminService {
         getPrincipalRoleByName(resolutionManifest, principalRoleName);
     CatalogEntity catalogEntity = getCatalogByName(resolutionManifest, catalogName);
     CatalogRoleEntity catalogRoleEntity = getCatalogRoleByName(resolutionManifest, catalogRoleName);
-    return metaStoreManager.revokeUsageOnRoleFromGrantee(
-        getCurrentPolarisContext(), catalogEntity, catalogRoleEntity, principalRoleEntity);
+    PrivilegeResult result =
+        metaStoreManager.revokeUsageOnRoleFromGrantee(
+            getCurrentPolarisContext(), catalogEntity, catalogRoleEntity, principalRoleEntity);
+
+    // if revoking catalog_admin, check if principal still has catalog_admin on other catalogs
+    if (result.isSuccess()
+        && PolarisEntityConstants.getNameOfCatalogAdminRole().equals(catalogRoleName)) {
+      revokeCatalogRoleManagerIfNeeded(principalRoleEntity);
+    }
+
+    return result;
   }
 
   public List<PolarisEntity> listAssigneePrincipalsForPrincipalRole(String principalRoleName) {
@@ -2330,5 +2349,179 @@ public class PolarisAdminService {
                   + " supported for synthetic entities in external catalogs.",
               subTypes));
     }
+  }
+
+  /**
+   * Grants the catalog_role_manager principal role to all principals assigned to the specified
+   * principal role. This allows catalog admins to list principal roles.
+   */
+  private void grantCatalogRoleManagerIfNeeded(PrincipalRoleEntity principalRoleEntity) {
+    // Load catalog_role_manager directly from metastore
+    EntityResult catalogRoleManagerResult =
+        metaStoreManager.readEntityByName(
+            getCurrentPolarisContext(),
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+
+    if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      return;
+    }
+
+    PrincipalRoleEntity catalogRoleManagerEntity =
+        PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
+
+    // Find all principals that have this principal role and grant catalog_role_manager to them
+    LoadGrantsResult grantsResult =
+        metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), principalRoleEntity);
+
+    if (grantsResult.isSuccess()) {
+      for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {
+        // Check if this is a PRINCIPAL_ROLE_USAGE grant (principal using this role)
+        if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+          // Load the principal (grantee)
+          EntityResult principalResult =
+              metaStoreManager.loadEntity(
+                  getCurrentPolarisContext(),
+                  grant.getGranteeCatalogId(),
+                  grant.getGranteeId(),
+                  PolarisEntityType.PRINCIPAL);
+
+          if (principalResult.isSuccess() && principalResult.getEntity() != null) {
+            // Grant catalog_role_manager to this principal
+            metaStoreManager.grantUsageOnRoleToGrantee(
+                getCurrentPolarisContext(),
+                null,
+                catalogRoleManagerEntity,
+                PrincipalEntity.of(principalResult.getEntity()));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Revokes the catalog_role_manager principal role from all principals assigned to the specified
+   * principal role if they no longer have any catalog_admin grants.
+   */
+  private void revokeCatalogRoleManagerIfNeeded(PrincipalRoleEntity principalRoleEntity) {
+    // Load catalog_role_manager directly from metastore
+    EntityResult catalogRoleManagerResult =
+        metaStoreManager.readEntityByName(
+            getCurrentPolarisContext(),
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+
+    if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      return;
+    }
+
+    PrincipalRoleEntity catalogRoleManagerEntity =
+        PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
+
+    // Find all principals that have this principal role
+    LoadGrantsResult grantsResult =
+        metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), principalRoleEntity);
+
+    if (grantsResult.isSuccess()) {
+      for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {
+        // Check if this is a PRINCIPAL_ROLE_USAGE grant
+        if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+          // Load the principal
+          EntityResult principalResult =
+              metaStoreManager.loadEntity(
+                  getCurrentPolarisContext(),
+                  grant.getGranteeCatalogId(),
+                  grant.getGranteeId(),
+                  PolarisEntityType.PRINCIPAL);
+
+          if (principalResult.isSuccess() && principalResult.getEntity() != null) {
+            PrincipalEntity principal = PrincipalEntity.of(principalResult.getEntity());
+
+            // Check if this principal still has catalog_admin on any other catalog
+            if (!hasCatalogAdminOnAnyCatalog(principal)) {
+              // Revoke catalog_role_manager from this principal
+              metaStoreManager.revokeUsageOnRoleFromGrantee(
+                  getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Checks if the principal has catalog_admin on any catalog by examining all principal roles and
+   * their catalog role grants.
+   */
+  private boolean hasCatalogAdminOnAnyCatalog(PrincipalEntity principal) {
+    // Get all principal roles this principal has
+    LoadGrantsResult principalRolesGrants =
+        metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principal);
+
+    if (!principalRolesGrants.isSuccess()) {
+      return false;
+    }
+
+    // For each principal role, check if it has catalog_admin on any catalog
+    for (PolarisGrantRecord grant : principalRolesGrants.getGrantRecords()) {
+      if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+        // Load the principal role
+        EntityResult principalRoleResult =
+            metaStoreManager.loadEntity(
+                getCurrentPolarisContext(),
+                grant.getSecurableCatalogId(),
+                grant.getSecurableId(),
+                PolarisEntityType.PRINCIPAL_ROLE);
+
+        if (principalRoleResult.isSuccess() && principalRoleResult.getEntity() != null) {
+          PrincipalRoleEntity principalRole =
+              PrincipalRoleEntity.of(principalRoleResult.getEntity());
+
+          // Check if this principal role has any catalog role grants
+          if (hasCatalogAdminOnAnyCatalog(principalRole)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if the principal role has catalog_admin on any catalog by examining all catalog role
+   * grants.
+   */
+  private boolean hasCatalogAdminOnAnyCatalog(PrincipalRoleEntity principalRoleEntity) {
+    LoadGrantsResult grantList =
+        metaStoreManager.loadGrantsToGrantee(getCurrentPolarisContext(), principalRoleEntity);
+
+    if (!grantList.isSuccess()) {
+      return false;
+    }
+
+    for (PolarisGrantRecord grant : grantList.getGrantRecords()) {
+      if (grant.getPrivilegeCode() == PolarisPrivilege.CATALOG_ROLE_USAGE.getCode()) {
+        EntityResult roleEntityResult =
+            metaStoreManager.loadEntity(
+                getCurrentPolarisContext(),
+                grant.getSecurableCatalogId(),
+                grant.getSecurableId(),
+                PolarisEntityType.CATALOG_ROLE);
+
+        if (roleEntityResult.isSuccess()
+            && roleEntityResult.getEntity() != null
+            && PolarisEntityConstants.getNameOfCatalogAdminRole()
+                .equals(roleEntityResult.getEntity().getName())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -818,6 +818,10 @@ public class PolarisAdminService {
             entity.getName());
       }
     }
+
+    // After successfully dropping the catalog, check if any principals should lose
+    // catalog_role_manager because they no longer have catalog_admin on any catalog
+    revokeCatalogRoleManagerAfterCatalogDrop(entity);
   }
 
   public @Nonnull CatalogEntity getCatalog(String name) {
@@ -1479,8 +1483,16 @@ public class PolarisAdminService {
     if (FederatedEntities.isFederated(principalRoleEntity)) {
       throw new ValidationException("Cannot revoke a federated role from a principal");
     }
-    return metaStoreManager.revokeUsageOnRoleFromGrantee(
-        getCurrentPolarisContext(), null, principalRoleEntity, principalEntity);
+    PrivilegeResult result =
+        metaStoreManager.revokeUsageOnRoleFromGrantee(
+            getCurrentPolarisContext(), null, principalRoleEntity, principalEntity);
+
+    // Check if principal still has catalog_admin on any catalog after revoking this role
+    if (result.isSuccess()) {
+      revokeCatalogRoleManagerFromPrincipalIfNeeded(principalEntity);
+    }
+
+    return result;
   }
 
   public List<PolarisEntity> listPrincipalRolesAssigned(String principalName) {
@@ -2366,6 +2378,9 @@ public class PolarisAdminService {
             PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      LOGGER.warn(
+          "catalog_role_manager role not found. This role should be created during bootstrap. "
+              + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
 
@@ -2433,6 +2448,9 @@ public class PolarisAdminService {
             PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
 
     if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      LOGGER.warn(
+          "catalog_role_manager role not found. This role should be created during bootstrap. "
+              + "Existing deployments may need to re-bootstrap to enable this feature.");
       return;
     }
 
@@ -2540,5 +2558,92 @@ public class PolarisAdminService {
     }
 
     return false;
+  }
+
+  /**
+   * Revokes catalog_role_manager from a principal if they no longer have catalog_admin on any
+   * catalog. This is called when a principal role is revoked from a principal.
+   */
+  private void revokeCatalogRoleManagerFromPrincipalIfNeeded(PrincipalEntity principal) {
+    // Load catalog_role_manager directly from metastore
+    EntityResult catalogRoleManagerResult =
+        metaStoreManager.readEntityByName(
+            getCurrentPolarisContext(),
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+
+    if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      LOGGER.warn(
+          "catalog_role_manager role not found. This role should be created during bootstrap. "
+              + "Existing deployments may need to re-bootstrap to enable this feature.");
+      return;
+    }
+
+    PrincipalRoleEntity catalogRoleManagerEntity =
+        PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
+
+    // Check if this principal still has catalog_admin on any catalog
+    if (!hasCatalogAdminOnAnyCatalog(principal)) {
+      // Revoke catalog_role_manager from this principal
+      metaStoreManager.revokeUsageOnRoleFromGrantee(
+          getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
+    }
+  }
+
+  /**
+   * Revokes catalog_role_manager from all principals who had catalog_admin only on the dropped
+   * catalog. This is called after a catalog is successfully deleted.
+   */
+  private void revokeCatalogRoleManagerAfterCatalogDrop(CatalogEntity droppedCatalog) {
+    // Load catalog_role_manager directly from metastore
+    EntityResult catalogRoleManagerResult =
+        metaStoreManager.readEntityByName(
+            getCurrentPolarisContext(),
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogRoleManagerPrincipalRole());
+
+    if (!catalogRoleManagerResult.isSuccess() || catalogRoleManagerResult.getEntity() == null) {
+      LOGGER.warn(
+          "catalog_role_manager role not found. This role should be created during bootstrap. "
+              + "Existing deployments may need to re-bootstrap to enable this feature.");
+      return;
+    }
+
+    PrincipalRoleEntity catalogRoleManagerEntity =
+        PrincipalRoleEntity.of(catalogRoleManagerResult.getEntity());
+
+    // Find all principals that have catalog_role_manager
+    LoadGrantsResult grantsResult =
+        metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), catalogRoleManagerEntity);
+
+    if (grantsResult.isSuccess()) {
+      for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {
+        // Check if this is a PRINCIPAL_ROLE_USAGE grant (principal using catalog_role_manager)
+        if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+          // Load the principal
+          EntityResult principalResult =
+              metaStoreManager.loadEntity(
+                  getCurrentPolarisContext(),
+                  grant.getGranteeCatalogId(),
+                  grant.getGranteeId(),
+                  PolarisEntityType.PRINCIPAL);
+
+          if (principalResult.isSuccess() && principalResult.getEntity() != null) {
+            PrincipalEntity principal = PrincipalEntity.of(principalResult.getEntity());
+
+            // Check if this principal still has catalog_admin on any remaining catalog
+            if (!hasCatalogAdminOnAnyCatalog(principal)) {
+              // Revoke catalog_role_manager from this principal
+              metaStoreManager.revokeUsageOnRoleFromGrantee(
+                  getCurrentPolarisContext(), null, catalogRoleManagerEntity, principal);
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1246,6 +1246,29 @@ public class PolarisAdminService {
         authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.PRINCIPAL_ROLE);
 
     PrincipalRoleEntity entity = getPrincipalRoleByName(resolutionManifest, name);
+
+    // Before deleting the principal role, collect all principals that have this role
+    // We need to check them after deletion to revoke catalog_role_manager if needed
+    List<PrincipalEntity> principalsWithRole = new java.util.ArrayList<>();
+    LoadGrantsResult grantsResult =
+        metaStoreManager.loadGrantsOnSecurable(getCurrentPolarisContext(), entity);
+
+    if (grantsResult.isSuccess()) {
+      for (PolarisGrantRecord grant : grantsResult.getGrantRecords()) {
+        if (grant.getPrivilegeCode() == PolarisPrivilege.PRINCIPAL_ROLE_USAGE.getCode()) {
+          EntityResult principalResult =
+              metaStoreManager.loadEntity(
+                  getCurrentPolarisContext(),
+                  grant.getGranteeCatalogId(),
+                  grant.getGranteeId(),
+                  PolarisEntityType.PRINCIPAL);
+          if (principalResult.isSuccess() && principalResult.getEntity() != null) {
+            principalsWithRole.add(PrincipalEntity.of(principalResult.getEntity()));
+          }
+        }
+      }
+    }
+
     // TODO: Handle return value in case of concurrent modification
     DropEntityResult dropEntityResult =
         metaStoreManager.dropEntityIfExists(
@@ -1260,6 +1283,12 @@ public class PolarisAdminService {
             "Polaris service admin principal role cannot be dropped, "
                 + "concurrent modification detected. Please try again");
       }
+    }
+
+    // After successfully deleting the principal role, check if any principals
+    // should lose catalog_role_manager because they no longer have catalog_admin
+    for (PrincipalEntity principal : principalsWithRole) {
+      revokeCatalogRoleManagerFromPrincipalIfNeeded(principal);
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/Bootstrapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/Bootstrapper.java
@@ -81,8 +81,8 @@ class Bootstrapper {
 
   /**
    * Runs upgrade migration for a realm to ensure principal_role_viewer exists. This method runs in
-   * a proper CDI request context with RealmContextHolder set. It gracefully handles the case where
-   * the realm doesn't exist yet (fresh install).
+   * a proper CDI request context with RealmContextHolder set. Should be called AFTER bootstrap
+   * completes.
    *
    * @param realmId the realm ID to run the upgrade migration for
    */
@@ -91,11 +91,9 @@ class Bootstrapper {
     try {
       executor.submit(task).get(1, TimeUnit.MINUTES);
     } catch (Exception e) {
-      // This is expected for fresh installations where root container doesn't exist yet
-      LOGGER.debug(
-          "Upgrade migration for realm '{}' skipped or failed: {}. This is expected for fresh installations.",
-          realmId,
-          e.getMessage());
+      // This should not happen if called after bootstrap, but log it just in case
+      LOGGER.warn("Upgrade migration for realm '{}' failed: {}", realmId, e.getMessage());
+      LOGGER.debug("Upgrade migration exception details:", e);
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/Bootstrapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/Bootstrapper.java
@@ -29,14 +29,23 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.auth.AuthBootstrapUtil;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.service.context.catalog.RealmContextHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility class for running per-realm bootstrap tasks each in a fresh Request Context. */
 @ApplicationScoped
 class Bootstrapper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Bootstrapper.class);
+
   private final ExecutorService executor;
   private final RealmContextHolder realmContextHolder;
   private final MetaStoreManagerFactory factory;
@@ -56,7 +65,7 @@ class Bootstrapper {
       Iterable<String> realmIds, RootCredentialsSet rootCredentialsSet) {
     HashMap<String, PrincipalSecretsResult> result = new HashMap<>();
     for (String realmId : realmIds) {
-      Task t = new Task(realmContextHolder, realmId, rootCredentialsSet, factory);
+      BootstrapTask t = new BootstrapTask(realmContextHolder, realmId, rootCredentialsSet, factory);
       try {
         // Submit an async task per realm to ensure it runs in a fresh RequestContext.
         // Note: simultaneous bootstrap of multiple realms is an edge case - no need
@@ -70,7 +79,27 @@ class Bootstrapper {
     return result;
   }
 
-  private record Task(
+  /**
+   * Runs upgrade migration for a realm to ensure principal_role_viewer exists. This method runs in
+   * a proper CDI request context with RealmContextHolder set. It gracefully handles the case where
+   * the realm doesn't exist yet (fresh install).
+   *
+   * @param realmId the realm ID to run the upgrade migration for
+   */
+  void runUpgradeMigration(String realmId) {
+    UpgradeMigrationTask task = new UpgradeMigrationTask(realmContextHolder, realmId, factory);
+    try {
+      executor.submit(task).get(1, TimeUnit.MINUTES);
+    } catch (Exception e) {
+      // This is expected for fresh installations where root container doesn't exist yet
+      LOGGER.debug(
+          "Upgrade migration for realm '{}' skipped or failed: {}. This is expected for fresh installations.",
+          realmId,
+          e.getMessage());
+    }
+  }
+
+  private record BootstrapTask(
       RealmContextHolder realmContextHolder,
       String realmId,
       RootCredentialsSet rootCredentialsSet,
@@ -84,6 +113,31 @@ class Bootstrapper {
       // Make the realm ID effective in the current request context.
       realmContextHolder.set(() -> realmId);
       return factory.bootstrapRealms(Collections.singleton(realmId), rootCredentialsSet);
+    }
+  }
+
+  private record UpgradeMigrationTask(
+      RealmContextHolder realmContextHolder, String realmId, MetaStoreManagerFactory factory)
+      implements Callable<Void> {
+
+    @Override
+    @ActivateRequestContext
+    public Void call() {
+      // Note: each call to this method runs in a new CDI request context.
+      // Make the realm ID effective in the current request context.
+      realmContextHolder.set(() -> realmId);
+
+      RealmContext realmContext = () -> realmId;
+      PolarisMetaStoreManager metaStoreManager = factory.getOrCreateMetaStoreManager(realmContext);
+      BasePersistence metaStoreSession = factory.getOrCreateSession(realmContext);
+      PolarisCallContext callContext = new PolarisCallContext(realmContext, metaStoreSession);
+
+      AuthBootstrapUtil.ensurePrincipalRoleViewerExists(metaStoreManager, callContext);
+      LOGGER.info(
+          "Successfully ran upgrade migration for realm '{}' - principal_role_viewer role ensured",
+          realmId);
+
+      return null;
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -292,6 +292,13 @@ public class ServiceProducers {
           RootCredentialsSet.ENVIRONMENT_VARIABLE,
           RootCredentialsSet.SYSTEM_PROPERTY);
 
+      // Run upgrade migrations FIRST for all realms
+      // This is idempotent and will gracefully skip if the realm doesn't exist yet
+      for (String realmId : realmIds) {
+        bootstrapper.runUpgradeMigration(realmId);
+      }
+
+      // Then run bootstrap for realms that need it
       var result = bootstrapper.bootstrapRealms(realmIds, rootCredentialsSet);
 
       result.forEach(

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -292,14 +292,16 @@ public class ServiceProducers {
           RootCredentialsSet.ENVIRONMENT_VARIABLE,
           RootCredentialsSet.SYSTEM_PROPERTY);
 
-      // Run upgrade migrations FIRST for all realms
-      // This is idempotent and will gracefully skip if the realm doesn't exist yet
+      // Run bootstrap for realms that need it
+      var result = bootstrapper.bootstrapRealms(realmIds, rootCredentialsSet);
+
+      // Run upgrade migrations AFTER bootstrap for all realms
+      // For fresh installs: bootstrap creates principal_role_viewer, migration sees it exists
+      // For upgrades: bootstrap skips (already bootstrapped), migration creates
+      // principal_role_viewer
       for (String realmId : realmIds) {
         bootstrapper.runUpgradeMigration(realmId);
       }
-
-      // Then run bootstrap for realms that need it
-      var result = bootstrapper.bootstrapRealms(realmIds, rootCredentialsSet);
 
       result.forEach(
           (realm, secrets) -> {


### PR DESCRIPTION
Duplicate of https://github.com/apache/polaris/pull/3761 which got closed accidentally while rebasing 

Implements automatic principal role listing for `catalog_admin` users via a new system-managed `catalog_role_manager` role. Fixes #363

## Implementation

   - `catalog_role_manager` created at bootstrap with `PRINCIPAL_ROLE_LIST` privilege (read-only)
   -  Automatically granted to principals when they receive `catalog_admin` on any catalog
   -  Automatically revoked when all `catalog_admin` grants are removed

## Limitations

   - A new system role is introduced just to grant PRINCIPAL_ROLE_LIST for catalog_admin
   - Principal must be assigned to principal role before granting `catalog_admin`. If assigned after, revoke and re-grant `catalog_admin` to trigger auto-grant.
   - No backfill for existing `catalog_admin` grants (requires manual grant or re-grant)
   
   CC: @collado-mike 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
