### PR TITLE
Allow Polaris to be built against a locally built Quarkus snapshot

### DIFF
--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -38,7 +38,12 @@ if (!project.extra.has("duplicated-project-sources")) {
     kotlinGradle {
       ktfmt().googleStyle()
       // licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
-      target("*.gradle.kts", "build-logic/*.gradle.kts", "build-logic/src/**/*.kt*")
+      target(
+        "*.gradle.kts",
+        "build-logic/*.gradle.kts",
+        "build-logic/src/**/*.kt*",
+        "gradle/*.gradle.kts",
+      )
     }
   }
 }

--- a/extensions/auth/opa/tests/build.gradle.kts
+++ b/extensions/auth/opa/tests/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
   // Quarkus platform
   implementation(platform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-rest-jackson")
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  implementation(libs.rest.assured)
 
   // Add the OPA implementation as RUNTIME dependency to include in Quarkus app
   implementation(project(":polaris-extensions-auth-opa"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ picocli = "4.7.7"
 quarkus = "3.32.3"
 scala212 = "2.12.19"
 swagger = "1.6.16"
+vertx = "5.0.8"
 
 [bundles]
 
@@ -83,16 +84,19 @@ microprofile-fault-tolerance-api = { module = "org.eclipse.microprofile.fault-to
 mockito-core = { module = "org.mockito:mockito-core", version = "5.23.0" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version = "5.23.0" }
 mongodb-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version = "5.6.4" }
+opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "1.60.1" }
 opentelemetry-instrumentation-bom-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version= "2.20.1-alpha" }
 picocli = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.10" }
 quarkus-amazon-services-bom = { module = "io.quarkus.platform:quarkus-amazon-services-bom", version.ref="quarkus" }
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
+rest-assured = { module = "io.rest-assured:rest-assured", version = "6.0.0" }
 s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "4.11.0" }
 scala212-lang-library = { module = "org.scala-lang:scala-library", version.ref = "scala212" }
 scala212-lang-reflect = { module = "org.scala-lang:scala-reflect", version.ref = "scala212" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version = "2.0.17" }
+slf4j-jboss-logmanager = { module = "org.jboss.slf4j:slf4j-jboss-logmanager", version = "2.1.0.Final" }
 smallrye-common-annotation = { module = "io.smallrye.common:smallrye-common-annotation", version = "2.17.0" }
 smallrye-config-core = { module = "io.smallrye.config:smallrye-config-core", version = "3.16.0" }
 smallrye-jandex = { module = "io.smallrye:jandex", version = "3.5.3" }
