### PR TITLE
Demote `Initializing non-federated catalog` log message to DEBUG

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -287,7 +287,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       // credentials for non-rest remote catalog
       this.baseCatalog = federatedCatalog;
     } else {
-      LOGGER.atDebug().log("Initializing non-federated catalog");
+      LOGGER.debug("Initializing non-federated catalog");
       this.baseCatalog = catalogFactory().createCallContextCatalog(resolutionManifest);
     }
     this.namespaceCatalog =


### PR DESCRIPTION
This log message apparently happens per-request on many REST API endpoints, but does not convey a lot of information to the Polaris administrator in normal cases. Therefore, it is demoted from INFO to DEBUG.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
