### PR TITLE
CLI: Skip nested ns if existed during setup

### DIFF
--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -1160,15 +1160,7 @@ class SetupCommand(Command):
         existing_namespaces: Set[str] = set()
         listed_parents: Set[str] = set()
 
-        try:
-            for ns in catalog_api.list_namespaces(prefix=catalog_name).namespaces:
-                existing_namespaces.add(".".join(ns))
-                listed_parents.add("")
-        except NotFoundException:
-            # This is expected if the catalog has no namespaces yet
-            listed_parents.add("")
-        except Exception:
-            logger.exception(f"Failed to fetch namespaces for catalog '{catalog_name}'")
+        listed_parents.add("")
         all_namespaces_to_create = set()
         namespace_data_map = {}
         for ns_item in namespaces_config:
@@ -1248,7 +1240,7 @@ class SetupCommand(Command):
                     logger.info(
                         f"Namespace '{ns_name}' already exists in catalog '{catalog_name}'."
                     )
-                    existing_namespaces.add(ns)
+                    existing_namespaces.add(ns_name)
                 except Exception:
                     logger.exception(
                         f"Failed to create namespace '{ns_name}' in catalog '{catalog_name}'"


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently if u rerun setup twice which contains namespace creation such as following:
```
./polaris --profile dev setup apply site/content/guides/assets/polaris/reference-setup-config.yaml
```

The first attempt will work without error:
```
2026-03-24 00:00:59,521 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-03-24 00:00:59,571 INFO Creating namespace: 'dev_namespace' in catalog: 'quickstart_catalog'
2026-03-24 00:00:59,590 INFO Namespace 'dev_namespace' created successfully in catalog 'quickstart_catalog'.
2026-03-24 00:00:59,590 INFO Creating namespace: 'dev_namespace.sub_namespace' in catalog: 'quickstart_catalog'
2026-03-24 00:00:59,601 INFO Namespace 'dev_namespace.sub_namespace' created successfully in catalog 'quickstart_catalog'.
2026-03-24 00:00:59,601 INFO --- Finished processing namespaces for catalog: quickstart_catalog ---
```

But the second attempt will fail on nested namespace:
```
2026-03-24 00:01:01,563 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-03-24 00:01:01,569 INFO Skipping creation for already existing namespace 'dev_namespace' in catalog 'quickstart_catalog'
2026-03-24 00:01:01,569 INFO Creating namespace: 'dev_namespace.sub_namespace' in catalog: 'quickstart_catalog'
2026-03-24 00:01:01,583 ERROR Failed to create namespace 'dev_namespace.sub_namespace' in catalog 'quickstart_catalog'
Traceback (most recent call last):
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/cli/command/setup.py", line 1224, in _create_namespaces
    cmd.execute(api)
    ~~~~~~~~~~~^^^^^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/cli/command/namespaces.py", line 68, in execute
    catalog_api.create_namespace(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        prefix=self.catalog, create_namespace_request=request
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/yong/Desktop/GitHome/polaris/polaris-venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py", line 39, in wrapper_function
    return wrapper(*args, **kwargs)
  File "/Users/yong/Desktop/GitHome/polaris/polaris-venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py", line 136, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/api/iceberg_catalog_api.py", line 805, in create_namespace
    return self.api_client.response_deserialize(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        response_data=response_data,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        response_types_map=_response_types_map,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).data
    ^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/api_client.py", line 341, in response_deserialize
    raise ApiException.from_response(
          ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        http_resp=response_data,
        ^^^^^^^^^^^^^^^^^^^^^^^^
        body=response_text,
        ^^^^^^^^^^^^^^^^^^^
        data=return_data,
        ^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/exceptions.py", line 174, in from_response
    raise ConflictException(http_resp=http_resp, body=body, data=data)
apache_polaris.sdk.catalog.exceptions.ConflictException: (409)
Reason: Conflict
HTTP response headers: HTTPHeaderDict({'content-length': '144', 'Content-Type': 'application/json', 'X-Request-ID': '1bb6cecf-3ef9-4050-848c-a7a2a9864075_0000000000000000056'})
HTTP response body: error=ErrorModel(message='Cannot create namespace dev_namespace.sub_namespace. Namespace already exists', type='AlreadyExistsException', code=409, stack=None)

2026-03-24 00:01:01,588 INFO --- Finished processing namespaces for catalog: quickstart_catalog ---
```

This is due to earlier I didn't check if sub-namespace is existed or not and only checked on the top level. This PR addressed this problem by checking visited namespaces:
```
2026-03-23 23:57:50,619 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-03-23 23:57:50,623 INFO Skipping creation for already existing namespace 'dev_namespace' in catalog 'quickstart_catalog'
2026-03-23 23:57:50,626 INFO Skipping creation for already existing namespace 'dev_namespace.sub_namespace' in catalog 'quickstart_catalog'
2026-03-23 23:57:50,629 INFO --- Finished processing namespaces for catalog: quickstart_catalog ---
```


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
