### PR TITLE
IcebergCatalog- updateNamespaceProperties on single commit

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -239,13 +239,17 @@ public class CatalogHandlerUtils {
     Map<String, String> startProperties = catalog.loadNamespaceMetadata(namespace);
     Set<String> missing = Sets.difference(removals, startProperties.keySet());
 
-    if (!updates.isEmpty()) {
-      catalog.setProperties(namespace, updates);
-    }
+    if (catalog instanceof IcebergCatalog polarisCatalog) {
+      polarisCatalog.updateProperties(namespace, removals, updates);
+    } else {
+      if (!updates.isEmpty()) {
+        catalog.setProperties(namespace, updates);
+      }
 
-    if (!removals.isEmpty()) {
-      // remove the original set just in case there was an update just after loading properties
-      catalog.removeProperties(namespace, removals);
+      if (!removals.isEmpty()) {
+        // remove the original set just in case there was an update just after loading properties
+        catalog.removeProperties(namespace, removals);
+      }
     }
 
     return UpdateNamespacePropertiesResponse.builder()

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -735,6 +735,63 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     return true;
   }
 
+  /**
+   * Update properties for a namespace.
+   *
+   * @param namespace the namespace to update properties for
+   * @param removals the set of properties to remove
+   * @param updates the map of properties to update
+   * @return true if the properties were updated, false otherwise
+   */
+  public boolean updateProperties(
+      Namespace namespace, Set<String> removals, Map<String, String> updates)
+      throws NoSuchNamespaceException {
+    PolarisResolvedPathWrapper resolvedEntities = resolvedEntityView.getResolvedPath(namespace);
+    if (resolvedEntities == null) {
+      throw noSuchNamespaceException(namespace);
+    }
+    PolarisEntity entity = resolvedEntities.getRawLeafEntity();
+    Map<String, String> newProperties = new HashMap<>(entity.getPropertiesAsMap());
+
+    // Merge new properties into existing map.
+    newProperties.putAll(updates);
+    // Remove properties.
+    removals.forEach(newProperties::remove);
+
+    PolarisEntity updatedEntity =
+        new PolarisEntity.Builder(entity).setProperties(newProperties).build();
+
+    if (!realmConfig.getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+      LOGGER.debug("Validating no overlap with sibling tables or namespaces");
+      validateNoLocationOverlap(
+          NamespaceEntity.of(updatedEntity), resolvedEntities.getRawParentPath());
+    } else {
+      LOGGER.debug("Skipping location overlap validation for namespace '{}'", namespace);
+    }
+    if (!realmConfig.getConfig(
+        BehaviorChangeConfiguration.ALLOW_NAMESPACE_CUSTOM_LOCATION, catalogEntity)) {
+      if (updates.containsKey(PolarisEntityConstants.ENTITY_BASE_LOCATION)) {
+        validateNamespaceLocation(NamespaceEntity.of(entity), resolvedEntities);
+      }
+    }
+
+    List<PolarisEntity> parentPath = resolvedEntities.getRawFullPath();
+    PolarisEntity returnedEntity =
+        Optional.ofNullable(
+                getMetaStoreManager()
+                    .updateEntityPropertiesIfNotChanged(
+                        getCurrentPolarisContext(),
+                        PolarisEntity.toCoreList(parentPath),
+                        updatedEntity)
+                    .getEntity())
+            .map(PolarisEntity::new)
+            .orElse(null);
+    if (returnedEntity == null) {
+      throw new CommitConflictException("Concurrent modification of namespace: %s", namespace);
+    }
+    return true;
+  }
+
   @Override
   public boolean removeProperties(Namespace namespace, Set<String> properties)
       throws NoSuchNamespaceException {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 import com.azure.core.exception.HttpResponseException;
 import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import io.quarkus.test.junit.QuarkusMock;
@@ -2614,4 +2615,30 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
       }
     }
   }
+
+  @Test
+  public void testUpdateNamespacePropertiesAtomic() {
+    catalog.createNamespace(
+        NS,
+        ImmutableMap.of(
+            "prop1", "val1",
+            "prop2", "val2",
+            "prop3", "val3"));
+
+    catalog.updateProperties(
+        NS,
+        ImmutableSet.of("prop1", "prop2", "missing_prop"),
+        ImmutableMap.of(
+            "prop3", "new_val3",
+            "prop4", "val4",
+            "prop5", "val5"));
+
+    Map<String, String> properties = catalog.loadNamespaceMetadata(NS);
+    Assertions.assertThat(properties).containsEntry("prop3", "new_val3");
+    Assertions.assertThat(properties).containsEntry("prop4", "val4");
+    Assertions.assertThat(properties).containsEntry("prop5", "val5");
+    Assertions.assertThat(properties).doesNotContainKey("prop1");
+    Assertions.assertThat(properties).doesNotContainKey("prop2");
+  }
 }
+


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
First time Polaris contributor here! I've been working mostly on the Iceberg side.

We ran the PyIceberg Catalog Tests against Polaris (https://github.com/apache/iceberg-python/pull/3106) and discovered that Polaris can't handle adding / removing namespace properties at the same time.

This is because Polaris attempts to handle this as two commits (which run into concurrency issues), when the Iceberg spec supports a single commit.

This PR adds support for creating this single commit for Iceberg Catalogs.

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
