### PR TITLE
Fix SVN command for Release

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -396,7 +396,7 @@ jobs:
           exec_process cp helm/polaris-${version_without_rc}.tgz* "${dist_dev_dir}/helm-chart/${version_without_rc}/"
 
           exec_process cd "${dist_dev_dir}"
-          exec_process svn add "helm-chart/${version_without_rc}"
+          exec_process svn add --parents "helm-chart/${version_without_rc}"
 
           exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Stage Apache Polaris Helm chart ${version_without_rc} RC${rc_number}"
 


### PR DESCRIPTION
One-line change to ensure that SVN can find all parent nodes.

Previous error log:
```
DEBUG: Executing 'svn checkout --username *** --password *** --non-interactive https://dist.apache.org/repos/dist/dev/polaris /home/runner/work/polaris/polaris/releasey/polaris-dist-dev'
A    releasey/polaris-dist-dev/1.4.0
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0
A    releasey/polaris-dist-dev/1.4.0/apache-polaris-1.4.0.tar.gz
A    releasey/polaris-dist-dev/1.4.0/apache-polaris-1.4.0.tar.gz.asc
A    releasey/polaris-dist-dev/1.4.0/apache-polaris-1.4.0.tar.gz.sha512
A    releasey/polaris-dist-dev/1.4.0/apache-polaris-1.4.0.vote-email-body.txt
A    releasey/polaris-dist-dev/1.4.0/apache-polaris-1.4.0.vote-email-subject.txt
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.tgz
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.tgz.asc
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.tgz.sha512
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.zip
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.zip.asc
A    releasey/polaris-dist-dev/1.4.0/polaris-bin-1.4.0.zip.sha512
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/apache-polaris-iceberg-catalog-migrator-1.0.0.tar.gz
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/apache-polaris-iceberg-catalog-migrator-1.0.0.tar.gz.asc
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/apache-polaris-iceberg-catalog-migrator-1.0.0.tar.gz.sha512
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/iceberg-catalog-migrator-cli-1.0.0.jar
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/iceberg-catalog-migrator-cli-1.0.0.jar.asc
A    releasey/polaris-dist-dev/apache-polaris-iceberg-catalog-migrator/1.0.0/iceberg-catalog-migrator-cli-1.0.0.jar.sha512
Checked out revision 83124.
DEBUG: Executing 'mkdir -p /home/runner/work/polaris/polaris/releasey/polaris-dist-dev/helm-chart/1.4.0'
DEBUG: Executing 'cp helm/polaris-1.4.0.tgz helm/polaris-1.4.0.tgz.asc helm/polaris-1.4.0.tgz.prov helm/polaris-1.4.0.tgz.prov.asc helm/polaris-1.4.0.tgz.prov.sha512 helm/polaris-1.4.0.tgz.sha512 /home/runner/work/polaris/polaris/releasey/polaris-dist-dev/helm-chart/1.4.0/'
DEBUG: Executing 'cd /home/runner/work/polaris/polaris/releasey/polaris-dist-dev'
DEBUG: Executing 'svn add helm-chart/1.4.0'
svn: E150000: Can't find parent directory's node while trying to add '/home/runner/work/polaris/polaris/releasey/polaris-dist-dev/helm-chart/1.4.0'
svn: E155010: The node '/home/runner/work/polaris/polaris/releasey/polaris-dist-dev/helm-chart' was not found.
```

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [N/A] 💡 Added comments for complex logic
- [N/A] 🧾 Updated `CHANGELOG.md` (if needed)
- [N/A] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
