### PR TITLE
Update quickstart command

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
+++ b/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
@@ -179,7 +179,7 @@ docker attach $(docker ps -q --filter name=spark-sql)
 Once the Spark session starts, we can create a namespace and table within the catalog:
 
 ```sql
-USE quickstart_catalog;
+USE polaris;
 CREATE NAMESPACE IF NOT EXISTS quickstart_namespace;
 CREATE NAMESPACE IF NOT EXISTS quickstart_namespace.schema;
 USE NAMESPACE quickstart_namespace.schema;


### PR DESCRIPTION
Updating documentation. The command has been updated to from `quickstart_catalog` to `polaris`.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
