### PR TITLE
Fix broken docker-compose link in quick start guide

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/quick-start.md
+++ b/site/content/in-dev/unreleased/getting-started/quick-start.md
@@ -31,9 +31,9 @@ Use this guide to quickly start running Polaris. This is not intended for produc
 ## Running
 
 Run the following command:
-
+```bash
 curl -s https://raw.githubusercontent.com/apache/polaris/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
-
+```
 This command will:
 1. Create a Catalog named `quickstart_catalog` with RustFS-backed storage.
 2. Create a user principal `quickstart_user` with full access to the catalog.


### PR DESCRIPTION
## Description

Fixes #3965

Update the docker-compose raw URL reference in the Quick Start guide.

The command in `site/content/in-dev/unreleased/getting-started/quick-start.md`
was updated to use a different raw GitHub URL path referencing the `main` branch.

```bash
curl -s https://raw.githubusercontent.com/apache/polaris/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
```
Both the old and the new URLs point to the same file. This change only updates the URL format used in the documentation.

This change only affects the unreleased documentation and does not modify documentation for older released versions such as 1.3.0.