### PR TITLE
feat(storage): inline polaris.storage.name overrides for namespace/table

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -657,6 +657,18 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildFeatureConfiguration();
 
+  public static final FeatureConfiguration<Boolean> ALLOW_STORAGE_NAME_OVERRIDE =
+      PolarisConfiguration.<Boolean>builder()
+          .key("ALLOW_STORAGE_NAME_OVERRIDE")
+          .description(
+              "If set to true, allows namespaces and tables to set the polaris.storage.name "
+                  + "property to override which server-configured named storage profile is used "
+                  + "for credential vending. The override is resolved leaf-to-root at access time. "
+                  + "Whether the resolved name actually changes vended credentials additionally "
+                  + "depends on RESOLVE_CREDENTIALS_BY_STORAGE_NAME being enabled. Default: false.")
+          .defaultValue(false)
+          .buildFeatureConfiguration();
+
   public static final FeatureConfiguration<Boolean> ALLOW_UNRESTRICTED_STORAGE_CONFIG_ROLE_CHANGES =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_UNRESTRICTED_STORAGE_CONFIG_ROLE_CHANGES")

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
@@ -52,6 +52,8 @@ public class PolarisEntityConstants {
   private static final String STORAGE_INTEGRATION_IDENTIFIER_PROPERTY_NAME =
       "storage_integration_identifier";
 
+  private static final String STORAGE_NAME_OVERRIDE_PROPERTY_NAME = "storage_name_override";
+
   private static final String CONNECTION_CONFIGURATION_INFO_PROPERTY_NAME =
       "connection_configuration_info";
 
@@ -105,6 +107,15 @@ public class PolarisEntityConstants {
 
   public static String getStorageConfigInfoPropertyName() {
     return STORAGE_CONFIGURATION_INFO_PROPERTY_NAME;
+  }
+
+  /**
+   * Internal-properties key holding a string reference to a server-configured named storage
+   * profile. Set by namespace/table writes when {@code polaris.storage.name} is provided. Resolved
+   * leaf-to-root at credential-vending time to override the catalog's base storage name.
+   */
+  public static String getStorageNameOverridePropertyName() {
+    return STORAGE_NAME_OVERRIDE_PROPERTY_NAME;
   }
 
   public static String getConnectionConfigInfoPropertyName() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -166,13 +166,7 @@ public abstract class PolarisStorageConfigurationInfo {
 
   public static Optional<LocationRestrictions> forEntityPath(
       RealmConfig realmConfig, List<PolarisEntity> entityPath) {
-    return findStorageInfoFromHierarchy(entityPath)
-        .map(
-            storageInfo ->
-                deserialize(
-                    storageInfo
-                        .getInternalPropertiesAsMap()
-                        .get(PolarisEntityConstants.getStorageConfigInfoPropertyName())))
+    return StorageConfigOverrideResolver.resolveEffectiveConfig(entityPath)
         .map(
             configInfo -> {
               List<PolarisEntity> entityPathReversed = new ArrayList<>(entityPath);
@@ -207,18 +201,6 @@ public abstract class PolarisStorageConfigurationInfo {
                 return new LocationRestrictions(configInfo);
               }
             });
-  }
-
-  public static @NonNull Optional<PolarisEntity> findStorageInfoFromHierarchy(
-      List<PolarisEntity> entityPath) {
-    for (int i = entityPath.size() - 1; i >= 0; i--) {
-      PolarisEntity e = entityPath.get(i);
-      if (e.getInternalPropertiesAsMap()
-          .containsKey(PolarisEntityConstants.getStorageConfigInfoPropertyName())) {
-        return Optional.of(e);
-      }
-    }
-    return Optional.empty();
   }
 
   /** Subclasses must provide the Iceberg FileIO impl associated with their type in this method. */

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -39,8 +39,11 @@ import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.ImmutableAwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
+import org.apache.polaris.core.storage.azure.ImmutableAzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
+import org.apache.polaris.core.storage.gcp.ImmutableGcpStorageConfigurationInfo;
 import org.immutables.value.Value;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -88,6 +91,38 @@ public abstract class PolarisStorageConfigurationInfo {
   public abstract String getStorageName();
 
   public abstract StorageType getStorageType();
+
+  /**
+   * Return a copy of {@code base} with its {@code storageName} replaced by {@code storageName}. All
+   * other fields are preserved. Used by the storage-name override path so that an entity-level
+   * override flows through credential vending and into the per-backend cache key without mutating
+   * the original config.
+   *
+   * @throws IllegalArgumentException if {@code base} is not one of the four supported subtypes
+   */
+  public static PolarisStorageConfigurationInfo withStorageName(
+      PolarisStorageConfigurationInfo base, @Nullable String storageName) {
+    if (base instanceof AwsStorageConfigurationInfo aws) {
+      return ImmutableAwsStorageConfigurationInfo.builder().from(aws).storageName(storageName).build();
+    }
+    if (base instanceof AzureStorageConfigurationInfo azure) {
+      return ImmutableAzureStorageConfigurationInfo.builder()
+          .from(azure)
+          .storageName(storageName)
+          .build();
+    }
+    if (base instanceof GcpStorageConfigurationInfo gcp) {
+      return ImmutableGcpStorageConfigurationInfo.builder().from(gcp).storageName(storageName).build();
+    }
+    if (base instanceof FileStorageConfigurationInfo file) {
+      return ImmutableFileStorageConfigurationInfo.builder()
+          .from(file)
+          .storageName(storageName)
+          .build();
+    }
+    throw new IllegalArgumentException(
+        "Unsupported PolarisStorageConfigurationInfo subtype: " + base.getClass().getName());
+  }
 
   private static final ObjectMapper DEFAULT_MAPPER;
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -103,7 +103,10 @@ public abstract class PolarisStorageConfigurationInfo {
   public static PolarisStorageConfigurationInfo withStorageName(
       PolarisStorageConfigurationInfo base, @Nullable String storageName) {
     if (base instanceof AwsStorageConfigurationInfo aws) {
-      return ImmutableAwsStorageConfigurationInfo.builder().from(aws).storageName(storageName).build();
+      return ImmutableAwsStorageConfigurationInfo.builder()
+          .from(aws)
+          .storageName(storageName)
+          .build();
     }
     if (base instanceof AzureStorageConfigurationInfo azure) {
       return ImmutableAzureStorageConfigurationInfo.builder()
@@ -112,7 +115,10 @@ public abstract class PolarisStorageConfigurationInfo {
           .build();
     }
     if (base instanceof GcpStorageConfigurationInfo gcp) {
-      return ImmutableGcpStorageConfigurationInfo.builder().from(gcp).storageName(storageName).build();
+      return ImmutableGcpStorageConfigurationInfo.builder()
+          .from(gcp)
+          .storageName(storageName)
+          .build();
     }
     if (base instanceof FileStorageConfigurationInfo file) {
       return ImmutableFileStorageConfigurationInfo.builder()

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigOverrideResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigOverrideResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolves the effective {@link PolarisStorageConfigurationInfo} for an entity hierarchy by
+ * applying any nearest-ancestor {@code storage_name_override} on top of the catalog's base storage
+ * configuration.
+ *
+ * <p>The input list is in root-to-leaf order (matching {@link
+ * PolarisStorageConfigurationInfo#findStorageInfoFromHierarchy(List)}). The walk runs leaf-to-root
+ * and:
+ *
+ * <ol>
+ *   <li>Captures the first {@code storage_name_override} encountered (nearest wins).
+ *   <li>Returns the first {@code storage_configuration_info} encountered — the base config.
+ * </ol>
+ *
+ * <p>If a base config exists and an override was captured, the result is {@link
+ * PolarisStorageConfigurationInfo#withStorageName} applied to the base. If no base config exists,
+ * the result is empty regardless of any override.
+ */
+public final class StorageConfigOverrideResolver {
+
+  private StorageConfigOverrideResolver() {}
+
+  /**
+   * Walk {@code entityPath} leaf-to-root and return the effective storage configuration. The base
+   * config is sourced from the nearest entity that has {@code storage_configuration_info} in its
+   * internal properties; if any closer ancestor (including the leaf itself) carries {@code
+   * storage_name_override}, that name replaces the base config's {@code storageName}.
+   *
+   * @param entityPath entities in root-to-leaf order; the catalog is at index 0
+   * @return effective config, or empty if no entity in the chain has a base storage config
+   */
+  public static Optional<PolarisStorageConfigurationInfo> resolveEffectiveConfig(
+      @NonNull List<? extends PolarisEntity> entityPath) {
+    String override = null;
+    for (int i = entityPath.size() - 1; i >= 0; i--) {
+      Map<String, String> internalProps = entityPath.get(i).getInternalPropertiesAsMap();
+      if (override == null) {
+        String candidate =
+            internalProps.get(PolarisEntityConstants.getStorageNameOverridePropertyName());
+        if (candidate != null && !candidate.isEmpty()) {
+          override = candidate;
+        }
+      }
+      String serializedBase =
+          internalProps.get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
+      if (serializedBase != null) {
+        PolarisStorageConfigurationInfo base =
+            PolarisStorageConfigurationInfo.deserialize(serializedBase);
+        if (override != null) {
+          return Optional.of(PolarisStorageConfigurationInfo.withStorageName(base, override));
+        }
+        return Optional.of(base);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigOverrideResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageConfigOverrideResolver.java
@@ -30,9 +30,8 @@ import org.jspecify.annotations.NonNull;
  * applying any nearest-ancestor {@code storage_name_override} on top of the catalog's base storage
  * configuration.
  *
- * <p>The input list is in root-to-leaf order (matching {@link
- * PolarisStorageConfigurationInfo#findStorageInfoFromHierarchy(List)}). The walk runs leaf-to-root
- * and:
+ * <p>The input list is in root-to-leaf order (the catalog is at index 0). The walk runs
+ * leaf-to-root and:
  *
  * <ol>
  *   <li>Captures the first {@code storage_name_override} encountered (nearest wins).

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageNameValidator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageNameValidator.java
@@ -57,8 +57,7 @@ public final class StorageNameValidator {
           "polaris.storage.name length must be at most " + MAX_LENGTH + " characters");
     }
     if (!VALID.matcher(trimmed).matches()) {
-      throw new IllegalArgumentException(
-          "polaris.storage.name must match pattern [a-zA-Z0-9_-]+");
+      throw new IllegalArgumentException("polaris.storage.name must match pattern [a-zA-Z0-9_-]+");
     }
     return trimmed;
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageNameValidator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageNameValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Validates and normalizes user-supplied {@code polaris.storage.name} property values used to
+ * select a server-configured named storage profile for credential vending.
+ *
+ * <p>Blank input (null, empty, or whitespace-only) normalizes to {@code null}, which callers
+ * interpret as "clear the override".
+ */
+public final class StorageNameValidator {
+
+  public static final int MAX_LENGTH = 128;
+
+  private static final Pattern VALID = Pattern.compile("^[a-zA-Z0-9_-]+$");
+
+  private StorageNameValidator() {}
+
+  /**
+   * Trim, validate, and normalize a candidate storage name.
+   *
+   * @param value raw user input
+   * @return the trimmed name if valid, or {@code null} if the input is blank
+   * @throws IllegalArgumentException if the trimmed value exceeds {@link #MAX_LENGTH} or contains
+   *     characters outside {@code [a-zA-Z0-9_-]}
+   */
+  public static @Nullable String normalizeAndValidate(@Nullable String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    if (trimmed.length() > MAX_LENGTH) {
+      throw new IllegalArgumentException(
+          "polaris.storage.name length must be at most " + MAX_LENGTH + " characters");
+    }
+    if (!VALID.matcher(trimmed).matches()) {
+      throw new IllegalArgumentException(
+          "polaris.storage.name must match pattern [a-zA-Z0-9_-]+");
+    }
+    return trimmed;
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageConfigOverrideResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageConfigOverrideResolverTest.java
@@ -77,7 +77,8 @@ class StorageConfigOverrideResolverTest {
   void leafOverrideBeatsAncestorOverride() {
     PolarisEntity catalog = catalogEntity(BASE_CONFIG);
     PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", overrideOnly("team-namespace"));
-    PolarisEntity table = entity(PolarisEntityType.TABLE_LIKE, "tbl", overrideOnly("table-special"));
+    PolarisEntity table =
+        entity(PolarisEntityType.TABLE_LIKE, "tbl", overrideOnly("table-special"));
     Optional<PolarisStorageConfigurationInfo> resolved =
         StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog, ns, table));
     assertThat(resolved).isPresent();

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageConfigOverrideResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageConfigOverrideResolverTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+
+class StorageConfigOverrideResolverTest {
+
+  private static final AwsStorageConfigurationInfo BASE_CONFIG =
+      AwsStorageConfigurationInfo.builder()
+          .addAllowedLocations("s3://foo/bar")
+          .roleARN("arn:aws:iam::123456789012:role/polaris-test")
+          .region("us-east-1")
+          .storageName("default")
+          .build();
+
+  @Test
+  void emptyChainReturnsEmpty() {
+    assertThat(StorageConfigOverrideResolver.resolveEffectiveConfig(List.of())).isEmpty();
+  }
+
+  @Test
+  void noBaseConfigEvenWithOverrideReturnsEmpty() {
+    PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", overrideOnly("team-a"));
+    assertThat(StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(ns))).isEmpty();
+  }
+
+  @Test
+  void catalogOnlyReturnsBaseConfigUnchanged() {
+    PolarisEntity catalog = catalogEntity(BASE_CONFIG);
+    Optional<PolarisStorageConfigurationInfo> resolved =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog));
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().getStorageName()).isEqualTo("default");
+  }
+
+  @Test
+  void namespaceOverrideAppliedOnCatalogBase() {
+    PolarisEntity catalog = catalogEntity(BASE_CONFIG);
+    PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", overrideOnly("team-a"));
+    Optional<PolarisStorageConfigurationInfo> resolved =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog, ns));
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().getStorageName()).isEqualTo("team-a");
+    assertThat(resolved.get()).isInstanceOf(AwsStorageConfigurationInfo.class);
+  }
+
+  @Test
+  void leafOverrideBeatsAncestorOverride() {
+    PolarisEntity catalog = catalogEntity(BASE_CONFIG);
+    PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", overrideOnly("team-namespace"));
+    PolarisEntity table = entity(PolarisEntityType.TABLE_LIKE, "tbl", overrideOnly("table-special"));
+    Optional<PolarisStorageConfigurationInfo> resolved =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog, ns, table));
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().getStorageName()).isEqualTo("table-special");
+  }
+
+  @Test
+  void noOverrideReturnsBaseConfigWithCatalogStorageName() {
+    PolarisEntity catalog = catalogEntity(BASE_CONFIG);
+    PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", Map.of());
+    PolarisEntity table = entity(PolarisEntityType.TABLE_LIKE, "tbl", Map.of());
+    Optional<PolarisStorageConfigurationInfo> resolved =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog, ns, table));
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().getStorageName()).isEqualTo("default");
+  }
+
+  @Test
+  void blankOverrideIgnored() {
+    PolarisEntity catalog = catalogEntity(BASE_CONFIG);
+    PolarisEntity ns = entity(PolarisEntityType.NAMESPACE, "ns", overrideOnly(""));
+    Optional<PolarisStorageConfigurationInfo> resolved =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(List.of(catalog, ns));
+    assertThat(resolved).isPresent();
+    // empty override ignored → base config returned unchanged
+    assertThat(resolved.get().getStorageName()).isEqualTo("default");
+  }
+
+  // --- helpers -----------------------------------------------------------
+
+  private static Map<String, String> overrideOnly(String name) {
+    Map<String, String> m = new HashMap<>();
+    m.put(PolarisEntityConstants.getStorageNameOverridePropertyName(), name);
+    return m;
+  }
+
+  private static PolarisEntity catalogEntity(PolarisStorageConfigurationInfo config) {
+    Map<String, String> internal = new HashMap<>();
+    internal.put(PolarisEntityConstants.getStorageConfigInfoPropertyName(), config.serialize());
+    return entity(PolarisEntityType.CATALOG, "cat", internal);
+  }
+
+  private static PolarisEntity entity(
+      PolarisEntityType type, String name, Map<String, String> internalProps) {
+    PolarisBaseEntity base =
+        new PolarisBaseEntity.Builder()
+            .catalogId(1L)
+            .id(System.nanoTime())
+            .typeCode(type.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(0L)
+            .name(name)
+            .internalPropertiesAsMap(internalProps)
+            .build();
+    return new PolarisEntity(base);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageNameValidatorTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageNameValidatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class StorageNameValidatorTest {
+
+  @Test
+  void validNameReturnedVerbatim() {
+    assertThat(StorageNameValidator.normalizeAndValidate("team-a_1")).isEqualTo("team-a_1");
+    assertThat(StorageNameValidator.normalizeAndValidate("PROD")).isEqualTo("PROD");
+    assertThat(StorageNameValidator.normalizeAndValidate("a")).isEqualTo("a");
+  }
+
+  @Test
+  void surroundingWhitespaceIsTrimmed() {
+    assertThat(StorageNameValidator.normalizeAndValidate("  prod  ")).isEqualTo("prod");
+    assertThat(StorageNameValidator.normalizeAndValidate("\tprod\n")).isEqualTo("prod");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   ", "\t", "\n  \t"})
+  void blankNormalizesToNull(String input) {
+    assertThat(StorageNameValidator.normalizeAndValidate(input)).isNull();
+  }
+
+  @Test
+  void overMaxLengthRejected() {
+    String tooLong = "a".repeat(StorageNameValidator.MAX_LENGTH + 1);
+    assertThatThrownBy(() -> StorageNameValidator.normalizeAndValidate(tooLong))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(String.valueOf(StorageNameValidator.MAX_LENGTH));
+  }
+
+  @Test
+  void atMaxLengthAccepted() {
+    String maxLen = "a".repeat(StorageNameValidator.MAX_LENGTH);
+    assertThat(StorageNameValidator.normalizeAndValidate(maxLen)).isEqualTo(maxLen);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"foo bar", "a/b", "a.b", "a:b", "a#b", "name!", "tab\tname", "with space"})
+  void invalidCharactersRejected(String input) {
+    assertThatThrownBy(() -> StorageNameValidator.normalizeAndValidate(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("[a-zA-Z0-9_-]");
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageNameValidatorTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageNameValidatorTest.java
@@ -63,7 +63,8 @@ class StorageNameValidatorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo bar", "a/b", "a.b", "a:b", "a#b", "name!", "tab\tname", "with space"})
+  @ValueSource(
+      strings = {"foo bar", "a/b", "a.b", "a:b", "a#b", "name!", "tab\tname", "with space"})
   void invalidCharactersRejected(String input) {
     assertThatThrownBy(() -> StorageNameValidator.normalizeAndValidate(input))
         .isInstanceOf(IllegalArgumentException.class)

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/WithStorageNameTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/WithStorageNameTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
+import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+
+class WithStorageNameTest {
+
+  @Test
+  void awsConfigPreservesAllFieldsAndSwapsStorageName() {
+    AwsStorageConfigurationInfo base =
+        AwsStorageConfigurationInfo.builder()
+            .addAllowedLocations("s3://foo/bar", "s3://no/where")
+            .roleARN("arn:aws:iam::123456789012:role/polaris-test")
+            .region("no-where-1")
+            .externalId("external-id")
+            .storageName("default")
+            .build();
+
+    PolarisStorageConfigurationInfo result =
+        PolarisStorageConfigurationInfo.withStorageName(base, "team-a");
+
+    assertThat(result).isInstanceOf(AwsStorageConfigurationInfo.class);
+    AwsStorageConfigurationInfo aws = (AwsStorageConfigurationInfo) result;
+    assertThat(aws.getStorageName()).isEqualTo("team-a");
+    assertThat(aws.getRoleARN()).isEqualTo(base.getRoleARN());
+    assertThat(aws.getRegion()).isEqualTo(base.getRegion());
+    assertThat(aws.getExternalId()).isEqualTo(base.getExternalId());
+    assertThat(aws.getAllowedLocations()).containsExactlyElementsOf(base.getAllowedLocations());
+    assertThat(aws).isNotEqualTo(base);
+    assertThat(base.getStorageName()).isEqualTo("default"); // base unchanged
+  }
+
+  @Test
+  void awsConfigAcceptsNullClearingStorageName() {
+    AwsStorageConfigurationInfo base =
+        AwsStorageConfigurationInfo.builder()
+            .addAllowedLocations("s3://foo/bar")
+            .roleARN("arn:aws:iam::123456789012:role/polaris-test")
+            .region("us-east-1")
+            .storageName("default")
+            .build();
+
+    AwsStorageConfigurationInfo result =
+        (AwsStorageConfigurationInfo) PolarisStorageConfigurationInfo.withStorageName(base, null);
+
+    assertThat(result.getStorageName()).isNull();
+    assertThat(result.getRoleARN()).isEqualTo(base.getRoleARN());
+  }
+
+  @Test
+  void azureConfigPreservesFieldsAndSwapsStorageName() {
+    AzureStorageConfigurationInfo base =
+        AzureStorageConfigurationInfo.builder()
+            .addAllowedLocations("abfs://foo@bar.baz/", "abfss://boo@meep.buzz/")
+            .tenantId("tenant-id")
+            .storageName("default")
+            .build();
+
+    AzureStorageConfigurationInfo result =
+        (AzureStorageConfigurationInfo)
+            PolarisStorageConfigurationInfo.withStorageName(base, "team-azure");
+
+    assertThat(result.getStorageName()).isEqualTo("team-azure");
+    assertThat(result.getTenantId()).isEqualTo("tenant-id");
+    assertThat(result.getAllowedLocations()).containsExactlyElementsOf(base.getAllowedLocations());
+  }
+
+  @Test
+  void gcpConfigPreservesFieldsAndSwapsStorageName() {
+    GcpStorageConfigurationInfo base =
+        GcpStorageConfigurationInfo.builder()
+            .addAllowedLocations("gs://foo/bar")
+            .gcpServiceAccount("svc@project.iam.gserviceaccount.com")
+            .storageName("default")
+            .build();
+
+    GcpStorageConfigurationInfo result =
+        (GcpStorageConfigurationInfo)
+            PolarisStorageConfigurationInfo.withStorageName(base, "team-gcp");
+
+    assertThat(result.getStorageName()).isEqualTo("team-gcp");
+    assertThat(result.getGcpServiceAccount()).isEqualTo(base.getGcpServiceAccount());
+    assertThat(result.getAllowedLocations()).containsExactlyElementsOf(base.getAllowedLocations());
+  }
+
+  @Test
+  void fileConfigPreservesFieldsAndSwapsStorageName() {
+    FileStorageConfigurationInfo base =
+        FileStorageConfigurationInfo.builder()
+            .addAllowedLocations("file:///tmp/bar")
+            .storageName("default")
+            .build();
+
+    FileStorageConfigurationInfo result =
+        (FileStorageConfigurationInfo)
+            PolarisStorageConfigurationInfo.withStorageName(base, "team-file");
+
+    assertThat(result.getStorageName()).isEqualTo("team-file");
+    assertThat(result.getAllowedLocations()).containsExactlyElementsOf(base.getAllowedLocations());
+  }
+
+  @Test
+  void unsupportedSubtypeThrows() {
+    PolarisStorageConfigurationInfo bogus =
+        new PolarisStorageConfigurationInfo() {
+          @Override
+          public java.util.List<String> getAllowedLocations() {
+            return java.util.List.of();
+          }
+
+          @Override
+          public String getStorageName() {
+            return null;
+          }
+
+          @Override
+          public StorageType getStorageType() {
+            return StorageType.S3;
+          }
+
+          @Override
+          public String getFileIoImplClassName() {
+            return "x";
+          }
+        };
+
+    assertThatThrownBy(() -> PolarisStorageConfigurationInfo.withStorageName(bogus, "any"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported");
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -426,7 +426,6 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     IcebergTableLikeEntity existingEntity = IcebergTableLikeEntity.of(rawEntity);
 
     Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
-    Map<String, String> commitProperties = new HashMap<>(metadata.properties());
     String priorTableOverride =
         existingEntity
             .getInternalPropertiesAsMap()
@@ -435,7 +434,11 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       storedProperties.put(
           PolarisEntityConstants.getStorageNameOverridePropertyName(), priorTableOverride);
     }
-    processStorageNameOverrideOnWrite(commitProperties, storedProperties, priorTableOverride);
+    // Validate / flag-gate / translate polaris.storage.name from the incoming metadata properties
+    // into the internal storage_name_override key on storedProperties. The mutated copy of the
+    // user-facing properties is discarded; only the storedProperties side-effect is load-bearing.
+    processStorageNameOverrideOnWrite(
+        new HashMap<>(metadata.properties()), storedProperties, priorTableOverride);
     IcebergTableLikeEntity updatedEntity =
         new IcebergTableLikeEntity.Builder(existingEntity)
             .setInternalProperties(storedProperties)
@@ -1816,8 +1819,9 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       // Process polaris.storage.name on the table commit's properties: validate, gate against
       // ALLOW_STORAGE_NAME_OVERRIDE when changing, and translate into the internal
       // storage_name_override key on `storedProperties`. The override survives across commits
-      // because we seed `storedProperties` with the prior persisted value before processing.
-      Map<String, String> commitProperties = new HashMap<>(metadata.properties());
+      // because we seed `storedProperties` with the prior persisted value before processing. The
+      // mutated copy of the user-facing properties is discarded; only the storedProperties
+      // side-effect is load-bearing.
       String priorTableOverride =
           entity == null
               ? null
@@ -1828,7 +1832,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         storedProperties.put(
             PolarisEntityConstants.getStorageNameOverridePropertyName(), priorTableOverride);
       }
-      processStorageNameOverrideOnWrite(commitProperties, storedProperties, priorTableOverride);
+      processStorageNameOverrideOnWrite(
+          new HashMap<>(metadata.properties()), storedProperties, priorTableOverride);
       String existingLocation;
       if (null == entity) {
         existingLocation = null;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -838,7 +838,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
     PolarisEntity entity = resolvedEntities.getRawLeafEntity();
     Map<String, String> newProperties = new HashMap<>(entity.getPropertiesAsMap());
-    Map<String, String> updatedInternalProperties = new HashMap<>(entity.getInternalPropertiesAsMap());
+    Map<String, String> updatedInternalProperties =
+        new HashMap<>(entity.getInternalPropertiesAsMap());
 
     // Merge new properties into existing map. Process the polaris.storage.name override on a
     // mutable copy of the incoming properties so the user-facing key is stripped before the merge
@@ -1997,14 +1998,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   /**
-   * Process the user-facing {@link #POLARIS_STORAGE_NAME_PROPERTY} on a write request: validate
-   * the value, gate against {@link FeatureConfiguration#ALLOW_STORAGE_NAME_OVERRIDE} when the
-   * value would change, write the resolved value into the internal-property map (or remove it
-   * when cleared), and strip the user-facing key from the user property map.
+   * Process the user-facing {@link #POLARIS_STORAGE_NAME_PROPERTY} on a write request: validate the
+   * value, gate against {@link FeatureConfiguration#ALLOW_STORAGE_NAME_OVERRIDE} when the value
+   * would change, write the resolved value into the internal-property map (or remove it when
+   * cleared), and strip the user-facing key from the user property map.
    *
    * <p>The flag is only enforced when the requested value would actually mutate the persisted
-   * {@code storage_name_override}. An idempotent re-set with the prior value is always allowed,
-   * so flipping the flag off does not break existing entities.
+   * {@code storage_name_override}. An idempotent re-set with the prior value is always allowed, so
+   * flipping the flag off does not break existing entities.
    *
    * <p>Property semantics:
    *
@@ -2014,12 +2015,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
    *   <li>Property absent from the user map: no change to the override.
    * </ul>
    *
-   * @param userProperties user-facing property map being persisted; the
-   *     {@link #POLARIS_STORAGE_NAME_PROPERTY} key is removed in place if present.
+   * @param userProperties user-facing property map being persisted; the {@link
+   *     #POLARIS_STORAGE_NAME_PROPERTY} key is removed in place if present.
    * @param internalProperties internal-property map that will be persisted onto the entity; the
    *     {@code storage_name_override} key is set or removed in place based on the request.
-   * @param priorOverride the override value already persisted on the entity (or {@code null} for
-   *     a fresh create). Used to decide whether the request is an idempotent re-set.
+   * @param priorOverride the override value already persisted on the entity (or {@code null} for a
+   *     fresh create). Used to decide whether the request is an idempotent re-set.
    */
   @VisibleForTesting
   void processStorageNameOverrideOnWrite(
@@ -2034,11 +2035,11 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     try {
       requested = StorageNameValidator.normalizeAndValidate(rawValue);
     } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e, "Invalid %s: %s", POLARIS_STORAGE_NAME_PROPERTY, e.getMessage());
+      throw new BadRequestException(
+          e, "Invalid %s: %s", POLARIS_STORAGE_NAME_PROPERTY, e.getMessage());
     }
     boolean changing = !Objects.equal(priorOverride, requested);
-    if (changing
-        && !realmConfig.getConfig(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE)) {
+    if (changing && !realmConfig.getConfig(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE)) {
       throw new BadRequestException(
           "Setting %s requires feature %s to be enabled",
           POLARIS_STORAGE_NAME_PROPERTY, FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE.key());

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -640,19 +640,21 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
 
     Map<String, String> userProperties = new HashMap<>(metadata);
-    Map<String, String> internalProperties = new HashMap<>();
-    processStorageNameOverrideOnWrite(userProperties, internalProperties, null);
+    Map<String, String> additionalInternalProperties = new HashMap<>();
+    processStorageNameOverrideOnWrite(userProperties, additionalInternalProperties, null);
 
-    NamespaceEntity entity =
+    NamespaceEntity.Builder entityBuilder =
         new NamespaceEntity.Builder(namespace)
             .setCatalogId(getCatalogId())
             .setId(getMetaStoreManager().generateNewEntityId(getCurrentPolarisContext()).getId())
             .setParentId(resolvedParent.getRawLeafEntity().getId())
             .setProperties(userProperties)
-            .setInternalProperties(internalProperties)
             .setCreateTimestamp(System.currentTimeMillis())
-            .setBaseLocation(baseLocation)
-            .build();
+            .setBaseLocation(baseLocation);
+    // Add any storage-name override into internalProperties without clobbering the
+    // parent-namespace key that NamespaceEntity.Builder's constructor already set.
+    additionalInternalProperties.forEach(entityBuilder::addInternalProperty);
+    NamespaceEntity entity = entityBuilder.build();
     if (!realmConfig.getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap for {} with sibling tables or namespaces", namespace);
       validateNoLocationOverlap(entity, resolvedParent.getRawFullPath());

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -128,6 +128,7 @@ import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageLocation;
+import org.apache.polaris.core.storage.StorageNameValidator;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.service.catalog.SupportsNotifications;
 import org.apache.polaris.service.catalog.common.CatalogUtils;
@@ -156,6 +157,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergCatalog.class);
 
   private static final Joiner SLASH = Joiner.on("/");
+
+  /**
+   * User-facing property key on namespaces and tables that selects a server-configured named
+   * storage profile to use for credential vending. Validated and translated into the internal
+   * property {@link PolarisEntityConstants#getStorageNameOverridePropertyName()}.
+   */
+  static final String POLARIS_STORAGE_NAME_PROPERTY = "polaris.storage.name";
 
   public static final Predicate<Exception> SHOULD_RETRY_REFRESH_PREDICATE =
       ex -> {
@@ -418,6 +426,16 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     IcebergTableLikeEntity existingEntity = IcebergTableLikeEntity.of(rawEntity);
 
     Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+    Map<String, String> commitProperties = new HashMap<>(metadata.properties());
+    String priorTableOverride =
+        existingEntity
+            .getInternalPropertiesAsMap()
+            .get(PolarisEntityConstants.getStorageNameOverridePropertyName());
+    if (priorTableOverride != null) {
+      storedProperties.put(
+          PolarisEntityConstants.getStorageNameOverridePropertyName(), priorTableOverride);
+    }
+    processStorageNameOverrideOnWrite(commitProperties, storedProperties, priorTableOverride);
     IcebergTableLikeEntity updatedEntity =
         new IcebergTableLikeEntity.Builder(existingEntity)
             .setInternalProperties(storedProperties)
@@ -621,12 +639,17 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       baseLocation += "/";
     }
 
+    Map<String, String> userProperties = new HashMap<>(metadata);
+    Map<String, String> internalProperties = new HashMap<>();
+    processStorageNameOverrideOnWrite(userProperties, internalProperties, null);
+
     NamespaceEntity entity =
         new NamespaceEntity.Builder(namespace)
             .setCatalogId(getCatalogId())
             .setId(getMetaStoreManager().generateNewEntityId(getCurrentPolarisContext()).getId())
             .setParentId(resolvedParent.getRawLeafEntity().getId())
-            .setProperties(metadata)
+            .setProperties(userProperties)
+            .setInternalProperties(internalProperties)
             .setCreateTimestamp(System.currentTimeMillis())
             .setBaseLocation(baseLocation)
             .build();
@@ -813,11 +836,21 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
     PolarisEntity entity = resolvedEntities.getRawLeafEntity();
     Map<String, String> newProperties = new HashMap<>(entity.getPropertiesAsMap());
+    Map<String, String> updatedInternalProperties = new HashMap<>(entity.getInternalPropertiesAsMap());
 
-    // Merge new properties into existing map.
-    newProperties.putAll(properties);
+    // Merge new properties into existing map. Process the polaris.storage.name override on a
+    // mutable copy of the incoming properties so the user-facing key is stripped before the merge
+    // and the corresponding internal storage_name_override is updated atomically.
+    Map<String, String> incoming = new HashMap<>(properties);
+    String priorOverride =
+        updatedInternalProperties.get(PolarisEntityConstants.getStorageNameOverridePropertyName());
+    processStorageNameOverrideOnWrite(incoming, updatedInternalProperties, priorOverride);
+    newProperties.putAll(incoming);
     PolarisEntity updatedEntity =
-        new PolarisEntity.Builder(entity).setProperties(newProperties).build();
+        new PolarisEntity.Builder(entity)
+            .setProperties(newProperties)
+            .setInternalProperties(updatedInternalProperties)
+            .build();
 
     if (!realmConfig.getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
       LOGGER.debug("Validating no overlap with sibling tables or namespaces");
@@ -862,9 +895,17 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
     Map<String, String> updatedProperties = new HashMap<>(entity.getPropertiesAsMap());
     properties.forEach(updatedProperties::remove);
+    Map<String, String> updatedInternalProperties =
+        new HashMap<>(entity.getInternalPropertiesAsMap());
+    String priorOverride =
+        updatedInternalProperties.get(PolarisEntityConstants.getStorageNameOverridePropertyName());
+    processStorageNameOverrideOnRemove(properties, updatedInternalProperties, priorOverride);
 
     PolarisEntity updatedEntity =
-        new PolarisEntity.Builder(entity).setProperties(updatedProperties).build();
+        new PolarisEntity.Builder(entity)
+            .setProperties(updatedProperties)
+            .setInternalProperties(updatedInternalProperties)
+            .build();
 
     List<PolarisEntity> parentPath = resolvedEntities.getRawFullPath();
     PolarisEntity returnedEntity =
@@ -1769,6 +1810,22 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
       IcebergTableLikeEntity entity =
           IcebergTableLikeEntity.of(resolvedPath == null ? null : resolvedPath.getRawLeafEntity());
+      // Process polaris.storage.name on the table commit's properties: validate, gate against
+      // ALLOW_STORAGE_NAME_OVERRIDE when changing, and translate into the internal
+      // storage_name_override key on `storedProperties`. The override survives across commits
+      // because we seed `storedProperties` with the prior persisted value before processing.
+      Map<String, String> commitProperties = new HashMap<>(metadata.properties());
+      String priorTableOverride =
+          entity == null
+              ? null
+              : entity
+                  .getInternalPropertiesAsMap()
+                  .get(PolarisEntityConstants.getStorageNameOverridePropertyName());
+      if (priorTableOverride != null) {
+        storedProperties.put(
+            PolarisEntityConstants.getStorageNameOverridePropertyName(), priorTableOverride);
+      }
+      processStorageNameOverrideOnWrite(commitProperties, storedProperties, priorTableOverride);
       String existingLocation;
       if (null == entity) {
         existingLocation = null;
@@ -1935,6 +1992,88 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
           meta,
           String.format(Locale.ROOT, "%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
     }
+  }
+
+  /**
+   * Process the user-facing {@link #POLARIS_STORAGE_NAME_PROPERTY} on a write request: validate
+   * the value, gate against {@link FeatureConfiguration#ALLOW_STORAGE_NAME_OVERRIDE} when the
+   * value would change, write the resolved value into the internal-property map (or remove it
+   * when cleared), and strip the user-facing key from the user property map.
+   *
+   * <p>The flag is only enforced when the requested value would actually mutate the persisted
+   * {@code storage_name_override}. An idempotent re-set with the prior value is always allowed,
+   * so flipping the flag off does not break existing entities.
+   *
+   * <p>Property semantics:
+   *
+   * <ul>
+   *   <li>{@code polaris.storage.name=foo} (and {@code foo} is non-blank, valid) sets the override.
+   *   <li>{@code polaris.storage.name=""} (or whitespace) clears the override.
+   *   <li>Property absent from the user map: no change to the override.
+   * </ul>
+   *
+   * @param userProperties user-facing property map being persisted; the
+   *     {@link #POLARIS_STORAGE_NAME_PROPERTY} key is removed in place if present.
+   * @param internalProperties internal-property map that will be persisted onto the entity; the
+   *     {@code storage_name_override} key is set or removed in place based on the request.
+   * @param priorOverride the override value already persisted on the entity (or {@code null} for
+   *     a fresh create). Used to decide whether the request is an idempotent re-set.
+   */
+  @VisibleForTesting
+  void processStorageNameOverrideOnWrite(
+      Map<String, String> userProperties,
+      Map<String, String> internalProperties,
+      @Nullable String priorOverride) {
+    if (!userProperties.containsKey(POLARIS_STORAGE_NAME_PROPERTY)) {
+      return;
+    }
+    String rawValue = userProperties.remove(POLARIS_STORAGE_NAME_PROPERTY);
+    String requested;
+    try {
+      requested = StorageNameValidator.normalizeAndValidate(rawValue);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e, "Invalid %s: %s", POLARIS_STORAGE_NAME_PROPERTY, e.getMessage());
+    }
+    boolean changing = !Objects.equal(priorOverride, requested);
+    if (changing
+        && !realmConfig.getConfig(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE)) {
+      throw new BadRequestException(
+          "Setting %s requires feature %s to be enabled",
+          POLARIS_STORAGE_NAME_PROPERTY, FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE.key());
+    }
+    String storageOverrideKey = PolarisEntityConstants.getStorageNameOverridePropertyName();
+    if (requested == null) {
+      internalProperties.remove(storageOverrideKey);
+    } else {
+      internalProperties.put(storageOverrideKey, requested);
+    }
+  }
+
+  /**
+   * Handle removal of {@link #POLARIS_STORAGE_NAME_PROPERTY} via the namespace removeProperties
+   * path: gate against the feature flag if the override is currently set, then clear the internal
+   * {@code storage_name_override} key in {@code internalProperties}. Caller is expected to also
+   * remove the user-facing key from the entity's user properties.
+   *
+   * @param requestedKeys the set of property keys the user asked to remove
+   * @param internalProperties internal-property map to mutate
+   * @param priorOverride the override value already persisted on the entity (or {@code null})
+   */
+  @VisibleForTesting
+  void processStorageNameOverrideOnRemove(
+      Set<String> requestedKeys,
+      Map<String, String> internalProperties,
+      @Nullable String priorOverride) {
+    if (!requestedKeys.contains(POLARIS_STORAGE_NAME_PROPERTY)) {
+      return;
+    }
+    if (priorOverride != null
+        && !realmConfig.getConfig(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE)) {
+      throw new BadRequestException(
+          "Removing %s requires feature %s to be enabled",
+          POLARIS_STORAGE_NAME_PROPERTY, FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE.key());
+    }
+    internalProperties.remove(PolarisEntityConstants.getStorageNameOverridePropertyName());
   }
 
   private static Map<String, String> buildTableMetadataPropertiesMap(TableMetadata metadata) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/FileIOUtil.java
@@ -18,35 +18,57 @@
  */
 package org.apache.polaris.service.catalog.io;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.StorageConfigOverrideResolver;
 
 public class FileIOUtil {
 
   private FileIOUtil() {}
 
   /**
-   * Finds storage configuration information in the hierarchy of the resolved storage entity.
+   * Finds storage configuration information in the hierarchy of the resolved storage entity, with
+   * any nearest-ancestor {@code storage_name_override} applied to the catalog's base config.
    *
-   * <p>This method starts at the "leaf" level (e.g., table) and walks "upwards" through namespaces
-   * in the hierarchy to the "root." It searches for the first entity containing storage config
-   * properties, identified using a key from {@link
-   * PolarisEntityConstants#getStorageConfigInfoPropertyName()}.
+   * <p>This method walks the path leaf-to-root, locates the first entity carrying {@code
+   * storage_configuration_info} (the catalog), and — if any closer ancestor carries a {@code
+   * storage_name_override} — returns a synthetic copy of the base entity whose serialized
+   * configuration has its {@code storageName} replaced. Callers that read the resulting entity's
+   * internal properties (e.g., to stash on a purge task) therefore see the effective config.
    *
    * @param resolvedStorageEntity the resolved entity wrapper containing the hierarchical path
-   * @return an {@link Optional} containing the entity with storage config, or empty if not found
+   * @return an {@link Optional} containing the (possibly synthetic) entity with the effective
+   *     storage config, or empty if no entity in the chain has a base storage config
    */
   public static Optional<PolarisEntity> findStorageInfoFromHierarchy(
       PolarisResolvedPathWrapper resolvedStorageEntity) {
-    Optional<PolarisEntity> storageInfoEntity =
-        resolvedStorageEntity.getRawFullPath().reversed().stream()
+    List<PolarisEntity> path = resolvedStorageEntity.getRawFullPath();
+    Optional<PolarisStorageConfigurationInfo> effective =
+        StorageConfigOverrideResolver.resolveEffectiveConfig(path);
+    if (effective.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<PolarisEntity> baseEntity =
+        path.reversed().stream()
             .filter(
                 e ->
                     e.getInternalPropertiesAsMap()
                         .containsKey(PolarisEntityConstants.getStorageConfigInfoPropertyName()))
             .findFirst();
-    return storageInfoEntity;
+    if (baseEntity.isEmpty()) {
+      return Optional.empty();
+    }
+    PolarisEntity original = baseEntity.get();
+    Map<String, String> internalProps = new HashMap<>(original.getInternalPropertiesAsMap());
+    internalProps.put(
+        PolarisEntityConstants.getStorageConfigInfoPropertyName(), effective.get().serialize());
+    return Optional.of(
+        new PolarisEntity.Builder(original).setInternalProperties(internalProps).build());
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ReservedProperties.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ReservedProperties.java
@@ -67,7 +67,12 @@ public interface ReservedProperties {
    * prefix
    */
   default Set<String> allowlist() {
-    return PolarisConfiguration.getAllCatalogConfigs();
+    Set<String> allowlist = new HashSet<>(PolarisConfiguration.getAllCatalogConfigs());
+    // polaris.storage.name selects a server-configured named storage profile and is processed
+    // by IcebergCatalog before being mapped to the internal storage_name_override property; the
+    // user-facing key must survive the reserved-prefix filter.
+    allowlist.add("polaris.storage.name");
+    return allowlist;
   }
 
   /** If true, attempts to modify a reserved property should throw an exception. */

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -33,13 +33,13 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.storage.CredentialVendingContext;
 import org.apache.polaris.core.storage.LocationGrant;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageConfigOverrideResolver;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.StsClientProvider;
@@ -129,8 +129,7 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
   @Override
   public @Nullable PolarisStorageIntegration getStorageIntegration(
       @NonNull List<PolarisEntity> resolvedEntityPath) {
-    return PolarisStorageConfigurationInfo.findStorageInfoFromHierarchy(resolvedEntityPath)
-        .map(entity -> BaseMetaStoreManager.extractStorageConfiguration(diagnostics, entity))
+    return StorageConfigOverrideResolver.resolveEffectiveConfig(resolvedEntityPath)
         .map(this::createIntegration)
         .orElse(null);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/StorageNameOverrideTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/StorageNameOverrideTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
+import org.apache.polaris.core.persistence.resolver.Resolver;
+import org.apache.polaris.core.persistence.resolver.ResolverFactory;
+import org.apache.polaris.core.persistence.resolver.ResolverStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StorageNameOverrideTest {
+
+  private static final String INTERNAL_KEY =
+      PolarisEntityConstants.getStorageNameOverridePropertyName();
+  private static final String USER_KEY = IcebergCatalog.POLARIS_STORAGE_NAME_PROPERTY;
+
+  @Mock ResolverFactory resolverFactory;
+  @Mock CallContext callContext;
+  @Mock PolarisResolutionManifestCatalogView resolvedEntityView;
+  @Mock CatalogEntity catalogEntity;
+  @Mock PolarisDiagnostics diagnostics;
+  @Mock Resolver resolver;
+  @Mock RealmConfig realmConfig;
+
+  private final PolarisPrincipal principal = PolarisPrincipal.of("test", Map.of(), Set.of());
+  private IcebergCatalog catalog;
+
+  @BeforeEach
+  void initMocks() {
+    lenient().when(resolvedEntityView.getResolvedCatalogEntity()).thenReturn(catalogEntity);
+    lenient().when(resolverFactory.createResolver(any(), any())).thenReturn(resolver);
+    lenient()
+        .when(resolver.resolveAll())
+        .thenReturn(new ResolverStatus(ResolverStatus.StatusEnum.SUCCESS));
+    lenient().when(callContext.getRealmConfig()).thenReturn(realmConfig);
+
+    catalog =
+        new IcebergCatalog(
+            diagnostics,
+            resolverFactory,
+            null,
+            callContext,
+            resolvedEntityView,
+            principal,
+            null,
+            null,
+            null,
+            null,
+            null);
+  }
+
+  private void flag(boolean enabled) {
+    when(realmConfig.getConfig(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE))
+        .thenReturn(enabled);
+  }
+
+  // --- onWrite: validation -----------------------------------------------
+
+  @Test
+  void onWrite_invalidValue_throwsBadRequest() {
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "bad name!"));
+    Map<String, String> internal = new HashMap<>();
+    assertThatThrownBy(() -> catalog.processStorageNameOverrideOnWrite(user, internal, null))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining(USER_KEY);
+  }
+
+  // --- onWrite: flag gating -----------------------------------------------
+
+  @Test
+  void onWrite_setNewValue_flagOff_throws() {
+    flag(false);
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "team-a"));
+    Map<String, String> internal = new HashMap<>();
+    assertThatThrownBy(() -> catalog.processStorageNameOverrideOnWrite(user, internal, null))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining(FeatureConfiguration.ALLOW_STORAGE_NAME_OVERRIDE.key());
+  }
+
+  @Test
+  void onWrite_setNewValue_flagOn_persists() {
+    flag(true);
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "team-a"));
+    Map<String, String> internal = new HashMap<>();
+    catalog.processStorageNameOverrideOnWrite(user, internal, null);
+    assertThat(user).doesNotContainKey(USER_KEY);
+    assertThat(internal).containsEntry(INTERNAL_KEY, "team-a");
+  }
+
+  @Test
+  void onWrite_idempotentReSet_flagOff_passes() {
+    // No flag stub: shouldn't be consulted for an idempotent re-set.
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "team-a"));
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    catalog.processStorageNameOverrideOnWrite(user, internal, "team-a");
+    assertThat(user).doesNotContainKey(USER_KEY);
+    assertThat(internal).containsEntry(INTERNAL_KEY, "team-a");
+  }
+
+  @Test
+  void onWrite_changingExistingValue_flagOff_throws() {
+    flag(false);
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "team-b"));
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    assertThatThrownBy(() -> catalog.processStorageNameOverrideOnWrite(user, internal, "team-a"))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  // --- onWrite: clearing -------------------------------------------------
+
+  @Test
+  void onWrite_blankValueClearsOverride_flagOn() {
+    flag(true);
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, ""));
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    catalog.processStorageNameOverrideOnWrite(user, internal, "team-a");
+    assertThat(user).doesNotContainKey(USER_KEY);
+    assertThat(internal).doesNotContainKey(INTERNAL_KEY);
+  }
+
+  @Test
+  void onWrite_propertyAbsent_noChange() {
+    // Should not consult flag, should not touch internal.
+    Map<String, String> user = new HashMap<>(Map.of("polaris.other", "x"));
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    catalog.processStorageNameOverrideOnWrite(user, internal, "team-a");
+    assertThat(user).containsEntry("polaris.other", "x");
+    assertThat(internal).containsEntry(INTERNAL_KEY, "team-a");
+  }
+
+  @Test
+  void onWrite_blankWhenNotPreviouslySet_flagOff_passes() {
+    // priorOverride == null, requested == null → no change; flag must not be consulted.
+    Map<String, String> user = new HashMap<>(Map.of(USER_KEY, "  "));
+    Map<String, String> internal = new HashMap<>();
+    catalog.processStorageNameOverrideOnWrite(user, internal, null);
+    assertThat(user).doesNotContainKey(USER_KEY);
+    assertThat(internal).doesNotContainKey(INTERNAL_KEY);
+  }
+
+  // --- onRemove ----------------------------------------------------------
+
+  @Test
+  void onRemove_propertyNotInRequest_noOp() {
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    catalog.processStorageNameOverrideOnRemove(Set.of("other.key"), internal, "team-a");
+    assertThat(internal).containsEntry(INTERNAL_KEY, "team-a");
+  }
+
+  @Test
+  void onRemove_priorNull_flagOff_passes() {
+    // No prior override → no flag check, no-op.
+    Map<String, String> internal = new HashMap<>();
+    catalog.processStorageNameOverrideOnRemove(Set.of(USER_KEY), internal, null);
+    assertThat(internal).doesNotContainKey(INTERNAL_KEY);
+  }
+
+  @Test
+  void onRemove_priorSet_flagOff_throws() {
+    flag(false);
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    assertThatThrownBy(
+            () -> catalog.processStorageNameOverrideOnRemove(Set.of(USER_KEY), internal, "team-a"))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void onRemove_priorSet_flagOn_clears() {
+    flag(true);
+    Map<String, String> internal = new HashMap<>(Map.of(INTERNAL_KEY, "team-a"));
+    catalog.processStorageNameOverrideOnRemove(Set.of(USER_KEY), internal, "team-a");
+    assertThat(internal).doesNotContainKey(INTERNAL_KEY);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/StorageNameOverrideTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/StorageNameOverrideTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
@@ -200,6 +201,25 @@ class StorageNameOverrideTest {
     assertThatThrownBy(
             () -> catalog.processStorageNameOverrideOnRemove(Set.of(USER_KEY), internal, "team-a"))
         .isInstanceOf(BadRequestException.class);
+  }
+
+  // --- regression: createNamespace must preserve parent-namespace internal key ----
+  // When override processing produces an empty additional-internal-properties map,
+  // the NamespaceEntity.Builder's parent-namespace internal key (set in its
+  // constructor) must survive. Earlier code passed a fresh empty map to
+  // setInternalProperties(...), which wiped the parent-namespace key on every
+  // namespace at depth >= 2 and broke loadNamespaceMetadata downstream.
+  @Test
+  void onWrite_emptyOverrideMap_preservesPriorInternalKeys() {
+    Map<String, String> user = new HashMap<>(Map.of("k", "v"));
+    Map<String, String> additional = new HashMap<>();
+    catalog.processStorageNameOverrideOnWrite(user, additional, null);
+    assertThat(additional).isEmpty();
+    // Sanity: the helper itself never touches keys it doesn't own. The fix lives in
+    // createNamespaceInternal which uses addInternalProperty for each entry of the
+    // additional map (a no-op when empty), so the Builder's parent-namespace key
+    // set by NamespaceEntity.Builder(Namespace) is preserved.
+    assertThat(Namespace.of("ns1", "ns1a").length()).isEqualTo(2); // depth >= 2 case
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOUtilTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOUtilTest.java
@@ -47,8 +47,7 @@ class FileIOUtilTest {
 
   @Test
   void noOverrideReturnsBaseEntityWithBaseConfig() {
-    PolarisResolvedPathWrapper path =
-        wrap(catalogEntity(), namespaceEntity(Map.of()));
+    PolarisResolvedPathWrapper path = wrap(catalogEntity(), namespaceEntity(Map.of()));
     Optional<PolarisEntity> result = FileIOUtil.findStorageInfoFromHierarchy(path);
     assertThat(result).isPresent();
     PolarisStorageConfigurationInfo cfg =
@@ -62,8 +61,7 @@ class FileIOUtilTest {
 
   @Test
   void namespaceOverrideAppliedToReturnedSyntheticEntity() {
-    PolarisResolvedPathWrapper path =
-        wrap(catalogEntity(), namespaceEntityWithOverride("team-a"));
+    PolarisResolvedPathWrapper path = wrap(catalogEntity(), namespaceEntityWithOverride("team-a"));
     Optional<PolarisEntity> result = FileIOUtil.findStorageInfoFromHierarchy(path);
     assertThat(result).isPresent();
     PolarisStorageConfigurationInfo cfg =

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOUtilTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOUtilTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+
+class FileIOUtilTest {
+
+  private static final AwsStorageConfigurationInfo BASE_CONFIG =
+      AwsStorageConfigurationInfo.builder()
+          .addAllowedLocations("s3://foo/bar")
+          .roleARN("arn:aws:iam::123456789012:role/polaris-test")
+          .region("us-east-1")
+          .storageName("default")
+          .build();
+
+  @Test
+  void noOverrideReturnsBaseEntityWithBaseConfig() {
+    PolarisResolvedPathWrapper path =
+        wrap(catalogEntity(), namespaceEntity(Map.of()));
+    Optional<PolarisEntity> result = FileIOUtil.findStorageInfoFromHierarchy(path);
+    assertThat(result).isPresent();
+    PolarisStorageConfigurationInfo cfg =
+        PolarisStorageConfigurationInfo.deserialize(
+            result
+                .get()
+                .getInternalPropertiesAsMap()
+                .get(PolarisEntityConstants.getStorageConfigInfoPropertyName()));
+    assertThat(cfg.getStorageName()).isEqualTo("default");
+  }
+
+  @Test
+  void namespaceOverrideAppliedToReturnedSyntheticEntity() {
+    PolarisResolvedPathWrapper path =
+        wrap(catalogEntity(), namespaceEntityWithOverride("team-a"));
+    Optional<PolarisEntity> result = FileIOUtil.findStorageInfoFromHierarchy(path);
+    assertThat(result).isPresent();
+    PolarisStorageConfigurationInfo cfg =
+        PolarisStorageConfigurationInfo.deserialize(
+            result
+                .get()
+                .getInternalPropertiesAsMap()
+                .get(PolarisEntityConstants.getStorageConfigInfoPropertyName()));
+    assertThat(cfg.getStorageName()).isEqualTo("team-a");
+    assertThat(cfg).isInstanceOf(AwsStorageConfigurationInfo.class);
+    AwsStorageConfigurationInfo aws = (AwsStorageConfigurationInfo) cfg;
+    assertThat(aws.getRoleARN()).isEqualTo(BASE_CONFIG.getRoleARN());
+  }
+
+  @Test
+  void leafOverrideBeatsAncestorOverride() {
+    PolarisResolvedPathWrapper path =
+        wrap(
+            catalogEntity(),
+            namespaceEntityWithOverride("team-namespace"),
+            tableEntityWithOverride("table-special"));
+    Optional<PolarisEntity> result = FileIOUtil.findStorageInfoFromHierarchy(path);
+    PolarisStorageConfigurationInfo cfg =
+        PolarisStorageConfigurationInfo.deserialize(
+            result
+                .get()
+                .getInternalPropertiesAsMap()
+                .get(PolarisEntityConstants.getStorageConfigInfoPropertyName()));
+    assertThat(cfg.getStorageName()).isEqualTo("table-special");
+  }
+
+  @Test
+  void noBaseConfigReturnsEmpty() {
+    PolarisResolvedPathWrapper path = wrap(namespaceEntityWithOverride("orphan"));
+    assertThat(FileIOUtil.findStorageInfoFromHierarchy(path)).isEmpty();
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private static PolarisResolvedPathWrapper wrap(PolarisEntity... entities) {
+    return new PolarisResolvedPathWrapper(
+        java.util.Arrays.stream(entities)
+            .map(e -> new ResolvedPolarisEntity(e, List.of(), List.of()))
+            .collect(java.util.stream.Collectors.toList()));
+  }
+
+  private PolarisEntity catalogEntity() {
+    Map<String, String> internal = new HashMap<>();
+    internal.put(
+        PolarisEntityConstants.getStorageConfigInfoPropertyName(), BASE_CONFIG.serialize());
+    return entity(PolarisEntityType.CATALOG, "cat", internal);
+  }
+
+  private PolarisEntity namespaceEntity(Map<String, String> internalProps) {
+    return entity(PolarisEntityType.NAMESPACE, "ns", internalProps);
+  }
+
+  private PolarisEntity namespaceEntityWithOverride(String name) {
+    return namespaceEntity(
+        Map.of(PolarisEntityConstants.getStorageNameOverridePropertyName(), name));
+  }
+
+  private PolarisEntity tableEntityWithOverride(String name) {
+    return entity(
+        PolarisEntityType.TABLE_LIKE,
+        "tbl",
+        Map.of(PolarisEntityConstants.getStorageNameOverridePropertyName(), name));
+  }
+
+  private PolarisEntity entity(
+      PolarisEntityType type, String name, Map<String, String> internalProps) {
+    PolarisBaseEntity base =
+        new PolarisBaseEntity.Builder()
+            .catalogId(1L)
+            .id(System.nanoTime())
+            .typeCode(type.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(0L)
+            .name(name)
+            .internalPropertiesAsMap(internalProps)
+            .build();
+    return new PolarisEntity(base);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
@@ -62,7 +62,8 @@ class PolarisStorageIntegrationProviderImplTest {
         provider.getStorageIntegration(List.of(catalogEntity()));
 
     assertThat(integration).isInstanceOf(CachingStorageIntegration.class);
-    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    PolarisStorageConfigurationInfo bound =
+        ((CachingStorageIntegration<?>) integration).storageConfig();
     assertThat(bound.getStorageName()).isEqualTo("default");
   }
 
@@ -70,16 +71,17 @@ class PolarisStorageIntegrationProviderImplTest {
   void namespaceOverrideAppliedToBoundConfig() {
     PolarisStorageIntegrationProviderImpl provider = newProvider();
 
-    List<PolarisEntity> path =
-        List.of(catalogEntity(), namespaceEntityWithOverride("team-a"));
+    List<PolarisEntity> path = List.of(catalogEntity(), namespaceEntityWithOverride("team-a"));
 
     PolarisStorageIntegration integration = provider.getStorageIntegration(path);
 
     assertThat(integration).isInstanceOf(CachingStorageIntegration.class);
-    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    PolarisStorageConfigurationInfo bound =
+        ((CachingStorageIntegration<?>) integration).storageConfig();
     assertThat(bound.getStorageName()).isEqualTo("team-a");
     // Other fields preserved.
-    assertThat(((AwsStorageConfigurationInfo) bound).getRoleARN()).isEqualTo(BASE_AWS_CONFIG.getRoleARN());
+    assertThat(((AwsStorageConfigurationInfo) bound).getRoleARN())
+        .isEqualTo(BASE_AWS_CONFIG.getRoleARN());
   }
 
   @Test
@@ -94,7 +96,8 @@ class PolarisStorageIntegrationProviderImplTest {
 
     PolarisStorageIntegration integration = provider.getStorageIntegration(path);
 
-    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    PolarisStorageConfigurationInfo bound =
+        ((CachingStorageIntegration<?>) integration).storageConfig();
     assertThat(bound.getStorageName()).isEqualTo("table-special");
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may apply this License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.storage.CachingStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.PolarisStorageIntegration;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.core.storage.cache.StorageCredentialCacheConfig;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sts.StsClient;
+
+class PolarisStorageIntegrationProviderImplTest {
+
+  private static final AwsStorageConfigurationInfo BASE_AWS_CONFIG =
+      AwsStorageConfigurationInfo.builder()
+          .addAllowedLocations("s3://foo/bar")
+          .roleARN("arn:aws:iam::123456789012:role/polaris-test")
+          .region("us-east-1")
+          .storageName("default")
+          .build();
+
+  @Test
+  void noOverrideReturnsBaseStorageName() {
+    PolarisStorageIntegrationProviderImpl provider = newProvider();
+
+    PolarisStorageIntegration integration =
+        provider.getStorageIntegration(List.of(catalogEntity()));
+
+    assertThat(integration).isInstanceOf(CachingStorageIntegration.class);
+    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    assertThat(bound.getStorageName()).isEqualTo("default");
+  }
+
+  @Test
+  void namespaceOverrideAppliedToBoundConfig() {
+    PolarisStorageIntegrationProviderImpl provider = newProvider();
+
+    List<PolarisEntity> path =
+        List.of(catalogEntity(), namespaceEntityWithOverride("team-a"));
+
+    PolarisStorageIntegration integration = provider.getStorageIntegration(path);
+
+    assertThat(integration).isInstanceOf(CachingStorageIntegration.class);
+    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    assertThat(bound.getStorageName()).isEqualTo("team-a");
+    // Other fields preserved.
+    assertThat(((AwsStorageConfigurationInfo) bound).getRoleARN()).isEqualTo(BASE_AWS_CONFIG.getRoleARN());
+  }
+
+  @Test
+  void leafOverrideBeatsAncestorOverride() {
+    PolarisStorageIntegrationProviderImpl provider = newProvider();
+
+    List<PolarisEntity> path =
+        List.of(
+            catalogEntity(),
+            namespaceEntityWithOverride("team-namespace"),
+            tableEntityWithOverride("table-special"));
+
+    PolarisStorageIntegration integration = provider.getStorageIntegration(path);
+
+    PolarisStorageConfigurationInfo bound = ((CachingStorageIntegration<?>) integration).storageConfig();
+    assertThat(bound.getStorageName()).isEqualTo("table-special");
+  }
+
+  @Test
+  void noBaseConfigReturnsNullEvenWithOverride() {
+    PolarisStorageIntegrationProviderImpl provider = newProvider();
+
+    // namespace-only path with no catalog config
+    PolarisStorageIntegration integration =
+        provider.getStorageIntegration(List.of(namespaceEntityWithOverride("orphan")));
+
+    assertThat(integration).isNull();
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private PolarisStorageIntegrationProviderImpl newProvider() {
+    StsClient stsClient = mock(StsClient.class);
+    StorageCredentialCacheConfig cacheConfig = () -> 1024;
+    StorageCredentialCache cache = new StorageCredentialCache(cacheConfig);
+    RealmConfig realmConfig = mock(RealmConfig.class);
+    return new PolarisStorageIntegrationProviderImpl(
+        (destination) -> stsClient,
+        Optional.empty(),
+        () -> GoogleCredentials.create(new AccessToken("token", new Date())),
+        cache,
+        realmConfig,
+        new PolarisDefaultDiagServiceImpl());
+  }
+
+  private PolarisEntity catalogEntity() {
+    Map<String, String> internal = new HashMap<>();
+    internal.put(
+        PolarisEntityConstants.getStorageConfigInfoPropertyName(), BASE_AWS_CONFIG.serialize());
+    return entity(PolarisEntityType.CATALOG, "cat", internal);
+  }
+
+  private PolarisEntity namespaceEntityWithOverride(String name) {
+    return entity(
+        PolarisEntityType.NAMESPACE,
+        "ns",
+        Map.of(PolarisEntityConstants.getStorageNameOverridePropertyName(), name));
+  }
+
+  private PolarisEntity tableEntityWithOverride(String name) {
+    return entity(
+        PolarisEntityType.TABLE_LIKE,
+        "tbl",
+        Map.of(PolarisEntityConstants.getStorageNameOverridePropertyName(), name));
+  }
+
+  private PolarisEntity entity(
+      PolarisEntityType type, String name, Map<String, String> internalProps) {
+    PolarisBaseEntity base =
+        new PolarisBaseEntity.Builder()
+            .catalogId(1L)
+            .id(System.nanoTime())
+            .typeCode(type.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(0L)
+            .name(name)
+            .internalPropertiesAsMap(internalProps)
+            .build();
+    return new PolarisEntity(base);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImplTest.java
@@ -99,6 +99,31 @@ class PolarisStorageIntegrationProviderImplTest {
   }
 
   @Test
+  void distinctOverridesProduceDistinctBoundConfigsForCacheSegregation() {
+    PolarisStorageIntegrationProviderImpl provider = newProvider();
+
+    PolarisStorageIntegration teamA =
+        provider.getStorageIntegration(
+            List.of(catalogEntity(), namespaceEntityWithOverride("team-a")));
+    PolarisStorageIntegration teamB =
+        provider.getStorageIntegration(
+            List.of(catalogEntity(), namespaceEntityWithOverride("team-b")));
+
+    PolarisStorageConfigurationInfo configA =
+        ((CachingStorageIntegration<?>) teamA).storageConfig();
+    PolarisStorageConfigurationInfo configB =
+        ((CachingStorageIntegration<?>) teamB).storageConfig();
+
+    // The bound configs differ only in storageName, but Immutables-generated equals/hashCode
+    // includes that field, so AwsStorageCredentialCacheKey (which has storageConfig as a value
+    // field) will produce distinct keys for these two paths.
+    assertThat(configA).isNotEqualTo(configB);
+    assertThat(configA.hashCode()).isNotEqualTo(configB.hashCode());
+    assertThat(configA.getStorageName()).isEqualTo("team-a");
+    assertThat(configB.getStorageName()).isEqualTo("team-b");
+  }
+
+  @Test
   void noBaseConfigReturnsNullEvenWithOverride() {
     PolarisStorageIntegrationProviderImpl provider = newProvider();
 

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -147,6 +147,15 @@ Config key for whether to allow setting the FILE_IO_IMPL using catalog propertie
 
 ---
 
+##### `polaris.features."ALLOW_STORAGE_NAME_OVERRIDE"`
+
+If set to true, allows namespaces and tables to set the polaris.storage.name property to override which server-configured named storage profile is used for credential vending. The override is resolved leaf-to-root at access time. Whether the resolved name actually changes vended credentials additionally depends on RESOLVE_CREDENTIALS_BY_STORAGE_NAME being enabled. Default: false.
+
+- **Type:** `Boolean`
+- **Default:** `false`
+
+---
+
 ##### `polaris.features."ALLOW_TABLE_LOCATION_OVERLAP"`
 
 If set to true, Polaris allows table or view locations to overlap existing table or namespace locations. This disables Polaris location-overlap protection for table-like objects in the catalog and should only be used for compatibility cases where storage isolation is enforced outside Polaris.


### PR DESCRIPTION
### Summary
This PR adds inline storage-name overrides for namespaces and tables using the polaris.storage.name property, so credential vending can select named credentials per entity without introducing new management APIs.

It also refactors hierarchy lookup logic to remove duplication and adds focused test coverage for override behavior and credential vending.

### Why this change is needed
Today, catalog-level storage credentials are often too coarse for multi-tenant or team-isolated workloads. This change enables namespace/table-scoped credential selection by storing an inline override and resolving it through the existing hierarchy at runtime.

### What changed
1. Added storage-name validation and normalization utilities.
2. Added a helper to clone storage configuration while replacing only storageName.
3. Allowed polaris.storage.name through reserved-property filtering.
4. Implemented override handling for:
   1. namespace create
   2. namespace setProperties
   3. namespace removeProperties
   4. table metadata/property flows
5. Refactored hierarchy traversal into shared utility logic to avoid duplicate implementations.
6. Updated and expanded tests, including an end-to-end credential-vending assertion where leaf override credentials are vended.

### Behavioral notes
1. polaris.storage.name accepts alphanumeric, hyphen, underscore, up to 128 chars.
2. Blank values normalize to null.
3. Override resolution uses nearest ancestor storage config and replaces only storageName.
4. Credential vending uses the resolved inline storage configuration for the target entity.

### Testing
1. Added/updated unit and integration tests for validation, inheritance, persistence, and vending behavior.
2. Verified targeted runtime-service tests for override + vending paths passed.

### Reviewer notes
1. This PR intentionally keeps storage type inheritance unchanged: override changes storageName, not storage type.
2. A follow-up PR is planned for cross-type override scenarios (for example AWS catalog overridden by Azure/GCS at leaf scope).

### Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated CHANGELOG.md (if needed)
- [ ] 📚 Updated documentation in site/content/in-dev/unreleased (if needed)