### PR TITLE
Update Spark Plugin BUNDLE-LICENSE/NOTICE for 1.4.0 / Alternative approach

### DIFF
--- a/plugins/spark/v3.5/spark/BUNDLE-LICENSE
+++ b/plugins/spark/v3.5/spark/BUNDLE-LICENSE
@@ -213,224 +213,176 @@ License: https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Iceberg.
+********************************************************************************
 
-Copyright: 2017-2025 The Apache Software Foundation
-Project URL: https://iceberg.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+FOLLOWING TAKEN FROM THE `LICENSE` FILE OF `iceberg-spark-runtime-3.5*.jar`:
 
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Spark.
-
-Copyright: 2014 and onwards The Apache Software Foundation
-Project URL: https://spark.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+********************************************************************************
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Guava.
+This binary artifact contains Apache Avro.
 
-Copyright: 2006-2020 The Guava Authors
-Project URL: https://github.com/google/guava
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains jspecify.
-
-Copyright: Google LLC - SpotBugs Team
-Project URL: https://github.com/jspecify/jspecify
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright: Copyright 2010-2019 The Apache Software Foundation
+Home page: https://avro.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Datasketches.
+This binary artifact contains the Jackson JSON processor.
 
-Copyright: 2020 The Apache Software Foundation
-           2015-2018 Yahoo
-           2019 Verizon Media
-Project URL: https://datasketches.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright: 2007-2019 Tatu Saloranta and other contributors
+Home page: http://jackson.codehaus.org/
+License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 This binary artifact contains Apache Parquet.
 
 Copyright: 2014-2024 The Apache Software Foundation
-Project URL: https://parquet.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains FastUtil.
-
-Copyright: 2002-2014 Sebastiano Vigna
-Project URL: http://fastutil.di.unimi.it/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache ORC.
-
-Copyright: 2013 and onwards The Apache Software Foundation.
-Project URL: https://orc.apache.org
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Arrow.
-
-Copyright: 2016-2025 The Apache Software Foundation
-Project URL: https://arrow.apache.org
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Caffeine by Ben Manes.
-
-Copyright: 2014-2019 Ben Manes and contributors
-Project URL: https://github.com/ben-manes/caffeine
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains RoaringBitmap.
-
-Copyright: (c) 2013-... the RoaringBitmap authors
-Project URL: https://github.com/RoaringBitmap/RoaringBitmap
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains failsafe.
-
-Copyright: Jonathan Halterman and friends
-Project URL: https://failsafe.dev/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Project Nessie.
-
-Copyright: 2015-2025 Dremio Corporation
-Project URL: https://projectnessie.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Avro.
-
-Copyright: 2010-2019 The Apache Software Foundation
-Project URL: https://avro.apache.org
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains the Jackson JSON processor.
-
-Copyright: 2007-2020 Tatu Saloranta and other contributors
-Project URL: http://jackson.codehaus.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Airlift Aircompressor.
-
-Copyright: 2011-2020 Aircompressor authors.
-Project URL: https://github.com/airlift/aircompressor
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache HttpComponents Client.
-
-Copyright: 1999-2022 The Apache Software Foundation.
-Project URL: https://hc.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Netty's buffer library.
-
-Copyright: 2014-2020 The Netty Project
-Project URL: https://netty.io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Home page: https://parquet.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
 This binary artifact contains Apache Thrift.
 
 Copyright: 2006-2017 The Apache Software Foundation.
-Project URL: https://thrift.apache.org/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Jetbrains Annotations.
-
-Copyright: 2000-2020 JetBrains s.r.o.
-Project URL: https://github.com/JetBrains/java-annotations
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Google FlatBuffers.
-
-Copyright: 2013-2020 Google Inc.
-Home page: https://google.github.io/flatbuffers/
+Home page: https://thrift.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains ThreeTen.
+This binary artifact contains code from Daniel Lemire's JavaFastPFOR project.
 
-Copyright: 2007-present, Stephen Colebourne & Michael Nascimento Santos.
-Project URL: https://www.threeten.org/threeten-extra/
-License: BSD 3-Clause
-| All rights reserved.
+Copyright: 2013 Daniel Lemire
+Home page: https://github.com/lemire/JavaFastPFOR
+License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains fastutil.
+
+Copyright: 2002-2014 Sebastiano Vigna
+Home page: http://fastutil.di.unimi.it/
+License: http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache ORC.
+
+Copyright: 2013 and onwards The Apache Software Foundation.
+Home page: https://orc.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Hive's storage API via ORC.
+
+Copyright: 2008-2020 The Apache Software Foundation
+Home page: https://hive.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Google protobuf via ORC.
+
+Copyright: 2008 Google Inc.
+Home page: https://developers.google.com/protocol-buffers
+License: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE (BSD)
+
+License text:
+
+| Copyright 2008 Google Inc.  All rights reserved.
 |
