### PR TITLE
feat(gcp): Add Hierarchical Namespace (HNS) support for GCS bucket 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 - Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
+- Added Hierarchical Namespace (HNS) support for GCS catalogs. Iceberg table creation and Spark
+  ingestion now work against HNS-enabled GCS buckets via a two-part design:
+    - A new `prepareLocations` hook on `PolarisStorageIntegration` runs before table creation and
+      pre-materializes the table's top-level folders (`table/`, `metadata/`, `data/`) on HNS
+      buckets via the GCS Storage Control API. Non-GCS storage types use a no-op default.
+    - GCS credential vending now adds a folder rule (`inRole:roles/storage.folderAdmin`,
+      constrained by access-boundary path conditions) for HNS-enabled buckets only, letting
+      Spark create partition subfolders at write time without admin credentials. HNS status is
+      auto-detected per bucket at credential-vending time; no user-facing catalog flag is needed.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,16 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Fixed `renameTable` to return HTTP 204 (No Content) instead of 200, as per the Iceberg REST Catalog spec.
 
 ### New Features
+- Added Hierarchical Namespace (HNS) support for GCS catalogs. Iceberg table creation and Spark
+  ingestion now work against HNS-enabled GCS buckets via a two-part design:
+    - A new `prepareLocations` hook on `PolarisStorageIntegration` runs before table creation and
+      pre-materializes the table's top-level folders (`table/`, `metadata/`, `data/`) on HNS
+      buckets via the GCS Storage Control API. Non-GCS storage types use a no-op default.
+    - GCS credential vending now adds a folder rule (`inRole:roles/storage.folderAdmin`,
+      constrained by access-boundary path conditions) for HNS-enabled buckets only, letting
+      Spark create partition subfolders at write time without admin credentials. HNS status is
+      auto-detected per bucket at credential-vending time; no user-facing catalog flag is needed.
+
 - Added `envFrom` support in Helm chart.
 - Added summarize subcommand to Polaris CLI.
 - Added find and tables options to Polaris CLI.

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageIntegration.java
@@ -55,4 +55,14 @@ public interface PolarisStorageIntegration {
       @NonNull List<LocationGrant> grants,
       @NonNull Optional<String> refreshEndpoint,
       @NonNull CredentialVendingContext context);
+
+  /**
+   * Hook invoked before a table is created to pre-materialize storage locations that the underlying
+   * storage system requires to exist before files can be written into them.
+   *
+   * <p>The default is a no-op. Storage types that need explicit folder creation (e.g. GCS with
+   * Hierarchical Namespace enabled) override this. Passed locations include the table location and
+   * its metadata/data subpaths.
+   */
+  default void prepareLocations(@NonNull List<String> locations) {}
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocationPreparer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocationPreparer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Prepares storage locations before table creation writes initial metadata.
+ *
+ * <p>Most storage backends do not need explicit preparation. Backends with first-class directory or
+ * folder resources, such as GCS Hierarchical Namespace buckets, can implement this interface to
+ * materialize required parent folders before Iceberg writes nested files.
+ */
+@FunctionalInterface
+public interface StorageLocationPreparer {
+  void prepareLocations(@NonNull List<String> locations);
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -19,7 +19,9 @@
 package org.apache.polaris.core.storage;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.view.ViewMetadata;
@@ -76,6 +78,23 @@ public class StorageUtil {
         properties.get(IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY));
     locations.remove(null);
     return removeRedundantLocations(locations);
+  }
+
+  /**
+   * Given a baseLocation and table properties, extracts the locations that may need explicit
+   * materialization before a new table's initial metadata is written.
+   */
+  public static @NonNull List<String> getLocationsToPrepareForTable(
+      String baseLocation, Map<String, String> properties) {
+    String metadataPath =
+        Optional.ofNullable(
+                properties.get(IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY))
+            .orElse(baseLocation + "/metadata");
+    String dataPath =
+        Optional.ofNullable(
+                properties.get(IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY))
+            .orElse(baseLocation + "/data");
+    return List.of(baseLocation, metadataPath, dataPath);
   }
 
   /** Given a ViewMetadata, extracts the locations where the view's [meta]data might be found. */

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -28,6 +28,10 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.iam.credentials.v1.GenerateAccessTokenRequest;
 import com.google.cloud.iam.credentials.v1.GenerateAccessTokenResponse;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
@@ -43,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.StructuredLogKeys;
@@ -55,6 +60,7 @@ import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.apache.polaris.core.storage.StorageLocationPreparer;
 import org.apache.polaris.core.storage.StorageUri;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.core.storage.cache.StorageCredentialCacheKey;
@@ -83,6 +89,7 @@ public class GcpCredentialsStorageIntegration
   private final HttpTransportFactory transportFactory;
   private final GcpCredentialOps credentialOps;
   private final Optional<GcpAttributionParams> attributionParams;
+  private final StorageLocationPreparer folderPreparer;
 
   public GcpCredentialsStorageIntegration(
       GoogleCredentials sourceCredentials,
@@ -96,7 +103,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         GcpCredentialOps.DEFAULT,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -112,7 +120,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         GcpCredentialOps.DEFAULT,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -128,7 +137,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         credentialOps,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -145,7 +155,45 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         credentialOps,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      @NonNull StorageLocationPreparer folderPreparer) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        GcpCredentialOps.DEFAULT,
+        resolveAttributionParams(realmConfig),
+        folderPreparer);
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      GcpCredentialOps credentialOps,
+      @NonNull StorageLocationPreparer folderPreparer) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        credentialOps,
+        resolveAttributionParams(realmConfig),
+        folderPreparer);
   }
 
   /**
@@ -161,6 +209,26 @@ public class GcpCredentialsStorageIntegration
       RealmConfig realmConfig,
       GcpCredentialOps credentialOps,
       Optional<GcpAttributionParams> attributionParams) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        credentialOps,
+        attributionParams,
+        locations -> {});
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      GcpCredentialOps credentialOps,
+      Optional<GcpAttributionParams> attributionParams,
+      @NonNull StorageLocationPreparer folderPreparer) {
     super(cache, realmConfig, storageConfig);
     // Needed for when environment variable GOOGLE_APPLICATION_CREDENTIALS points to google service
     // account key json
@@ -169,6 +237,7 @@ public class GcpCredentialsStorageIntegration
     this.transportFactory = transportFactory;
     this.credentialOps = credentialOps;
     this.attributionParams = attributionParams;
+    this.folderPreparer = Objects.requireNonNull(folderPreparer, "folderPreparer");
   }
 
   /**
@@ -209,6 +278,11 @@ public class GcpCredentialsStorageIntegration
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_WIF_AUDIENCE),
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_FILE),
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_ID)));
+  }
+
+  @Override
+  public void prepareLocations(@NonNull List<String> locations) {
+    folderPreparer.prepareLocations(locations);
   }
 
   @Override
@@ -312,7 +386,11 @@ public class GcpCredentialsStorageIntegration
         resolveSourceCredentials(key, gcpStorageConfig, sourceCredentials, credentialOps);
 
     CredentialAccessBoundary accessBoundary =
-        generateAccessBoundaryRules(readLocations, listLocations, writeLocations);
+        generateAccessBoundaryRules(
+            readLocations,
+            listLocations,
+            writeLocations,
+            bucket -> isHnsBucket(bucket, credentialsToDownscope));
     DownscopedCredentials credentials =
         DownscopedCredentials.newBuilder()
             .setHttpTransportFactory(transportFactory)
@@ -387,7 +465,7 @@ public class GcpCredentialsStorageIntegration
    * Returns the credential to be used as the source for downscoping. If a specific service account
    * is configured, it impersonates that account first.
    */
-  private static GoogleCredentials getBaseCredentials(
+  public static GoogleCredentials getBaseCredentials(
       GcpStorageConfigurationInfo storageConfig,
       GoogleCredentials sourceCredentials,
       GcpCredentialOps credentialOps) {
@@ -451,8 +529,32 @@ public class GcpCredentialsStorageIntegration
       @NonNull Set<String> allowedReadLocations,
       @NonNull Set<String> allowedListLocations,
       @NonNull Set<String> allowedWriteLocations) {
+    return generateAccessBoundaryRules(
+        allowedReadLocations, allowedListLocations, allowedWriteLocations, bucket -> false);
+  }
+
+  @VisibleForTesting
+  public static CredentialAccessBoundary generateAccessBoundaryRules(
+      boolean allowListOperation,
+      @NonNull Set<String> allowedReadLocations,
+      @NonNull Set<String> allowedWriteLocations,
+      @NonNull Predicate<String> isHnsBucket) {
+    return generateAccessBoundaryRules(
+        allowedReadLocations,
+        allowListOperation ? allowedReadLocations : Set.of(),
+        allowedWriteLocations,
+        isHnsBucket);
+  }
+
+  @VisibleForTesting
+  public static CredentialAccessBoundary generateAccessBoundaryRules(
+      @NonNull Set<String> allowedReadLocations,
+      @NonNull Set<String> allowedListLocations,
+      @NonNull Set<String> allowedWriteLocations,
+      @NonNull Predicate<String> isHnsBucket) {
     Map<String, LinkedHashSet<String>> readConditionsByBucket = new LinkedHashMap<>();
     Map<String, LinkedHashSet<String>> writeConditionsByBucket = new LinkedHashMap<>();
+    Map<String, LinkedHashSet<String>> folderConditionsByBucket = new LinkedHashMap<>();
     HashSet<String> bucketsWithList = new HashSet<>();
 
     Stream.concat(allowedReadLocations.stream(), allowedListLocations.stream())
@@ -490,6 +592,9 @@ public class GcpCredentialsStorageIntegration
           writeConditionsByBucket
               .computeIfAbsent(bucket, key -> new LinkedHashSet<>())
               .add(resourceNameStartsWithExpression(bucket, path));
+          folderConditionsByBucket
+              .computeIfAbsent(bucket, key -> new LinkedHashSet<>())
+              .add(folderNameStartsWithExpression(bucket, path));
         });
 
     CredentialAccessBoundary.Builder accessBoundaryBuilder = CredentialAccessBoundary.newBuilder();
@@ -526,13 +631,61 @@ public class GcpCredentialsStorageIntegration
           builder.setAvailablePermissions(List.of("inRole:roles/storage.legacyBucketWriter"));
           accessBoundaryBuilder.addRule(builder.build());
         });
+    folderConditionsByBucket.forEach(
+        (bucket, conditions) -> {
+          if (conditions.isEmpty() || !isHnsBucket.test(bucket)) {
+            return;
+          }
+          CredentialAccessBoundary.AccessBoundaryRule.Builder builder =
+              CredentialAccessBoundary.AccessBoundaryRule.newBuilder();
+          builder.setAvailableResource(bucketResource(bucket));
+          builder.setAvailabilityCondition(
+              CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+                  .setExpression(String.join(" || ", conditions))
+                  .build());
+          builder.setAvailablePermissions(List.of("inRole:roles/storage.folderAdmin"));
+          accessBoundaryBuilder.addRule(builder.build());
+        });
     return accessBoundaryBuilder.build();
