### PR TITLE
Ban listenablefuture, error-prone and jsch

### DIFF
--- a/gradle/banned-dependencies.txt
+++ b/gradle/banned-dependencies.txt
@@ -37,3 +37,11 @@ javax.ws.rs:jsr311-api
 # See https://github.com/RoaringBitmap/RoaringBitmap/issues/749, should only use org.roaringbitmap:RoaringBitmap
 com.github.RoaringBitmap.RoaringBitmap
 org.roaringbitmap:roaringbitmap
+
+
+# `listenablefuture` is banned via a very high version anyways, banning it is safe
+com.google.guava:listenablefuture
+
+
+# Unmaintained since 2018, provides ssh functionality, risk of security issues
+com.jcraft:jsch

--- a/gradle/banned-quarkus-prod-dependencies.txt
+++ b/gradle/banned-quarkus-prod-dependencies.txt
@@ -27,3 +27,7 @@
 
 # Contains old javax.* annotations that we do not want
 javax.servlet:javax.servlet-api
+
+
+# Don't need compile-time annotations in runtime
+com.google.errorprone:error_prone_annotations

--- a/runtime/admin/distribution/LICENSE
+++ b/runtime/admin/distribution/LICENSE
@@ -670,20 +670,10 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This product bundles ErrorProne annotations.
-
-* Maven group:artifact IDs: com.google.errorprone:error_prone_annotations
-
-Project URL: https://errorprone.info
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 This product bundles Guava.
 
 * Maven group:artifact IDs: com.google.guava:failureaccess
 * Maven group:artifact IDs: com.google.guava:guava
-* Maven group:artifact IDs: com.google.guava:listenablefuture
 
 Project URL: https://github.com/google/guava
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -759,20 +759,10 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This product bundles ErrorProne annotations.
-
-* Maven group:artifact IDs: com.google.errorprone:error_prone_annotations
-
-Project URL: https://errorprone.info
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 This product bundles Guava.
 
 * Maven group:artifact IDs: com.google.guava:failureaccess
 * Maven group:artifact IDs: com.google.guava:guava
-* Maven group:artifact IDs: com.google.guava:listenablefuture
 
 Project URL: https://github.com/google/guava
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -890,41 +880,6 @@ License: Go License
 | THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 | (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 | OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-This product bundles JCraft JSch.
-
-* Maven group:artifact IDs: com.jcraft:jsch
-
-Project URL: http://www.jcraft.com/jsch/
-License: BSD License
-| Copyright (c) 2002-2015 Atsuhiko Yamanaka, JCraft,Inc. 
-| All rights reserved.
-| 
-| Redistribution and use in source and binary forms, with or without
-| modification, are permitted provided that the following conditions are met:
-| 
-|   1. Redistributions of source code must retain the above copyright notice,
-|      this list of conditions and the following disclaimer.
-| 
-|   2. Redistributions in binary form must reproduce the above copyright 
-|      notice, this list of conditions and the following disclaimer in 
-|      the documentation and/or other materials provided with the distribution.
-| 
-|   3. The names of the authors may not be used to endorse or promote products
-|      derived from this software without specific prior written permission.
-| 
-| THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
-| INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-| FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
-| INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
-| INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-| OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-| EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Globally ban listenablefuture and jsch, ban error-prone annotations in Quarkus prod runtime.