-| * Redistribution and use in source and binary forms, with or without
-|   modification, are permitted provided that the following conditions are met:
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
 |
-| * Redistributions of source code must retain the above copyright notice,
-|   this list of conditions and the following disclaimer.
-|
-| * Redistributions in binary form must reproduce the above copyright notice,
-|   this list of conditions and the following disclaimer in the documentation
-|   and/or other materials provided with the distribution.
-|
-| * Neither the name of JSR-310 nor the names of its contributors
-|   may be used to endorse or promote products derived from this software
-|   without specific prior written permission.
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
 |
 | THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 | "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 | LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+|
+| Code generated by the Protocol Buffer compiler is owned by the owner
+| of the input file used when generating it.  This code is not
+| standalone and requires a support library to be linked with it.  This
+| support library is itself covered by the above license.
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Eclipse Collections.
+This binary artifact contains Airlift Aircompressor.
 
-Copyright: 2021 Goldman Sachs.
-Project URL: https://github.com/eclipse-collections/eclipse-collections/
-License: EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+Copyright: 2011-2019 Aircompressor authors.
+Home page: https://github.com/airlift/aircompressor
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains JetBrains annotations.
+
+Copyright: 2000-2020 JetBrains s.r.o.
+Home page: https://github.com/JetBrains/java-annotations
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains code from Cloudera Kite.
+
+Copyright: 2013-2017 Cloudera Inc.
+Home page: https://kitesdk.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains code from Presto.
+
+Copyright: 2016 Facebook and contributors
+Home page: https://prestodb.io/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Google Guava.
+
+Copyright: 2006-2019 The Guava Authors
+Home page: https://github.com/google/guava
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Google Error Prone Annotations.
+
+Copyright: Copyright 2011-2019 The Error Prone Authors
+Home page: https://github.com/google/error-prone
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
 This binary artifact contains checkerframework checker-qual Annotations.
 
 Copyright: 2004-2019 the Checker Framework developers
-Project URL: https://github.com/typetools/checker-framework
-License: MIT License
+Home page: https://github.com/typetools/checker-framework
+License: https://github.com/typetools/checker-framework/blob/master/LICENSE.txt (MIT license)
+
+License text:
 | The annotations are licensed under the MIT License.  (The text of this
 | license appears below.)  More specifically, all the parts of the Checker
 | Framework that you might want to include with your own program use the
@@ -461,123 +413,144 @@ License: MIT License
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Google Error Prone Annotations.
+This binary artifact contains Caffeine by Ben Manes.
 
-Copyright: Copyright 2011-2019 The Error Prone Authors
-Project URL: https://github.com/google/error-prone
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright: 2014-2019 Ben Manes and contributors
+Home page: https://github.com/ben-manes/caffeine
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Arrow.
+
+Copyright: 2016-2019 The Apache Software Foundation.
+Home page: https://arrow.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Netty's buffer library.
+
+Copyright: 2014-2020 The Netty Project
+Home page: https://netty.io/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Google FlatBuffers.
+
+Copyright: 2013-2020 Google Inc.
+Home page: https://google.github.io/flatbuffers/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains ThreeTen.
+
+Copyright: 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+Home page: https://www.threeten.org/threeten-extra/
+License: https://github.com/ThreeTen/threeten-extra/blob/master/LICENSE.txt (BSD 3-clause)
+
+License text:
+
+| All rights reserved.
+|
+| * Redistribution and use in source and binary forms, with or without
+|   modification, are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+|
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains code from Project Nessie.
+
+Copyright: 2015-2025 Dremio Corporation.
+Home page: https://projectnessie.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Spark.
+
+* vectorized reading of definition levels in BaseVectorizedParquetValuesReader.java
+* portions of the extensions parser
+* casting logic in AssignmentAlignmentSupport
+* implementation of SetAccumulator.
+
+Copyright: 2011-2018 The Apache Software Foundation
+Home page: https://spark.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Home page: https://delta.io/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary includes code from Apache Commons.
+
+* Core ArrayUtil.
+
+Copyright: 2020 The Apache Software Foundation
+Home page: https://commons.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache HttpComponents Client.
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Home page: https://hc.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache HttpComponents Client.
+
+* retry and error handling logic in ExponentialHttpRequestRetryStrategy.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Home page: https://hc.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
 This binary artifact contains Eclipse MicroProfile OpenAPI.
 
