### PR TITLE
Use appropriate scope in producer methods

### DIFF
--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
@@ -39,6 +39,7 @@ import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 public class AdminToolProducers {
 
   @Produces
+  @ApplicationScoped
   public MetaStoreManagerFactory metaStoreManagerFactory(
       QuarkusPersistenceConfiguration persistenceConfiguration,
       @Any Instance<MetaStoreManagerFactory> metaStoreManagerFactories) {
@@ -60,6 +61,7 @@ public class AdminToolProducers {
   }
 
   @Produces
+  @ApplicationScoped
   public PolarisStorageIntegrationProvider storageIntegrationProvider() {
     // A storage integration provider is not required when running the admin tool.
     return new PolarisStorageIntegrationProvider() {
@@ -74,12 +76,14 @@ public class AdminToolProducers {
   }
 
   @Produces
+  @ApplicationScoped
   public RealmConfigurationSource configurationStore() {
     // A configuration source is not required when running the admin tool.
     return RealmConfigurationSource.EMPTY_CONFIG;
   }
 
   @Produces
+  @ApplicationScoped
   public RealmConfig dummyRealmConfig(RealmConfigurationSource configurationSource) {
     // Use a random realm ID for RealmConfig since the PolarisConfigurationStore is empty anyway
     String absentId = UUID.randomUUID().toString();

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -202,6 +202,7 @@ public class ServiceProducers {
   // Polaris service beans - selected from @Identifier-annotated beans
 
   @Produces
+  @Singleton // used in instanceof checks
   public RealmContextResolver realmContextResolver(
       RealmContextConfiguration config, @Any Instance<RealmContextResolver> realmContextResolvers) {
     return realmContextResolvers.select(Identifier.Literal.of(config.type())).get();
@@ -215,6 +216,7 @@ public class ServiceProducers {
   }
 
   @Produces
+  @Singleton // used in instanceof checks
   public PolarisEventListener polarisEventListener(
       PolarisEventListenerConfiguration config,
       @Any Instance<PolarisEventListener> polarisEventListeners) {
@@ -222,6 +224,7 @@ public class ServiceProducers {
   }
 
   @Produces
+  @Singleton // used in instanceof checks
   public MetaStoreManagerFactory metaStoreManagerFactory(
       PersistenceConfiguration config,
       @Any Instance<MetaStoreManagerFactory> metaStoreManagerFactories) {
@@ -243,6 +246,7 @@ public class ServiceProducers {
   }
 
   @Produces
+  @ApplicationScoped
   public UserSecretsManagerFactory userSecretsManagerFactory(
       SecretsManagerConfiguration config,
       @Any Instance<UserSecretsManagerFactory> userSecretsManagerFactories) {
@@ -353,12 +357,14 @@ public class ServiceProducers {
   }
 
   @Produces
+  @ApplicationScoped
   public RateLimiter rateLimiter(
       RateLimiterFilterConfiguration config, @Any Instance<RateLimiter> rateLimiters) {
     return rateLimiters.select(Identifier.Literal.of(config.type())).get();
   }
 
   @Produces
+  @ApplicationScoped
   public TokenBucketFactory tokenBucketFactory(
       TokenBucketConfiguration config, @Any Instance<TokenBucketFactory> tokenBucketFactories) {
     return tokenBucketFactories.select(Identifier.Literal.of(config.type())).get();
@@ -425,6 +431,7 @@ public class ServiceProducers {
   }
 
   @Produces
+  @ApplicationScoped
   public OidcTenantResolver oidcTenantResolver(
       OidcConfiguration config, @Any Instance<OidcTenantResolver> resolvers) {
     return resolvers.select(Identifier.Literal.of(config.tenantResolver())).get();


### PR DESCRIPTION
Some producer methods are not annotated, which means that the produced beans get the `@Dependent` scope by default. This is incorrect for some of the beans. This PR fixes it.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
