### PR TITLE
Set Quarkus config profile `it` explicitly

### DIFF
--- a/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
@@ -43,6 +43,8 @@ testing {
             // is not smart enough :(
             systemProperty("build.output.directory", layout.buildDirectory.asFile.get())
             dependsOn(tasks.named("quarkusBuild"))
+            // Set the 'it' profile explicitly
+            jvmArgumentProviders.add(CommandLineArgumentProvider { listOf("-Dquarkus.profile=it") })
           }
         }
         tasks.named(sources.compileJavaTaskName).configure {


### PR DESCRIPTION
Integration tests using Quarkus versions before 3.32.4 somehow implicitly got the `quarkus.profile=it` setting. This seemed to be changed in 3.32.4, so that integration tests start with the `prod` (= default) profile, cauting integration tests to fail, because the necessary configurations are just not there.

Looking at the [Quarkus config reference](https://quarkus.io/guides/config-reference#default-profiles), it seems that there is no `it` profile.

Explicitly setting the config profile to `it`, although not sure why that changed in 3.32.4, seems safer anyways.