-Copyright: 2017 Contributors to the Eclipse Foundation
-Project URL: https://github.com/microprofile/microprofile-open-api
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Jakarta Annotation.
-
-Project URL: https://projects.eclipse.org/projects/ee4j.ca
-License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Jakarta Validation.
-
-Project URL: https://beanvalidation.org
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Jakarta Servlet.
-
-Project URL: https://projects.eclipse.org/projects/ee4j.servlet
-License: EPL 2.0 - https://www.eclipse.org/legal/epl-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Micrometer.
-
-Copyright: 2017-Present VMware, Inc. All Rights Reserved.
-Project URL: https://github.com/micrometer-metrics/micrometer
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Commons Compress.
-
-Copyright: 2002-2025 The Apache Software Foundation
-Project URL: https://commons.apache.org/proper/commons-compress/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Commons Codec.
-
-Copyright: 2002-2025 The Apache Software Foundation
-Project URL: https://commons.apache.org/proper/commons-codec/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains SLF4J.
-
-Copyright: 2004-2022 QOS.ch Sarl (Switzerland)
-Project URL: http://www.slf4j.org
-License: MIT License
-| Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
-| All rights reserved.
-|
-| Permission is hereby granted, free  of charge, to any person obtaining
-| a  copy  of this  software  and  associated  documentation files  (the
-| "Software"), to  deal in  the Software without  restriction, including
-| without limitation  the rights to  use, copy, modify,  merge, publish,
-| distribute,  sublicense, and/or sell  copies of  the Software,  and to
-| permit persons to whom the Software  is furnished to do so, subject to
-| the following conditions:
-|
-| The  above  copyright  notice  and  this permission  notice  shall  be
-| included in all copies or substantial portions of the Software.
-|
-| THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
-| EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
-| MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
-| NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-| LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-| OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
-| WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-This binary artifact contains j2objc.
-
-Project URL: https://github.com/google/j2objc/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Commons IO.
-
-Copyright: 2002-2025 The Apache Software Foundation
-Project URL: https://commons.apache.org/proper/commons-io/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Commons Lang3.
-
-Copyright: 2001-2025 The Apache Software Foundation
-Project URL: https://commons.apache.org/proper/commons-lang/
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-This binary artifact contains OpenHFT.
-
-Copyright: 2014 Higher Frequency Trading http://www.higherfrequencytrading.com
-Project URL: https://github.com/OpenHFT
-License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
+Home page: https://github.com/microprofile/microprofile-open-api
+License: https://www.apache.org/licenses/LICENSE-2.0

