### PR TITLE
Add optional traversal limit for commit offset lookup

### DIFF
--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/PersistenceParams.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/PersistenceParams.java
@@ -83,6 +83,14 @@ public interface PersistenceParams {
   @WithDefault(DEFAULT_MAX_SERIALIZED_VALUE_SIZE_STRING)
   MemorySize maxSerializedValueSize();
 
+  /**
+   * Maximum number of commit-IDs to traverse while resolving an offset for commit log iteration.
+   *
+   * <p>A value of {@code 0} disables the safeguard (unlimited traversal).
+   */
+  @WithDefault("0")
+  long commitOffsetLookupMaxTraversal();
+
   @PolarisImmutable
   interface BuildablePersistenceParams extends PersistenceParams {
     static ImmutableBuildablePersistenceParams.Builder builder() {
@@ -129,6 +137,12 @@ public interface PersistenceParams {
     @Value.Default
     default MemorySize maxSerializedValueSize() {
       return DEFAULT_MAX_SERIALIZED_VALUE_SIZE;
+    }
+
+    @Override
+    @Value.Default
+    default long commitOffsetLookupMaxTraversal() {
+      return 0L;
     }
   }
 }

--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/exceptions/CommitOffsetTraversalLimitExceededException.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/exceptions/CommitOffsetTraversalLimitExceededException.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.api.exceptions;
+
+/** Thrown when offset resolution would exceed the configured traversal safeguard. */
+public class CommitOffsetTraversalLimitExceededException extends PersistenceException {
+  private final String refName;
+  private final long offset;
+  private final long traversed;
+  private final long maxTraversal;
+
+  public CommitOffsetTraversalLimitExceededException(
+      String refName, long offset, long traversed, long maxTraversal) {
+    super(
+        "Exceeded commit offset traversal limit while resolving offset "
+            + offset
+            + " for ref '"
+            + refName
+            + "'. Traversed="
+            + traversed
+            + ", max="
+            + maxTraversal);
+    this.refName = refName;
+    this.offset = offset;
+    this.traversed = traversed;
+    this.maxTraversal = maxTraversal;
+  }
+
+  public String refName() {
+    return refName;
+  }
+
+  public long offset() {
+    return offset;
+  }
+
+  public long traversed() {
+    return traversed;
+  }
+
+  public long maxTraversal() {
+    return maxTraversal;
+  }
+}
+

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
@@ -32,6 +32,7 @@ import java.util.OptionalLong;
 import org.agrona.collections.LongArrayList;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.commit.Commits;
+import org.apache.polaris.persistence.nosql.api.exceptions.CommitOffsetTraversalLimitExceededException;
 import org.apache.polaris.persistence.nosql.api.obj.BaseCommitObj;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 
@@ -69,7 +70,7 @@ final class CommitsImpl implements Commits {
     }
 
     visited.add(head.id());
-    var traversed = 1L;
+    var traversed = 0L;
     var tail = head.tail();
     outer:
     while (tail.length != 0) {
@@ -77,18 +78,11 @@ final class CommitsImpl implements Commits {
         if (tailId == offset) {
           break outer;
         }
-        visited.add(tailId);
         if (maxTraversal != UNLIMITED_TRAVERSAL && ++traversed > maxTraversal) {
-          throw new IllegalStateException(
-              "Exceeded commit offset traversal limit while resolving offset "
-                  + offset
-                  + " for ref '"
-                  + refName
-                  + "'. Traversed="
-                  + traversed
-                  + ", max="
-                  + maxTraversal);
+          throw new CommitOffsetTraversalLimitExceededException(
+              refName, offset, traversed, maxTraversal);
         }
+        visited.add(tailId);
       }
 
       while (!visited.isEmpty()) {
@@ -180,15 +174,8 @@ final class CommitsImpl implements Commits {
           }
           lastId = tailId;
           if (maxTraversal != UNLIMITED_TRAVERSAL && ++traversed > maxTraversal) {
-            throw new IllegalStateException(
-                "Exceeded commit offset traversal limit while resolving offset "
-                    + off
-                    + " for ref '"
-                    + refName
-                    + "'. Traversed="
-                    + traversed
-                    + ", max="
-                    + maxTraversal);
+            throw new CommitOffsetTraversalLimitExceededException(
+                refName, off, traversed, maxTraversal);
           }
         }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
@@ -38,6 +38,7 @@ import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 final class CommitsImpl implements Commits {
   private final Persistence persistence;
   private static final int REVERSE_COMMIT_FETCH_SIZE = 20;
+  private static final long UNLIMITED_TRAVERSAL = 0L;
 
   @SuppressWarnings("CdiInjectionPointsInspection")
   @Inject
@@ -55,13 +56,12 @@ final class CommitsImpl implements Commits {
 
     var head = headOpt.get();
     var type = head.type().id();
+    var maxTraversal = persistence.params().commitOffsetLookupMaxTraversal();
 
     // find commit with Obj.id() == offset, memoize visited commits
 
     // Contains the seen IDs, without the 'offset', in _natural_ order (most recent commit ID first)
     var visited = new LongArrayList();
-
-    // TODO add safeguard to limit the work done when finding the commit with ID 'offset'
 
     // Only walk, if the most recent commit ID is != offset
     if (head.id() == offset) {
@@ -69,6 +69,7 @@ final class CommitsImpl implements Commits {
     }
 
     visited.add(head.id());
+    var traversed = 1L;
     var tail = head.tail();
     outer:
     while (tail.length != 0) {
@@ -77,6 +78,17 @@ final class CommitsImpl implements Commits {
           break outer;
         }
         visited.add(tailId);
+        if (maxTraversal != UNLIMITED_TRAVERSAL && ++traversed > maxTraversal) {
+          throw new IllegalStateException(
+              "Exceeded commit offset traversal limit while resolving offset "
+                  + offset
+                  + " for ref '"
+                  + refName
+                  + "'. Traversed="
+                  + traversed
+                  + ", max="
+                  + maxTraversal);
+        }
       }
 
       while (!visited.isEmpty()) {
@@ -146,8 +158,7 @@ final class CommitsImpl implements Commits {
 
     var head = headOpt.get();
     var type = head.type().id();
-
-    // TODO add safeguard to limit the work done when finding the commit with ID 'offset'
+    var maxTraversal = persistence.params().commitOffsetLookupMaxTraversal();
 
     if (offset.isPresent()) {
       var off = offset.getAsLong();
@@ -157,6 +168,7 @@ final class CommitsImpl implements Commits {
         return singletonList(head).iterator();
       }
 
+      var traversed = 0L;
       var tail = head.tail();
       outer:
       while (tail.length != 0) {
@@ -167,6 +179,17 @@ final class CommitsImpl implements Commits {
             break outer;
           }
           lastId = tailId;
+          if (maxTraversal != UNLIMITED_TRAVERSAL && ++traversed > maxTraversal) {
+            throw new IllegalStateException(
+                "Exceeded commit offset traversal limit while resolving offset "
+                    + off
+                    + " for ref '"
+                    + refName
+                    + "'. Traversed="
+                    + traversed
+                    + ", max="
+                    + maxTraversal);
+          }
         }
 
         var id = objRef(type, lastId, 1);

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/TestCommitLogOffsetTraversalLimit.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/TestCommitLogOffsetTraversalLimit.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.impl.commits;
+
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.PersistenceParams;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.apache.polaris.persistence.nosql.testextension.BackendSpec;
+import org.apache.polaris.persistence.nosql.testextension.PersistenceTestExtension;
+import org.apache.polaris.persistence.nosql.testextension.PolarisPersistence;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@BackendSpec
+@ExtendWith(PersistenceTestExtension.class)
+public class TestCommitLogOffsetTraversalLimit {
+
+  @PolarisPersistence Backend backend;
+  @PolarisPersistence MonotonicClock clock;
+  @PolarisPersistence IdGenerator idGenerator;
+
+  @Test
+  public void commitLog_offsetLookup_failsFastWhenLimitExceeded() throws Exception {
+    var persistence =
+        backend.newPersistence(
+            identity(),
+            PersistenceParams.BuildablePersistenceParams.builder()
+                .commitOffsetLookupMaxTraversal(3)
+                .build(),
+            UUID.randomUUID().toString(),
+            clock,
+            idGenerator);
+
+    var refName = "ref-" + UUID.randomUUID();
+    persistence.createReference(refName, Optional.empty());
+
+    var committer = persistence.createCommitter(refName, SimpleCommitTestObj.class, String.class);
+    for (int i = 0; i < 10; i++) {
+      var payload = "commit #" + i;
+      committer.commit(
+          (state, refObjSupplier) ->
+              state.commitResult("ok", ImmutableSimpleCommitTestObj.builder().payload(payload), refObjSupplier.get()));
+    }
+
+    // Offset value that will never be found and requires traversal to resolve.
+    assertThatThrownBy(
+            () ->
+                persistence
+                    .commits()
+                    .commitLog(refName, OptionalLong.of(Long.MIN_VALUE + 7), SimpleCommitTestObj.class)
+                    .hasNext())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Exceeded commit offset traversal limit");
+  }
+
+  @Test
+  public void commitLogReversed_offsetLookup_failsFastWhenLimitExceeded() throws Exception {
+    Persistence persistence =
+        backend.newPersistence(
+            identity(),
+            PersistenceParams.BuildablePersistenceParams.builder()
+                .commitOffsetLookupMaxTraversal(3)
+                .build(),
+            UUID.randomUUID().toString(),
+            clock,
+            idGenerator);
+
+    var refName = "ref-" + UUID.randomUUID();
+    persistence.createReference(refName, Optional.empty());
+
+    var committer = persistence.createCommitter(refName, SimpleCommitTestObj.class, String.class);
+    for (int i = 0; i < 10; i++) {
+      var payload = "commit #" + i;
+      committer.commit(
+          (state, refObjSupplier) ->
+              state.commitResult("ok", ImmutableSimpleCommitTestObj.builder().payload(payload), refObjSupplier.get()));
+    }
+
+    assertThatThrownBy(() -> persistence.commits().commitLogReversed(refName, Long.MIN_VALUE + 7, SimpleCommitTestObj.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Exceeded commit offset traversal limit");
+  }
+}
+

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/TestCommitLogOffsetTraversalLimit.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/TestCommitLogOffsetTraversalLimit.java
@@ -19,8 +19,10 @@
 package org.apache.polaris.persistence.nosql.impl.commits;
 
 import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
@@ -29,6 +31,7 @@ import org.apache.polaris.ids.api.MonotonicClock;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.PersistenceParams;
 import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.apache.polaris.persistence.nosql.api.exceptions.CommitOffsetTraversalLimitExceededException;
 import org.apache.polaris.persistence.nosql.testextension.BackendSpec;
 import org.apache.polaris.persistence.nosql.testextension.PersistenceTestExtension;
 import org.apache.polaris.persistence.nosql.testextension.PolarisPersistence;
@@ -63,7 +66,10 @@ public class TestCommitLogOffsetTraversalLimit {
       var payload = "commit #" + i;
       committer.commit(
           (state, refObjSupplier) ->
-              state.commitResult("ok", ImmutableSimpleCommitTestObj.builder().payload(payload), refObjSupplier.get()));
+              state.commitResult(
+                  "ok",
+                  ImmutableSimpleCommitTestObj.builder().payload(payload),
+                  refObjSupplier.get()));
     }
 
     // Offset value that will never be found and requires traversal to resolve.
@@ -71,9 +77,11 @@ public class TestCommitLogOffsetTraversalLimit {
             () ->
                 persistence
                     .commits()
-                    .commitLog(refName, OptionalLong.of(Long.MIN_VALUE + 7), SimpleCommitTestObj.class)
-                    .hasNext())
-        .isInstanceOf(IllegalStateException.class)
+                    .commitLog(
+                        refName,
+                        OptionalLong.of(Long.MIN_VALUE + 7),
+                        SimpleCommitTestObj.class))
+        .isInstanceOf(CommitOffsetTraversalLimitExceededException.class)
         .hasMessageContaining("Exceeded commit offset traversal limit");
   }
 
@@ -97,12 +105,110 @@ public class TestCommitLogOffsetTraversalLimit {
       var payload = "commit #" + i;
       committer.commit(
           (state, refObjSupplier) ->
-              state.commitResult("ok", ImmutableSimpleCommitTestObj.builder().payload(payload), refObjSupplier.get()));
+              state.commitResult(
+                  "ok",
+                  ImmutableSimpleCommitTestObj.builder().payload(payload),
+                  refObjSupplier.get()));
     }
 
-    assertThatThrownBy(() -> persistence.commits().commitLogReversed(refName, Long.MIN_VALUE + 7, SimpleCommitTestObj.class))
-        .isInstanceOf(IllegalStateException.class)
+    assertThatThrownBy(
+            () ->
+                persistence
+                    .commits()
+                    .commitLogReversed(refName, Long.MIN_VALUE + 7, SimpleCommitTestObj.class))
+        .isInstanceOf(CommitOffsetTraversalLimitExceededException.class)
         .hasMessageContaining("Exceeded commit offset traversal limit");
+  }
+
+  @Test
+  public void commitLog_offsetLookup_succeedsWithinLimit() throws Exception {
+    var persistence =
+        backend.newPersistence(
+            identity(),
+            PersistenceParams.BuildablePersistenceParams.builder()
+                .commitOffsetLookupMaxTraversal(100)
+                .build(),
+            UUID.randomUUID().toString(),
+            clock,
+            idGenerator);
+
+    var refName = "ref-" + UUID.randomUUID();
+    persistence.createReference(refName, Optional.empty());
+
+    var committer = persistence.createCommitter(refName, SimpleCommitTestObj.class, String.class);
+    for (int i = 0; i < 10; i++) {
+      var payload = "commit #" + i;
+      committer.commit(
+          (state, refObjSupplier) ->
+              state.commitResult(
+                  "ok",
+                  ImmutableSimpleCommitTestObj.builder().payload(payload),
+                  refObjSupplier.get()));
+    }
+
+    var all = new ArrayList<SimpleCommitTestObj>();
+    persistence
+        .commits()
+        .commitLog(refName, OptionalLong.empty(), SimpleCommitTestObj.class)
+        .forEachRemaining(all::add);
+
+    var target = all.get(5);
+    var it =
+        persistence
+            .commits()
+            .commitLog(refName, OptionalLong.of(target.id()), SimpleCommitTestObj.class);
+    var first = it.next();
+    assertThat(first.id()).isEqualTo(target.id());
+    assertThat(first.payload()).isEqualTo(target.payload());
+  }
+
+  @Test
+  public void commitLogReversed_offsetLookup_succeedsWithinLimit() throws Exception {
+    var persistence =
+        backend.newPersistence(
+            identity(),
+            PersistenceParams.BuildablePersistenceParams.builder()
+                .commitOffsetLookupMaxTraversal(100)
+                .build(),
+            UUID.randomUUID().toString(),
+            clock,
+            idGenerator);
+
+    var refName = "ref-" + UUID.randomUUID();
+    persistence.createReference(refName, Optional.empty());
+
+    var committer = persistence.createCommitter(refName, SimpleCommitTestObj.class, String.class);
+    for (int i = 0; i < 10; i++) {
+      var payload = "commit #" + i;
+      committer.commit(
+          (state, refObjSupplier) ->
+              state.commitResult(
+                  "ok",
+                  ImmutableSimpleCommitTestObj.builder().payload(payload),
+                  refObjSupplier.get()));
+    }
+
+    // Build the chronological log (oldest -> newest) with a non-existent offset sentinel.
+    var chronological = new ArrayList<SimpleCommitTestObj>();
+    persistence
+        .commits()
+        .commitLogReversed(refName, 0L, SimpleCommitTestObj.class)
+        .forEachRemaining(chronological::add);
+
+    // Pick an offset somewhere in the first half; expect everything after it (newer commits).
+    var offsetCommit = chronological.get(3);
+    var expected =
+        chronological.subList(4, chronological.size()).stream()
+            .map(SimpleCommitTestObj::id)
+            .toList();
+
+    var actual = new ArrayList<Long>();
+    persistence
+        .commits()
+        .commitLogReversed(refName, offsetCommit.id(), SimpleCommitTestObj.class)
+        .forEachRemaining(c -> actual.add(c.id()));
+
+    assertThat(actual).containsExactlyElementsOf(expected);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a new `polaris.persistence.commit-offset-lookup-max-traversal` parameter (default `0` = unlimited) to optionally bound commit history traversal while resolving offsets.
- Enforce the limit in `CommitsImpl.commitLog()` and `CommitsImpl.commitLogReversed()` during offset lookup, failing fast with a clear exception when exceeded.
- Add tests covering the fail-fast behavior for both variants.

## Rationale
`CommitsImpl` currently walks commit history unbounded when resolving offsets. In pathological cases (very large histories or missing/far-back offsets) this can lead to unbounded work.

The safeguard is **opt-in** (default unlimited) to avoid breaking background/maintenance flows that may legitimately traverse the full log.

## Test plan
- `./gradlew :persistence:nosql:persistence-impl:test`

Fixes #4000