### PR TITLE
Fix getting start guide URL

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/quick-start.md
+++ b/site/content/in-dev/unreleased/getting-started/quick-start.md
@@ -33,7 +33,7 @@ Use this guide to quickly start running Polaris. This is not intended for produc
 Run the following command:
 
 ```bash
-curl -s https://raw.githubusercontent.com/apache/polaris/main/getting-started/quickstart/docker-compose.yml | docker compose -f - up
+curl -s https://raw.githubusercontent.com/apache/polaris/refs/heads/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
 
 ```
 This command will:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Sample fix for https://github.com/apache/polaris/issues/3962 but for main branch. As guides got moved into site, we will need to hit the updated URL.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