+  }
+
+  @VisibleForTesting
+  static boolean isHnsBucket(String bucket, GoogleCredentials sourceCredentials) {
+    try {
+      Storage storage = newStorageClient(sourceCredentials);
+      Bucket bucketMetadata =
+          storage.get(
+              bucket, Storage.BucketGetOption.fields(Storage.BucketField.HIERARCHICAL_NAMESPACE));
+      if (bucketMetadata == null) {
+        return false;
+      }
+      BucketInfo.HierarchicalNamespace hns = bucketMetadata.getHierarchicalNamespace();
+      return hns != null && Boolean.TRUE.equals(hns.getEnabled());
+    } catch (RuntimeException e) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("bucket", bucket)
+          .log("Failed to determine HNS status; defaulting to non-HNS", e);
+      return false;
+    }
+  }
+
+  @VisibleForTesting
+  static Storage newStorageClient(GoogleCredentials sourceCredentials) {
+    return StorageOptions.newBuilder().setCredentials(sourceCredentials).build().getService();
   }
 
   @VisibleForTesting
   static String resourceNameStartsWithExpression(String bucket, String path) {
     return String.format(
         "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
+        escapeCelLiteral(bucket), escapeCelLiteral(path));
+  }
+
+  @VisibleForTesting
+  static String folderNameStartsWithExpression(String bucket, String path) {
+    return String.format(
+        "resource.name.startsWith('projects/_/buckets/%s/folders/%s')",
         escapeCelLiteral(bucket), escapeCelLiteral(path));
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -28,6 +28,10 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.iam.credentials.v1.GenerateAccessTokenRequest;
 import com.google.cloud.iam.credentials.v1.GenerateAccessTokenResponse;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
@@ -43,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.config.FeatureConfiguration;
@@ -54,6 +59,7 @@ import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.apache.polaris.core.storage.StorageLocationPreparer;
 import org.apache.polaris.core.storage.StorageUri;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.core.storage.cache.StorageCredentialCacheKey;
@@ -82,6 +88,7 @@ public class GcpCredentialsStorageIntegration
   private final HttpTransportFactory transportFactory;
   private final GcpCredentialOps credentialOps;
   private final Optional<GcpAttributionParams> attributionParams;
+  private final StorageLocationPreparer folderPreparer;
 
   public GcpCredentialsStorageIntegration(
       GoogleCredentials sourceCredentials,
@@ -95,7 +102,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         GcpCredentialOps.DEFAULT,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -111,7 +119,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         GcpCredentialOps.DEFAULT,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -127,7 +136,8 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         credentialOps,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
   }
 
   public GcpCredentialsStorageIntegration(
@@ -144,7 +154,45 @@ public class GcpCredentialsStorageIntegration
         storageConfig,
         realmConfig,
         credentialOps,
-        resolveAttributionParams(realmConfig));
+        resolveAttributionParams(realmConfig),
+        locations -> {});
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      @NonNull StorageLocationPreparer folderPreparer) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        GcpCredentialOps.DEFAULT,
+        resolveAttributionParams(realmConfig),
+        folderPreparer);
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      GcpCredentialOps credentialOps,
+      @NonNull StorageLocationPreparer folderPreparer) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        credentialOps,
+        resolveAttributionParams(realmConfig),
+        folderPreparer);
   }
 
   /**
@@ -160,6 +208,26 @@ public class GcpCredentialsStorageIntegration
       RealmConfig realmConfig,
       GcpCredentialOps credentialOps,
       Optional<GcpAttributionParams> attributionParams) {
+    this(
+        sourceCredentials,
+        transportFactory,
+        cache,
+        storageConfig,
+        realmConfig,
+        credentialOps,
+        attributionParams,
+        locations -> {});
+  }
+
+  public GcpCredentialsStorageIntegration(
+      GoogleCredentials sourceCredentials,
+      HttpTransportFactory transportFactory,
+      StorageCredentialCache cache,
+      GcpStorageConfigurationInfo storageConfig,
+      RealmConfig realmConfig,
+      GcpCredentialOps credentialOps,
+      Optional<GcpAttributionParams> attributionParams,
+      @NonNull StorageLocationPreparer folderPreparer) {
     super(cache, realmConfig, storageConfig);
     // Needed for when environment variable GOOGLE_APPLICATION_CREDENTIALS points to google service
     // account key json
@@ -168,6 +236,7 @@ public class GcpCredentialsStorageIntegration
     this.transportFactory = transportFactory;
     this.credentialOps = credentialOps;
     this.attributionParams = attributionParams;
+    this.folderPreparer = Objects.requireNonNull(folderPreparer, "folderPreparer");
   }
 
   /**
@@ -208,6 +277,11 @@ public class GcpCredentialsStorageIntegration
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_WIF_AUDIENCE),
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_FILE),
             realmConfig.getConfig(FeatureConfiguration.GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_ID)));
+  }
+
+  @Override
+  public void prepareLocations(@NonNull List<String> locations) {
+    folderPreparer.prepareLocations(locations);
   }
 
   @Override
@@ -311,7 +385,11 @@ public class GcpCredentialsStorageIntegration
         resolveSourceCredentials(key, gcpStorageConfig, sourceCredentials, credentialOps);
 
     CredentialAccessBoundary accessBoundary =
-        generateAccessBoundaryRules(readLocations, listLocations, writeLocations);
+        generateAccessBoundaryRules(
+            readLocations,
+            listLocations,
+            writeLocations,
+            bucket -> isHnsBucket(bucket, credentialsToDownscope));
     DownscopedCredentials credentials =
         DownscopedCredentials.newBuilder()
             .setHttpTransportFactory(transportFactory)
@@ -386,7 +464,7 @@ public class GcpCredentialsStorageIntegration
    * Returns the credential to be used as the source for downscoping. If a specific service account
    * is configured, it impersonates that account first.
    */
-  private static GoogleCredentials getBaseCredentials(
+  public static GoogleCredentials getBaseCredentials(
       GcpStorageConfigurationInfo storageConfig,
       GoogleCredentials sourceCredentials,
       GcpCredentialOps credentialOps) {
@@ -450,8 +528,32 @@ public class GcpCredentialsStorageIntegration
       @NonNull Set<String> allowedReadLocations,
       @NonNull Set<String> allowedListLocations,
       @NonNull Set<String> allowedWriteLocations) {
+    return generateAccessBoundaryRules(
+        allowedReadLocations, allowedListLocations, allowedWriteLocations, bucket -> false);
+  }
+
+  @VisibleForTesting
+  public static CredentialAccessBoundary generateAccessBoundaryRules(
+      boolean allowListOperation,
+      @NonNull Set<String> allowedReadLocations,
+      @NonNull Set<String> allowedWriteLocations,
+      @NonNull Predicate<String> isHnsBucket) {
+    return generateAccessBoundaryRules(
+        allowedReadLocations,
+        allowListOperation ? allowedReadLocations : Set.of(),
+        allowedWriteLocations,
+        isHnsBucket);
+  }
+
+  @VisibleForTesting
+  public static CredentialAccessBoundary generateAccessBoundaryRules(
+      @NonNull Set<String> allowedReadLocations,
+      @NonNull Set<String> allowedListLocations,
+      @NonNull Set<String> allowedWriteLocations,
+      @NonNull Predicate<String> isHnsBucket) {
     Map<String, LinkedHashSet<String>> readConditionsByBucket = new LinkedHashMap<>();
     Map<String, LinkedHashSet<String>> writeConditionsByBucket = new LinkedHashMap<>();
+    Map<String, LinkedHashSet<String>> folderConditionsByBucket = new LinkedHashMap<>();
     HashSet<String> bucketsWithList = new HashSet<>();
 
     Stream.concat(allowedReadLocations.stream(), allowedListLocations.stream())
@@ -489,6 +591,9 @@ public class GcpCredentialsStorageIntegration
           writeConditionsByBucket
               .computeIfAbsent(bucket, key -> new LinkedHashSet<>())
               .add(resourceNameStartsWithExpression(bucket, path));
+          folderConditionsByBucket
+              .computeIfAbsent(bucket, key -> new LinkedHashSet<>())
+              .add(folderNameStartsWithExpression(bucket, path));
         });
 
     CredentialAccessBoundary.Builder accessBoundaryBuilder = CredentialAccessBoundary.newBuilder();
@@ -525,13 +630,61 @@ public class GcpCredentialsStorageIntegration
           builder.setAvailablePermissions(List.of("inRole:roles/storage.legacyBucketWriter"));
           accessBoundaryBuilder.addRule(builder.build());
         });
+    folderConditionsByBucket.forEach(
+        (bucket, conditions) -> {
+          if (conditions.isEmpty() || !isHnsBucket.test(bucket)) {
+            return;
+          }
+          CredentialAccessBoundary.AccessBoundaryRule.Builder builder =
+              CredentialAccessBoundary.AccessBoundaryRule.newBuilder();
+          builder.setAvailableResource(bucketResource(bucket));
+          builder.setAvailabilityCondition(
+              CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+                  .setExpression(String.join(" || ", conditions))
+                  .build());
+          builder.setAvailablePermissions(List.of("inRole:roles/storage.folderAdmin"));
+          accessBoundaryBuilder.addRule(builder.build());
+        });
     return accessBoundaryBuilder.build();
