### PR TITLE
fix(verify-release): fix bash pipe FD leak causing deadlock on maven checksum verification

### DIFF
--- a/tools/verify-release/verify-release.sh
+++ b/tools/verify-release/verify-release.sh
@@ -227,12 +227,10 @@ function proc_exec {
   "${@}" > "${output_file}" 2>&1
   exit_code=$?
   if [[ $exit_code -ne 0 ]]; then
-    local output=()
-    while IFS= read -r line; do
-      output+=("$line")
-    done < "${output_file}"
+    local output
+    output=$(cat "${output_file}")
     rm -f "${output_file}"
-    log_fatal "${err_msg}" "${output[@]}"
+    log_fatal "${err_msg}" "${output}"
     return 1
   fi
   rm -f "${output_file}"


### PR DESCRIPTION
Without this fix, the verify script deadlocks and stalls past a amount of artifacts processed during the Maven Repo Signature and Checksum Verification:

As I am no expert at this, I am relying on Claude's explanation that the process substitution used earlier doesn't close the pipe FDs reliably, which eventually ends up in a deadlock. The new code eliminates pipes altogether and therefore has nothing to leak.

If anyone has a better way of doing this, please suggest to raise a different PR - I am only going with this as this suggestion worked for me, but unsure if it is the correct long-term fix.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
