### PR TITLE
Helm chart: add support for specifying annotations on the Deployment resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### New Features
 
+- Added `deploymentAnnotations` support in Helm chart.
 - Added KMS properties (optional) to catalog storage config to enable S3 data encryption.
 - Added `topologySpreadConstraints` support in Helm chart.
 - Added `priorityClassName` support in Helm chart.

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -27,6 +27,10 @@ metadata:
     {{- if .Values.podLabels }}
     {{- tpl (toYaml .Values.podLabels) . | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- tpl (toYaml .Values.deploymentAnnotations) . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -86,6 +86,25 @@ tests:
           content:
             app.kubernetes.io/component: polaris
 
+  # metadata.annotations
+  - it: should not set deployment annotations by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should set deployment annotations
+    template: deployment.yaml
+    set:
+      deploymentAnnotations:
+        foo: bar
+        baz: qux
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            baz: qux
+
   # spec.replicas
   - it: should set default replicas
     template: deployment.yaml

--- a/helm/polaris/values.schema.json
+++ b/helm/polaris/values.schema.json
@@ -182,6 +182,13 @@
                 }
             }
         },
+        "deploymentAnnotations": {
+            "description": "Additional Annotations to apply to polaris deployment.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "extraEnv": {
             "description": "Advanced configuration via Environment Variables. Extra environment variables to add to the Polaris server container. You can pass here any valid EnvVar object: [EnvVar API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core) This can be useful to get configuration values from Kubernetes secrets or config maps.",
             "type": "array",

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -80,6 +80,11 @@ podLabels: {}
 # @section -- Pod Configuration
 configMapLabels: {}
 
+# @schema additionalProperties: {type: string}
+# -- Additional Annotations to apply to polaris deployment.
+# @section -- Deployment
+deploymentAnnotations: {}
+
 # Pod disruption budget settings.
 podDisruptionBudget:
   # -- Specifies whether a pod disruption budget should be created.

--- a/site/content/in-dev/unreleased/helm-chart/reference.md
+++ b/site/content/in-dev/unreleased/helm-chart/reference.md
@@ -28,6 +28,7 @@ weight: 900
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | The number of replicas to deploy (horizontal scaling). Beware that replicas are stateless; don't set this number > 1 when using in-memory meta store manager. See [Scaling](https://polaris.apache.org/in-dev/unreleased/helm-chart/production/#scaling) for production recommendations. |
+| deploymentAnnotations | object | `{}` | Additional Annotations to apply to polaris deployment. |
 | revisionHistoryLimit | int | `nil` | The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10). |
 
 ### Image


### PR DESCRIPTION
Fixes #3921 .

This PR adds support to a new value that allows specifying annotations on the Polaris Deployment.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