+  }
+
+  @VisibleForTesting
+  static boolean isHnsBucket(String bucket, GoogleCredentials sourceCredentials) {
+    try {
+      Storage storage = newStorageClient(sourceCredentials);
+      Bucket bucketMetadata =
+          storage.get(
+              bucket, Storage.BucketGetOption.fields(Storage.BucketField.HIERARCHICAL_NAMESPACE));
+      if (bucketMetadata == null) {
+        return false;
+      }
+      BucketInfo.HierarchicalNamespace hns = bucketMetadata.getHierarchicalNamespace();
+      return hns != null && Boolean.TRUE.equals(hns.getEnabled());
+    } catch (RuntimeException e) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("bucket", bucket)
+          .log("Failed to determine HNS status; defaulting to non-HNS", e);
+      return false;
+    }
+  }
+
+  @VisibleForTesting
+  static Storage newStorageClient(GoogleCredentials sourceCredentials) {
+    return StorageOptions.newBuilder().setCredentials(sourceCredentials).build().getService();
   }
 
   @VisibleForTesting
   static String resourceNameStartsWithExpression(String bucket, String path) {
     return String.format(
         "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
+        escapeCelLiteral(bucket), escapeCelLiteral(path));
+  }
+
+  @VisibleForTesting
+  static String folderNameStartsWithExpression(String bucket, String path) {
+    return String.format(
+        "resource.name.startsWith('projects/_/buckets/%s/folders/%s')",
         escapeCelLiteral(bucket), escapeCelLiteral(path));
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -85,7 +85,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
-  private final String gcsServiceKeyJsonFileLocation =
+  private final String gcsServiceKeyJson...tion =
       System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
   private static final String REFRESH_ENDPOINT = "get/credentials";
@@ -116,7 +116,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSubscope(boolean allowedListAction) throws Exception {
-    Assumptions.assumeThat(gcsServiceKeyJsonFileLocation)
+    Assumptions.assumeThat(gcsServiceKeyJson...tion)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -436,7 +436,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testRefreshCredentialsEndpointIsReturned() throws IOException {
-    Assumptions.assumeThat(gcsServiceKeyJsonFileLocation)
+    Assumptions.assumeThat(gcsServiceKeyJson...tion)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -650,10 +650,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     gen.initialize(2048);
     KeyPair keyPair = gen.generateKeyPair();
     String pem =
-        "-----BEGIN PRIVATE KEY-----\n"
-            + Base64.getMimeEncoder(64, "\n".getBytes(UTF_8))
-                .encodeToString(keyPair.getPrivate().getEncoded())
-            + "\n-----END PRIVATE KEY-----\n";
+        "[REDACTED PRIVATE KEY]\n";
     Path keyFile = tempDir.resolve("attribution-key.pem");
     Files.writeString(keyFile, pem);
 
@@ -705,5 +702,122 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     DecodedJWT jwt = JWT.decode(idp.retrieveSubjectToken());
     assertThat(jwt.getSubject()).isEqualTo("realm1/principal1");
     assertThat(jwt.getClaim("realm").asString()).isEqualTo("realm1");
+  }
+
+  // ── HNS folder-rule tests (predicate-driven) ──────────────────────────────────────
+
+  @Test
+  public void testGenerateAccessBoundaryHnsSingleBucketEmitsFolderRule() throws IOException {
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/path/to/data"),
+            Set.of("gs://bucket1/path/to/data"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    // read + write + folder
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(3);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsEnabled.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsMultipleBucketsPartialWrites() throws IOException {
+    // Two buckets read, one written. Only the written bucket gets a folder rule.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/normal/path/to/data", "gs://bucket1/awesome/path/to/data"),
+            Set.of("gs://bucket1/normal/path/to/data"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsWithMultipleBuckets.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsWithoutWritesNoFolderRules() throws IOException {
+    // Read-only locations: no write rule, no folder rule, even with HNS predicate=true.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://bucket1/path/to/data"), Set.of(), bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(1);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsWithoutWrites.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsSeparateMetadataAndDataBuckets() throws IOException {
+    // Metadata and data on different buckets. Both are HNS — expect folder rule on each.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://metadata-bucket/ns/table/metadata/", "gs://data-bucket/ns/table/data/"),
+            Set.of("gs://metadata-bucket/ns/table/metadata/", "gs://data-bucket/ns/table/data/"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    // 2 reads + 2 writes + 2 folder rules
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(6);
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsPredicateGating() {
+    // Mixed catalog: bucket1 is HNS, bucket2 is not. Only bucket1 gets a folder rule.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/data", "gs://bucket2/data"),
+            Set.of("gs://bucket1/data", "gs://bucket2/data"),
+            bucket -> bucket.equals("bucket1"));
+    assertThat(credentialAccessBoundary).isNotNull();
+    // 2 reads + 2 writes + 1 folder rule (only bucket1)
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(5);
+    long folderRuleCount =
+        credentialAccessBoundary.getAccessBoundaryRules().stream()
+            .filter(
+                rule ->
+                    rule.getAvailablePermissions().stream()
+                        .anyMatch(p -> p.equals("inRole:roles/storage.folderAdmin")))
+            .count();
+    assertThat(folderRuleCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryFolderRuleUsesCabRoleIdentifier() {
+    // Credential Access Boundary availablePermissions require inRole-prefixed role identifiers.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://b/p"), Set.of("gs://b/p"), bucket -> true);
+    CredentialAccessBoundary.AccessBoundaryRule folderRule =
+        credentialAccessBoundary.getAccessBoundaryRules().stream()
+            .filter(
+                rule ->
+                    rule.getAvailablePermissions().stream()
+                        .anyMatch(p -> p.equals("inRole:roles/storage.folderAdmin")))
+            .findFirst()
+            .orElseThrow();
+    assertThat(folderRule.getAvailablePermissions())
+        .containsExactlyInAnyOrder("inRole:roles/storage.folderAdmin");
+    // Scope is the folder hierarchy, never the managedFolders/ resource.
+    assertThat(folderRule.getAvailabilityCondition().getExpression())
+        .contains("folders/p")
+        .doesNotContain("managedFolders");
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryNonHnsOmitsFolderRule() {
+    // With predicate=false (or default 3-arg signature), no folder rule should be emitted.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://b/p"), Set.of("gs://b/p"), bucket -> false);
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(2);
+    assertThat(
+            credentialAccessBoundary.getAccessBoundaryRules().stream()
+                .flatMap(rule -> rule.getAvailablePermissions().stream()))
+        .noneMatch(p -> p.equals("inRole:roles/storage.folderAdmin"));
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -85,7 +85,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
-  private final String gcsServiceKeyJsonFileLocation =
+  private final String gcsServiceKeyJson...tion =
       System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
   private static final String REFRESH_ENDPOINT = "get/credentials";
@@ -116,7 +116,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSubscope(boolean allowedListAction) throws Exception {
-    Assumptions.assumeThat(gcsServiceKeyJsonFileLocation)
+    Assumptions.assumeThat(gcsServiceKeyJson...tion)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -437,7 +437,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testRefreshCredentialsEndpointIsReturned() throws IOException {
-    Assumptions.assumeThat(gcsServiceKeyJsonFileLocation)
+    Assumptions.assumeThat(gcsServiceKeyJson...tion)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -651,10 +651,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     gen.initialize(2048);
     KeyPair keyPair = gen.generateKeyPair();
     String pem =
-        "-----BEGIN PRIVATE KEY-----\n"
-            + Base64.getMimeEncoder(64, "\n".getBytes(UTF_8))
-                .encodeToString(keyPair.getPrivate().getEncoded())
-            + "\n-----END PRIVATE KEY-----\n";
+        "[REDACTED PRIVATE KEY]\n";
     Path keyFile = tempDir.resolve("attribution-key.pem");
     Files.writeString(keyFile, pem);
 
@@ -706,5 +703,122 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     DecodedJWT jwt = JWT.decode(idp.retrieveSubjectToken());
     assertThat(jwt.getSubject()).isEqualTo("realm1/principal1");
     assertThat(jwt.getClaim("realm").asString()).isEqualTo("realm1");
+  }
+
+  // ── HNS folder-rule tests (predicate-driven) ──────────────────────────────────────
+
+  @Test
+  public void testGenerateAccessBoundaryHnsSingleBucketEmitsFolderRule() throws IOException {
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/path/to/data"),
+            Set.of("gs://bucket1/path/to/data"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    // read + write + folder
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(3);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsEnabled.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsMultipleBucketsPartialWrites() throws IOException {
+    // Two buckets read, one written. Only the written bucket gets a folder rule.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/normal/path/to/data", "gs://bucket1/awesome/path/to/data"),
+            Set.of("gs://bucket1/normal/path/to/data"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsWithMultipleBuckets.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsWithoutWritesNoFolderRules() throws IOException {
+    // Read-only locations: no write rule, no folder rule, even with HNS predicate=true.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://bucket1/path/to/data"), Set.of(), bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(1);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryHnsWithoutWrites.json");
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsSeparateMetadataAndDataBuckets() throws IOException {
+    // Metadata and data on different buckets. Both are HNS — expect folder rule on each.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://metadata-bucket/ns/table/metadata/", "gs://data-bucket/ns/table/data/"),
+            Set.of("gs://metadata-bucket/ns/table/metadata/", "gs://data-bucket/ns/table/data/"),
+            bucket -> true);
+    assertThat(credentialAccessBoundary).isNotNull();
+    // 2 reads + 2 writes + 2 folder rules
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(6);
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryHnsPredicateGating() {
+    // Mixed catalog: bucket1 is HNS, bucket2 is not. Only bucket1 gets a folder rule.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true,
+            Set.of("gs://bucket1/data", "gs://bucket2/data"),
+            Set.of("gs://bucket1/data", "gs://bucket2/data"),
+            bucket -> bucket.equals("bucket1"));
+    assertThat(credentialAccessBoundary).isNotNull();
+    // 2 reads + 2 writes + 1 folder rule (only bucket1)
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(5);
+    long folderRuleCount =
+        credentialAccessBoundary.getAccessBoundaryRules().stream()
+            .filter(
+                rule ->
+                    rule.getAvailablePermissions().stream()
+                        .anyMatch(p -> p.equals("inRole:roles/storage.folderAdmin")))
+            .count();
+    assertThat(folderRuleCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryFolderRuleUsesCabRoleIdentifier() {
+    // Credential Access Boundary availablePermissions require inRole-prefixed role identifiers.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://b/p"), Set.of("gs://b/p"), bucket -> true);
+    CredentialAccessBoundary.AccessBoundaryRule folderRule =
+        credentialAccessBoundary.getAccessBoundaryRules().stream()
+            .filter(
+                rule ->
+                    rule.getAvailablePermissions().stream()
+                        .anyMatch(p -> p.equals("inRole:roles/storage.folderAdmin")))
+            .findFirst()
+            .orElseThrow();
+    assertThat(folderRule.getAvailablePermissions())
+        .containsExactlyInAnyOrder("inRole:roles/storage.folderAdmin");
+    // Scope is the folder hierarchy, never the managedFolders/ resource.
+    assertThat(folderRule.getAvailabilityCondition().getExpression())
+        .contains("folders/p")
+        .doesNotContain("managedFolders");
+  }
+
+  @Test
+  public void testGenerateAccessBoundaryNonHnsOmitsFolderRule() {
+    // With predicate=false (or default 3-arg signature), no folder rule should be emitted.
+    CredentialAccessBoundary credentialAccessBoundary =
+        GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
+            true, Set.of("gs://b/p"), Set.of("gs://b/p"), bucket -> false);
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(2);
+    assertThat(
+            credentialAccessBoundary.getAccessBoundaryRules().stream()
+                .flatMap(rule -> rule.getAvailablePermissions().stream()))
+        .noneMatch(p -> p.equals("inRole:roles/storage.folderAdmin"));
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -85,8 +85,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
-  private final String gcsServiceKeyJson...tion =
-      System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+  private final String gcsServiceKeyJsonLocation = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
   private static final String REFRESH_ENDPOINT = "get/credentials";
 
@@ -116,7 +115,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSubscope(boolean allowedListAction) throws Exception {
-    Assumptions.assumeThat(gcsServiceKeyJson...tion)
+    Assumptions.assumeThat(gcsServiceKeyJsonLocation)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -437,7 +436,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testRefreshCredentialsEndpointIsReturned() throws IOException {
-    Assumptions.assumeThat(gcsServiceKeyJson...tion)
+    Assumptions.assumeThat(gcsServiceKeyJsonLocation)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -651,7 +650,10 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     gen.initialize(2048);
     KeyPair keyPair = gen.generateKeyPair();
     String pem =
-        "[REDACTED PRIVATE KEY]\n";
+        "-----BEGIN PRIVATE KEY-----\n"
+            + Base64.getMimeEncoder(64, "\n".getBytes(UTF_8))
+                .encodeToString(keyPair.getPrivate().getEncoded())
+            + "\n-----END PRIVATE KEY-----\n";
     Path keyFile = tempDir.resolve("attribution-key.pem");
     Files.writeString(keyFile, pem);
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -85,8 +85,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
-  private final String gcsServiceKeyJson...tion =
-      System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+  private final String gcsServiceKeyJsonLocation = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
   private static final String REFRESH_ENDPOINT = "get/credentials";
 
@@ -116,7 +115,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSubscope(boolean allowedListAction) throws Exception {
-    Assumptions.assumeThat(gcsServiceKeyJson...tion)
+    Assumptions.assumeThat(gcsServiceKeyJsonLocation)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -436,7 +435,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   @Test
   public void testRefreshCredentialsEndpointIsReturned() throws IOException {
-    Assumptions.assumeThat(gcsServiceKeyJson...tion)
+    Assumptions.assumeThat(gcsServiceKeyJsonLocation)
         .describedAs("Environment variable GOOGLE_APPLICATION_CREDENTIALS not exits")
         .isNotNull()
         .isNotEmpty();
@@ -650,7 +649,10 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     gen.initialize(2048);
     KeyPair keyPair = gen.generateKeyPair();
     String pem =
-        "[REDACTED PRIVATE KEY]\n";
+        "-----BEGIN PRIVATE KEY-----\n"
+            + Base64.getMimeEncoder(64, "\n".getBytes(UTF_8))
+                .encodeToString(keyPair.getPrivate().getEncoded())
+            + "\n-----END PRIVATE KEY-----\n";
     Path keyFile = tempDir.resolve("attribution-key.pem");
     Files.writeString(keyFile, pem);
 

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsEnabled.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsEnabled.json
@@ -1,0 +1,32 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data/') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('path/to/data/')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.legacyBucketWriter"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data/')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.folderAdmin"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/folders/path/to/data/')"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsWithMultipleBuckets.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsWithMultipleBuckets.json
@@ -1,0 +1,32 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data/') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data/') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data/') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data/')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.legacyBucketWriter"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data/')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.folderAdmin"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/folders/normal/path/to/data/')"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsWithoutWrites.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryHnsWithoutWrites.json
@@ -1,0 +1,14 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data/') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('path/to/data/')"
+      }
+    }
+  ]
+}

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -660,9 +660,11 @@ License: BSD 3-Clause
 This product bundles Google Cloud Storage APIs.
 
 * Maven group:artifact IDs: com.google.api.grpc:gapic-google-cloud-storage-v2
+* Maven group:artifact IDs: com.google.api.grpc:grpc-google-cloud-storage-control-v2
 * Maven group:artifact IDs: com.google.api.grpc:grpc-google-cloud-storage-v2
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-iamcredentials-v1
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-monitoring-v3
+* Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-storage-control-v2
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-storage-v2
 * Maven group:artifact IDs: com.google.apis:google-api-services-storage
 
@@ -736,6 +738,7 @@ This product bundles Google Cloud APIs for Java.
 * Maven group:artifact IDs: com.google.cloud:google-cloud-iamcredentials
 * Maven group:artifact IDs: com.google.cloud:google-cloud-monitoring
 * Maven group:artifact IDs: com.google.cloud:google-cloud-storage
+* Maven group:artifact IDs: com.google.cloud:google-cloud-storage-control
 
 Project URL: https://github.com/googleapis/google-cloud-java
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -662,9 +662,11 @@ License: BSD 3-Clause
 This product bundles Google Cloud Storage APIs.
 
 * Maven group:artifact IDs: com.google.api.grpc:gapic-google-cloud-storage-v2
+* Maven group:artifact IDs: com.google.api.grpc:grpc-google-cloud-storage-control-v2
 * Maven group:artifact IDs: com.google.api.grpc:grpc-google-cloud-storage-v2
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-iamcredentials-v1
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-monitoring-v3
+* Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-storage-control-v2
 * Maven group:artifact IDs: com.google.api.grpc:proto-google-cloud-storage-v2
 * Maven group:artifact IDs: com.google.apis:google-api-services-storage
 
@@ -738,6 +740,7 @@ This product bundles Google Cloud APIs for Java.
 * Maven group:artifact IDs: com.google.cloud:google-cloud-iamcredentials
 * Maven group:artifact IDs: com.google.cloud:google-cloud-monitoring
 * Maven group:artifact IDs: com.google.cloud:google-cloud-storage
+* Maven group:artifact IDs: com.google.cloud:google-cloud-storage-control
 
 Project URL: https://github.com/googleapis/google-cloud-java
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
 
   implementation(platform(libs.google.cloud.storage.bom))
   implementation("com.google.cloud:google-cloud-storage")
+  implementation("com.google.cloud:google-cloud-storage-control")
   implementation(platform(libs.awssdk.bom))
   implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:iam-policy-builder")

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogFlociGcpIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogFlociGcpIT.java
@@ -166,7 +166,6 @@ public class PolarisRestCatalogFlociGcpIT {
         .setName(catalogName)
         .setStorageConfigInfo(
             GcpStorageConfigInfo.builder()
-                .setGcsServiceAccount(flociGcpAccess.projectId())
                 .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
                 .setAllowedLocations(List.of(baseLocation))
                 .build())

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -115,6 +115,8 @@ import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverPath;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.immutables.PolarisImmutable;
@@ -179,6 +181,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
   protected abstract StorageAccessConfigProvider storageAccessConfigProvider();
 
+  protected abstract PolarisStorageIntegrationProvider storageIntegrationProvider();
+
   protected abstract MutableAttributeMap eventAttributeMap();
 
   protected abstract IcebergMetricsReporter metricsReporter();
@@ -212,6 +216,31 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     CatalogEntity catalogEntity = resolutionManifest.getResolvedCatalogEntity();
     diagnostics().checkNotNull(catalogEntity, "No catalog available");
     return catalogEntity;
+  }
+
+  /**
+   * Pre-createTable hook: asks the storage integration to materialize any folders that must exist
+   * before the table's files can be written (e.g. GCS HNS folder objects). For storage types
+   * without this requirement the underlying call is a no-op.
+   *
+   * <p>Uses the {@link TableMetadata} produced by Iceberg table creation so implicit locations are
+   * the actual namespace-aware locations Iceberg will use, not a handler-side guess.
+   */
+  private void prepareStorageForTable(
+      TableIdentifier tableIdentifier, TableMetadata tableMetadata) {
+    PolarisResolvedPathWrapper resolvedStoragePath =
+        CatalogUtils.findResolvedStorageEntity(resolutionManifest, tableIdentifier);
+    if (resolvedStoragePath == null) {
+      return;
+    }
+    PolarisStorageIntegration integration =
+        storageIntegrationProvider().getStorageIntegration(resolvedStoragePath.getRawFullPath());
+    if (integration == null) {
+      return;
+    }
+    integration.prepareLocations(
+        StorageUtil.getLocationsToPrepareForTable(
+            tableMetadata.location(), tableMetadata.properties()));
   }
 
   private boolean shouldDecodeToken() {
@@ -677,6 +706,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     if (baseCatalog instanceof LocalIcebergCatalog polarisCatalog) {
       polarisCatalog.validateStagedTableCreate(ident, metadata);
+      prepareStorageForTable(ident, metadata);
     }
 
     Optional<AccessDelegationMode> resolvedMode = resolveAccessDelegationModes(delegationModes);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -113,6 +113,8 @@ import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverPath;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.immutables.PolarisImmutable;
@@ -176,6 +178,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
   protected abstract StorageAccessConfigProvider storageAccessConfigProvider();
 
+  protected abstract PolarisStorageIntegrationProvider storageIntegrationProvider();
+
   protected abstract EventAttributeMap eventAttributeMap();
 
   protected abstract PolarisMetricsReporter metricsReporter();
@@ -209,6 +213,31 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     CatalogEntity catalogEntity = resolutionManifest.getResolvedCatalogEntity();
     diagnostics().checkNotNull(catalogEntity, "No catalog available");
     return catalogEntity;
+  }
+
+  /**
+   * Pre-createTable hook: asks the storage integration to materialize any folders that must exist
+   * before the table's files can be written (e.g. GCS HNS folder objects). For storage types
+   * without this requirement the underlying call is a no-op.
+   *
+   * <p>Uses the {@link TableMetadata} produced by Iceberg table creation so implicit locations are
+   * the actual namespace-aware locations Iceberg will use, not a handler-side guess.
+   */
+  private void prepareStorageForTable(
+      TableIdentifier tableIdentifier, TableMetadata tableMetadata) {
+    PolarisResolvedPathWrapper resolvedStoragePath =
+        CatalogUtils.findResolvedStorageEntity(resolutionManifest, tableIdentifier);
+    if (resolvedStoragePath == null) {
+      return;
+    }
+    PolarisStorageIntegration integration =
+        storageIntegrationProvider().getStorageIntegration(resolvedStoragePath.getRawFullPath());
+    if (integration == null) {
+      return;
+    }
+    integration.prepareLocations(
+        StorageUtil.getLocationsToPrepareForTable(
+            tableMetadata.location(), tableMetadata.properties()));
   }
 
   private boolean shouldDecodeToken() {
@@ -713,6 +742,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     if (baseCatalog instanceof LocalIcebergCatalog polarisCatalog) {
       polarisCatalog.validateStagedTableCreate(ident, metadata);
+      prepareStorageForTable(ident, metadata);
     }
 
     Optional<AccessDelegationMode> resolvedMode = resolveAccessDelegationModes(delegationModes);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
@@ -35,6 +35,7 @@ import org.apache.polaris.core.credentials.PolarisCredentialManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.service.catalog.AccessDelegationModeResolver;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
@@ -58,6 +59,7 @@ public class IcebergCatalogHandlerFactory {
   @Inject CatalogHandlerUtils catalogHandlerUtils;
   @Inject @Any Instance<FederatedCatalogFactory> federatedCatalogFactories;
   @Inject StorageAccessConfigProvider storageAccessConfigProvider;
+  @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject IcebergMetricsReporter metricsReporter;
   @Inject Clock clock;
   @Inject AccessDelegationModeResolver accessDelegationModeResolver;
@@ -84,6 +86,7 @@ public class IcebergCatalogHandlerFactory {
         .catalogHandlerUtils(catalogHandlerUtils)
         .federatedCatalogFactories(federatedCatalogFactories)
         .storageAccessConfigProvider(storageAccessConfigProvider)
+        .storageIntegrationProvider(storageIntegrationProvider)
         .eventAttributeMap(eventAttributeMap)
         .metricsReporter(metricsReporter)
         .clock(clock)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
@@ -33,6 +33,7 @@ import org.apache.polaris.core.credentials.PolarisCredentialManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.service.catalog.AccessDelegationModeResolver;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
@@ -57,6 +58,7 @@ public class IcebergCatalogHandlerFactory {
   @Inject CatalogHandlerUtils catalogHandlerUtils;
   @Inject @Any Instance<FederatedCatalogFactory> federatedCatalogFactories;
   @Inject StorageAccessConfigProvider storageAccessConfigProvider;
+  @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject EventAttributeMap eventAttributeMap;
   @Inject PolarisMetricsReporter metricsReporter;
   @Inject Clock clock;
@@ -80,6 +82,7 @@ public class IcebergCatalogHandlerFactory {
         .catalogHandlerUtils(catalogHandlerUtils)
         .federatedCatalogFactories(federatedCatalogFactories)
         .storageAccessConfigProvider(storageAccessConfigProvider)
+        .storageIntegrationProvider(storageIntegrationProvider)
         .eventAttributeMap(eventAttributeMap)
         .metricsReporter(metricsReporter)
         .clock(clock)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -264,6 +264,35 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       FileIOFactory fileIOFactory,
       PolarisEventDispatcher polarisEventDispatcher,
       PolarisEventMetadataFactory eventMetadataFactory,
+      PolarisStorageIntegrationProvider storageIntegrationProvider) {
+    this(
+        diagnostics,
+        resolverFactory,
+        metaStoreManager,
+        callContext,
+        resolvedEntityView,
+        principal,
+        taskExecutor,
+        storageAccessConfigProvider,
+        fileIOFactory,
+        polarisEventDispatcher,
+        eventMetadataFactory,
+        IdempotencyRequestContext.DISABLED,
+        storageIntegrationProvider);
+  }
+
+  public LocalIcebergCatalog(
+      PolarisDiagnostics diagnostics,
+      ResolverFactory resolverFactory,
+      PolarisMetaStoreManager metaStoreManager,
+      CallContext callContext,
+      PolarisResolutionManifestCatalogView resolvedEntityView,
+      PolarisPrincipal principal,
+      TaskExecutor taskExecutor,
+      StorageAccessConfigProvider storageAccessConfigProvider,
+      FileIOFactory fileIOFactory,
+      PolarisEventDispatcher polarisEventDispatcher,
+      PolarisEventMetadataFactory eventMetadataFactory,
       IdempotencyRequestContext idempotencyRequestContext) {
     this(
         diagnostics,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -129,6 +129,8 @@ import org.apache.polaris.core.persistence.resolver.ResolverPath;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.core.storage.StorageUtil;
@@ -197,6 +199,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
   private final String catalogName;
   private final long catalogId;
+  private final PolarisStorageIntegrationProvider storageIntegrationProvider;
   private String defaultBaseLocation;
   private Map<String, String> catalogProperties;
   private final StorageAccessConfigProvider storageAccessConfigProvider;
@@ -245,7 +248,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         fileIOFactory,
         polarisEventDispatcher,
         eventMetadataFactory,
-        IdempotencyRequestContext.DISABLED);
+        IdempotencyRequestContext.DISABLED,
+        resolvedEntityPath -> null);
   }
 
   public LocalIcebergCatalog(
@@ -261,6 +265,36 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       PolarisEventDispatcher polarisEventDispatcher,
       PolarisEventMetadataFactory eventMetadataFactory,
       IdempotencyRequestContext idempotencyRequestContext) {
+    this(
+        diagnostics,
+        resolverFactory,
+        metaStoreManager,
+        callContext,
+        resolvedEntityView,
+        principal,
+        taskExecutor,
+        storageAccessConfigProvider,
+        fileIOFactory,
+        polarisEventDispatcher,
+        eventMetadataFactory,
+        idempotencyRequestContext,
+        resolvedEntityPath -> null);
+  }
+
+  public LocalIcebergCatalog(
+      PolarisDiagnostics diagnostics,
+      ResolverFactory resolverFactory,
+      PolarisMetaStoreManager metaStoreManager,
+      CallContext callContext,
+      PolarisResolutionManifestCatalogView resolvedEntityView,
+      PolarisPrincipal principal,
+      TaskExecutor taskExecutor,
+      StorageAccessConfigProvider storageAccessConfigProvider,
+      FileIOFactory fileIOFactory,
+      PolarisEventDispatcher polarisEventDispatcher,
+      PolarisEventMetadataFactory eventMetadataFactory,
+      IdempotencyRequestContext idempotencyRequestContext,
+      PolarisStorageIntegrationProvider storageIntegrationProvider) {
     this.diagnostics = diagnostics;
     this.resolverFactory = resolverFactory;
     this.callContext = callContext;
@@ -277,6 +311,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     this.polarisEventDispatcher = polarisEventDispatcher;
     this.eventMetadataFactory = eventMetadataFactory;
     this.idempotencyRequestContext = idempotencyRequestContext;
+    this.storageIntegrationProvider = storageIntegrationProvider;
   }
 
   @Override
@@ -1284,6 +1319,21 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                 catalogEntity, tableIdentifier, resolvedNamespace, location, storageLeafEntity));
   }
 
+  @VisibleForTesting
+  void prepareStorageForTableCreation(
+      TableIdentifier tableIdentifier,
+      TableMetadata tableMetadata,
+      PolarisResolvedPathWrapper resolvedStorageEntity) {
+    PolarisStorageIntegration integration =
+        storageIntegrationProvider.getStorageIntegration(resolvedStorageEntity.getRawFullPath());
+    if (integration == null) {
+      return;
+    }
+    integration.prepareLocations(
+        StorageUtil.getLocationsToPrepareForTable(
+            tableMetadata.location(), tableMetadata.properties()));
+  }
+
   /**
    * Validates that the specified {@code location} is valid for whatever storage config is found for
    * this TableLike's parent hierarchy.
@@ -1869,6 +1919,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         // and that the metadata file points to a location within the table's directory structure
         validateMetadataFileInTableDir(
             tableIdentifier, metadata.location(), nextMetadataFileLocation(metadata));
+      }
+
+      if (base == null) {
+        prepareStorageForTableCreation(tableIdentifier, metadata, resolvedStorageEntity);
       }
 
       tableFileIO =

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -135,6 +135,8 @@ import org.apache.polaris.core.persistence.resolver.ResolverPath;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.core.storage.StorageUtil;
@@ -202,6 +204,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
   private final String catalogName;
   private final long catalogId;
+  private final PolarisStorageIntegrationProvider storageIntegrationProvider;
   private String defaultBaseLocation;
   private Map<String, String> catalogProperties;
   private final StorageAccessConfigProvider storageAccessConfigProvider;
@@ -250,7 +253,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         fileIOFactory,
         polarisEventDispatcher,
         eventMetadataFactory,
-        IdempotencyRequestContext.DISABLED);
+        IdempotencyRequestContext.DISABLED,
+        resolvedEntityPath -> null);
   }
 
   public LocalIcebergCatalog(
@@ -266,6 +270,36 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       PolarisEventDispatcher polarisEventDispatcher,
       PolarisEventMetadataFactory eventMetadataFactory,
       IdempotencyRequestContext idempotencyRequestContext) {
+    this(
+        diagnostics,
+        resolverFactory,
+        metaStoreManager,
+        callContext,
+        resolvedEntityView,
+        principal,
+        taskExecutor,
+        storageAccessConfigProvider,
+        fileIOFactory,
+        polarisEventDispatcher,
+        eventMetadataFactory,
+        idempotencyRequestContext,
+        resolvedEntityPath -> null);
+  }
+
+  public LocalIcebergCatalog(
+      PolarisDiagnostics diagnostics,
+      ResolverFactory resolverFactory,
+      PolarisMetaStoreManager metaStoreManager,
+      CallContext callContext,
+      PolarisResolutionManifestCatalogView resolvedEntityView,
+      PolarisPrincipal principal,
+      TaskExecutor taskExecutor,
+      StorageAccessConfigProvider storageAccessConfigProvider,
+      FileIOFactory fileIOFactory,
+      PolarisEventDispatcher polarisEventDispatcher,
+      PolarisEventMetadataFactory eventMetadataFactory,
+      IdempotencyRequestContext idempotencyRequestContext,
+      PolarisStorageIntegrationProvider storageIntegrationProvider) {
     this.diagnostics = diagnostics;
     this.resolverFactory = resolverFactory;
     this.callContext = callContext;
@@ -282,6 +316,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     this.polarisEventDispatcher = polarisEventDispatcher;
     this.eventMetadataFactory = eventMetadataFactory;
     this.idempotencyRequestContext = idempotencyRequestContext;
+    this.storageIntegrationProvider = storageIntegrationProvider;
   }
 
   @Override
@@ -1299,6 +1334,21 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         resolvedStorageEntity.getRawFullPath());
   }
 
+  @VisibleForTesting
+  void prepareStorageForTableCreation(
+      TableIdentifier tableIdentifier,
+      TableMetadata tableMetadata,
+      PolarisResolvedPathWrapper resolvedStorageEntity) {
+    PolarisStorageIntegration integration =
+        storageIntegrationProvider.getStorageIntegration(resolvedStorageEntity.getRawFullPath());
+    if (integration == null) {
+      return;
+    }
+    integration.prepareLocations(
+        StorageUtil.getLocationsToPrepareForTable(
+            tableMetadata.location(), tableMetadata.properties()));
+  }
+
   /**
    * Validates that the specified {@code location} is valid for whatever storage config is found for
    * this TableLike's parent hierarchy.
@@ -1950,6 +2000,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         // and that the metadata file points to a location within the table's directory structure
         validateMetadataFileInTableDir(
             tableIdentifier, metadata.location(), nextMetadataFileLocation(metadata));
+      }
+
+      if (base == null) {
+        prepareStorageForTableCreation(tableIdentifier, metadata, resolvedStorageEntity);
       }
 
       tableFileIO =

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -269,6 +269,35 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       FileIOFactory fileIOFactory,
       PolarisEventDispatcher polarisEventDispatcher,
       PolarisEventMetadataFactory eventMetadataFactory,
+      PolarisStorageIntegrationProvider storageIntegrationProvider) {
+    this(
+        diagnostics,
+        resolverFactory,
+        metaStoreManager,
+        callContext,
+        resolvedEntityView,
+        principal,
+        taskExecutor,
+        storageAccessConfigProvider,
+        fileIOFactory,
+        polarisEventDispatcher,
+        eventMetadataFactory,
+        IdempotencyRequestContext.DISABLED,
+        storageIntegrationProvider);
+  }
+
+  public LocalIcebergCatalog(
+      PolarisDiagnostics diagnostics,
+      ResolverFactory resolverFactory,
+      PolarisMetaStoreManager metaStoreManager,
+      CallContext callContext,
+      PolarisResolutionManifestCatalogView resolvedEntityView,
+      PolarisPrincipal principal,
+      TaskExecutor taskExecutor,
+      StorageAccessConfigProvider storageAccessConfigProvider,
+      FileIOFactory fileIOFactory,
+      PolarisEventDispatcher polarisEventDispatcher,
+      PolarisEventMetadataFactory eventMetadataFactory,
       IdempotencyRequestContext idempotencyRequestContext) {
     this(
         diagnostics,

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
@@ -32,6 +32,7 @@ import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
@@ -57,6 +58,7 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
   private final CallContext callContext;
   private final PolarisPrincipal principal;
   private final IdempotencyRequestContext idempotencyRequestContext;
+  private final PolarisStorageIntegrationProvider storageIntegrationProvider;
 
   @Inject
   public PolarisLocalCatalogFactory(
@@ -70,7 +72,8 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext,
       PolarisPrincipal principal,
-      IdempotencyRequestContext idempotencyRequestContext) {
+      IdempotencyRequestContext idempotencyRequestContext,
+      PolarisStorageIntegrationProvider storageIntegrationProvider) {
     this.diagnostics = diagnostics;
     this.resolverFactory = resolverFactory;
     this.taskExecutor = taskExecutor;
@@ -82,6 +85,34 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
     this.callContext = callContext;
     this.principal = principal;
     this.idempotencyRequestContext = idempotencyRequestContext;
+    this.storageIntegrationProvider = storageIntegrationProvider;
+  }
+
+  public PolarisLocalCatalogFactory(
+      PolarisDiagnostics diagnostics,
+      ResolverFactory resolverFactory,
+      TaskExecutor taskExecutor,
+      StorageAccessConfigProvider storageAccessConfigProvider,
+      FileIOFactory fileIOFactory,
+      PolarisEventDispatcher polarisEventDispatcher,
+      PolarisEventMetadataFactory eventMetadataFactory,
+      PolarisMetaStoreManager metaStoreManager,
+      CallContext callContext,
+      PolarisPrincipal principal,
+      IdempotencyRequestContext idempotencyRequestContext) {
+    this(
+        diagnostics,
+        resolverFactory,
+        taskExecutor,
+        storageAccessConfigProvider,
+        fileIOFactory,
+        polarisEventDispatcher,
+        eventMetadataFactory,
+        metaStoreManager,
+        callContext,
+        principal,
+        idempotencyRequestContext,
+        resolvedEntityPath -> null);
   }
 
   @Override
@@ -106,7 +137,8 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
             fileIOFactory,
             polarisEventDispatcher,
             eventMetadataFactory,
-            idempotencyRequestContext);
+            idempotencyRequestContext,
+            storageIntegrationProvider);
 
     Map<String, String> catalogProperties = new HashMap<>(catalog.getPropertiesAsMap());
     String defaultBaseLocation = catalog.getBaseLocation();

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/HierarchicalFolderLocationPreparer.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/HierarchicalFolderLocationPreparer.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.polaris.core.storage.StorageLocationPreparer;
+import org.apache.polaris.core.storage.StorageUri;
+import org.apache.polaris.core.storage.StorageUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for cloud-storage folder preparers whose backing store has hierarchical-namespace
+ * semantics (folders are first-class resources that must exist before nested files can be written).
+ * Handles URI parsing, folder hierarchy resolution, and bucket-level grouping; subclasses implement
+ * the storage-specific folder-creation call.
+ *
+ * <p>Today there is one concrete implementation (GCS HNS). Azure ADLS Gen2 is the next likely reuse
+ * case, hence the abstraction lives in this package rather than inside the GCS class.
+ *
+ * <p>The template method {@link #prepareLocations(List)} drives the pipeline: filter by scheme,
+ * resolve folder hierarchies, group by bucket, and delegate to {@link
+ * #createFoldersForBucket(String, List)}.
+ */
+public abstract class HierarchicalFolderLocationPreparer implements StorageLocationPreparer {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(HierarchicalFolderLocationPreparer.class);
+  private static final Predicate<String> NOT_BLANK = Predicate.not(String::isEmpty);
+  private static final String PATH_SEPARATOR = "/";
+  private static final String TRAILING_SLASHES_REGEX = "/+$";
+
+  /** Represents a single folder that needs to be created, with its bucket and path. */
+  protected record FolderToCreate(String bucketName, String folderPath) {}
+
+  /** Returns the URI scheme prefix for this storage type (e.g. {@code "gs://"} for GCS). */
+  protected abstract String schemePrefix();
+
+  /**
+   * Creates the given folders in the specified bucket. Called once per unique bucket after
+   * grouping. Implementations must be idempotent against folders that already exist.
+   */
+  protected abstract void createFoldersForBucket(String bucketName, List<FolderToCreate> folders);
+
+  @Override
+  public void prepareLocations(List<String> storageLocations) {
+    List<FolderToCreate> allFolders =
+        storageLocations.stream()
+            .filter(loc -> loc != null && loc.startsWith(schemePrefix()))
+            .flatMap(loc -> extractFoldersFromPath(loc).stream())
+            .distinct()
+            .toList();
+
+    if (allFolders.isEmpty()) {
+      return;
+    }
+
+    allFolders.stream()
+        .collect(Collectors.groupingBy(FolderToCreate::bucketName))
+        .forEach(this::createFoldersForBucket);
+  }
+
+  protected List<FolderToCreate> extractFoldersFromPath(String storagePath) {
+    String bucketName = StorageUtil.getBucket(storagePath);
+    if (bucketName == null || bucketName.isEmpty()) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("path", storagePath)
+          .log("Could not extract bucket name from storage path; skipping folder preparation");
+      return List.of();
+    }
+
+    String objectPath = extractObjectPath(storagePath);
+    if (objectPath == null || objectPath.isEmpty()) {
+      return List.of();
+    }
+
+    return buildPathHierarchy(objectPath).stream()
+        .map(folder -> new FolderToCreate(bucketName, folder))
+        .toList();
+  }
+
+  /** Strips the scheme, bucket, and slashes from a storage URI, returning the object path. */
+  protected static String extractObjectPath(String storageUri) {
+    return Optional.of(StorageUri.parse(storageUri).rawPath())
+        .filter(NOT_BLANK)
+        .filter(path -> !PATH_SEPARATOR.equals(path))
+        .map(path -> path.startsWith(PATH_SEPARATOR) ? path.substring(1) : path)
+        .map(path -> path.replaceAll(TRAILING_SLASHES_REGEX, ""))
+        .filter(NOT_BLANK)
+        .orElse("");
+  }
+
+  /**
+   * Builds the parent hierarchy for an object path: hierarchical storage systems require every
+   * parent folder to exist before a child can be created.
+   *
+   * <p>For example, {@code "warehouse/ns1/table1"} produces {@code ["warehouse", "warehouse/ns1",
+   * "warehouse/ns1/table1"]}.
+   */
+  public static List<String> buildPathHierarchy(String objectPath) {
+    String[] segments =
+        Arrays.stream(objectPath.split(PATH_SEPARATOR)).filter(NOT_BLANK).toArray(String[]::new);
+
+    if (segments.length == 0) {
+      return List.of();
+    }
+
+    return IntStream.range(1, segments.length + 1)
+        .mapToObj(i -> String.join(PATH_SEPARATOR, Arrays.copyOf(segments, i)))
+        .toList();
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -45,8 +45,10 @@ import org.apache.polaris.core.storage.aws.StsClientProvider;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.core.storage.gcp.GcpCredentialOps;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
+import org.apache.polaris.service.storage.gcs.GcsStorageLocationPreparer;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -98,7 +100,15 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
     this.gcpFactory =
         storageConfig ->
             new GcpCredentialsStorageIntegration(
-                gcpCredsProvider.get(), gcpTransportFactory, cache, storageConfig, realmConfig);
+                gcpCredsProvider.get(),
+                gcpTransportFactory,
+                cache,
+                storageConfig,
+                realmConfig,
+                new GcsStorageLocationPreparer(
+                    () ->
+                        GcpCredentialsStorageIntegration.getBaseCredentials(
+                            storageConfig, gcpCredsProvider.get(), GcpCredentialOps.DEFAULT)));
     this.azureFactory =
         storageConfig -> new AzureCredentialsStorageIntegration(cache, storageConfig, realmConfig);
   }
@@ -120,7 +130,15 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
     this.gcpFactory =
         storageConfig ->
             new GcpCredentialsStorageIntegration(
-                gcpCredsProvider.get(), gcpTransportFactory, cache, storageConfig, realmConfig);
+                gcpCredsProvider.get(),
+                gcpTransportFactory,
+                cache,
+                storageConfig,
+                realmConfig,
+                new GcsStorageLocationPreparer(
+                    () ->
+                        GcpCredentialsStorageIntegration.getBaseCredentials(
+                            storageConfig, gcpCredsProvider.get(), GcpCredentialOps.DEFAULT)));
     this.azureFactory =
         storageConfig -> new AzureCredentialsStorageIntegration(cache, storageConfig, realmConfig);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparer.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparer.java
@@ -50,6 +50,7 @@ public class GcsStorageLocationPreparer extends HierarchicalFolderLocationPrepar
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorageLocationPreparer.class);
   private static final String GCS_STORAGE_LAYOUT = "_";
+  private static final String STORAGE_EMULATOR_HOST = "STORAGE_EMULATOR_HOST";
 
   private final Supplier<GoogleCredentials> credentialsSupplier;
 
@@ -142,8 +143,15 @@ public class GcsStorageLocationPreparer extends HierarchicalFolderLocationPrepar
   }
 
   Bucket fetchBucketMetadata(String bucketName) {
-    Storage storage =
-        StorageOptions.newBuilder().setCredentials(credentialsSupplier.get()).build().getService();
+    StorageOptions.Builder options =
+        StorageOptions.newBuilder().setCredentials(credentialsSupplier.get());
+    String emulatorHost =
+        Optional.ofNullable(System.getProperty(STORAGE_EMULATOR_HOST))
+            .orElseGet(() -> System.getenv(STORAGE_EMULATOR_HOST));
+    if (emulatorHost != null && !emulatorHost.isBlank()) {
+      options.setHost(emulatorHost);
+    }
+    Storage storage = options.build().getService();
 
     return Optional.ofNullable(
             storage.get(

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparer.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparer.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage.gcs;
+
+import static org.apache.polaris.core.storage.StorageLocation.ensureTrailingSlash;
+
+import com.google.api.gax.rpc.AlreadyExistsException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.storage.control.v2.BucketName;
+import com.google.storage.control.v2.CreateFolderRequest;
+import com.google.storage.control.v2.Folder;
+import com.google.storage.control.v2.StorageControlClient;
+import com.google.storage.control.v2.StorageControlSettings;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo.StorageType;
+import org.apache.polaris.service.storage.HierarchicalFolderLocationPreparer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GCS implementation of {@link HierarchicalFolderLocationPreparer}. Detects whether the target
+ * bucket uses Hierarchical Namespace (HNS) and, if so, creates the full folder hierarchy required
+ * before Iceberg metadata and data files can be written. For flat-namespace buckets, this is a
+ * no-op.
+ */
+public class GcsStorageLocationPreparer extends HierarchicalFolderLocationPreparer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorageLocationPreparer.class);
+  private static final String GCS_STORAGE_LAYOUT = "_";
+
+  private final Supplier<GoogleCredentials> credentialsSupplier;
+
+  public GcsStorageLocationPreparer(Supplier<GoogleCredentials> credentialsSupplier) {
+    this.credentialsSupplier = credentialsSupplier;
+  }
+
+  @Override
+  protected String schemePrefix() {
+    return StorageType.GCS.getPrefixes().getFirst();
+  }
+
+  @Override
+  protected void createFoldersForBucket(String bucketName, List<FolderToCreate> folders) {
+    boolean hnsEnabled = resolveHnsStatus(bucketName);
+    LOGGER
+        .atInfo()
+        .addKeyValue("bucket", bucketName)
+        .addKeyValue("hnsEnabled", hnsEnabled)
+        .addKeyValue("folderCount", folders.size())
+        .log("GCS bucket HNS status for table creation");
+
+    if (hnsEnabled) {
+      createHnsFoldersInBucket(bucketName, folders);
+    }
+  }
+
+  private void createHnsFoldersInBucket(String bucketName, List<FolderToCreate> folders) {
+    try (StorageControlClient controlClient = createStorageControlClient()) {
+      String parent = BucketName.format(GCS_STORAGE_LAYOUT, bucketName);
+      folders.forEach(
+          folder -> createFolderIfNotExists(controlClient, parent, folder.folderPath()));
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format(
+              "Failed to initialize StorageControlClient for HNS folder creation in bucket '%s'",
+              bucketName),
+          e);
+    } catch (RuntimeException e) {
+      if (isGrpcConfigurationError(e)) {
+        LOGGER
+            .atWarn()
+            .addKeyValue("bucket", bucketName)
+            .addKeyValue("folderCount", folders.size())
+            .addKeyValue("error", e.getMessage())
+            .log(
+                "Failed to create HNS folders due to gRPC/networking configuration issue; "
+                    + "table creation may fail if folders don't exist",
+                e);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Filters out gRPC/networking misconfigurations that surface as runtime errors. In those cases we
+   * warn rather than fail the table creation, because the client can usually still proceed (the
+   * folders may be auto-created at write time, or the cluster's networking can be fixed without
+   * redeploying Polaris).
+   */
+  private boolean isGrpcConfigurationError(RuntimeException e) {
+    String message = e.getMessage();
+    Throwable cause = e.getCause();
+
+    return (message != null
+            && (message.contains("census")
+                || message.contains("JNDI")
+                || message.contains("grpc")
+                || message.contains("Unable to apply census stats")))
+        || (cause != null
+            && (cause instanceof ClassNotFoundException
+                || cause instanceof javax.naming.NamingException));
+  }
+
+  private boolean resolveHnsStatus(String bucketName) {
+    try {
+      Bucket bucket = fetchBucketMetadata(bucketName);
+      return Optional.ofNullable(bucket.getHierarchicalNamespace())
+          .map(BucketInfo.HierarchicalNamespace::getEnabled)
+          .orElse(false);
+    } catch (RuntimeException e) {
+      throw new RuntimeException(
+          String.format(
+              "Failed to check HNS status for GCS bucket '%s'. "
+                  + "Table creation is blocked until the bucket status can be verified.",
+              bucketName),
+          e);
+    }
+  }
+
+  Bucket fetchBucketMetadata(String bucketName) {
+    Storage storage =
+        StorageOptions.newBuilder().setCredentials(credentialsSupplier.get()).build().getService();
+
+    return Optional.ofNullable(
+            storage.get(
+                bucketName,
+                Storage.BucketGetOption.fields(Storage.BucketField.HIERARCHICAL_NAMESPACE)))
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    String.format(
+                        "GCS bucket '%s' not found. Cannot proceed with table creation.",
+                        bucketName)));
+  }
+
+  private void createFolderIfNotExists(
+      StorageControlClient controlClient, String parent, String folderPath) {
+    String folderId = ensureTrailingSlash(folderPath);
+    try {
+      CreateFolderRequest request =
+          CreateFolderRequest.newBuilder()
+              .setParent(parent)
+              .setFolderId(folderId)
+              .setFolder(Folder.newBuilder().build())
+              .build();
+
+      controlClient.createFolder(request);
+      LOGGER.atDebug().addKeyValue("folder", folderId).log("Created HNS folder");
+    } catch (AlreadyExistsException e) {
+      LOGGER.atDebug().addKeyValue("folder", folderId).log("HNS folder already exists, skipping");
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("Failed to create HNS folder '%s': %s", folderId, e.getMessage()), e);
+    }
+  }
+
+  StorageControlClient createStorageControlClient() throws IOException {
+    GoogleCredentials credentials = credentialsSupplier.get();
+    StorageControlSettings settings =
+        StorageControlSettings.newBuilder().setCredentialsProvider(() -> credentials).build();
+    return StorageControlClient.create(settings);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -23,9 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,8 +50,10 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -82,7 +86,10 @@ import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.service.catalog.AccessDelegationMode;
 import org.apache.polaris.service.catalog.AccessDelegationModeResolver;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
@@ -93,6 +100,7 @@ import org.apache.polaris.service.metrics.IcebergMetricsReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 class IcebergCatalogHandlerTest {
 
@@ -100,6 +108,8 @@ class IcebergCatalogHandlerTest {
   private static final Namespace NS1 = Namespace.of("ns1");
   private static final TableIdentifier TABLE2 = TableIdentifier.of(NS1, "table2");
   private static final String TABLE_LOCATION = "s3://fake-bucket/tables/table2";
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
 
   private final PolarisResolutionManifest resolutionManifest =
       mock(PolarisResolutionManifest.class);
@@ -114,6 +124,11 @@ class IcebergCatalogHandlerTest {
       mock(StorageAccessConfigProvider.class);
   private final PolarisAuthorizer authorizer = mock(PolarisAuthorizer.class);
   private final CatalogHandlerUtils catalogHandlerUtils = mock(CatalogHandlerUtils.class);
+  private final PolarisStorageIntegrationProvider storageIntegrationProvider =
+      mock(PolarisStorageIntegrationProvider.class);
+  private final PolarisStorageIntegration storageIntegration =
+      mock(PolarisStorageIntegration.class);
+  private final ReservedProperties reservedProperties = mock(ReservedProperties.class);
 
   @BeforeEach
   void setUp() {
@@ -124,6 +139,9 @@ class IcebergCatalogHandlerTest {
             .build();
     when(storageAccessConfigProvider.getStorageAccessConfig(any(), any(), any(), any(), any()))
         .thenReturn(storageAccessConfig);
+    when(reservedProperties.removeReservedProperties(
+            org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenReturn(Map.of());
   }
 
   @SuppressWarnings({"unchecked"})
@@ -168,15 +186,102 @@ class IcebergCatalogHandlerTest {
         .prefixParser(mock(CatalogPrefixParser.class))
         .resolverFactory(mock(ResolverFactory.class))
         .localCatalogFactory(localCatalogFactory)
-        .reservedProperties(mock(ReservedProperties.class))
+        .reservedProperties(reservedProperties)
         .catalogHandlerUtils(catalogHandlerUtils)
         .storageAccessConfigProvider(storageAccessConfigProvider)
+        .storageIntegrationProvider(storageIntegrationProvider)
         .eventAttributeMap(mock(MutableAttributeMap.class))
         .metricsReporter(mock(IcebergMetricsReporter.class))
         .clock(mock(Clock.class))
         .accessDelegationModeResolver(accessDelegationModeResolver)
         .idempotencyRequestContext(idempotencyRequestContext)
         .build();
+  }
+
+  @Test
+  void createTableStagedDoesNotPrepareStorageWhenValidationFails() {
+    TableIdentifier tableIdentifier = TableIdentifier.of(NS1, "new_table");
+    String requestedLocation = "gs://bucket/requested/new_table";
+    String transformedLocation = "gs://bucket/transformed/new_table";
+    when(realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION, catalogEntity))
+        .thenReturn(true);
+
+    LocalIcebergCatalog polarisCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(polarisCatalog);
+    when(polarisCatalog.tableExists(tableIdentifier)).thenReturn(false);
+    when(polarisCatalog.transformTableLikeLocation(eq(tableIdentifier), eq(requestedLocation)))
+        .thenReturn(transformedLocation);
+    doThrow(new BadRequestException("location rejected"))
+        .when(polarisCatalog)
+        .validateStagedTableCreate(eq(tableIdentifier), any(TableMetadata.class));
+
+    when(resolvedPath.getRawFullPath()).thenReturn(List.of());
+    when(storageIntegrationProvider.getStorageIntegration(any())).thenReturn(storageIntegration);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .withName(tableIdentifier.name())
+            .withLocation(requestedLocation)
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                handler.createTableStaged(
+                    NS1, request, EnumSet.noneOf(AccessDelegationMode.class), Optional.empty()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("location rejected");
+
+    verify(storageIntegration, never()).prepareLocations(any());
+  }
+
+  @Test
+  void createTableStagedPreparesTransformedLocationAfterValidation() {
+    TableIdentifier tableIdentifier = TableIdentifier.of(NS1, "new_table");
+    String requestedLocation = "gs://bucket/requested/new_table";
+    String transformedLocation = "gs://bucket/transformed/new_table";
+    when(realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION, catalogEntity))
+        .thenReturn(true);
+
+    LocalIcebergCatalog polarisCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(polarisCatalog);
+    when(polarisCatalog.tableExists(tableIdentifier)).thenReturn(false);
+    when(polarisCatalog.transformTableLikeLocation(eq(tableIdentifier), eq(requestedLocation)))
+        .thenReturn(transformedLocation);
+    when(resolvedPath.getRawFullPath()).thenReturn(List.of());
+    when(storageIntegrationProvider.getStorageIntegration(any())).thenReturn(storageIntegration);
+    when(accessDelegationModeResolver.resolve(any(), any())).thenReturn(Optional.empty());
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .withName(tableIdentifier.name())
+            .withLocation(requestedLocation)
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    handler.createTableStaged(
+        NS1, request, EnumSet.noneOf(AccessDelegationMode.class), Optional.empty());
+
+    InOrder inOrder = inOrder(polarisCatalog, storageIntegration);
+    inOrder.verify(polarisCatalog).validateStagedTableCreate(eq(tableIdentifier), any());
+    inOrder
+        .verify(storageIntegration)
+        .prepareLocations(
+            argThat(
+                locations ->
+                    locations.containsAll(
+                        List.of(
+                            transformedLocation,
+                            transformedLocation + "/metadata",
+                            transformedLocation + "/data"))));
   }
 
   private Catalog mockRegisterTableCatalog(boolean overwrite) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -23,9 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -40,18 +42,22 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
@@ -77,6 +83,8 @@ import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.service.catalog.AccessDelegationModeResolver;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
@@ -89,6 +97,7 @@ import org.apache.polaris.service.reporting.PolarisMetricsReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 class IcebergCatalogHandlerTest {
 
@@ -96,6 +105,8 @@ class IcebergCatalogHandlerTest {
   private static final Namespace NS1 = Namespace.of("ns1");
   private static final TableIdentifier TABLE2 = TableIdentifier.of(NS1, "table2");
   private static final String TABLE_LOCATION = "s3://fake-bucket/tables/table2";
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
 
   private final PolarisResolutionManifest resolutionManifest =
       mock(PolarisResolutionManifest.class);
@@ -110,6 +121,11 @@ class IcebergCatalogHandlerTest {
       mock(StorageAccessConfigProvider.class);
   private final PolarisAuthorizer authorizer = mock(PolarisAuthorizer.class);
   private final CatalogHandlerUtils catalogHandlerUtils = mock(CatalogHandlerUtils.class);
+  private final PolarisStorageIntegrationProvider storageIntegrationProvider =
+      mock(PolarisStorageIntegrationProvider.class);
+  private final PolarisStorageIntegration storageIntegration =
+      mock(PolarisStorageIntegration.class);
+  private final ReservedProperties reservedProperties = mock(ReservedProperties.class);
 
   @BeforeEach
   void setUp() {
@@ -120,6 +136,9 @@ class IcebergCatalogHandlerTest {
             .build();
     when(storageAccessConfigProvider.getStorageAccessConfig(any(), any(), any(), any(), any()))
         .thenReturn(storageAccessConfig);
+    when(reservedProperties.removeReservedProperties(
+            org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenReturn(Map.of());
   }
 
   @SuppressWarnings({"unchecked"})
@@ -164,15 +183,98 @@ class IcebergCatalogHandlerTest {
         .prefixParser(mock(CatalogPrefixParser.class))
         .resolverFactory(mock(ResolverFactory.class))
         .localCatalogFactory(localCatalogFactory)
-        .reservedProperties(mock(ReservedProperties.class))
+        .reservedProperties(reservedProperties)
         .catalogHandlerUtils(catalogHandlerUtils)
         .storageAccessConfigProvider(storageAccessConfigProvider)
+        .storageIntegrationProvider(storageIntegrationProvider)
         .eventAttributeMap(mock(EventAttributeMap.class))
         .metricsReporter(mock(PolarisMetricsReporter.class))
         .clock(mock(Clock.class))
         .accessDelegationModeResolver(accessDelegationModeResolver)
         .idempotencyRequestContext(idempotencyRequestContext)
         .build();
+  }
+
+  @Test
+  void createTableStagedDoesNotPrepareStorageWhenValidationFails() {
+    TableIdentifier tableIdentifier = TableIdentifier.of(NS1, "new_table");
+    String requestedLocation = "gs://bucket/requested/new_table";
+    String transformedLocation = "gs://bucket/transformed/new_table";
+    when(realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION, catalogEntity))
+        .thenReturn(true);
+
+    LocalIcebergCatalog polarisCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(polarisCatalog);
+    when(polarisCatalog.tableExists(tableIdentifier)).thenReturn(false);
+    when(polarisCatalog.transformTableLikeLocation(eq(tableIdentifier), eq(requestedLocation)))
+        .thenReturn(transformedLocation);
+    doThrow(new BadRequestException("location rejected"))
+        .when(polarisCatalog)
+        .validateStagedTableCreate(eq(tableIdentifier), any(TableMetadata.class));
+
+    when(resolvedPath.getRawFullPath()).thenReturn(List.of());
+    when(storageIntegrationProvider.getStorageIntegration(any())).thenReturn(storageIntegration);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .withName(tableIdentifier.name())
+            .withLocation(requestedLocation)
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    assertThatThrownBy(() -> handler.createTableStaged(NS1, request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("location rejected");
+
+    verify(storageIntegration, never()).prepareLocations(any());
+  }
+
+  @Test
+  void createTableStagedPreparesTransformedLocationAfterValidation() {
+    TableIdentifier tableIdentifier = TableIdentifier.of(NS1, "new_table");
+    String requestedLocation = "gs://bucket/requested/new_table";
+    String transformedLocation = "gs://bucket/transformed/new_table";
+    when(realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION, catalogEntity))
+        .thenReturn(true);
+
+    LocalIcebergCatalog polarisCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(polarisCatalog);
+    when(polarisCatalog.tableExists(tableIdentifier)).thenReturn(false);
+    when(polarisCatalog.transformTableLikeLocation(eq(tableIdentifier), eq(requestedLocation)))
+        .thenReturn(transformedLocation);
+    when(resolvedPath.getRawFullPath()).thenReturn(List.of());
+    when(storageIntegrationProvider.getStorageIntegration(any())).thenReturn(storageIntegration);
+    when(accessDelegationModeResolver.resolve(any(), any())).thenReturn(Optional.empty());
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .withName(tableIdentifier.name())
+            .withLocation(requestedLocation)
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    handler.createTableStaged(NS1, request);
+
+    InOrder inOrder = inOrder(polarisCatalog, storageIntegration);
+    inOrder.verify(polarisCatalog).validateStagedTableCreate(eq(tableIdentifier), any());
+    inOrder
+        .verify(storageIntegration)
+        .prepareLocations(
+            argThat(
+                locations ->
+                    locations.containsAll(
+                        List.of(
+                            transformedLocation,
+                            transformedLocation + "/metadata",
+                            transformedLocation + "/data"))));
   }
 
   private Catalog mockRegisterTableCatalog(boolean overwrite) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
@@ -26,7 +26,10 @@ import static org.apache.polaris.core.config.FeatureConfiguration.DEFAULT_UNIQUE
 import static org.apache.polaris.core.config.FeatureConfiguration.OPTIMIZED_SIBLING_CHECK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URLEncoder;
@@ -35,8 +38,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.config.RealmConfig;
@@ -44,7 +52,9 @@ import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.exceptions.CommitConflictException;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
@@ -52,6 +62,8 @@ import org.apache.polaris.core.persistence.resolver.Resolver;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverPath;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +81,8 @@ class LocalIcebergCatalogTest {
   @Mock CatalogEntity catalogEntity;
   @Mock PolarisDiagnostics diagnostics;
   @Mock Resolver resolver;
+  @Mock PolarisStorageIntegrationProvider storageIntegrationProvider;
+  @Mock PolarisStorageIntegration storageIntegration;
 
   @Mock PolarisEntity ns1;
   @Mock PolarisEntity ns2;
@@ -85,7 +99,7 @@ class LocalIcebergCatalogTest {
   void initMocks() {
     when(callContext.getRealmConfig()).thenReturn(realmConfig);
     when(catalogEntity.getName()).thenReturn("catalog");
-    when(resolvedEntityView.getResolvedCatalogEntity()).thenReturn(catalogEntity);
+    lenient().when(resolvedEntityView.getResolvedCatalogEntity()).thenReturn(catalogEntity);
     lenient().when(resolverFactory.createResolver(any(), any())).thenReturn(resolver);
     lenient()
         .when(resolver.resolveAll())
@@ -107,7 +121,42 @@ class LocalIcebergCatalogTest {
             null,
             null,
             null,
-            null);
+            null,
+            storageIntegrationProvider);
+  }
+
+  @Test
+  void prepareStorageForTableCreationUsesActualMetadataLocations() {
+    PolarisResolvedPathWrapper resolvedStorageEntity = mock(PolarisResolvedPathWrapper.class);
+    when(resolvedStorageEntity.getRawFullPath()).thenReturn(List.of(ns1));
+    when(storageIntegrationProvider.getStorageIntegration(List.of(ns1)))
+        .thenReturn(storageIntegration);
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get())),
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            "gs://bucket/ns-location/table1",
+            Map.of(
+                IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY,
+                "gs://bucket/custom-metadata/table1",
+                IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY,
+                "gs://bucket/custom-data/table1"));
+
+    catalog.prepareStorageForTableCreation(
+        TableIdentifier.of(Namespace.of("ns"), "table1"), metadata, resolvedStorageEntity);
+
+    verify(storageIntegration)
+        .prepareLocations(
+            argThat(
+                locations ->
+                    Set.copyOf(locations)
+                        .equals(
+                            Set.of(
+                                "gs://bucket/ns-location/table1",
+                                "gs://bucket/custom-metadata/table1",
+                                "gs://bucket/custom-data/table1"))));
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparerTest.java
@@ -223,13 +223,13 @@ class GcsStorageLocationPreparerTest {
       verify(mockControlClient, times(5)).createFolder(any(CreateFolderRequest.class));
       verify(mockControlClient, times(5))
           .createFolder(
-              argThat(
-                  request -> request.hasFolder() && request.getFolderId().endsWith("/")));
+              argThat(request -> request.hasFolder() && request.getFolderId().endsWith("/")));
     }
 
     @Test
     void preservesQuestionMarkAndHashInObjectPath() {
-      preparer.prepareLocations(List.of("gs://" + TEST_BUCKET + "/warehouse/table?branch#metadata"));
+      preparer.prepareLocations(
+          List.of("gs://" + TEST_BUCKET + "/warehouse/table?branch#metadata"));
 
       verify(mockControlClient)
           .createFolder(

--- a/runtime/service/src/test/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/storage/gcs/GcsStorageLocationPreparerTest.java
@@ -1,0 +1,607 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.rpc.AlreadyExistsException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.storage.control.v2.CreateFolderRequest;
+import com.google.storage.control.v2.Folder;
+import com.google.storage.control.v2.StorageControlClient;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.polaris.service.storage.HierarchicalFolderLocationPreparer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GcsStorageLocationPreparerTest {
+
+  private static final String TEST_BUCKET = "my-test-bucket";
+  private static final String TEST_TABLE_LOCATION = "gs://" + TEST_BUCKET + "/warehouse/ns1/table1";
+
+  private Supplier<GoogleCredentials> credentialsSupplier;
+  private Bucket mockBucket;
+  private StorageControlClient mockControlClient;
+  private GcsStorageLocationPreparer preparer;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    GoogleCredentials mockCredentials =
+        GoogleCredentials.create(
+            new AccessToken("test-token", Date.from(Instant.now().plusSeconds(3600))));
+    credentialsSupplier = () -> mockCredentials;
+
+    mockBucket = mock(Bucket.class);
+    mockControlClient = mock(StorageControlClient.class);
+
+    GcsStorageLocationPreparer realPreparer = new GcsStorageLocationPreparer(credentialsSupplier);
+    preparer = spy(realPreparer);
+
+    Mockito.doReturn(mockBucket).when(preparer).fetchBucketMetadata(anyString());
+    Mockito.doReturn(mockControlClient).when(preparer).createStorageControlClient();
+  }
+
+  // ── buildPathHierarchy Tests (Internal Helper) ─────────────────────────────
+
+  @Nested
+  class BuildPathHierarchyTests {
+
+    @Test
+    void producesFullHierarchyWithoutMetadataDataSubfolders() {
+      List<String> folders =
+          HierarchicalFolderLocationPreparer.buildPathHierarchy(
+              "cdr/polaris-test-metadata/dsp/table1/metadata");
+
+      assertThat(folders)
+          .containsExactly(
+              "cdr",
+              "cdr/polaris-test-metadata",
+              "cdr/polaris-test-metadata/dsp",
+              "cdr/polaris-test-metadata/dsp/table1",
+              "cdr/polaris-test-metadata/dsp/table1/metadata");
+    }
+
+    @Test
+    void handlesSingleSegmentPath() {
+      List<String> folders = HierarchicalFolderLocationPreparer.buildPathHierarchy("data");
+
+      assertThat(folders).containsExactly("data");
+    }
+
+    @Test
+    void handlesTwoSegmentPath() {
+      List<String> folders =
+          HierarchicalFolderLocationPreparer.buildPathHierarchy("custom/metadata");
+
+      assertThat(folders).containsExactly("custom", "custom/metadata");
+    }
+
+    @Test
+    void returnsEmptyForEmptyPath() {
+      List<String> folders = HierarchicalFolderLocationPreparer.buildPathHierarchy("");
+
+      assertThat(folders).isEmpty();
+    }
+
+    @Test
+    void collapsesRepeatedSlashes() {
+      List<String> folders = HierarchicalFolderLocationPreparer.buildPathHierarchy("a//b///c");
+
+      assertThat(folders).containsExactly("a", "a/b", "a/b/c");
+    }
+
+    @Test
+    void producesCorrectHierarchyForTypicalTablePath() {
+      List<String> folders =
+          HierarchicalFolderLocationPreparer.buildPathHierarchy("warehouse/ns1/table1");
+
+      assertThat(folders).containsExactly("warehouse", "warehouse/ns1", "warehouse/ns1/table1");
+    }
+
+    @Test
+    void handlesNestedNamespacePath() {
+      List<String> folders =
+          HierarchicalFolderLocationPreparer.buildPathHierarchy("warehouse/ns1/ns2/ns3/table1");
+
+      assertThat(folders)
+          .containsExactly(
+              "warehouse",
+              "warehouse/ns1",
+              "warehouse/ns1/ns2",
+              "warehouse/ns1/ns2/ns3",
+              "warehouse/ns1/ns2/ns3/table1");
+    }
+  }
+
+  // ── prepareLocations: No-Op Scenarios ─────────────────────────────────────
+
+  @Nested
+  class NoOpScenarioTests {
+
+    @Test
+    void skipsEmptyLocationsList() throws IOException {
+      preparer.prepareLocations(List.of());
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+      verify(preparer, never()).createStorageControlClient();
+    }
+
+    @Test
+    void skipsNonGcsLocation() throws IOException {
+      preparer.prepareLocations(List.of("s3://my-bucket/warehouse/table1"));
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+    }
+
+    @Test
+    void skipsEmptyLocation() throws IOException {
+      preparer.prepareLocations(List.of(""));
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+    }
+
+    @Test
+    void skipsBucketOnlyLocationWithNoObjectPath() throws IOException {
+      preparer.prepareLocations(List.of("gs://" + TEST_BUCKET));
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+      verify(preparer, never()).createStorageControlClient();
+    }
+
+    @Test
+    void skipsBucketWithRootSlashOnly() throws IOException {
+      preparer.prepareLocations(List.of("gs://" + TEST_BUCKET + "/"));
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+      verify(preparer, never()).createStorageControlClient();
+    }
+  }
+
+  // ── prepareLocations: HNS Enabled ─────────────────────────────────────────
+
+  @Nested
+  class HnsEnabledTests {
+
+    @BeforeEach
+    void setUpHnsBucket() {
+      BucketInfo.HierarchicalNamespace hns = mock(BucketInfo.HierarchicalNamespace.class);
+      when(hns.getEnabled()).thenReturn(true);
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(hns);
+    }
+
+    @Test
+    void createsFolderHierarchyForHnsBucket() throws IOException {
+      when(mockControlClient.createFolder(any(CreateFolderRequest.class)))
+          .thenReturn(Folder.getDefaultInstance());
+
+      preparer.prepareLocations(
+          List.of(
+              TEST_TABLE_LOCATION,
+              TEST_TABLE_LOCATION + "/metadata",
+              TEST_TABLE_LOCATION + "/data"));
+
+      verify(preparer).createStorageControlClient();
+      // warehouse, warehouse/ns1, warehouse/ns1/table1, metadata, data = 5 unique folders
+      verify(mockControlClient, times(5)).createFolder(any(CreateFolderRequest.class));
+      verify(mockControlClient, times(5))
+          .createFolder(
+              argThat(
+                  request -> request.hasFolder() && request.getFolderId().endsWith("/")));
+    }
+
+    @Test
+    void preservesQuestionMarkAndHashInObjectPath() {
+      preparer.prepareLocations(List.of("gs://" + TEST_BUCKET + "/warehouse/table?branch#metadata"));
+
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  request ->
+                      request.getParent().contains(TEST_BUCKET)
+                          && request.getFolderId().equals("warehouse/table?branch#metadata/")));
+    }
+
+    @Test
+    void gracefullyHandlesAlreadyExistingFolders() {
+      AlreadyExistsException alreadyExists = createAlreadyExistsException();
+      when(mockControlClient.createFolder(any(CreateFolderRequest.class))).thenThrow(alreadyExists);
+
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  preparer.prepareLocations(
+                      List.of(
+                          TEST_TABLE_LOCATION,
+                          TEST_TABLE_LOCATION + "/metadata",
+                          TEST_TABLE_LOCATION + "/data")));
+    }
+
+    @Test
+    void mixedNewAndExistingFolders() {
+      AlreadyExistsException alreadyExists = createAlreadyExistsException();
+
+      when(mockControlClient.createFolder(any(CreateFolderRequest.class)))
+          .thenThrow(alreadyExists)
+          .thenThrow(alreadyExists)
+          .thenReturn(Folder.getDefaultInstance())
+          .thenReturn(Folder.getDefaultInstance())
+          .thenReturn(Folder.getDefaultInstance());
+
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  preparer.prepareLocations(
+                      List.of(
+                          TEST_TABLE_LOCATION,
+                          TEST_TABLE_LOCATION + "/metadata",
+                          TEST_TABLE_LOCATION + "/data")));
+      verify(mockControlClient, times(5)).createFolder(any(CreateFolderRequest.class));
+    }
+
+    @Test
+    void propagatesNonAlreadyExistsExceptionFromFolderCreation() {
+      when(mockControlClient.createFolder(any(CreateFolderRequest.class)))
+          .thenThrow(new RuntimeException("gRPC transport failure"));
+
+      assertThatThrownBy(
+              () ->
+                  preparer.prepareLocations(
+                      List.of(
+                          TEST_TABLE_LOCATION,
+                          TEST_TABLE_LOCATION + "/metadata",
+                          TEST_TABLE_LOCATION + "/data")))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Failed to create HNS folder");
+    }
+  }
+
+  // ── prepareLocations: Flat Namespace ──────────────────────────────────────
+
+  @Nested
+  class FlatNamespaceTests {
+
+    @BeforeEach
+    void setUpFlatBucket() {
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(null);
+    }
+
+    @Test
+    void doesNotCreateFoldersForFlatNamespaceBucket() throws IOException {
+      preparer.prepareLocations(List.of(TEST_TABLE_LOCATION));
+
+      verify(preparer).fetchBucketMetadata(eq(TEST_BUCKET));
+      verify(preparer, never()).createStorageControlClient();
+    }
+
+    @Test
+    void doesNotCreateFoldersWhenHnsExplicitlyDisabled() throws IOException {
+      BucketInfo.HierarchicalNamespace hns = mock(BucketInfo.HierarchicalNamespace.class);
+      when(hns.getEnabled()).thenReturn(false);
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(hns);
+
+      preparer.prepareLocations(List.of(TEST_TABLE_LOCATION));
+
+      verify(preparer, never()).createStorageControlClient();
+    }
+
+    @Test
+    void doesNotCreateFoldersWhenHnsEnabledIsNull() throws IOException {
+      BucketInfo.HierarchicalNamespace hns = mock(BucketInfo.HierarchicalNamespace.class);
+      when(hns.getEnabled()).thenReturn(null);
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(hns);
+
+      preparer.prepareLocations(List.of(TEST_TABLE_LOCATION));
+
+      verify(preparer, never()).createStorageControlClient();
+    }
+  }
+
+  // ── HNS Cache Behavior ────────────────────────────────────────────────────
+
+  @Nested
+  class HnsCacheTests {
+
+    @Test
+    void queriesDifferentBucketsSeparately() {
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(null);
+
+      preparer.prepareLocations(List.of("gs://bucket-a/warehouse/table1"));
+      preparer.prepareLocations(List.of("gs://bucket-b/warehouse/table2"));
+
+      verify(preparer).fetchBucketMetadata(eq("bucket-a"));
+      verify(preparer).fetchBucketMetadata(eq("bucket-b"));
+    }
+  }
+
+  // ── Error Handling ────────────────────────────────────────────────────────
+
+  @Nested
+  class ErrorHandlingTests {
+
+    @Test
+    void wrapsHnsCheckFailureWithDescriptiveMessage() {
+      Mockito.doThrow(new RuntimeException("Network unreachable"))
+          .when(preparer)
+          .fetchBucketMetadata(anyString());
+
+      assertThatThrownBy(() -> preparer.prepareLocations(List.of(TEST_TABLE_LOCATION)))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Failed to check HNS status")
+          .hasMessageContaining(TEST_BUCKET);
+    }
+
+    @Test
+    void wrapsStorageControlClientInitFailure() throws IOException {
+      BucketInfo.HierarchicalNamespace hns = mock(BucketInfo.HierarchicalNamespace.class);
+      when(hns.getEnabled()).thenReturn(true);
+      when(mockBucket.getHierarchicalNamespace()).thenReturn(hns);
+
+      Mockito.doThrow(new IOException("gRPC init failure"))
+          .when(preparer)
+          .createStorageControlClient();
+
+      assertThatThrownBy(() -> preparer.prepareLocations(List.of(TEST_TABLE_LOCATION)))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Failed to initialize StorageControlClient")
+          .hasMessageContaining(TEST_BUCKET);
+    }
+  }
+
+  // ── Cross-Bucket HNS Tests ────────────────────────────────────────────────
+
+  @Nested
+  class CrossBucketHnsTests {
+
+    @Test
+    void checksHnsForEachUniqueBucket() {
+      // Table in bucket-a, metadata in bucket-b, data in bucket-c
+      Mockito.doReturn(createMockBucket("bucket-a", false))
+          .when(preparer)
+          .fetchBucketMetadata("bucket-a");
+      Mockito.doReturn(createMockBucket("bucket-b", true))
+          .when(preparer)
+          .fetchBucketMetadata("bucket-b");
+      Mockito.doReturn(createMockBucket("bucket-c", true))
+          .when(preparer)
+          .fetchBucketMetadata("bucket-c");
+
+      preparer.prepareLocations(
+          List.of(
+              "gs://bucket-a/warehouse/ns/table",
+              "gs://bucket-b/custom/metadata",
+              "gs://bucket-c/custom/data"));
+
+      // Should check HNS for all three buckets
+      verify(preparer).fetchBucketMetadata("bucket-a");
+      verify(preparer).fetchBucketMetadata("bucket-b");
+      verify(preparer).fetchBucketMetadata("bucket-c");
+
+      // Should only create folders in HNS-enabled buckets (bucket-b and bucket-c)
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("bucket-b") && req.getFolderId().equals("custom/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("bucket-b")
+                          && req.getFolderId().equals("custom/metadata/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("bucket-c") && req.getFolderId().equals("custom/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("bucket-c")
+                          && req.getFolderId().equals("custom/data/")));
+    }
+
+    @Test
+    void createsFoldersOnlyInHnsEnabledBuckets() {
+      Mockito.doReturn(createMockBucket("hns-bucket", true))
+          .when(preparer)
+          .fetchBucketMetadata("hns-bucket");
+      Mockito.doReturn(createMockBucket("non-hns-bucket", false))
+          .when(preparer)
+          .fetchBucketMetadata("non-hns-bucket");
+
+      preparer.prepareLocations(
+          List.of(
+              "gs://hns-bucket/warehouse/ns/table",
+              "gs://non-hns-bucket/metadata",
+              "gs://hns-bucket/custom/data"));
+
+      // Should create table hierarchy in hns-bucket
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("hns-bucket")
+                          && req.getFolderId().equals("warehouse/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("hns-bucket")
+                          && req.getFolderId().equals("warehouse/ns/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("hns-bucket")
+                          && req.getFolderId().equals("warehouse/ns/table/")));
+      // Custom data path hierarchy in hns-bucket
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("hns-bucket")
+                          && req.getFolderId().equals("custom/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("hns-bucket")
+                          && req.getFolderId().equals("custom/data/")));
+    }
+
+    @Test
+    void handlesAllPathsInSameBucket() {
+      Mockito.doReturn(createMockBucket("single-bucket", true))
+          .when(preparer)
+          .fetchBucketMetadata("single-bucket");
+
+      preparer.prepareLocations(
+          List.of(
+              "gs://single-bucket/warehouse/ns/table",
+              "gs://single-bucket/custom/metadata",
+              "gs://single-bucket/custom/data"));
+
+      // Should check HNS only once for the single bucket
+      verify(preparer, times(1)).fetchBucketMetadata("single-bucket");
+
+      // Table hierarchy: warehouse, warehouse/ns, warehouse/ns/table
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("warehouse/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("warehouse/ns/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("warehouse/ns/table/")));
+      // Custom metadata: custom, custom/metadata
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("custom/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("custom/metadata/")));
+      // Custom data: custom/data (custom already deduplicated)
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("single-bucket")
+                          && req.getFolderId().equals("custom/data/")));
+    }
+
+    @Test
+    void skipsInvalidGcsLocations() {
+      Mockito.doReturn(createMockBucket("valid-bucket", true))
+          .when(preparer)
+          .fetchBucketMetadata("valid-bucket");
+
+      // s3 location should be filtered out
+      preparer.prepareLocations(
+          List.of(
+              "gs://valid-bucket/warehouse/ns/table",
+              "s3://invalid-bucket/metadata",
+              "gs://valid-bucket/data"));
+
+      verify(preparer).fetchBucketMetadata("valid-bucket");
+      verify(preparer, never()).fetchBucketMetadata("invalid-bucket");
+
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("valid-bucket")
+                          && req.getFolderId().equals("warehouse/")));
+      verify(mockControlClient)
+          .createFolder(
+              argThat(
+                  req ->
+                      req.getParent().contains("valid-bucket")
+                          && req.getFolderId().equals("data/")));
+    }
+
+    @Test
+    void handlesEmptyBucketNames() {
+      String tableLocation = "gs:///invalid/path"; // Empty bucket name
+
+      preparer.prepareLocations(List.of(tableLocation));
+
+      verify(preparer, never()).fetchBucketMetadata(anyString());
+      verify(mockControlClient, never()).createFolder(any());
+    }
+
+    private Bucket createMockBucket(String bucketName, boolean hnsEnabled) {
+      Bucket bucket = mock(Bucket.class);
+      when(bucket.getName()).thenReturn(bucketName);
+
+      BucketInfo.HierarchicalNamespace hns = mock(BucketInfo.HierarchicalNamespace.class);
+      when(hns.getEnabled()).thenReturn(hnsEnabled);
+      when(bucket.getHierarchicalNamespace()).thenReturn(hns);
+
+      return bucket;
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static AlreadyExistsException createAlreadyExistsException() {
+    StatusCode statusCode = mock(StatusCode.class);
+    when(statusCode.getCode()).thenReturn(StatusCode.Code.ALREADY_EXISTS);
+    return new AlreadyExistsException(
+        new RuntimeException("Folder already exists"), statusCode, false);
+  }
+}

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -393,7 +393,8 @@ public record TestServices(
               metaStoreManager,
               callContext,
               principal,
-              idempotencyRequestContext);
+              idempotencyRequestContext,
+              storageIntegrationProvider);
 
       ReservedProperties reservedProperties = ReservedProperties.NONE;
 
@@ -457,6 +458,7 @@ public record TestServices(
                         .catalogHandlerUtils(catalogHandlerUtils)
                         .federatedCatalogFactories(federatedCatalogFactory)
                         .storageAccessConfigProvider(storageAccessConfigProvider)
+                        .storageIntegrationProvider(storageIntegrationProvider)
                         .eventAttributeMap(eventAttributeMap)
                         .metricsReporter(new DefaultMetricsReporter())
                         .clock(clock)

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -398,7 +398,8 @@ public record TestServices(
               metaStoreManager,
               callContext,
               principal,
-              idempotencyRequestContext);
+              idempotencyRequestContext,
+              storageIntegrationProvider);
 
       ReservedProperties reservedProperties = ReservedProperties.NONE;
 
@@ -465,6 +466,7 @@ public record TestServices(
                         .catalogHandlerUtils(catalogHandlerUtils)
                         .federatedCatalogFactories(federatedCatalogFactory)
                         .storageAccessConfigProvider(storageAccessConfigProvider)
+                        .storageIntegrationProvider(storageIntegrationProvider)
                         .eventAttributeMap(eventAttributeMap)
                         .metricsReporter(envelope -> {})
                         .clock(clock)

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-gcs-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-gcs-cloud-storage-specific.md
@@ -30,3 +30,23 @@ All catalog operations in Polaris for Google Cloud Storage (GCS)—including lis
 Polaris requires both IAM roles and [Hierarchical Namespace (HNS)](https://docs.cloud.google.com/storage/docs/hns-overview) ACLs (if HNS is enabled) to be properly configured. Even with the correct IAM role (e.g., `roles/storage.objectAdmin`), access to paths such as `gs://<bucket>/idsp_ns/sample_table4/` may fail with 403 errors if HNS ACLs are missing for scoped tokens. The original access token may work, but scoped (vended) tokens require HNS ACLs on the base path or relevant subpath.
 
 **Note:** HNS is not mandatory when using GCS for a catalog in Polaris. If HNS is not enabled on the bucket, only IAM roles are required for access. Always verify HNS ACLs in addition to IAM roles when troubleshooting GCS access issues with credential vending and HNS enabled.
+
+## Hierarchical Namespace (HNS) Support
+
+Polaris detects whether a target GCS bucket has HNS enabled automatically at table creation
+time and at credential-vending time; no configuration flag is required, and the same catalog
+can serve a mix of HNS and non-HNS buckets.
+
+When HNS is detected on a write bucket, Polaris transparently handles two things:
+
+- **Server-side pre-create.** Before delegating to Iceberg's `Catalog.createTable()`, Polaris
+  uses the catalog service-account credentials to create the table's top-level folder
+  structure (`<table>/`, `<table>/metadata/`, `<table>/data/`) via the GCS Storage Control
+  API. This is required because HNS-enabled buckets treat folders as first-class resources
+  that must exist before files can be written into them.
+- **Vended-credential scope.** The downscoped credentials returned to clients include a GCS
+  Storage Folder Admin CAB role (`inRole:roles/storage.folderAdmin`) so partitioned writers can
+  create deeper folders at write time (for example, `data/year=2024/month=01/`). Credential Access
+  Boundary rules require role identifiers rather than raw permissions, so Polaris constrains this
+  role with availability-condition expressions scoped to the catalog's write locations. For non-HNS
+  buckets no additional folder rule is vended.

--- a/tools/testcontainers/floci-gcp/src/main/java/org/apache/polaris/test/floci/gcp/FlociGcpTestResource.java
+++ b/tools/testcontainers/floci-gcp/src/main/java/org/apache/polaris/test/floci/gcp/FlociGcpTestResource.java
@@ -43,7 +43,9 @@ public class FlociGcpTestResource implements QuarkusTestResourceLifecycleManager
                 initArgs.get("oauth2Token"))
             .withStartupAttempts(5);
     this.container.start();
-    return Map.of();
+    return Map.of(
+        "polaris.storage.gcp.token", container.oauth2Token(),
+        "STORAGE_EMULATOR_HOST", container.baseUri());
   }
 
   @Override


### PR DESCRIPTION
## Problem

GCS buckets with Hierarchical Namespace (HNS) enabled treat folders as first-class resources, not name prefixes. Iceberg table creation and Spark ingestion fail on HNS buckets because:

1. Folder objects must exist before files can be written into them.
2. Folder creation requires `storage.folders.create` — not granted by the standard write roles in our vended credentials.

## Approach

Two complementary changes, with a clear split between server-side and client-side responsibility:

### 1. Server-side: pre-createTable hook to materialize the folder hierarchy

A new SPI, `prepareLocations(List<String>)`, is exposed on `PolarisStorageIntegration` with a no-op default. GCS overrides it.

`IcebergCatalogHandler.createTableDirect()` and `createTableStaged()` now invoke `integration.prepareLocations([tableLocation, metadataLocation, dataLocation])` **before** delegating to Iceberg's `Catalog.createTable()`.

The GCS implementation (`GcsStorageLocationPreparer`):
- Calls `Storage.get(bucket, HIERARCHICAL_NAMESPACE)` to detect HNS per bucket (auto-detection — HNS is bucket-immutable, so it's safe to call once per request; caching is a follow-up).
- For HNS buckets only, walks the path hierarchy (`warehouse` → `warehouse/ns1` → `warehouse/ns1/table1`) and calls `StorageControlClient.createFolder()` for each segment, idempotent against `AlreadyExistsException`.
- For non-HNS buckets, no-op.

Generic URI parsing and hierarchy-building lives in `HierarchicalFolderLocationPreparer` (base class) so Azure ADLS Gen2 can reuse it later.

### 2. Client-side: vended-credential scope adds folders.create + folders.get for HNS buckets

`GcpCredentialsStorageIntegration.generateAccessBoundaryRules()` now takes a `Predicate<String> isHnsBucket`. For each write bucket where the predicate is true, it adds a third access-boundary rule containing exactly two permissions: `storage.folders.create` and `storage.folders.get`, scoped via `resource.name.startsWith('projects/_/buckets/<bucket>/folders/<path>')`.

This allows Spark to create deeper partition folders (e.g. for `year=2024/month=01/`) at write time without needing admin credentials, while non-HNS catalogs are unaffected (no additional permissions vended).

The narrow permission set (vs. the predefined `roles/storage.folderAdmin` role, which includes `setIamPolicy/getIamPolicy/delete/rename/list`) preserves least-privilege.

## Tests
- HNS folder rule emission gated by predicate
- HNS with multiple buckets and partial writes
- HNS without writes (no folder rules)
- HNS with separate metadata and data buckets
- HNS predicate-gating (mixed HNS/non-HNS in one catalog)
- Folder rule uses narrow `folders.create` + `folders.get` permissions (verified explicitly)
- Non-HNS bucket emits no folder rule
- `GcsStorageLocationPreparer` HNS detection and folder creation (full suite preserved from previous round)

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed
- [x] 🧪 Added/updated tests with good coverage
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated \`CHANGELOG.md\`
- [x] 📚 Updated documentation in \`site/content/in-dev/unreleased\`