### PR TITLE
Site: allow "latest" sublinks

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -142,6 +142,7 @@ in the main source tree:
 7. Update the "latest" redirect to point to the new release:
     1. Edit `/releases/latest/index.md` in the `versioned-docs` branch (i.e., `site/content/releases/latest/index.md` if using the Git worktree)
     2. Update the `redirect_to` parameter in the front matter to point to the new release (e.g., change `redirect_to: '/releases/1.3.0/'` to `redirect_to: '/releases/1.4.0/'`)
+    3. Edit `site/static/.htaccess` in the `main` branch and update the version in the `RewriteRule` for `releases/latest/` (e.g., change `/releases/1.3.0/$1` to `/releases/1.4.0/$1`). This rule handles deep links like `/releases/latest/getting-started/`.
 8. Changes to the site added and committed to Git
 9. Changes pushed to GitHub - both the `main` and the `versioned-docs` folder
 10. The last step triggers the job to publish the web site

--- a/site/static/.htaccess
+++ b/site/static/.htaccess
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Wildcard redirect for /releases/latest/{subpath} → /releases/x.y.z/{subpath}
+# This ensures that deep links like /releases/latest/getting-started/ work correctly.
+# Note: the root /releases/latest/ redirect is also handled here (empty subpath).
+#
+# IMPORTANT: update this version number when publishing a new latest release
+# (alongside site/content/releases/latest/index.md in the versioned-docs branch).
+RewriteEngine On
+RewriteRule ^releases/latest$ /releases/1.3.0/ [R=302,L]
+RewriteRule ^releases/latest/(.*)$ /releases/1.3.0/$1 [R=302,L]


### PR DESCRIPTION
This change introduces an .htaccess file that enables sublinks like `/releases/latest/getting-started/` to work properly: they now redirect the browser to `/releases/x.y.z/getting-started/`.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
