### PR TITLE
CLI: Fix catalog command

### DIFF
--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -156,7 +156,7 @@ class CatalogsCommand(Command):
                 elif self.catalog_authentication_type == AuthenticationType.SIGV4.value:
                     if not self.catalog_role_arn or not self.catalog_signing_region:
                         raise Exception(
-                            f"Authentication type 'SIGV4 requires"
+                            f"Authentication type 'SIGV4' requires"
                             f" {Argument.to_flag_name(Arguments.CATALOG_ROLE_ARN)}"
                             f" and {Argument.to_flag_name(Arguments.CATALOG_SIGNING_REGION)}"
                         )
@@ -338,7 +338,7 @@ class CatalogsCommand(Command):
             )
 
         service_identity = None
-        if self.catalog_service_identity_type == ServiceIdentityType.AWS_IAM:
+        if self.catalog_service_identity_type == ServiceIdentityType.AWS_IAM.value:
             service_identity = AwsIamServiceIdentityInfo(
                 identity_type=self.catalog_service_identity_type.upper(),
                 iam_arn=self.catalog_service_identity_iam_arn,


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR fixed two things fro catalogs CLI:
1. Missing `'` for `SIGV4`
2. For second comparison with catalog_service_identity_type, we are not compare with value for enum

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
