### PR TITLE
POC: Add labels to LoadTableResponse from entity internal properties

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.iceberg.MetadataUpdate;
@@ -344,7 +345,19 @@ public class IcebergCatalogAdapter
             return Response.notModified().build();
           }
 
-          return tryInsertETagHeader(Response.ok(response.get()), response.get(), namespace, table)
+          // Enrich response with labels from entity internal properties
+          Map<String, String> tableLabels = catalog.getLabelsForTable(tableIdentifier);
+          Object responseEntity;
+          if (tableLabels.isEmpty()) {
+            responseEntity = response.get();
+          } else {
+            responseEntity =
+                new LoadTableResponseWithLabels(
+                    response.get(), new LoadTableResponseWithLabels.Labels(tableLabels));
+          }
+
+          return tryInsertETagHeader(
+                  Response.ok(responseEntity), response.get(), namespace, table)
               .build();
         });
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -684,6 +684,25 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     return null; // could be an external catalog
   }
 
+  /**
+   * Extract labels from a table entity's internal properties. Properties with the "label." prefix
+   * are catalog-scoped metadata (not part of Iceberg table state) and are surfaced as labels in the
+   * LoadTableResponse.
+   */
+  public Map<String, String> getLabelsForTable(TableIdentifier tableIdentifier) {
+    IcebergTableLikeEntity entity = getTableEntity(tableIdentifier);
+    if (entity == null) {
+      return Map.of();
+    }
+    Map<String, String> labels = new java.util.HashMap<>();
+    entity.getInternalPropertiesAsMap().forEach((key, value) -> {
+      if (key.startsWith("label.")) {
+        labels.put(key.substring(6), value);
+      }
+    });
+    return labels;
+  }
+
   public LoadTableResponse loadTable(TableIdentifier tableIdentifier, String snapshots) {
     return loadTableIfStale(tableIdentifier, null, snapshots).get();
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LoadTableResponseWithLabels.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LoadTableResponseWithLabels.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.Map;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+/**
+ * Wraps a standard LoadTableResponse with an optional labels field for catalog metadata
+ * enrichment. Labels are ephemeral API-level annotations — not part of table state.
+ *
+ * <p>This is a proof-of-concept for the IRC Labels proposal. Labels are derived from Polaris
+ * entity internal properties (prefix "label."), which are catalog-scoped and separate from Iceberg
+ * table metadata.
+ */
+public class LoadTableResponseWithLabels {
+
+  @JsonUnwrapped private final LoadTableResponse delegate;
+  private final Labels labels;
+
+  public LoadTableResponseWithLabels(LoadTableResponse delegate, Labels labels) {
+    this.delegate = delegate;
+    this.labels = labels;
+  }
+
+  public LoadTableResponse getDelegate() {
+    return delegate;
+  }
+
+  public Labels getLabels() {
+    return labels;
+  }
+
+  public static class Labels {
+    private final Map<String, String> table;
+
+    public Labels(Map<String, String> table) {
+      this.table = table;
+    }
+
+    public Map<String, String> getTable() {
+      return table;
+    }
+  }
+}


### PR DESCRIPTION
Surfaces catalog-scoped metadata as labels in the IRC LoadTableResponse. Labels are derived from Polaris entity internalProperties with 'label.' prefix — these are catalog-managed, not part of Iceberg table state.

Addresses apache/polaris#3222 (business-oriented metadata in Polaris). Labels provide a standard IRC protocol mechanism for surfacing ownership, classification, domain, and other catalog context to any consuming engine.

New files: LoadTableResponseWithLabels.java (Jackson wrapper)
Modified: IcebergCatalogHandler (getLabelsForTable), IcebergCatalogAdapter (enrichment)

Proof-of-concept for the IRC Labels proposal: https://github.com/apache/iceberg/issues/15521.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->