### PR TITLE
CI/Helm: only build the Docker image once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,8 @@ jobs:
           name: upload-${{ github.job }}-artifacts
           path: *test-archive-path
 
-  helm-tests-image-build:
-    name: Helm Tests Image Build
+  docker-image-build:
+    name: Polaris Docker Image Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -201,11 +201,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Image build
         env: *gradle_env_vars
-        run: |
-          ./gradlew \
-            :polaris-server:assemble \
-            :polaris-server:quarkusAppPartsBuild --rerun \
-            -Dquarkus.container-image.build=true
+        run: ./gradlew :polaris-server:assemble -Dquarkus.container-image.build=true
       - name: Save image to tar
         run: |
           docker save apache/polaris:latest | zstd -T0 > polaris-image.tar.zst
@@ -220,7 +216,7 @@ jobs:
     name: Helm Tests (Helm ${{ matrix.helm-version }} - K8s ${{ matrix.kubernetes-version }})
     runs-on: ubuntu-latest
     needs: 
-      - helm-tests-image-build
+      - docker-image-build
     timeout-minutes: 60
     strategy:
       matrix:
@@ -429,7 +425,7 @@ jobs:
       - runtime-service-int-tests
       - admin-tool-tests
       - integration-tests
-      - helm-tests-image-build
+      - docker-image-build
       - helm-tests
       - python-client
       - regtest


### PR DESCRIPTION
This change saves CI compute by creating the Docker image only once, then saving it as a GitHub artifact that subsequent jobs can use.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
