### PR TITLE
docs: fix broken docker-compose URL in 1.3.0 quickstart

### DIFF
--- a/1.3.0/getting-started/quick-start.md
+++ b/1.3.0/getting-started/quick-start.md
@@ -32,7 +32,7 @@ Use this guide to quickly start running Polaris. This is not intended for produc
 Run the following command:
 
 ```bash
-curl -s https://raw.githubusercontent.com/apache/polaris/main/getting-started/quickstart/docker-compose.yml | docker compose -f - up
+curl -s https://raw.githubusercontent.com/apache/polaris/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
 
 ```
 This command will:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Fix docker compose URL in getting started doc in 1.3.0 version. The update path is matching to https://github.com/apache/polaris/pull/3968.

Here is the location validation:
<img width="2546" height="784" alt="image" src="https://github.com/user-attachments/assets/4d2c85ad-a60a-480e-9470-0c6e2c59ebc4" />


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
