### PR TITLE
Fix site layouts for API doc when using released version

### DIFF
--- a/site/layouts/partials/openapiUrl.html
+++ b/site/layouts/partials/openapiUrl.html
@@ -19,9 +19,13 @@ under the License.
 {{- $ver := partial "releaseVersion.html" . -}}
 {{- $spec := ( .Get 0 ) -}}
 {{- $url := "" -}}
+{{- $incubating := "" -}}
+{{- if lt $ver "1.4.0" -}}
+{{- $incubating = "-incubating" -}}
+{{- end -}}
 {{- if eq $ver "[unreleased]" -}}
 {{- $url = printf "https://github.com/apache/polaris/raw/refs/heads/main/spec/%s" $spec }}
 {{- else -}}
-{{- $url = printf "https://github.com/apache/polaris/raw/refs/tags/polaris-%s/spec/%s" $ver $spec }}
+{{- $url = printf "https://github.com/apache/polaris/raw/refs/tags/apache-polaris-%s%s/spec/%s" $ver $incubating $spec }}
 {{- end -}}
 {{- return $url -}}

--- a/site/layouts/shortcodes/redoc-polaris.html
+++ b/site/layouts/shortcodes/redoc-polaris.html
@@ -18,10 +18,14 @@ Copied from Docsy shortcodes/redoc.html.
 {{- $ver := partial "releaseVersion.html" . -}}
 {{- $spec := ( .Get 0 ) -}}
 {{- $url := "" -}}
+{{- $incubating := "" -}}
+{{- if lt $ver "1.4.0" -}}
+{{- $incubating = "-incubating" -}}
+{{- end -}}
 {{- if eq $ver "[unreleased]" -}}
 {{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/%s" $spec }}
 {{- else -}}
-{{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/tags/polaris-%s/spec/%s" $ver $spec }}
+{{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-%s%s/spec/%s" $ver $incubating $spec }}
 {{- end -}}
 
 <!-- CSS style overrides for Redoc API docs -->


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

With recent project graduation and released doc change, these break the API docs for older released version such as following when accessing API docs for 1.3.0:
```
-- https://polaris.apache.org/releases/1.3.0/polaris-api-specs/polaris-management-api/
https://editor.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/polaris-1.3.0/spec/polaris-management-service.yml
-- https://polaris.apache.org/releases/1.3.0/polaris-api-specs/polaris-catalog-api/
https://editor.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/polaris-1.3.0/spec/generated/bundled-polaris-catalog-service.yaml
```

There are two problems here:
1. the older released are on `-incubating` tags but the current code will use the one without (is we want to remove incubating, we should create tags for the corresponding old tags)
2. the tag names are `apache-polaris-xxx` instead of `polaris-xxx`

With above changes, we will then have following:
```
-- http://localhost:1313/releases/1.3.0/polaris-api-specs/polaris-management-api/
https://editor.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-1.3.0-incubating/spec/polaris-management-service.yml
-- http://localhost:1313/releases/1.3.0/polaris-api-specs/polaris-catalog-api/
https://editor.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-1.3.0-incubating/spec/generated/bundled-polaris-catalog-service.yaml
```
<img width="2546" height="784" alt="image" src="https://github.com/user-attachments/assets/c11d9a84-3283-4331-9f91-dc6901528b98" />
<img width="2546" height="784" alt="image" src="https://github.com/user-attachments/assets/a2b88008-aa6f-4216-9ddd-1a8b2b434b70" />



## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
