### PR TITLE
core: rename Resolvable.CATALOG_ROLES to Resolvable.CALLER_CATALOG_ROLES

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -96,7 +96,13 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
     addTopLevelName(PolarisEntityConstants.getRootContainerName(), PolarisEntityType.ROOT, true);
   }
 
-  /** Adds a name of a top-level entity (Catalog, Principal, PrincipalRole) to be resolved. */
+  /**
+   * Adds a named entity to be resolved via the resolver's name-based registration surface.
+   *
+   * <p>This includes top-level entities (Catalog, Principal, PrincipalRole), and also {@code
+   * CATALOG_ROLE}. For {@code CATALOG_ROLE}, a reference catalog must be present on the
+   * manifest/resolver context.
+   */
   public void addTopLevelName(String entityName, PolarisEntityType entityType, boolean isOptional) {
     addedTopLevelNames.put(entityName, entityType);
     if (isOptional) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolvable.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolvable.java
@@ -36,14 +36,12 @@ public enum Resolvable {
   /** Resolve explicitly registered paths (via addPath/addPassthroughPath). */
   REQUESTED_PATHS,
   /**
-   * Resolve any additional top-level entities explicitly registered via addTopLevelName, such as
-   * catalog/principal/principal-role names used for authorization beyond the caller and reference
-   * catalog.
+   * Resolve any additional top-level entities explicitly registered via {@link
+   * PolarisResolutionManifest#addTopLevelName}, such as catalog/principal/principal-role names used
+   * for authorization beyond the caller and reference catalog.
    *
-   * <p>Note: this currently also covers requested {@code CATALOG_ROLE} names because they share the
-   * same {@link PolarisResolutionManifest} registration surface ({@code addTopLevelName}). Although
-   * grouped here for compatibility, catalog-role name resolution still requires the reference
-   * catalog context.
+   * <p>All entity types resolved here share the same {@link
+   * PolarisResolutionManifest#addTopLevelName} registration surface.
    */
   REQUESTED_TOP_LEVEL_ENTITIES
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -840,20 +840,21 @@ public class Resolver {
   }
 
   /**
-   * Resolve the reference catalog and determine all activated role. The principal and principal
-   * roles should have already been resolved
+   * Resolve the reference catalog and optionally determine all caller-activated catalog roles. The
+   * principal and principal roles should have already been resolved.
    *
    * @param toValidate all entities we have resolved incrementally, possibly with some entries
    *     coming from cache, hence we will have to verify that these entities have not changed in the
    *     backend
-   * @param referenceCatalogName name of the reference catalog to resolve, along with all catalog
-   *     roles which are activated
+   * @param referenceCatalogName name of the reference catalog to resolve
+   * @param resolveCallerCatalogRoles whether to resolve caller-activated catalog roles for the
+   *     reference catalog
    * @return the status of resolution
    */
   private ResolverStatus resolveReferenceCatalog(
       @Nonnull List<ResolvedPolarisEntity> toValidate,
       @Nonnull String referenceCatalogName,
-      boolean resolveCatalogRoles) {
+      boolean resolveCallerCatalogRoles) {
     // resolve the catalog
     this.resolvedReferenceCatalog =
         this.resolveByName(toValidate, PolarisEntityType.CATALOG, referenceCatalogName);
@@ -864,7 +865,7 @@ public class Resolver {
       return new ResolverStatus(PolarisEntityType.CATALOG, this.referenceCatalogName);
     }
 
-    if (resolveCatalogRoles) {
+    if (resolveCallerCatalogRoles) {
       // determine the set of catalog roles which have been activated
       long catalogId = this.resolvedReferenceCatalog.getEntity().getId();
       for (ResolvedPolarisEntity principalRole : resolvedCallerPrincipalRoles) {

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/ResolverTest.java
@@ -149,6 +149,9 @@ public class ResolverTest extends BaseResolverTest {
     ResolverStatus status =
         resolver.resolveSelections(Set.of(Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
     Assertions.assertThat(status.getStatus()).isEqualTo(ResolverStatus.StatusEnum.SUCCESS);
+    ResolvedPolarisEntity resolvedCatalog = resolver.getResolvedReferenceCatalog();
+    Assertions.assertThat(resolvedCatalog).isNotNull();
+    Assertions.assertThat(resolvedCatalog.getEntity().getName()).isEqualTo("test");
   }
 
   @Test


### PR DESCRIPTION
Resolvable enum was recently introduced to enable the caller to select specific entities for resolution rather than resolving everything. See PR: https://github.com/apache/polaris/pull/3760

This PR renames CATALOG_ROLES to CALLER_CATALOG_ROLES instead to make it obvious whether we are resolving the principal's activated catalog roles vs the catalog roles that are requested as the target of the action (like creating a CATALOG_ROLE).

Also added a private helper to detect if CATALOG_ROLE is requested as a part of the top level entities and would require referenced catalog resolution.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
