### PR TITLE
[bug] Fix website ML Archive Links

### DIFF
--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -56,7 +56,6 @@ cascade:
 | Development oriented content
 | mailto:dev-subscribe@polaris.apache.org[Subscribe to dev@]
 
-
 pass:[<a href="https://lists.apache.org/list.html?dev@polaris.apache.org" target="_blank" rel="noopener">Mailing List Archives</a>]
 | Notifications about GitHub issues and PRs
 | mailto:issues-subscribe@polaris.apache.org[Subscribe to issues@]


### PR DESCRIPTION
From title. Currently, all links point to `dev@polaris.apache.org`, which is incorrrect.

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [N/A] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [N/A] 💡 Added comments for complex logic
- [N/A] 🧾 Updated `CHANGELOG.md` (if needed)
- [N/A] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
