### PR TITLE
Releasey: Move GH release artifacts upload into `gh create release`

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -395,16 +395,16 @@ jobs:
           - \`apache/polaris-admin:${final_release_tag}\` - Polaris Admin Tool"
           # ********************************************************************************
 
-          # Create GitHub release
-          exec_process gh release create "${final_release_tag}" \
+          # Collect all artifacts to attach from the artifacts directory
+          readarray -t artifacts_to_attach < <(find "${artifacts_dir}" -type f -name "*.tar.gz" -o -name "*.tgz" -o -name "*.asc" -o -name "*.sha512" -o -name "*.prov")
+
+          # Create GitHub release and immediately publish it
+          exec_process gh release create \
             --title "${release_title}" \
             --notes "${release_notes}" \
-            --target "${rc_commit}"
-
-          # Attach all artifacts from the artifacts directory
-          find "${artifacts_dir}" -type f -name "*.tar.gz" -o -name "*.tgz" -o -name "*.asc" -o -name "*.sha512" -o -name "*.prov" | while read -r file; do
-            exec_process gh release upload "${final_release_tag}" "${file}"
-          done
+            --target "${rc_commit}" \
+            "${final_release_tag}" \
+            "${artifacts_to_attach[@]}"
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           ## GitHub Release


### PR DESCRIPTION
This change, despite potentially counting as a simplification, enables us to use [GitHub immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) in the future. GH immutable releases do not allow attaching/changing release artifacts after the release has been created.