### PR TITLE
Fix Artifact Hub repository ID

### DIFF
--- a/helm/polaris/artifacthub-repo.yml
+++ b/helm/polaris/artifacthub-repo.yml
@@ -18,7 +18,7 @@
 #
 
 # Artifact Hub repository metadata file
-repositoryID: apache-polaris
+repositoryID: dd03f016-7fa6-4f4a-81c4-41a1da6be562
 owners:
   - name: Apache Polaris PMC
     email: dev@polaris.apache.org


### PR DESCRIPTION
The repository ID must correspond to the ID declared in Artifact Hub: dd03f016-7fa6-4f4a-81c4-41a1da6be562.

PMC members with access to the Artifact Hub org can easily verify this.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