@@ -101,6 +105,7 @@ swagger-jaxrs = { module = "io.swagger:swagger-jaxrs", version.ref = "swagger" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.3" }
 testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "4.1.1" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
+vertx-core = { module = "io.vertx:vertx-core", version.ref = "vertx" }
 weld-junit5 = { module = "org.jboss.weld:weld-junit5", version = "5.0.3.Final" }
 weld-core-bom = { module = "org.jboss.weld:weld-core-bom", version = "6.0.4.Final" }
 

--- a/gradle/quarkus-local.init.gradle.kts
+++ b/gradle/quarkus-local.init.gradle.kts
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+val quarkusGroupIds =
+  listOf(
+    "io.quarkus",
+    "io.quarkus.arc",
+    "io.quarkus.qute",
+    "io.quarkus.resteasy.reactive",
+    "io.quarkus.vertx.utils",
+  )
+
+// You can override the version like this: -PquarkusVersion=99.99.99
+val quarkusVersion: String =
+  gradle.providers.gradleProperty("quarkusVersion").orElse("999-SNAPSHOT").get()
+
+val quarkusGroupIdsStr = quarkusGroupIds.map { "'$it'" }.joinToString(", ")
+
+logger.warn(
+  """
+    Configuring for a local Quarkus build using version $quarkusVersion, expected in the local Maven repository!
+      - Maven Central will not be used for the group IDs $quarkusGroupIdsStr.
+      - Gradle plugin repo will not be used for the group IDs $quarkusGroupIdsStr.
+      - A Maven Local repo will be added to handle the group IDs $quarkusGroupIdsStr.
+  """
+    .trimIndent()
+)
+
+/**
+ * This is a special Gradle init script to configure the Polaris build to use a local Quarkus build,
+ * installed in the local Maven repository (~/.m2/repository).
+ *
+ * Local Quarkus builds do not emit a platform bom, so this script also "redirects" the Quarkus
+ * platform bom to the "non-platform" bom.
+ *
+ * Invocation works like any Gradle build, but you have to tell Gradle to use this script:
+ *
+ * ./gradlew --init-script gradle/quarkus-local.init.gradle.kts ...
+ *
+ * Prerequisite
+ * ============
+ * 1. Checkout the Quarkus repository
+ * 2. Perform a local build: ./mvnw -Dquickly install
+ *
+ * Background
+ * ==========
+ *
+ * Gradle init scripts are executed before the build script is evaluated, but *AFTER*
+ * settings.gradle[.kts]!
+ *
+ * The actual execution order is:
+ * 1. The pluginManagement block in settings.gradle.kts
+ * 2. The rest of the settings.gradle.kts, including the dependencyResolutionManagement block, is
+ *    evaluated.
+ * 3. This init script is evaluated.
+ *
+ * We have to apply the repository rules for both the pluginManagement and
+ * dependencyResolutionManagement.
+ *
+ * The pluginManagement block *MUST* be "self-contained", i.e., it does not "see" anything outside
+ * itself. This is because the pluginManagement block has to be evaluated first, before anything
+ * else.
+ *
+ * It would be nicer to have this part in settings.gradle.kts, but the excludeGroup+includeGroup
+ * statements would "confuse" Renovate (it would "blindly" consider those, unconditionally).
+ */
+
+// Used to apply the Quarkus tweaks only to the root project and its children,
+// but not to the build-logic.
+val rootProjectName = "polaris"
+
+settingsEvaluated {
+  if (rootProject.name == rootProjectName) {
+    val mavenCentralRepoName = "MavenRepo"
+    val gradleCentralRepoName = "Gradle Central Plugin Repository"
+
+    fun RepositoryHandler.applyLocalQuarkus() {
+      all {
+        if (name == mavenCentralRepoName || name == gradleCentralRepoName) {
+          content { quarkusGroupIds.forEach { excludeGroup(it) } }
+        }
+      }
+      mavenLocal { content { quarkusGroupIds.forEach { includeGroup(it) } } }
+    }
+
+    pluginManagement {
+      repositories { applyLocalQuarkus() }
+      resolutionStrategy {
+        eachPlugin {
+          if (requested.id.id == "io.quarkus") {
+            useModule("io.quarkus:io.quarkus.gradle.plugin:${quarkusVersion}")
+          }
+        }
+      }
+    }
+    dependencyResolutionManagement { repositories { applyLocalQuarkus() } }
+  }
+}
+
+beforeProject {
+  if (rootProject.name == rootProjectName) {
+    configurations.all {
+      resolutionStrategy {
+        eachDependency {
+          if (quarkusGroupIds.contains(requested.group)) {
+            when (requested.name) {
+              "quarkus-fs-util" -> {
+                // skip! this is not part of the main Quarkus build
+              }
+              else -> {
+                // Nag user, so it's obvious that we're building for a local Quarkus build
+                logger.warn("Using $quarkusVersion for ${requested.module}")
+                useVersion(quarkusVersion)
+              }
+            }
+          } else if (requested.group == "io.quarkus.platform" && requested.name == "quarkus-bom") {
+            // Nag user, so it's obvious that we're building for a local Quarkus build
+            logger.warn(
+              "Updating ${requested.module} to io.quarkus:${requested.name}:$quarkusVersion"
+            )
+            useTarget("io.quarkus:${requested.name}:$quarkusVersion")
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle/quarkus-prerelease.init.gradle.kts
+++ b/gradle/quarkus-prerelease.init.gradle.kts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+val quarkusGroupIds =
+  listOf(
+    "io.quarkus",
+    "io.quarkus.arc",
+    "io.quarkus.qute",
+    "io.quarkus.resteasy.reactive",
+    "io.quarkus.vertx.utils",
+  )
+
+// You must specify the Quarkus version like this: -PquarkusVersion=99.99.99
+val quarkusVersionProvider: Provider<String> = gradle.providers.gradleProperty("quarkusVersion")
+
+if (!quarkusVersionProvider.isPresent) {
+  throw GradleException("Must specify the Quarkus version to use using -PquarkusVersion=a.b.c")
+}
+
+val quarkusVersion = quarkusVersionProvider.get()
+
+val quarkusGroupIdsStr = quarkusGroupIds.map { "'$it'" }.joinToString(", ")
+
+logger.warn(
+  """
+    Configuring for a Quarkus prerelease using version $quarkusVersion!
+  """
+    .trimIndent()
+)
+
+/**
+ * This is a special Gradle init script to configure the Polaris build to use a pre-release Quarkus
+ * version.
+ *
+ * Quarkus pre-releases do not have a platform bom published, so this script also "redirects" the
+ * Quarkus platform bom to the "non-platform" bom.
+ *
+ * Invocation works like any Gradle build, but you have to tell Gradle to use this script:
+ *
+ * ./gradlew --init-script gradle/quarkus-prerelease.init.gradle.kts -PquarkusVersion=a.b.c ...
+ *
+ * Prerequisite
+ * ============
+ * 1. Checkout the Quarkus repository
+ * 2. Perform a local build: ./mvnw -Dquickly install
+ *
+ * Background
+ * ==========
+ *
+ * Gradle init scripts are executed before the build script is evaluated, but *AFTER*
+ * settings.gradle[.kts]!
+ *
+ * The actual execution order is:
+ * 1. The pluginManagement block in settings.gradle.kts
+ * 2. The rest of the settings.gradle.kts, including the dependencyResolutionManagement block, is
+ *    evaluated.
+ * 3. This init script is evaluated.
+ */
+
+// Used to apply the Quarkus tweaks only to the root project and its children,
+// but not to the build-logic.
+val rootProjectName = "polaris"
+
+beforeProject {
+  if (rootProject.name == rootProjectName) {
+    configurations.all {
+      resolutionStrategy {
+        eachDependency {
+          if (quarkusGroupIds.contains(requested.group)) {
+            when (requested.name) {
+              "quarkus-fs-util" -> {
+                // skip! this is not part of the main Quarkus build
+              }
+              else -> {
+                // Nag user, so it's obvious that we're building for a local Quarkus build
+                logger.warn("Using $quarkusVersion for ${requested.module}")
+                useVersion(quarkusVersion)
+              }
+            }
+          } else if (requested.group == "io.quarkus.platform" && requested.name == "quarkus-bom") {
+            // Nag user, so it's obvious that we're building for a local Quarkus build
+            logger.warn(
+              "Updating ${requested.module} to io.quarkus:${requested.name}:$quarkusVersion"
+            )
+            useTarget("io.quarkus:${requested.name}:$quarkusVersion")
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle/use-apache-snapshots.init.gradle.kts
+++ b/gradle/use-apache-snapshots.init.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+logger.warn("Configuring with Apache Snapshots repository!")
+
+val rootProjectName = "polaris"
+
+settingsEvaluated {
+  if (rootProject.name == rootProjectName) {
+    dependencyResolutionManagement {
+      repositories {
+        maven {
+          name = "ApacheSnapshots"
+          url = uri("https://repository.apache.org/content/repositories/snapshots/")
+          mavenContent { snapshotsOnly() }
+        }
+      }
+    }
+  }
+}

--- a/persistence/nosql/async/vertx/build.gradle.kts
+++ b/persistence/nosql/async/vertx/build.gradle.kts
@@ -31,7 +31,8 @@ dependencies {
   implementation(libs.guava)
 
   compileOnly(enforcedPlatform(libs.quarkus.bom))
-  compileOnly("io.vertx:vertx-core")
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  compileOnly(libs.vertx.core)
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
@@ -47,7 +48,8 @@ dependencies {
   testFixturesApi(libs.jakarta.enterprise.cdi.api)
 
   testFixturesApi(enforcedPlatform(libs.quarkus.bom))
-  testFixturesApi("io.vertx:vertx-core")
+  // Need the full dep reference for local Quarkus snapshot builds
+  testFixturesApi(libs.vertx.core)
 
   testImplementation(testFixtures(project(":polaris-async-api")))
 }

--- a/plugins/spark/v3.5/integration/build.gradle.kts
+++ b/plugins/spark/v3.5/integration/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 
   implementation(project(":polaris-runtime-service"))
 
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  implementation(libs.slf4j.jboss.logmanager)
+
   testImplementation(
     "org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}:${icebergVersion}"
   )

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
   implementation("io.quarkus:quarkus-picocli")
   implementation("io.quarkus:quarkus-container-image-docker")
 
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  implementation(platform(libs.jackson.bom))
+
   implementation(project(":polaris-runtime-common"))
 
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
   implementation("io.quarkus:quarkus-smallrye-context-propagation")
   implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
   runtimeOnly("io.quarkus:quarkus-jdbc-postgresql")
+  // Needed for local Quarkus snapshot builds
+  implementation(platform(libs.opentelemetry.bom))
 
   implementation(libs.jakarta.enterprise.cdi.api)
   implementation(libs.jakarta.inject.api)
@@ -202,6 +204,12 @@ dependencies {
   // This dependency brings in RESTEasy Classic, which conflicts with Quarkus RESTEasy Reactive;
   // it must not be present during Quarkus augmentation otherwise Quarkus tests won't start.
   intTestRuntimeOnly(libs.keycloak.admin.client)
+
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  testImplementation(libs.rest.assured)
+  cloudTestImplementation(libs.rest.assured)
+  intTestImplementation(libs.rest.assured)
+  integrationTestImplementation(libs.rest.assured)
 }
 
 tasks.named("javadoc") { dependsOn("jandex") }

--- a/runtime/spark-tests/build.gradle.kts
+++ b/runtime/spark-tests/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     exclude(group = "org.scala-lang", module = "scala-reflect")
   }
 
+  // Needed for Quarkus snapshot and prereleases without the Quarkus platform bom
+  implementation(libs.slf4j.jboss.logmanager)
+
   implementation(project(":polaris-runtime-service"))
 
   testImplementation(project(":polaris-tests"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,7 +53,7 @@ fun polarisProject(name: String, directory: File) {
 
 val projects = Properties()
 
-loadProperties(file("gradle/projects.main.properties")).forEach { name, directory ->
+loadProperties(file("gradle/projects.main.properties")).forEach { (name, directory) ->
   polarisProject(name as String, file(directory as String))
 }
 
@@ -117,25 +117,11 @@ plugins {
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
   repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
   repositories {
     mavenCentral()
-    val useApacheSnapshots =
-      providers.gradleProperty("useApacheSnapshots").orNull?.toBoolean() == true
-    if (useApacheSnapshots) {
-      // This is a hack to let Renovate _not_ query the Apache snapshot repository for all
-      // dependencies.
-      // See https://github.com/renovatebot/renovate/discussions/41291
-      fun configureIndirectForRenovate(asfSnap: MavenArtifactRepository) {
-        asfSnap.url = uri("https://repository.apache.org/content/repositories/snapshots/")
-        asfSnap.mavenContent { snapshotsOnly() }
-      }
-      maven {
-        name = "ApacheSnapshots"
-        configureIndirectForRenovate(this)
-      }
-    }
     gradlePluginPortal()
   }
 }
@@ -171,7 +157,7 @@ develocity {
   } else {
     // In all other cases, especially PR CI runs, use Gradle's public Develocity instance.
     var cfgPrjId: String? = System.getenv("DEVELOCITY_PROJECT_ID")
-    projectId = if (cfgPrjId == null || cfgPrjId.isEmpty()) "polaris" else cfgPrjId
+    projectId = if (cfgPrjId.isNullOrEmpty()) "polaris" else cfgPrjId
     buildScan {
       val isGradleTosAccepted = "true" == System.getenv("GRADLE_TOS_ACCEPTED")
       val isGitHubPullRequest = gitHubRef?.startsWith("refs/pull/") ?: false
@@ -189,7 +175,7 @@ develocity {
         System.getenv("GITHUB_SERVER_URL")?.run {
           val ghUrl = this
           val ghRepo = System.getenv("GITHUB_REPOSITORY")
-          val prNumber = gitHubRef!!.substringAfter("refs/pull/").substringBefore("/merge")
+          val prNumber = gitHubRef.substringAfter("refs/pull/").substringBefore("/merge")
           link("GitHub pull request", "$ghUrl/$ghRepo/pull/$prNumber")
         }
       }


### PR DESCRIPTION
This change allows Polaris to use Quarkus artifacts from the local Maven repository, think: `~/.m2/repository`, for the build.

The implementation is completely transparent to the "non Quarkus snapshot" build, as all necessary tweaks are applied via a Gradle init script that needs to be manually configured during the Gradle invocation. In other words: no harm to the "normal" build.

As we collaborate with the Quarkus project, it is a win-win to have some support to build Polaris against a custom Quarkus build. This allows both "Polaris people" and "Quarkus people" to test changes and fixes before a release and/or to investigate issues.

On top, there's another Gradle init script to build Polaris against a Quarkus pre-release, for example, 4.0.0.CR1. Those releases to not publish a platform bom, so some special handling is needed.

It seemed convenient to move the existing special handling for Apache Snapshots to a separate init script as well, removing some clutter from the main settings.gradle.kts file.
