### PR TITLE
Replace helm/chart-testing-action with manual ct installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,19 @@ jobs:
         with:
           version: ${{ matrix.helm-version }}
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        run: |
+          CT_VERSION=3.14.0
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64|amd64) ARCH=amd64 ;;
+            aarch64|arm64) ARCH=arm64 ;;
+          esac
+          curl -sSLo ct.tar.gz "https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_${ARCH}.tar.gz"
+          sudo tar -xzf ct.tar.gz -C /usr/local/bin ct
+          mkdir -p .ct
+          tar -xzf ct.tar.gz --strip-components=1 -C .ct etc
+          rm ct.tar.gz
+          pip install yamllint yamale
       - name: Set up helm-docs
         run: |
           go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest


### PR DESCRIPTION
The chart-testing-action@v2.8.0 transitively depends on astral-sh/setup-uv, which is not allowed in the apache org.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
