### PR TITLE
Add doap.rdf file for Polaris

### DIFF
--- a/doap.rdf
+++ b/doap.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+
+  <Project rdf:about="https://polaris.apache.org/">
+    <created>2026-02-20</created>
+    <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
+    <name>Apache Polaris</name>
+    <homepage rdf:resource="https://polaris.apache.org" />
+    <asfext:pmc rdf:resource="https://polaris.apache.org" />
+    <shortdesc>Apache Polaris is an open-source, fully-featured catalog for lakehouse.</shortdesc>
+    <description>Apache Polaris implements the Apache Iceberg REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris, Apache Flink, Apache Spark, ...</description>
+    <bug-database rdf:resource="https://github.com/apache/polaris/issues" />
+    <mailing-list rdf:resource="https://polaris.apache.org/community/" />
+    <download-page rdf:resource="https://polaris.apache.org/downloads/" />
+    <programming-language>Java</programming-language>
+    <programming-language>Python</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/big-data" />
+    <category rdf:resource="http://projects.apache.org/category/data-engineering" />
+    <category rdf:resource="http://projects.apache.org/category/database" />
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/polaris" />
+        <browse rdf:resource="https://github.com/apache/polaris" />
+      </GitRepository>
+    </repository>
+    <release>
+      <Version>
+        <name>1.3.0-incubating</name>
+        <created>2026-01-16</created>
+        <revision>1.3.0-incubating</revision>
+      </Version>
+    </release>
+  </Project>
+</rdf:RDF>


### PR DESCRIPTION
This files is used to populate projects.apache.org (comdev).

I reviewed the process with ASF Infra, and according to https://projects.apache.org/create.html, it's OK to put `doap.rdf` on GitHub/GitBox (as soon as it's public).

Once this PR is merged, I will update `projects.xml` feed on comdev svn.