### PR TITLE
doc: introduce guidelines for AI-generated contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Contributors may use a variety of tools when preparing changes to Polaris, inclu
 * The pull request author **must understand the implementation end-to-end** and be able to **explain and justify the design and code** during review.
 * Tools, including AI systems, **are not** considered contributors. **Responsibility and authorship remain with the human** submitting the change.
 * Contributors are encouraged to **disclose** significant AI assistance in the pull request description for transparency.
-* **Respect ASF policy**. Ensure generated content does not introduce incompatible licenses or undisclosed third-party code; review the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) and licensing rules when in doubt.
+* **Respect ASF policy**. Contributors are responsible for ensuring generated code can be contributed to Polaris under ASF license and [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).
 
 ## Java version requirements
 


### PR DESCRIPTION
This PR proposes adding a short guideline around AI-assisted contributions. The goal is not to restrict how contributors use development tools, but to clarify contributor accountability.

In particular, the guideline emphasizes that the human submitting a pull request:
- remains the author of the change
- must understand the implementation end-to-end
- must be able to justify the design and code during review

This is similar in spirit to recent discussions and updates in other ASF projects (for example Apache Iceberg). This PR is intended as a starting point for discussion and wording refinement.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