--- a/plugins/spark/v3.5/spark/BUNDLE-NOTICE
+++ b/plugins/spark/v3.5/spark/BUNDLE-NOTICE
@@ -9,64 +9,35 @@ to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Project Nessie with the following in its NOTICE
-file:
-| Nessie
-| Copyright 2015-2025 Dremio Corporation
-|
-| ---------------------------------------
-| This project includes code from Apache Polaris, with the following in its NOTICE file:
-|
-| | Apache Polaris
-| | Copyright 2024 The Apache Software Foundation
-| |
-| | This product includes software developed at
-| | The Apache Software Foundation (http://www.apache.org/).
-| |
-| | The initial code for the Polaris project was donated
-| | to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+********************************************************************************
+
+FOLLOWING TAKEN FROM THE `NOTICE` FILE OF `iceberg-spark-runtime-3.5*.jar`:
+
+********************************************************************************
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains the Jackson JSON processor with the following in its NOTICE
-file:
-| # Jackson JSON processor
+This binary artifact contains code from Kite, developed at Cloudera, Inc. with
+the following copyright notice:
+
+| Copyright 2013 Cloudera Inc.
 |
-| Jackson is a high-performance, Free/Open Source JSON processing library.
-| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-| been in development since 2007.
-| It is currently developed by a community of developers.
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
 |
-| ## Copyright
+|   http://www.apache.org/licenses/LICENSE-2.0
 |
-| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-|
-| ## Licensing
-|
-| Jackson 2.x core and extension components are licensed under Apache License 2.0
-| To find the details that apply to this artifact see the accompanying LICENSE file.
-|
-| ## Credits
-|
-| A list of contributors may be found from CREDITS(-2.x) file, which is included
-| in some artifacts (usually source distributions); but is always available
-| from the source code management (SCM) system project uses.
-|
-| ## FastDoubleParser
-|
-| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-| under the following copyright.
-|
-| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-|
-| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-| and the licenses and copyrights that apply to that code.
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Aircompressor with the following in its NOTICE
-file:
+This binary artifact includes Airlift Aircompressor with the following in its
+NOTICE file:
 
 | Snappy Copyright Notices
 | =========================
@@ -108,8 +79,47 @@ file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Netty's buffer library with the following in its NOTICE
+This binary artifact includes Google Protobuf with the following copyright
+notice:
+
+| Copyright 2008 Google Inc.  All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+|
+| Code generated by the Protocol Buffer compiler is owned by the owner
+| of the input file used when generating it.  This code is not
+| standalone and requires a support library to be linked with it.  This
+| support library is itself covered by the above license.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Netty buffers with the following in its NOTICE
 file:
+
 |                             The Netty Project
 |                             =================
 |
@@ -360,124 +370,44 @@ file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Eclipse MicroProfile OpenAPI with the following in its NOTICE
+This binary artifact includes Project Nessie with the following in its NOTICE
 file:
+
+| Nessie
+| Copyright 2015-2025 Dremio Corporation
+|
+| ---------------------------------------
+| This project includes code from Apache Polaris (incubating), with the following in its NOTICE file:
+|
+| | Apache Polaris (incubating)
+| | Copyright 2024 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (http://www.apache.org/).
+| |
+| | The initial code for the Polaris project was donated
+| | to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Eclipse MicroProfile OpenAPI with the following in its NOTICE file:
+
 | =========================================================================
 | ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
 | ==  Version 2.0, in this case for MicroProfile OpenAPI                 ==
 | =========================================================================
-| 
+|
 | The majority of this software were originally based on the following:
 | * Swagger Core
 |   https://github.com/swagger-api/swagger-core
 |   under Apache License, v2.0
-| 
-| 
+|
+|
 | SPDXVersion: SPDX-2.1
 | PackageName: Eclipse MicroProfile
 | PackageHomePage: http://www.eclipse.org/microprofile
 | PackageLicenseDeclared: Apache-2.0
-| 
+|
 | PackageCopyrightText: <text>
 | Arthur De Magalhaes arthurdm@ca.ibm.com
 | </text>
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Jakarta Validation with the following in its NOTICE
-file:
-| # Notices for Eclipse Jakarta Validation
-| 
-| This content is produced and maintained by the Eclipse Jakarta Validation
-| project.
-| 
-| * Project home: https://projects.eclipse.org/projects/ee4j.validation
-| 
-| ## Trademarks
-| 
-|  Jakarta Validation is a trademark of the Eclipse Foundation.
-| 
-| ## Copyright
-| 
-| All content is the property of the respective authors or their employers. For
-| more information regarding authorship of content, please consult the listed
-| source code repository logs.
-| 
-| ## Declared Project Licenses
-| 
-| This program and the accompanying materials are made available under the terms
-| of the Apache License, Version 2.0 which is available at
-| https://www.apache.org/licenses/LICENSE-2.0.
-| 
-| SPDX-License-Identifier: Apache-2.0
-| 
-| ## Source Code
-| 
-| The project maintains the following source code repositories:
-| 
-| * [The specification repository](https://github.com/jakartaee/validation-spec)
-| * [The API repository](https://github.com/jakartaee/validation)
-| * [The TCK repository](https://github.com/jakartaee/validation-tck)
-| 
-| ## Third-party Content
-| 
-| This project leverages the following third party content.
-| 
-| Test dependencies:
-| 
-|  * [TestNG](https://github.com/cbeust/testng) - Apache License 2.0
-|  * [JCommander](https://github.com/cbeust/jcommander) - Apache License 2.0
-|  * [SnakeYAML](https://bitbucket.org/asomov/snakeyaml/src) - Apache License 2.0
-|
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Micrometer with the following in its NOTICE
-file:
-| Micrometer
-| 
-| Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
-| 
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
-| 
-|    https://www.apache.org/licenses/LICENSE-2.0
-| 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
-| 
-| -------------------------------------------------------------------------------
-| 
-| This product contains a modified portion of 'io.netty.util.internal.logging',
-| in the Netty/Common library distributed by The Netty Project:
-| 
-|   * Copyright 2013 The Netty Project
-|   * License: Apache License v2.0
-|   * Homepage: https://netty.io
-| 
-| This product contains a modified portion of 'StringUtils.isBlank()',
-| in the Commons Lang library distributed by The Apache Software Foundation:
-| 
-|   * Copyright 2001-2019 The Apache Software Foundation
-|   * License: Apache License v2.0
-|   * Homepage: https://commons.apache.org/proper/commons-lang/
-| 
-| This product contains a modified portion of 'JsonUtf8Writer',
-| in the Moshi library distributed by Square, Inc:
-| 
-|   * Copyright 2010 Google Inc.
-|   * License: Apache License v2.0
-|   * Homepage: https://github.com/square/moshi
-| 
-| This product contains a modified portion of the 'org.springframework.lang'
-| package in the Spring Framework library, distributed by VMware, Inc:
-| 
-|   * Copyright 2002-2019 the original author or authors.
-|   * License: Apache License v2.0
-|   * Homepage: https://spring.io/projects/spring-framework
-
---------------------------------------------------------------------------------


### PR DESCRIPTION
This is the "copy from Iceberg's LICENSE" approach.

Fixes #3873
