### PR TITLE
Exclude Jetty from Polaris Server

### DIFF
--- a/extensions/federation/hadoop/build.gradle.kts
+++ b/extensions/federation/hadoop/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     exclude("com.sun.jersey", "jersey-server")
     exclude("com.sun.jersey", "jersey-servlet")
     exclude("io.dropwizard.metrics", "metrics-core")
+    exclude(group = "org.eclipse.jetty")
   }
   implementation(libs.hadoop.client.api)
   implementation(libs.hadoop.client.runtime)


### PR DESCRIPTION
Jetty is a web server and servlet container with its own lifecycle. This can easily confuse or even conflict with consuming application dependencies. If started, it can also cause issues, potentially security issues.
