### PR TITLE
feat: Add S3 Tables credential vending support for federated catalogs

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -161,6 +161,18 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setKmsUnavailable(awsConfig.getKmsUnavailable())
             .build();
       }
+      if (configInfo instanceof AwsS3TablesStorageConfigurationInfo s3TablesConfig) {
+        return AwsS3TablesStorageConfigInfo.builder()
+            .setRoleArn(s3TablesConfig.getRoleARN())
+            .setExternalId(s3TablesConfig.getExternalId())
+            .setRegion(s3TablesConfig.getRegion())
+            .setCurrentKmsKey(s3TablesConfig.getCurrentKmsKey())
+            .setAllowedKmsKeys(s3TablesConfig.getAllowedKmsKeys())
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3_TABLES)
+            .setAllowedLocations(s3TablesConfig.getAllowedLocations())
+            .setStorageName(s3TablesConfig.getStorageName())
+            .build();
+      }
       if (configInfo instanceof AzureStorageConfigurationInfo azureConfig) {
         return AzureStorageConfigInfo.builder()
             .setTenantId(azureConfig.getTenantId())
@@ -185,18 +197,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
             .setAllowedLocations(fileConfigModel.getAllowedLocations())
             .setStorageName(fileConfigModel.getStorageName())
-            .build();
-      }
-      if (configInfo instanceof AwsS3TablesStorageConfigurationInfo s3TablesConfig) {
-        return AwsS3TablesStorageConfigInfo.builder()
-            .setRoleArn(s3TablesConfig.getRoleARN())
-            .setExternalId(s3TablesConfig.getExternalId())
-            .setRegion(s3TablesConfig.getRegion())
-            .setCurrentKmsKey(s3TablesConfig.getCurrentKmsKey())
-            .setAllowedKmsKeys(s3TablesConfig.getAllowedKmsKeys())
-            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3_TABLES)
-            .setAllowedLocations(s3TablesConfig.getAllowedLocations())
-            .setStorageName(s3TablesConfig.getStorageName())
             .build();
       }
       return null;
@@ -346,7 +346,8 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                     .build();
             break;
           case S3_TABLES:
-            if (defaultBaseLocation == null || !defaultBaseLocation.startsWith("arn:")) {
+            if (defaultBaseLocation == null
+                || !defaultBaseLocation.startsWith("arn:aws:s3tables")) {
               throw new BadRequestException(
                   "S3 Tables catalogs require default-base-location to be an S3 Tables "
                       + "bucket ARN (e.g. arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket)"

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -317,6 +317,29 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                     .build();
             config = awsConfig;
             break;
+          case S3_TABLES:
+            if (defaultBaseLocation == null
+                || !defaultBaseLocation.startsWith(
+                    PolarisStorageConfigurationInfo.S3_TABLES_ARN_PREFIX)) {
+              throw new BadRequestException(
+                  "S3 Tables catalogs require default-base-location to be an S3 Tables "
+                      + "bucket ARN (e.g. arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket)"
+                      + ", but got: %s",
+                  defaultBaseLocation);
+            }
+            AwsS3TablesStorageConfigInfo s3TablesConfigModel =
+                (AwsS3TablesStorageConfigInfo) storageConfigModel;
+            config =
+                AwsS3TablesStorageConfigurationInfo.builder()
+                    .allowedLocations(allowedLocations)
+                    .storageName(storageConfigModel.getStorageName())
+                    .roleARN(s3TablesConfigModel.getRoleArn())
+                    .externalId(s3TablesConfigModel.getExternalId())
+                    .region(s3TablesConfigModel.getRegion())
+                    .currentKmsKey(s3TablesConfigModel.getCurrentKmsKey())
+                    .allowedKmsKeys(s3TablesConfigModel.getAllowedKmsKeys())
+                    .build();
+            break;
           case AZURE:
             AzureStorageConfigInfo azureConfigModel = (AzureStorageConfigInfo) storageConfigModel;
             config =
@@ -343,28 +366,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                 FileStorageConfigurationInfo.builder()
                     .allowedLocations(allowedLocations)
                     .storageName(storageConfigModel.getStorageName())
-                    .build();
-            break;
-          case S3_TABLES:
-            if (defaultBaseLocation == null
-                || !defaultBaseLocation.startsWith("arn:aws:s3tables")) {
-              throw new BadRequestException(
-                  "S3 Tables catalogs require default-base-location to be an S3 Tables "
-                      + "bucket ARN (e.g. arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket)"
-                      + ", but got: %s",
-                  defaultBaseLocation);
-            }
-            AwsS3TablesStorageConfigInfo s3TablesConfigModel =
-                (AwsS3TablesStorageConfigInfo) storageConfigModel;
-            config =
-                AwsS3TablesStorageConfigurationInfo.builder()
-                    .allowedLocations(allowedLocations)
-                    .storageName(storageConfigModel.getStorageName())
-                    .roleARN(s3TablesConfigModel.getRoleArn())
-                    .externalId(s3TablesConfigModel.getExternalId())
-                    .region(s3TablesConfigModel.getRegion())
-                    .currentKmsKey(s3TablesConfigModel.getCurrentKmsKey())
-                    .allowedKmsKeys(s3TablesConfigModel.getAllowedKmsKeys())
                     .build();
             break;
           default:

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.polaris.core.admin.model.AwsS3TablesStorageConfigInfo;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -48,6 +49,7 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.secrets.SecretReference;
 import org.apache.polaris.core.storage.FileStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
@@ -183,6 +185,18 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
             .setAllowedLocations(fileConfigModel.getAllowedLocations())
             .setStorageName(fileConfigModel.getStorageName())
+            .build();
+      }
+      if (configInfo instanceof AwsS3TablesStorageConfigurationInfo s3TablesConfig) {
+        return AwsS3TablesStorageConfigInfo.builder()
+            .setRoleArn(s3TablesConfig.getRoleARN())
+            .setExternalId(s3TablesConfig.getExternalId())
+            .setRegion(s3TablesConfig.getRegion())
+            .setCurrentKmsKey(s3TablesConfig.getCurrentKmsKey())
+            .setAllowedKmsKeys(s3TablesConfig.getAllowedKmsKeys())
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3_TABLES)
+            .setAllowedLocations(s3TablesConfig.getAllowedLocations())
+            .setStorageName(s3TablesConfig.getStorageName())
             .build();
       }
       return null;
@@ -329,6 +343,27 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                 FileStorageConfigurationInfo.builder()
                     .allowedLocations(allowedLocations)
                     .storageName(storageConfigModel.getStorageName())
+                    .build();
+            break;
+          case S3_TABLES:
+            if (defaultBaseLocation == null || !defaultBaseLocation.startsWith("arn:")) {
+              throw new BadRequestException(
+                  "S3 Tables catalogs require default-base-location to be an S3 Tables "
+                      + "bucket ARN (e.g. arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket)"
+                      + ", but got: %s",
+                  defaultBaseLocation);
+            }
+            AwsS3TablesStorageConfigInfo s3TablesConfigModel =
+                (AwsS3TablesStorageConfigInfo) storageConfigModel;
+            config =
+                AwsS3TablesStorageConfigurationInfo.builder()
+                    .allowedLocations(allowedLocations)
+                    .storageName(storageConfigModel.getStorageName())
+                    .roleARN(s3TablesConfigModel.getRoleArn())
+                    .externalId(s3TablesConfigModel.getExternalId())
+                    .region(s3TablesConfigModel.getRegion())
+                    .currentKmsKey(s3TablesConfigModel.getCurrentKmsKey())
+                    .allowedKmsKeys(s3TablesConfigModel.getAllowedKmsKeys())
                     .build();
             break;
           default:

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -202,7 +202,7 @@ public abstract class PolarisStorageConfigurationInfo {
     AZURE(List.of("abfs://", "wasb://", "abfss://", "wasbs://")),
     GCS("gs://"),
     FILE("file://"),
-    S3_TABLES("arn:"),
+    S3_TABLES("arn:aws:s3tables"),
     ;
 
     private final List<String> prefixes;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -40,6 +40,7 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
@@ -59,6 +60,7 @@ import org.slf4j.LoggerFactory;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = AwsStorageConfigurationInfo.class),
+  @JsonSubTypes.Type(value = AwsS3TablesStorageConfigurationInfo.class),
   @JsonSubTypes.Type(value = AzureStorageConfigurationInfo.class),
   @JsonSubTypes.Type(value = GcpStorageConfigurationInfo.class),
   @JsonSubTypes.Type(value = FileStorageConfigurationInfo.class),
@@ -200,6 +202,7 @@ public abstract class PolarisStorageConfigurationInfo {
     AZURE(List.of("abfs://", "wasb://", "abfss://", "wasbs://")),
     GCS("gs://"),
     FILE("file://"),
+    S3_TABLES("arn:"),
     ;
 
     private final List<String> prefixes;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -196,13 +196,16 @@ public abstract class PolarisStorageConfigurationInfo {
     }
   }
 
+  /** ARN prefix for S3 Tables resources. */
+  public static final String S3_TABLES_ARN_PREFIX = "arn:aws:s3tables";
+
   /** Polaris' storage type, each has a fixed prefix for its location */
   public enum StorageType {
     S3(List.of("s3://", "s3a://")),
+    S3_TABLES(S3_TABLES_ARN_PREFIX),
     AZURE(List.of("abfs://", "wasb://", "abfss://", "wasbs://")),
     GCS("gs://"),
     FILE("file://"),
-    S3_TABLES("arn:aws:s3tables"),
     ;
 
     private final List<String> prefixes;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -18,22 +18,16 @@
  */
 package org.apache.polaris.core.storage.aws;
 
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
-import static org.apache.polaris.core.storage.aws.AwsSessionTagsBuilder.buildSessionTags;
-
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import java.net.URI;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.CredentialVendingContext;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
@@ -41,7 +35,6 @@ import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.core.storage.StorageUri;
 import org.apache.polaris.core.storage.StorageUtil;
-import org.apache.polaris.core.storage.aws.StsClientProvider.StsDestination;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -51,9 +44,6 @@ import software.amazon.awssdk.policybuilder.iam.IamPolicy;
 import software.amazon.awssdk.policybuilder.iam.IamResource;
 import software.amazon.awssdk.policybuilder.iam.IamStatement;
 import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
-import software.amazon.awssdk.services.sts.model.Tag;
 
 /** Credential vendor that supports generating */
 public class AwsCredentialsStorageIntegration
@@ -93,90 +83,42 @@ public class AwsCredentialsStorageIntegration
       @Nonnull PolarisPrincipal polarisPrincipal,
       Optional<String> refreshCredentialsEndpoint,
       @Nonnull CredentialVendingContext credentialVendingContext) {
-    int storageCredentialDurationSeconds =
-        realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
     AwsStorageConfigurationInfo storageConfig = config();
     String region = storageConfig.getRegion();
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
 
-    boolean includePrincipalNameInSubscopedCredential =
-        realmConfig.getConfig(FeatureConfiguration.INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL);
-    List<String> sessionTagFieldNames =
-        realmConfig.getConfig(FeatureConfiguration.SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL);
-    Set<SessionTagField> enabledSessionTagFields =
-        sessionTagFieldNames.stream()
-            .map(SessionTagField::fromConfigName)
-            .flatMap(Optional::stream)
-            .collect(Collectors.toCollection(() -> EnumSet.noneOf(SessionTagField.class)));
-
-    String roleSessionName =
-        includePrincipalNameInSubscopedCredential
-            ? AwsRoleSessionNameSanitizer.sanitize("polaris-" + polarisPrincipal.getName())
-            : "PolarisAwsCredentialsStorageIntegration";
-
     if (shouldUseSts(storageConfig)) {
-      AssumeRoleRequest.Builder request =
-          AssumeRoleRequest.builder()
-              .externalId(storageConfig.getExternalId())
-              .roleArn(storageConfig.getRoleARN())
-              .roleSessionName(roleSessionName)
-              .policy(
-                  policyString(
-                          storageConfig,
-                          allowListOperation,
-                          allowedReadLocations,
-                          allowedWriteLocations,
-                          region)
-                      .toJson())
-              .durationSeconds(storageCredentialDurationSeconds);
+      String policyJson =
+          policyString(
+                  storageConfig,
+                  allowListOperation,
+                  allowedReadLocations,
+                  allowedWriteLocations,
+                  region)
+              .toJson();
 
-      // Add session tags for the configured fields.
-      // Note: trace_id is only present in context when the caller has included it
-      // (StorageAccessConfigProvider populates it when "trace_id" is in enabledSessionTagFields).
-      if (!enabledSessionTagFields.isEmpty()) {
-        List<Tag> sessionTags =
-            buildSessionTags(
-                polarisPrincipal.getName(), credentialVendingContext, enabledSessionTagFields);
-        if (!sessionTags.isEmpty()) {
-          request.tags(sessionTags);
-          // Mark all tags as transitive for role chaining support
-          request.transitiveTagKeys(
-              sessionTags.stream().map(Tag::key).collect(java.util.stream.Collectors.toList()));
-        }
+      AwsStsUtil.assumeRoleAndPopulateConfig(
+          accessConfig,
+          realmConfig,
+          storageConfig.getRoleARN(),
+          storageConfig.getExternalId(),
+          storageConfig.getStsEndpointUri(),
+          region,
+          policyJson,
+          "PolarisAwsCredentialsStorageIntegration",
+          polarisPrincipal,
+          credentialVendingContext,
+          credentialsProvider,
+          stsClientProvider,
+          refreshCredentialsEndpoint);
+    } else {
+      if (region != null) {
+        accessConfig.put(StorageAccessProperty.CLIENT_REGION, region);
       }
-
-      credentialsProvider.ifPresent(
-          cp -> request.overrideConfiguration(b -> b.credentialsProvider(cp)));
-
-      @SuppressWarnings("resource")
-      // Note: stsClientProvider returns "thin" clients that do not need closing
-      StsClient stsClient =
-          stsClientProvider.stsClient(StsDestination.of(storageConfig.getStsEndpointUri(), region));
-
-      AssumeRoleResponse response = stsClient.assumeRole(request.build());
-      accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
-      accessConfig.put(
-          StorageAccessProperty.AWS_SECRET_KEY, response.credentials().secretAccessKey());
-      accessConfig.put(StorageAccessProperty.AWS_TOKEN, response.credentials().sessionToken());
-      Optional.ofNullable(response.credentials().expiration())
-          .ifPresent(
-              i -> {
-                accessConfig.put(
-                    StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
-                accessConfig.put(
-                    StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
-                    String.valueOf(i.toEpochMilli()));
-              });
+      refreshCredentialsEndpoint.ifPresent(
+          endpoint ->
+              accessConfig.put(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT, endpoint));
     }
-
-    if (region != null) {
-      accessConfig.put(StorageAccessProperty.CLIENT_REGION, region);
-    }
-
-    refreshCredentialsEndpoint.ifPresent(
-        endpoint -> {
-          accessConfig.put(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT, endpoint);
-        });
 
     URI endpointUri = storageConfig.getEndpointUri();
     if (endpointUri != null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -310,7 +310,7 @@ public class AwsCredentialsStorageIntegration
     return policyBuilder.addStatement(allowGetObjectStatementBuilder.build()).build();
   }
 
-  private static void addKmsKeyPolicy(
+  static void addKmsKeyPolicy(
       String kmsKeyArn,
       List<String> allowedKmsKeys,
       IamPolicy.Builder policyBuilder,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
+import static org.apache.polaris.core.storage.aws.AwsSessionTagsBuilder.buildSessionTags;
+
+import jakarta.annotation.Nonnull;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.core.storage.InMemoryStorageIntegration;
+import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.apache.polaris.core.storage.aws.StsClientProvider.StsDestination;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.policybuilder.iam.IamEffect;
+import software.amazon.awssdk.policybuilder.iam.IamPolicy;
+import software.amazon.awssdk.policybuilder.iam.IamResource;
+import software.amazon.awssdk.policybuilder.iam.IamStatement;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Tag;
+
+/**
+ * Credential vendor for Amazon S3 Tables. Generates IAM session policies using {@code s3tables:*}
+ * actions scoped to table-level ARNs, rather than the path-based {@code s3:*} policies used by
+ * {@link AwsCredentialsStorageIntegration}.
+ */
+public class AwsS3TablesCredentialsStorageIntegration
+    extends InMemoryStorageIntegration<AwsS3TablesStorageConfigurationInfo> {
+
+  private final StsClientProvider stsClientProvider;
+  private final Optional<AwsCredentialsProvider> credentialsProvider;
+
+  public AwsS3TablesCredentialsStorageIntegration(
+      AwsS3TablesStorageConfigurationInfo config,
+      StsClientProvider stsClientProvider,
+      Optional<AwsCredentialsProvider> credentialsProvider) {
+    super(config, AwsS3TablesCredentialsStorageIntegration.class.getName());
+    this.stsClientProvider = stsClientProvider;
+    this.credentialsProvider = credentialsProvider;
+  }
+
+  @Override
+  public StorageAccessConfig getSubscopedCreds(
+      @Nonnull RealmConfig realmConfig,
+      boolean allowListOperation,
+      @Nonnull Set<String> allowedReadLocations,
+      @Nonnull Set<String> allowedWriteLocations,
+      @Nonnull PolarisPrincipal polarisPrincipal,
+      Optional<String> refreshCredentialsEndpoint,
+      @Nonnull CredentialVendingContext credentialVendingContext) {
+
+    AwsS3TablesStorageConfigurationInfo storageConfig = config();
+    String region = storageConfig.getRegion();
+    int durationSeconds = realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
+
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    // Generate s3tables:* session policy
+    IamPolicy policy =
+        buildS3TablesPolicy(storageConfig, allowedReadLocations, allowedWriteLocations);
+
+    // Role session name
+    boolean includePrincipalName =
+        realmConfig.getConfig(FeatureConfiguration.INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL);
+    String roleSessionName =
+        includePrincipalName
+            ? AwsRoleSessionNameSanitizer.sanitize("polaris-" + polarisPrincipal.getName())
+            : "PolarisAwsS3TablesCredentialsStorageIntegration";
+
+    AssumeRoleRequest.Builder request =
+        AssumeRoleRequest.builder()
+            .externalId(storageConfig.getExternalId())
+            .roleArn(storageConfig.getRoleARN())
+            .roleSessionName(roleSessionName)
+            .policy(policy.toJson())
+            .durationSeconds(durationSeconds);
+
+    // Session tags support
+    List<String> sessionTagFieldNames =
+        realmConfig.getConfig(FeatureConfiguration.SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL);
+    Set<SessionTagField> enabledSessionTagFields =
+        sessionTagFieldNames.stream()
+            .map(SessionTagField::fromConfigName)
+            .flatMap(Optional::stream)
+            .collect(Collectors.toCollection(() -> EnumSet.noneOf(SessionTagField.class)));
+
+    if (!enabledSessionTagFields.isEmpty()) {
+      List<Tag> sessionTags =
+          buildSessionTags(
+              polarisPrincipal.getName(), credentialVendingContext, enabledSessionTagFields);
+      if (!sessionTags.isEmpty()) {
+        request.tags(sessionTags);
+        request.transitiveTagKeys(sessionTags.stream().map(Tag::key).collect(Collectors.toList()));
+      }
+    }
+
+    credentialsProvider.ifPresent(
+        cp -> request.overrideConfiguration(b -> b.credentialsProvider(cp)));
+
+    @SuppressWarnings("resource")
+    StsClient stsClient =
+        stsClientProvider.stsClient(StsDestination.of(storageConfig.getStsEndpointUri(), region));
+
+    AssumeRoleResponse response = stsClient.assumeRole(request.build());
+    accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
+    accessConfig.put(
+        StorageAccessProperty.AWS_SECRET_KEY, response.credentials().secretAccessKey());
+    accessConfig.put(StorageAccessProperty.AWS_TOKEN, response.credentials().sessionToken());
+    Optional.ofNullable(response.credentials().expiration())
+        .ifPresent(
+            i -> {
+              accessConfig.put(
+                  StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
+              accessConfig.put(
+                  StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                  String.valueOf(i.toEpochMilli()));
+            });
+
+    if (region != null) {
+      accessConfig.put(StorageAccessProperty.CLIENT_REGION, region);
+    }
+
+    refreshCredentialsEndpoint.ifPresent(
+        endpoint ->
+            accessConfig.put(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT, endpoint));
+
+    return accessConfig.build();
+  }
+
+  /**
+   * Builds an IAM policy with s3tables:* actions scoped to the provided ARN resources.
+   *
+   * <p>Read actions ({@code s3tables:GetTableData}, {@code s3tables:GetTableMetadataLocation}) are
+   * scoped to all read and write ARNs. Write actions ({@code s3tables:UpdateTableMetadataLocation},
+   * {@code s3tables:PutTableData}) are scoped to write ARNs only.
+   */
+  private IamPolicy buildS3TablesPolicy(
+      AwsS3TablesStorageConfigurationInfo storageConfig,
+      Set<String> readLocations,
+      Set<String> writeLocations) {
+    IamPolicy.Builder policyBuilder = IamPolicy.builder();
+
+    // Read statement scoped to all ARNs (read + write)
+    IamStatement.Builder readStatement =
+        IamStatement.builder()
+            .effect(IamEffect.ALLOW)
+            .addAction("s3tables:GetTableData")
+            .addAction("s3tables:GetTableMetadataLocation");
+
+    Stream.concat(readLocations.stream(), writeLocations.stream())
+        .distinct()
+        .forEach(arn -> readStatement.addResource(IamResource.create(arn)));
+
+    policyBuilder.addStatement(readStatement.build());
+
+    // Write statement scoped to write ARNs only
+    boolean canWrite = !writeLocations.isEmpty();
+    if (canWrite) {
+      IamStatement.Builder writeStatement =
+          IamStatement.builder()
+              .effect(IamEffect.ALLOW)
+              .addAction("s3tables:UpdateTableMetadataLocation")
+              .addAction("s3tables:PutTableData");
+
+      writeLocations.forEach(arn -> writeStatement.addResource(IamResource.create(arn)));
+      policyBuilder.addStatement(writeStatement.build());
+    }
+
+    // KMS policy if configured
+    AwsCredentialsStorageIntegration.addKmsKeyPolicy(
+        storageConfig.getCurrentKmsKey(),
+        storageConfig.getAllowedKmsKeys(),
+        policyBuilder,
+        canWrite,
+        storageConfig.getRegion(),
+        null);
+
+    return policyBuilder.build();
+  }
+
+  @Override
+  public @Nonnull Map<String, Map<PolarisStorageActions, ValidationResult>>
+      validateAccessToLocations(
+          @Nonnull RealmConfig realmConfig,
+          @Nonnull AwsS3TablesStorageConfigurationInfo storageConfig,
+          @Nonnull Set<PolarisStorageActions> actions,
+          @Nonnull Set<String> locations) {
+    // No-op stub for S3 Tables — real validation deferred to a follow-up PR.
+    return Map.of();
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
@@ -56,6 +56,16 @@ import software.amazon.awssdk.services.sts.model.Tag;
 public class AwsS3TablesCredentialsStorageIntegration
     extends InMemoryStorageIntegration<AwsS3TablesStorageConfigurationInfo> {
 
+  // S3 Tables IAM actions for read operations
+  public static final String ACTION_GET_TABLE_DATA = "s3tables:GetTableData";
+  public static final String ACTION_GET_TABLE_METADATA_LOCATION =
+      "s3tables:GetTableMetadataLocation";
+
+  // S3 Tables IAM actions for write operations
+  public static final String ACTION_UPDATE_TABLE_METADATA_LOCATION =
+      "s3tables:UpdateTableMetadataLocation";
+  public static final String ACTION_PUT_TABLE_DATA = "s3tables:PutTableData";
+
   private final StsClientProvider stsClientProvider;
   private final Optional<AwsCredentialsProvider> credentialsProvider;
 
@@ -173,8 +183,8 @@ public class AwsS3TablesCredentialsStorageIntegration
     IamStatement.Builder readStatement =
         IamStatement.builder()
             .effect(IamEffect.ALLOW)
-            .addAction("s3tables:GetTableData")
-            .addAction("s3tables:GetTableMetadataLocation");
+            .addAction(ACTION_GET_TABLE_DATA)
+            .addAction(ACTION_GET_TABLE_METADATA_LOCATION);
 
     Stream.concat(readLocations.stream(), writeLocations.stream())
         .distinct()
@@ -188,8 +198,8 @@ public class AwsS3TablesCredentialsStorageIntegration
       IamStatement.Builder writeStatement =
           IamStatement.builder()
               .effect(IamEffect.ALLOW)
-              .addAction("s3tables:UpdateTableMetadataLocation")
-              .addAction("s3tables:PutTableData");
+              .addAction(ACTION_UPDATE_TABLE_METADATA_LOCATION)
+              .addAction(ACTION_PUT_TABLE_DATA);
 
       writeLocations.forEach(arn -> writeStatement.addResource(IamResource.create(arn)));
       policyBuilder.addStatement(writeStatement.build());
@@ -214,7 +224,9 @@ public class AwsS3TablesCredentialsStorageIntegration
           @Nonnull AwsS3TablesStorageConfigurationInfo storageConfig,
           @Nonnull Set<PolarisStorageActions> actions,
           @Nonnull Set<String> locations) {
-    // No-op stub for S3 Tables — real validation deferred to a follow-up PR.
+    // TODO(https://github.com/apache/polaris/issues/4302): Implement S3 Tables location
+    // validation. This requires calling s3tables:GetTableBucket or similar to verify that the
+    // configured role can actually access the table bucket ARN.
     return Map.of();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegration.java
@@ -18,35 +18,22 @@
  */
 package org.apache.polaris.core.storage.aws;
 
-import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
-import static org.apache.polaris.core.storage.aws.AwsSessionTagsBuilder.buildSessionTags;
-
 import jakarta.annotation.Nonnull;
-import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.CredentialVendingContext;
 import org.apache.polaris.core.storage.InMemoryStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.StorageAccessConfig;
-import org.apache.polaris.core.storage.StorageAccessProperty;
-import org.apache.polaris.core.storage.aws.StsClientProvider.StsDestination;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.policybuilder.iam.IamEffect;
 import software.amazon.awssdk.policybuilder.iam.IamPolicy;
 import software.amazon.awssdk.policybuilder.iam.IamResource;
 import software.amazon.awssdk.policybuilder.iam.IamStatement;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
-import software.amazon.awssdk.services.sts.model.Tag;
 
 /**
  * Credential vendor for Amazon S3 Tables. Generates IAM session policies using {@code s3tables:*}
@@ -90,78 +77,26 @@ public class AwsS3TablesCredentialsStorageIntegration
 
     AwsS3TablesStorageConfigurationInfo storageConfig = config();
     String region = storageConfig.getRegion();
-    int durationSeconds = realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
-
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
 
     // Generate s3tables:* session policy
     IamPolicy policy =
         buildS3TablesPolicy(storageConfig, allowedReadLocations, allowedWriteLocations);
 
-    // Role session name
-    boolean includePrincipalName =
-        realmConfig.getConfig(FeatureConfiguration.INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL);
-    String roleSessionName =
-        includePrincipalName
-            ? AwsRoleSessionNameSanitizer.sanitize("polaris-" + polarisPrincipal.getName())
-            : "PolarisAwsS3TablesCredentialsStorageIntegration";
-
-    AssumeRoleRequest.Builder request =
-        AssumeRoleRequest.builder()
-            .externalId(storageConfig.getExternalId())
-            .roleArn(storageConfig.getRoleARN())
-            .roleSessionName(roleSessionName)
-            .policy(policy.toJson())
-            .durationSeconds(durationSeconds);
-
-    // Session tags support
-    List<String> sessionTagFieldNames =
-        realmConfig.getConfig(FeatureConfiguration.SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL);
-    Set<SessionTagField> enabledSessionTagFields =
-        sessionTagFieldNames.stream()
-            .map(SessionTagField::fromConfigName)
-            .flatMap(Optional::stream)
-            .collect(Collectors.toCollection(() -> EnumSet.noneOf(SessionTagField.class)));
-
-    if (!enabledSessionTagFields.isEmpty()) {
-      List<Tag> sessionTags =
-          buildSessionTags(
-              polarisPrincipal.getName(), credentialVendingContext, enabledSessionTagFields);
-      if (!sessionTags.isEmpty()) {
-        request.tags(sessionTags);
-        request.transitiveTagKeys(sessionTags.stream().map(Tag::key).collect(Collectors.toList()));
-      }
-    }
-
-    credentialsProvider.ifPresent(
-        cp -> request.overrideConfiguration(b -> b.credentialsProvider(cp)));
-
-    @SuppressWarnings("resource")
-    StsClient stsClient =
-        stsClientProvider.stsClient(StsDestination.of(storageConfig.getStsEndpointUri(), region));
-
-    AssumeRoleResponse response = stsClient.assumeRole(request.build());
-    accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
-    accessConfig.put(
-        StorageAccessProperty.AWS_SECRET_KEY, response.credentials().secretAccessKey());
-    accessConfig.put(StorageAccessProperty.AWS_TOKEN, response.credentials().sessionToken());
-    Optional.ofNullable(response.credentials().expiration())
-        .ifPresent(
-            i -> {
-              accessConfig.put(
-                  StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
-              accessConfig.put(
-                  StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
-                  String.valueOf(i.toEpochMilli()));
-            });
-
-    if (region != null) {
-      accessConfig.put(StorageAccessProperty.CLIENT_REGION, region);
-    }
-
-    refreshCredentialsEndpoint.ifPresent(
-        endpoint ->
-            accessConfig.put(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT, endpoint));
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        realmConfig,
+        storageConfig.getRoleARN(),
+        storageConfig.getExternalId(),
+        storageConfig.getStsEndpointUri(),
+        region,
+        policy.toJson(),
+        "PolarisAwsS3TablesCredentialsStorageIntegration",
+        polarisPrincipal,
+        credentialVendingContext,
+        credentialsProvider,
+        stsClientProvider,
+        refreshCredentialsEndpoint);
 
     return accessConfig.build();
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsS3TablesStorageConfigurationInfo.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.annotation.Nullable;
+import java.net.URI;
+import java.util.List;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+
+/** AWS S3 Tables storage configuration information. */
+@PolarisImmutable
+@JsonSerialize(as = ImmutableAwsS3TablesStorageConfigurationInfo.class)
+@JsonDeserialize(as = ImmutableAwsS3TablesStorageConfigurationInfo.class)
+@JsonTypeName("AwsS3TablesStorageConfigurationInfo")
+public abstract class AwsS3TablesStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
+
+  public static ImmutableAwsS3TablesStorageConfigurationInfo.Builder builder() {
+    return ImmutableAwsS3TablesStorageConfigurationInfo.builder();
+  }
+
+  @Override
+  public StorageType getStorageType() {
+    return StorageType.S3_TABLES;
+  }
+
+  @Override
+  public String getFileIoImplClassName() {
+    return "org.apache.iceberg.aws.s3.S3FileIO";
+  }
+
+  /** IAM role ARN used to assume credentials for S3 Tables access. */
+  @Nullable
+  public abstract String getRoleARN();
+
+  /** AWS region where the S3 Tables bucket resides. */
+  @Nullable
+  public abstract String getRegion();
+
+  /** Optional external ID for STS AssumeRole trust policy. */
+  @Nullable
+  public abstract String getExternalId();
+
+  /** KMS Key ARN for server-side encryption, used for writes, optional. */
+  @Nullable
+  public abstract String getCurrentKmsKey();
+
+  /** List of allowed KMS Key ARNs for reading, optional. */
+  @Nullable
+  public abstract List<String> getAllowedKmsKeys();
+
+  /** Optional STS endpoint URI override. */
+  @Nullable
+  public abstract String getStsEndpoint();
+
+  @JsonIgnore
+  @Nullable
+  public URI getStsEndpointUri() {
+    return getStsEndpoint() == null ? null : URI.create(getStsEndpoint());
+  }
+
+  @Value.Check
+  @Override
+  protected void check() {
+    super.check();
+    String arn = getRoleARN();
+    if (arn != null) {
+      AwsStorageConfigurationInfo.validateArn(arn);
+    }
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStsUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStsUtil.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import jakarta.annotation.Nullable;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.apache.polaris.core.storage.aws.StsClientProvider.StsDestination;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Tag;
+
+/** Shared STS assume-role utilities used by both S3 and S3 Tables credential integrations. */
+public final class AwsStsUtil {
+
+  private AwsStsUtil() {}
+
+  /**
+   * Assumes an IAM role via STS and populates the access config with the resulting temporary
+   * credentials.
+   */
+  public static void assumeRoleAndPopulateConfig(
+      StorageAccessConfig.Builder accessConfig,
+      RealmConfig realmConfig,
+      String roleArn,
+      @Nullable String externalId,
+      @Nullable URI stsEndpointUri,
+      @Nullable String region,
+      String policyJson,
+      String defaultRoleSessionName,
+      PolarisPrincipal polarisPrincipal,
+      CredentialVendingContext credentialVendingContext,
+      Optional<AwsCredentialsProvider> credentialsProvider,
+      StsClientProvider stsClientProvider,
+      Optional<String> refreshCredentialsEndpoint) {
+
+    int durationSeconds = realmConfig.getConfig(FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS);
+
+    boolean includePrincipalName =
+        realmConfig.getConfig(FeatureConfiguration.INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL);
+    String roleSessionName =
+        includePrincipalName
+            ? AwsRoleSessionNameSanitizer.sanitize("polaris-" + polarisPrincipal.getName())
+            : defaultRoleSessionName;
+
+    AssumeRoleRequest.Builder request =
+        AssumeRoleRequest.builder()
+            .externalId(externalId)
+            .roleArn(roleArn)
+            .roleSessionName(roleSessionName)
+            .policy(policyJson)
+            .durationSeconds(durationSeconds);
+
+    List<String> sessionTagFieldNames =
+        realmConfig.getConfig(FeatureConfiguration.SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL);
+    Set<SessionTagField> enabledSessionTagFields =
+        sessionTagFieldNames.stream()
+            .map(SessionTagField::fromConfigName)
+            .flatMap(Optional::stream)
+            .collect(Collectors.toCollection(() -> EnumSet.noneOf(SessionTagField.class)));
+
+    if (!enabledSessionTagFields.isEmpty()) {
+      List<Tag> sessionTags =
+          AwsSessionTagsBuilder.buildSessionTags(
+              polarisPrincipal.getName(), credentialVendingContext, enabledSessionTagFields);
+      if (!sessionTags.isEmpty()) {
+        request.tags(sessionTags);
+        request.transitiveTagKeys(sessionTags.stream().map(Tag::key).collect(Collectors.toList()));
+      }
+    }
+
+    credentialsProvider.ifPresent(
+        cp -> request.overrideConfiguration(b -> b.credentialsProvider(cp)));
+
+    @SuppressWarnings("resource")
+    StsClient stsClient =
+        stsClientProvider.stsClient(StsDestination.of(stsEndpointUri, region));
+
+    AssumeRoleResponse response = stsClient.assumeRole(request.build());
+    accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
+    accessConfig.put(StorageAccessProperty.AWS_SECRET_KEY, response.credentials().secretAccessKey());
+    accessConfig.put(StorageAccessProperty.AWS_TOKEN, response.credentials().sessionToken());
+    Optional.ofNullable(response.credentials().expiration())
+        .ifPresent(
+            i -> {
+              accessConfig.put(
+                  StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
+              accessConfig.put(
+                  StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                  String.valueOf(i.toEpochMilli()));
+            });
+
+    if (region != null) {
+      accessConfig.put(StorageAccessProperty.CLIENT_REGION, region);
+    }
+
+    refreshCredentialsEndpoint.ifPresent(
+        endpoint ->
+            accessConfig.put(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT, endpoint));
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegrationTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.config.RealmConfigImpl;
+import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+class AwsS3TablesCredentialsStorageIntegrationTest {
+
+  private static final Instant EXPIRE_TIME = Instant.now().plusMillis(3600_000);
+  private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/polaris-s3tables-role";
+  private static final String TABLE_ARN =
+      "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket/table/abc123";
+  private static final PolarisPrincipal PRINCIPAL =
+      PolarisPrincipal.of("test-principal", Map.of(), Set.of());
+
+  private static final AssumeRoleResponse ASSUME_ROLE_RESPONSE =
+      AssumeRoleResponse.builder()
+          .credentials(
+              Credentials.builder()
+                  .accessKeyId("accessKey")
+                  .secretAccessKey("secretKey")
+                  .sessionToken("sess")
+                  .expiration(EXPIRE_TIME)
+                  .build())
+          .build();
+
+  private static final RealmConfig REALM_CONFIG =
+      new RealmConfigImpl((rc, name) -> null, () -> "realm");
+
+  private AwsS3TablesCredentialsStorageIntegration createIntegration(StsClient stsClient) {
+    AwsS3TablesStorageConfigurationInfo config =
+        AwsS3TablesStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(TABLE_ARN))
+            .roleARN(ROLE_ARN)
+            .region("us-east-1")
+            .build();
+    return new AwsS3TablesCredentialsStorageIntegration(
+        config, (destination) -> stsClient, Optional.empty());
+  }
+
+  @Test
+  void testS3TablesReadOnlyPolicy() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        false,
+        Set.of(TABLE_ARN),
+        Set.of(),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+    String policy = captor.getValue().policy();
+
+    assertThat(policy).contains("s3tables:GetTableData");
+    assertThat(policy).contains("s3tables:GetTableMetadataLocation");
+    assertThat(policy).doesNotContain("s3tables:UpdateTableMetadataLocation");
+    assertThat(policy).doesNotContain("s3tables:PutTableData");
+    assertThat(policy).contains(TABLE_ARN);
+  }
+
+  @Test
+  void testS3TablesReadWritePolicy() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        false,
+        Set.of(TABLE_ARN),
+        Set.of(TABLE_ARN),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+    String policy = captor.getValue().policy();
+
+    assertThat(policy).contains("s3tables:GetTableData");
+    assertThat(policy).contains("s3tables:GetTableMetadataLocation");
+    assertThat(policy).contains("s3tables:UpdateTableMetadataLocation");
+    assertThat(policy).contains("s3tables:PutTableData");
+    assertThat(policy).contains(TABLE_ARN);
+  }
+
+  @Test
+  void testNoS3ActionsInPolicy() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        true,
+        Set.of(TABLE_ARN),
+        Set.of(TABLE_ARN),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+    String policy = captor.getValue().policy();
+
+    // Must not contain any s3: actions
+    assertThat(policy).doesNotContain("\"s3:");
+    assertThat(policy).doesNotContain("s3:GetObject");
+    assertThat(policy).doesNotContain("s3:PutObject");
+    assertThat(policy).doesNotContain("s3:ListBucket");
+    assertThat(policy).doesNotContain("s3:GetBucketLocation");
+    assertThat(policy).doesNotContain("kms:");
+  }
+
+  @Test
+  void testAllowListOperationIgnored() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    // Call with allowListOperation=true
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        true,
+        Set.of(TABLE_ARN),
+        Set.of(),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captorWithList =
+        ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captorWithList.capture());
+    String policyWithList = captorWithList.getValue().policy();
+
+    // Reset and call with allowListOperation=false
+    Mockito.reset(stsClient);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        false,
+        Set.of(TABLE_ARN),
+        Set.of(),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captorWithoutList =
+        ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captorWithoutList.capture());
+    String policyWithoutList = captorWithoutList.getValue().policy();
+
+    // Policies should be identical regardless of allowListOperation
+    assertThat(policyWithList).isEqualTo(policyWithoutList);
+  }
+
+  @Test
+  void testCredentialsReturned() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    StorageAccessConfig result =
+        integration.getSubscopedCreds(
+            REALM_CONFIG,
+            false,
+            Set.of(TABLE_ARN),
+            Set.of(),
+            PRINCIPAL,
+            Optional.empty(),
+            CredentialVendingContext.empty());
+
+    assertThat(result.get(StorageAccessProperty.AWS_KEY_ID)).isEqualTo("accessKey");
+    assertThat(result.get(StorageAccessProperty.AWS_SECRET_KEY)).isEqualTo("secretKey");
+    assertThat(result.get(StorageAccessProperty.AWS_TOKEN)).isEqualTo("sess");
+    assertThat(result.get(StorageAccessProperty.EXPIRATION_TIME))
+        .isEqualTo(String.valueOf(EXPIRE_TIME.toEpochMilli()));
+  }
+
+  @Test
+  void testAssumeRoleCalledWithCorrectParams() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+
+    AwsS3TablesCredentialsStorageIntegration integration = createIntegration(stsClient);
+
+    integration.getSubscopedCreds(
+        REALM_CONFIG,
+        false,
+        Set.of(TABLE_ARN),
+        Set.of(),
+        PRINCIPAL,
+        Optional.empty(),
+        CredentialVendingContext.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+
+    AssumeRoleRequest request = captor.getValue();
+    assertThat(request.roleArn()).isEqualTo(ROLE_ARN);
+    assertThat(request.policy()).isNotEmpty();
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesCredentialsStorageIntegrationTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.polaris.core.storage.aws;
 
+import static org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration.ACTION_GET_TABLE_DATA;
+import static org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration.ACTION_GET_TABLE_METADATA_LOCATION;
+import static org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration.ACTION_PUT_TABLE_DATA;
+import static org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration.ACTION_UPDATE_TABLE_METADATA_LOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -95,10 +99,10 @@ class AwsS3TablesCredentialsStorageIntegrationTest {
     Mockito.verify(stsClient).assumeRole(captor.capture());
     String policy = captor.getValue().policy();
 
-    assertThat(policy).contains("s3tables:GetTableData");
-    assertThat(policy).contains("s3tables:GetTableMetadataLocation");
-    assertThat(policy).doesNotContain("s3tables:UpdateTableMetadataLocation");
-    assertThat(policy).doesNotContain("s3tables:PutTableData");
+    assertThat(policy).contains(ACTION_GET_TABLE_DATA);
+    assertThat(policy).contains(ACTION_GET_TABLE_METADATA_LOCATION);
+    assertThat(policy).doesNotContain(ACTION_UPDATE_TABLE_METADATA_LOCATION);
+    assertThat(policy).doesNotContain(ACTION_PUT_TABLE_DATA);
     assertThat(policy).contains(TABLE_ARN);
   }
 
@@ -123,10 +127,10 @@ class AwsS3TablesCredentialsStorageIntegrationTest {
     Mockito.verify(stsClient).assumeRole(captor.capture());
     String policy = captor.getValue().policy();
 
-    assertThat(policy).contains("s3tables:GetTableData");
-    assertThat(policy).contains("s3tables:GetTableMetadataLocation");
-    assertThat(policy).contains("s3tables:UpdateTableMetadataLocation");
-    assertThat(policy).contains("s3tables:PutTableData");
+    assertThat(policy).contains(ACTION_GET_TABLE_DATA);
+    assertThat(policy).contains(ACTION_GET_TABLE_METADATA_LOCATION);
+    assertThat(policy).contains(ACTION_UPDATE_TABLE_METADATA_LOCATION);
+    assertThat(policy).contains(ACTION_PUT_TABLE_DATA);
     assertThat(policy).contains(TABLE_ARN);
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsS3TablesStorageConfigurationInfoTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+
+class AwsS3TablesStorageConfigurationInfoTest {
+
+  private static final String TABLE_BUCKET_ARN =
+      "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket";
+  private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/polaris-s3tables-role";
+
+  @Test
+  void testSerializationRoundTrip() {
+    AwsS3TablesStorageConfigurationInfo original =
+        AwsS3TablesStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(TABLE_BUCKET_ARN))
+            .roleARN(ROLE_ARN)
+            .region("us-east-1")
+            .externalId("ext-123")
+            .build();
+
+    String json = original.serialize();
+    PolarisStorageConfigurationInfo deserialized =
+        PolarisStorageConfigurationInfo.deserialize(json);
+
+    assertThat(deserialized).isInstanceOf(AwsS3TablesStorageConfigurationInfo.class);
+    AwsS3TablesStorageConfigurationInfo result = (AwsS3TablesStorageConfigurationInfo) deserialized;
+
+    assertThat(result.getStorageType())
+        .isEqualTo(PolarisStorageConfigurationInfo.StorageType.S3_TABLES);
+    assertThat(result.getRoleARN()).isEqualTo(ROLE_ARN);
+    assertThat(result.getRegion()).isEqualTo("us-east-1");
+    assertThat(result.getExternalId()).isEqualTo("ext-123");
+    assertThat(result.getAllowedLocations()).containsExactly(TABLE_BUCKET_ARN);
+    assertThat(result.getFileIoImplClassName()).isEqualTo("org.apache.iceberg.aws.s3.S3FileIO");
+  }
+
+  @Test
+  void testArnPrefixedLocationsAccepted() {
+    AwsS3TablesStorageConfigurationInfo config =
+        AwsS3TablesStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(TABLE_BUCKET_ARN))
+            .roleARN(ROLE_ARN)
+            .build();
+
+    assertThat(config.getStorageType())
+        .isEqualTo(PolarisStorageConfigurationInfo.StorageType.S3_TABLES);
+  }
+
+  @Test
+  void testNonArnLocationRejected() {
+    assertThatThrownBy(
+            () ->
+                AwsS3TablesStorageConfigurationInfo.builder()
+                    .allowedLocations(Set.of("s3://my-bucket/prefix"))
+                    .roleARN(ROLE_ARN)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Location prefix not allowed");
+  }
+
+  @Test
+  void testNullFieldsAccepted() {
+    AwsS3TablesStorageConfigurationInfo config =
+        AwsS3TablesStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(TABLE_BUCKET_ARN))
+            .build();
+
+    assertThat(config.getRoleARN()).isNull();
+    assertThat(config.getRegion()).isNull();
+    assertThat(config.getExternalId()).isNull();
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsStsUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsStsUtilTest.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.storage.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.config.RealmConfigImpl;
+import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageAccessProperty;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+class AwsStsUtilTest {
+
+  private static final Instant EXPIRE_TIME = Instant.now().plusMillis(3600_000);
+  private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/polaris-role";
+  private static final String EXTERNAL_ID = "ext-id-123";
+  private static final String REGION = "us-east-1";
+  private static final String POLICY_JSON = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+  private static final String DEFAULT_SESSION_NAME = "PolarisTestIntegration";
+  private static final PolarisPrincipal PRINCIPAL =
+      PolarisPrincipal.of("test-principal", Map.of(), Set.of());
+
+  private static final AssumeRoleResponse ASSUME_ROLE_RESPONSE =
+      AssumeRoleResponse.builder()
+          .credentials(
+              Credentials.builder()
+                  .accessKeyId("accessKey")
+                  .secretAccessKey("secretKey")
+                  .sessionToken("sessionToken")
+                  .expiration(EXPIRE_TIME)
+                  .build())
+          .build();
+
+  private static final RealmConfig DEFAULT_REALM_CONFIG =
+      new RealmConfigImpl((rc, name) -> null, () -> "realm");
+
+  private StsClient mockStsClient() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenReturn(ASSUME_ROLE_RESPONSE);
+    return stsClient;
+  }
+
+  @Test
+  void testAssumeRoleCalledWithCorrectParameters() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+
+    AssumeRoleRequest request = captor.getValue();
+    assertThat(request.roleArn()).isEqualTo(ROLE_ARN);
+    assertThat(request.externalId()).isEqualTo(EXTERNAL_ID);
+    assertThat(request.policy()).isEqualTo(POLICY_JSON);
+    assertThat(request.durationSeconds()).isEqualTo(3600);
+  }
+
+  @Test
+  void testCredentialsPopulatedInAccessConfig() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    StorageAccessConfig result = accessConfig.build();
+    assertThat(result.get(StorageAccessProperty.AWS_KEY_ID)).isEqualTo("accessKey");
+    assertThat(result.get(StorageAccessProperty.AWS_SECRET_KEY)).isEqualTo("secretKey");
+    assertThat(result.get(StorageAccessProperty.AWS_TOKEN)).isEqualTo("sessionToken");
+  }
+
+  @Test
+  void testExpirationTimeSetWhenPresent() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    StorageAccessConfig result = accessConfig.build();
+    String expectedMs = String.valueOf(EXPIRE_TIME.toEpochMilli());
+    assertThat(result.get(StorageAccessProperty.EXPIRATION_TIME)).isEqualTo(expectedMs);
+    assertThat(result.get(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS))
+        .isEqualTo(expectedMs);
+  }
+
+  @Test
+  void testClientRegionSetWhenRegionNotNull() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    StorageAccessConfig result = accessConfig.build();
+    assertThat(result.get(StorageAccessProperty.CLIENT_REGION)).isEqualTo(REGION);
+  }
+
+  @Test
+  void testClientRegionNotSetWhenRegionNull() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        null,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    StorageAccessConfig result = accessConfig.build();
+    assertThat(result.get(StorageAccessProperty.CLIENT_REGION)).isNull();
+  }
+
+  @Test
+  void testRefreshCredentialsEndpointSetWhenProvided() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    String endpoint = "https://refresh.example.com/credentials";
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.of(endpoint));
+
+    StorageAccessConfig result = accessConfig.build();
+    assertThat(result.get(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT))
+        .isEqualTo(endpoint);
+  }
+
+  @Test
+  void testRefreshCredentialsEndpointNotSetWhenEmpty() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    StorageAccessConfig result = accessConfig.build();
+    assertThat(result.get(StorageAccessProperty.AWS_REFRESH_CREDENTIALS_ENDPOINT)).isNull();
+  }
+
+  @Test
+  void testUsesDefaultRoleSessionNameWhenPrincipalNameDisabled() {
+    // Default config has INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL = false
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+    assertThat(captor.getValue().roleSessionName()).isEqualTo(DEFAULT_SESSION_NAME);
+  }
+
+  @Test
+  void testUsesSanitizedPrincipalNameWhenEnabled() {
+    // Create a realm config with INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL = true
+    RealmConfig realmConfig =
+        new RealmConfigImpl(
+            (rc, name) -> {
+              if ("INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL".equals(name)) {
+                return true;
+              }
+              return null;
+            },
+            () -> "realm");
+
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        realmConfig,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+    // The role session name should be sanitized principal name prefixed with "polaris-"
+    assertThat(captor.getValue().roleSessionName()).isEqualTo("polaris-test-principal");
+  }
+
+  @Test
+  void testSessionTagsAddedWhenConfigured() {
+    // Create a realm config with session tags enabled (realm, principal)
+    RealmConfig realmConfig =
+        new RealmConfigImpl(
+            (rc, name) -> {
+              if ("SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL".equals(name)) {
+                return List.of("realm", "principal");
+              }
+              return null;
+            },
+            () -> "realm");
+
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    CredentialVendingContext context =
+        CredentialVendingContext.builder()
+            .realm(Optional.of("test-realm"))
+            .build();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        realmConfig,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        context,
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+
+    AssumeRoleRequest request = captor.getValue();
+    assertThat(request.tags()).isNotEmpty();
+    assertThat(request.tags())
+        .anyMatch(tag -> tag.key().equals("polaris:realm") && tag.value().equals("test-realm"));
+    assertThat(request.tags())
+        .anyMatch(
+            tag -> tag.key().equals("polaris:principal") && tag.value().equals("test-principal"));
+    // Transitive tag keys should match the tag keys
+    assertThat(request.transitiveTagKeys()).containsExactlyInAnyOrder("polaris:realm", "polaris:principal");
+  }
+
+  @Test
+  void testNoSessionTagsWhenNotConfigured() {
+    // Default config has SESSION_TAGS_IN_SUBSCOPED_CREDENTIAL = empty list
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = (destination) -> stsClient;
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        null,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(stsClient).assumeRole(captor.capture());
+
+    AssumeRoleRequest request = captor.getValue();
+    assertThat(request.tags()).isEmpty();
+  }
+
+  @Test
+  void testStsEndpointUriPassedToProvider() {
+    StsClient stsClient = mockStsClient();
+    StsClientProvider provider = Mockito.mock(StsClientProvider.class);
+    Mockito.when(provider.stsClient(Mockito.any())).thenReturn(stsClient);
+    StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
+
+    URI stsEndpoint = URI.create("https://sts.us-east-1.amazonaws.com");
+
+    AwsStsUtil.assumeRoleAndPopulateConfig(
+        accessConfig,
+        DEFAULT_REALM_CONFIG,
+        ROLE_ARN,
+        EXTERNAL_ID,
+        stsEndpoint,
+        REGION,
+        POLICY_JSON,
+        DEFAULT_SESSION_NAME,
+        PRINCIPAL,
+        CredentialVendingContext.empty(),
+        Optional.empty(),
+        provider,
+        Optional.empty());
+
+    ArgumentCaptor<StsClientProvider.StsDestination> destCaptor =
+        ArgumentCaptor.forClass(StsClientProvider.StsDestination.class);
+    Mockito.verify(provider).stsClient(destCaptor.capture());
+    assertThat(destCaptor.getValue()).isEqualTo(StsClientProvider.StsDestination.of(stsEndpoint, REGION));
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import jakarta.enterprise.context.RequestScoped;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A request-scoped CDI bean that holds the captured config map from the remote catalog's loadTable
+ * response. Used to pass the {@code tableId} from the HTTP interception layer to the catalog
+ * handler for S3 Tables ARN construction.
+ *
+ * <p>Thread safety: CDI {@code @RequestScoped} beans are inherently isolated per request. The
+ * {@code volatile} keyword ensures visibility across threads within the same request if async
+ * processing is used.
+ */
+@RequestScoped
+public class CapturedConfigHolder {
+
+  private volatile Map<String, String> capturedConfig;
+
+  public void setCapturedConfig(Map<String, String> config) {
+    this.capturedConfig = config;
+  }
+
+  public Optional<String> getTableId() {
+    Map<String, String> config = this.capturedConfig;
+    if (config != null) {
+      return Optional.ofNullable(config.get("tableId"));
+    }
+    return Optional.empty();
+  }
+
+  public void clear() {
+    this.capturedConfig = null;
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 public class CapturedConfigHolder {
 
   /** Config key for the S3 Tables table identifier in the loadTable response config section. */
-  public static final String TABLE_ID_CONFIG_KEY = "tableId";
+  public static final String S3TABLES_TABLE_ID_CONFIG_KEY = "tableId";
 
   private volatile Map<String, String> capturedConfig;
 
@@ -46,7 +46,7 @@ public class CapturedConfigHolder {
   public Optional<String> getTableId() {
     Map<String, String> config = this.capturedConfig;
     if (config != null) {
-      return Optional.ofNullable(config.get(TABLE_ID_CONFIG_KEY));
+      return Optional.ofNullable(config.get(S3TABLES_TABLE_ID_CONFIG_KEY));
     }
     return Optional.empty();
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolder.java
@@ -34,6 +34,9 @@ import java.util.Optional;
 @RequestScoped
 public class CapturedConfigHolder {
 
+  /** Config key for the S3 Tables table identifier in the loadTable response config section. */
+  public static final String TABLE_ID_CONFIG_KEY = "tableId";
+
   private volatile Map<String, String> capturedConfig;
 
   public void setCapturedConfig(Map<String, String> config) {
@@ -43,7 +46,7 @@ public class CapturedConfigHolder {
   public Optional<String> getTableId() {
     Map<String, String> config = this.capturedConfig;
     if (config != null) {
-      return Optional.ofNullable(config.get("tableId"));
+      return Optional.ofNullable(config.get(TABLE_ID_CONFIG_KEY));
     }
     return Optional.empty();
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClient.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClient.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTRequest;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A delegating wrapper around the Iceberg {@link RESTClient} that intercepts responses to extract
+ * the {@code config} section from loadTable responses. When a {@link LoadTableResponse} is
+ * received, the config map (containing {@code tableId} for S3 Tables) is captured and stored in the
+ * request-scoped {@link CapturedConfigHolder}.
+ */
+public class ConfigCapturingHTTPClient implements RESTClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigCapturingHTTPClient.class);
+
+  private final RESTClient delegate;
+  private final CapturedConfigHolder capturedConfigHolder;
+
+  public ConfigCapturingHTTPClient(RESTClient delegate, CapturedConfigHolder holder) {
+    this.delegate = delegate;
+    this.capturedConfigHolder = holder;
+  }
+
+  @Override
+  public <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    T response = delegate.get(path, queryParams, responseType, headers, errorHandler);
+    captureConfigIfLoadTable(response);
+    return response;
+  }
+
+  @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    T response = delegate.post(path, body, responseType, headers, errorHandler);
+    captureConfigIfLoadTable(response);
+    return response;
+  }
+
+  @Override
+  public <T extends RESTResponse> T delete(
+      String path,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return delegate.delete(path, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T postForm(
+      String path,
+      Map<String, String> formData,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return delegate.postForm(path, formData, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+    delegate.head(path, headers, errorHandler);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override
+  public RESTClient withAuthSession(org.apache.iceberg.rest.auth.AuthSession session) {
+    return new ConfigCapturingHTTPClient(delegate.withAuthSession(session), capturedConfigHolder);
+  }
+
+  private <T> void captureConfigIfLoadTable(T response) {
+    try {
+      if (response instanceof LoadTableResponse loadTableResponse) {
+        Map<String, String> config = loadTableResponse.config();
+        if (config != null && !config.isEmpty()) {
+          capturedConfigHolder.setCapturedConfig(config);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to capture config from loadTable response", e);
+    }
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClient.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClient.java
@@ -32,8 +32,11 @@ import org.slf4j.LoggerFactory;
 /**
  * A delegating wrapper around the Iceberg {@link RESTClient} that intercepts responses to extract
  * the {@code config} section from loadTable responses. When a {@link LoadTableResponse} is
- * received, the config map (containing {@code tableId} for S3 Tables) is captured and stored in the
- * request-scoped {@link CapturedConfigHolder}.
+ * received, the config map is captured and stored in the request-scoped {@link
+ * CapturedConfigHolder}.
+ *
+ * <p>TODO: Remove this workaround once Iceberg natively exposes server-assigned metadata in the
+ * RESTCatalog client API. See https://github.com/apache/iceberg/issues/16399
  */
 public class ConfigCapturingHTTPClient implements RESTClient {
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -943,11 +943,10 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
       // For S3 Tables catalogs, replace s3:// table locations with the constructed table ARN.
       // s3tables:* IAM actions require ARN resources, not s3:// paths.
+      // Assumption: the federated catalog loadTable call has already succeeded at this point,
+      // and the CapturedConfigHolder contains the tableId from the remote response.
       CatalogEntity catalogEntity = CatalogEntity.of(getResolvedCatalogEntity());
-      boolean isS3Tables =
-          catalogEntity.getStorageConfigurationInfo() != null
-              && catalogEntity.getStorageConfigurationInfo().getStorageType()
-                  == PolarisStorageConfigurationInfo.StorageType.S3_TABLES;
+      boolean isS3Tables = isS3TablesCatalog(catalogEntity);
 
       if (isS3Tables && capturedConfigHolder().getTableId().isPresent()) {
         String tableArn =
@@ -960,12 +959,14 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
             .addKeyValue("tableArn", tableArn)
             .log("Replaced table locations with S3 Tables ARN for credential vending");
       } else if (isS3Tables) {
-        LOGGER
-            .atWarn()
-            .addKeyValue("tableIdentifier", tableIdentifier)
-            .log(
-                "S3 Tables catalog but no tableId captured from remote response; "
-                    + "credential vending will proceed without ARN-scoped permissions");
+        // Fail closed: S3 Tables catalogs require a tableId to construct the table ARN
+        // for scoped credential vending. Without it, we cannot generate a properly scoped
+        // IAM session policy.
+        throw new BadRequestException(
+            "Cannot vend credentials for S3 Tables table '%s': "
+                + "no tableId was captured from the remote catalog response. "
+                + "Ensure the remote S3 Tables endpoint returns tableId in the loadTable config.",
+            tableIdentifier);
       }
 
       // For federated catalogs, validate that table locations are within allowed locations.
@@ -1004,6 +1005,13 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     }
 
     return responseBuilder;
+  }
+
+  /** Checks whether the resolved catalog entity is configured with S3_TABLES storage type. */
+  private boolean isS3TablesCatalog(CatalogEntity catalogEntity) {
+    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
+    return storageConfig != null
+        && storageConfig.getStorageType() == PolarisStorageConfigurationInfo.StorageType.S3_TABLES;
   }
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -114,7 +114,6 @@ import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.rest.PolarisEndpoints;
 import org.apache.polaris.core.storage.PolarisStorageActions;
-import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.immutables.PolarisImmutable;
@@ -893,9 +892,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     // when data-access is specified but access delegation grants are not found.
     Table table = baseCatalog.loadTable(tableIdentifier);
 
-    // Capture tableId from remote catalog response for S3 Tables ARN construction
-    Optional<String> capturedTableId = capturedConfigHolder().getTableId();
-
     if (table instanceof BaseTable baseTable) {
       TableMetadata tableMetadata = baseTable.operations().current();
       LoadTableResponse response =
@@ -904,8 +900,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
                   tableMetadata,
                   resolvedMode,
                   actionsRequested,
-                  refreshCredentialsEndpoint,
-                  capturedTableId)
+                  refreshCredentialsEndpoint)
               .build();
       return Optional.of(filterResponseToSnapshots(response, snapshots));
     } else if (table instanceof BaseMetadataTable) {
@@ -922,8 +917,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       TableMetadata tableMetadata,
       Optional<AccessDelegationMode> delegationMode,
       Set<PolarisStorageActions> actions,
-      Optional<String> refreshCredentialsEndpoint,
-      Optional<String> capturedTableId) {
+      Optional<String> refreshCredentialsEndpoint) {
     LoadTableResponse.Builder responseBuilder =
         LoadTableResponse.builder().withTableMetadata(tableMetadata);
     PolarisResolvedPathWrapper resolvedStoragePath =
@@ -941,12 +935,18 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
       Set<String> tableLocations = StorageUtil.getLocationsUsedByTable(tableMetadata);
 
-      // For S3 Tables catalogs, replace s3:// table locations with the constructed table ARN.
-      // s3tables:* IAM actions require ARN resources, not s3:// paths.
-      // Assumption: the federated catalog loadTable call has already succeeded at this point,
-      // and the CapturedConfigHolder contains the tableId from the remote response.
-      CatalogEntity catalogEntity = CatalogEntity.of(getResolvedCatalogEntity());
-      boolean isS3Tables = isS3TablesCatalog(catalogEntity);
+      // For federated S3 Tables catalogs, replace s3:// table locations with the constructed
+      // table ARN. s3tables:* IAM actions require ARN resources, not s3:// paths.
+      // This block is only relevant for federated catalogs (not IcebergCatalog) since S3_TABLES
+      // storage type is exclusively used with external/federated catalog configurations.
+      if (!(baseCatalog instanceof IcebergCatalog)) {
+        CatalogEntity catalogEntity = CatalogEntity.of(getResolvedCatalogEntity());
+        tableLocations =
+            S3TablesUtil.resolveTableLocations(
+                tableIdentifier,
+                tableLocations,
+                catalogEntity,
+                capturedConfigHolder().getTableId());
 
       if (isS3Tables && capturedConfigHolder().getTableId().isPresent()) {
         String tableArn =
@@ -959,9 +959,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
             .addKeyValue("tableArn", tableArn)
             .log("Replaced table locations with S3 Tables ARN for credential vending");
       } else if (isS3Tables) {
-        // Fail closed: S3 Tables catalogs require a tableId to construct the table ARN
-        // for scoped credential vending. Without it, we cannot generate a properly scoped
-        // IAM session policy.
         throw new BadRequestException(
             "Cannot vend credentials for S3 Tables table '%s': "
                 + "no tableId was captured from the remote catalog response. "
@@ -1005,45 +1002,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     }
 
     return responseBuilder;
-  }
-
-  /** Checks whether the resolved catalog entity is configured with S3_TABLES storage type. */
-  private boolean isS3TablesCatalog(CatalogEntity catalogEntity) {
-    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
-    return storageConfig != null
-        && storageConfig.getStorageType() == PolarisStorageConfigurationInfo.StorageType.S3_TABLES;
-  }
-
-  /**
-   * Constructs an S3 Tables ARN from the catalog's default-base-location and a tableId. The
-   * default-base-location for S3 Tables catalogs is the table bucket ARN (e.g.,
-   * arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket). The resulting table ARN is
-   * bucket-arn/table/tableId.
-   */
-  private String constructS3TablesArn(CatalogEntity catalogEntity, String tableId) {
-    String baseLocation = catalogEntity.getBaseLocation();
-    return baseLocation + "/table/" + tableId;
-  }
-
-  /**
-   * Validates that a constructed S3 Tables ARN falls under one of the catalog's allowed locations.
-   * This prevents a malicious remote catalog from returning a tableId that would construct an ARN
-   * outside the catalog's authorized scope.
-   */
-  private void validateS3TablesArn(
-      TableIdentifier tableIdentifier, String tableArn, CatalogEntity catalogEntity) {
-    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
-    if (storageConfig == null) {
-      return;
-    }
-    List<String> allowedLocations = storageConfig.getAllowedLocations();
-    boolean isAllowed =
-        allowedLocations.stream().anyMatch(allowed -> tableArn.startsWith(allowed + "/"));
-    if (!isAllowed) {
-      throw new ForbiddenException(
-          "Table '%s' has ARN '%s' which is outside the catalog's allowed locations: %s",
-          tableIdentifier, tableArn, allowedLocations);
-    }
   }
 
   private void validateRemoteTableLocations(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -114,6 +114,7 @@ import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.rest.PolarisEndpoints;
 import org.apache.polaris.core.storage.PolarisStorageActions;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.immutables.PolarisImmutable;
@@ -202,6 +203,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
   protected abstract CatalogHandlerUtils catalogHandlerUtils();
 
   protected abstract StorageAccessConfigProvider storageAccessConfigProvider();
+
+  protected abstract CapturedConfigHolder capturedConfigHolder();
 
   protected abstract EventAttributeMap eventAttributeMap();
 
@@ -494,7 +497,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
                   PolarisStorageActions.READ,
                   PolarisStorageActions.WRITE,
                   PolarisStorageActions.LIST),
-              refreshCredentialsEndpoint)
+              refreshCredentialsEndpoint,
+              Optional.empty())
           .build();
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
@@ -600,7 +604,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
             metadata,
             resolvedMode,
             Set.of(PolarisStorageActions.ALL),
-            refreshCredentialsEndpoint)
+            refreshCredentialsEndpoint,
+            Optional.empty())
         .build();
   }
 
@@ -888,6 +893,9 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     // when data-access is specified but access delegation grants are not found.
     Table table = baseCatalog.loadTable(tableIdentifier);
 
+    // Capture tableId from remote catalog response for S3 Tables ARN construction
+    Optional<String> capturedTableId = capturedConfigHolder().getTableId();
+
     if (table instanceof BaseTable baseTable) {
       TableMetadata tableMetadata = baseTable.operations().current();
       LoadTableResponse response =
@@ -896,7 +904,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
                   tableMetadata,
                   resolvedMode,
                   actionsRequested,
-                  refreshCredentialsEndpoint)
+                  refreshCredentialsEndpoint,
+                  capturedTableId)
               .build();
       return Optional.of(filterResponseToSnapshots(response, snapshots));
     } else if (table instanceof BaseMetadataTable) {
@@ -913,7 +922,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       TableMetadata tableMetadata,
       Optional<AccessDelegationMode> delegationMode,
       Set<PolarisStorageActions> actions,
-      Optional<String> refreshCredentialsEndpoint) {
+      Optional<String> refreshCredentialsEndpoint,
+      Optional<String> capturedTableId) {
     LoadTableResponse.Builder responseBuilder =
         LoadTableResponse.builder().withTableMetadata(tableMetadata);
     PolarisResolvedPathWrapper resolvedStoragePath =
@@ -931,8 +941,36 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
       Set<String> tableLocations = StorageUtil.getLocationsUsedByTable(tableMetadata);
 
-      // For federated catalogs, validate that table locations are within allowed locations
-      if (isFederated) {
+      // For S3 Tables catalogs, replace s3:// table locations with the constructed table ARN.
+      // s3tables:* IAM actions require ARN resources, not s3:// paths.
+      CatalogEntity catalogEntity = CatalogEntity.of(getResolvedCatalogEntity());
+      boolean isS3Tables =
+          catalogEntity.getStorageConfigurationInfo() != null
+              && catalogEntity.getStorageConfigurationInfo().getStorageType()
+                  == PolarisStorageConfigurationInfo.StorageType.S3_TABLES;
+
+      if (isS3Tables && capturedConfigHolder().getTableId().isPresent()) {
+        String tableArn =
+            constructS3TablesArn(catalogEntity, capturedConfigHolder().getTableId().get());
+        validateS3TablesArn(tableIdentifier, tableArn, catalogEntity);
+        tableLocations = Set.of(tableArn);
+        LOGGER
+            .atDebug()
+            .addKeyValue("tableIdentifier", tableIdentifier)
+            .addKeyValue("tableArn", tableArn)
+            .log("Replaced table locations with S3 Tables ARN for credential vending");
+      } else if (isS3Tables) {
+        LOGGER
+            .atWarn()
+            .addKeyValue("tableIdentifier", tableIdentifier)
+            .log(
+                "S3 Tables catalog but no tableId captured from remote response; "
+                    + "credential vending will proceed without ARN-scoped permissions");
+      }
+
+      // For federated catalogs, validate that table locations are within allowed locations.
+      // Skip validation for S3 Tables — ARN locations won't match s3:// allowed locations.
+      if (isFederated && !isS3Tables) {
         validateRemoteTableLocations(tableIdentifier, tableLocations, resolvedStoragePath);
       }
 
@@ -966,6 +1004,38 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     }
 
     return responseBuilder;
+  }
+
+  /**
+   * Constructs an S3 Tables ARN from the catalog's default-base-location and a tableId. The
+   * default-base-location for S3 Tables catalogs is the table bucket ARN (e.g.,
+   * arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket). The resulting table ARN is
+   * bucket-arn/table/tableId.
+   */
+  private String constructS3TablesArn(CatalogEntity catalogEntity, String tableId) {
+    String baseLocation = catalogEntity.getBaseLocation();
+    return baseLocation + "/table/" + tableId;
+  }
+
+  /**
+   * Validates that a constructed S3 Tables ARN falls under one of the catalog's allowed locations.
+   * This prevents a malicious remote catalog from returning a tableId that would construct an ARN
+   * outside the catalog's authorized scope.
+   */
+  private void validateS3TablesArn(
+      TableIdentifier tableIdentifier, String tableArn, CatalogEntity catalogEntity) {
+    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
+    if (storageConfig == null) {
+      return;
+    }
+    List<String> allowedLocations = storageConfig.getAllowedLocations();
+    boolean isAllowed =
+        allowedLocations.stream().anyMatch(allowed -> tableArn.startsWith(allowed + "/"));
+    if (!isAllowed) {
+      throw new ForbiddenException(
+          "Table '%s' has ARN '%s' which is outside the catalog's allowed locations: %s",
+          tableIdentifier, tableArn, allowedLocations);
+    }
   }
 
   private void validateRemoteTableLocations(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -496,8 +496,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
                   PolarisStorageActions.READ,
                   PolarisStorageActions.WRITE,
                   PolarisStorageActions.LIST),
-              refreshCredentialsEndpoint,
-              Optional.empty())
+              refreshCredentialsEndpoint)
           .build();
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
@@ -603,8 +602,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
             metadata,
             resolvedMode,
             Set.of(PolarisStorageActions.ALL),
-            refreshCredentialsEndpoint,
-            Optional.empty())
+            refreshCredentialsEndpoint)
         .build();
   }
 
@@ -939,31 +937,16 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       // table ARN. s3tables:* IAM actions require ARN resources, not s3:// paths.
       // This block is only relevant for federated catalogs (not IcebergCatalog) since S3_TABLES
       // storage type is exclusively used with external/federated catalog configurations.
+      boolean isS3Tables = false;
       if (!(baseCatalog instanceof IcebergCatalog)) {
         CatalogEntity catalogEntity = CatalogEntity.of(getResolvedCatalogEntity());
+        isS3Tables = S3TablesUtil.isS3TablesCatalog(catalogEntity);
         tableLocations =
             S3TablesUtil.resolveTableLocations(
                 tableIdentifier,
                 tableLocations,
                 catalogEntity,
                 capturedConfigHolder().getTableId());
-
-      if (isS3Tables && capturedConfigHolder().getTableId().isPresent()) {
-        String tableArn =
-            constructS3TablesArn(catalogEntity, capturedConfigHolder().getTableId().get());
-        validateS3TablesArn(tableIdentifier, tableArn, catalogEntity);
-        tableLocations = Set.of(tableArn);
-        LOGGER
-            .atDebug()
-            .addKeyValue("tableIdentifier", tableIdentifier)
-            .addKeyValue("tableArn", tableArn)
-            .log("Replaced table locations with S3 Tables ARN for credential vending");
-      } else if (isS3Tables) {
-        throw new BadRequestException(
-            "Cannot vend credentials for S3 Tables table '%s': "
-                + "no tableId was captured from the remote catalog response. "
-                + "Ensure the remote S3 Tables endpoint returns tableId in the loadTable config.",
-            tableIdentifier);
       }
 
       // For federated catalogs, validate that table locations are within allowed locations.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
@@ -56,6 +56,7 @@ public class IcebergCatalogHandlerFactory {
   @Inject CatalogHandlerUtils catalogHandlerUtils;
   @Inject @Any Instance<FederatedCatalogFactory> federatedCatalogFactories;
   @Inject StorageAccessConfigProvider storageAccessConfigProvider;
+  @Inject CapturedConfigHolder capturedConfigHolder;
   @Inject EventAttributeMap eventAttributeMap;
   @Inject PolarisMetricsReporter metricsReporter;
   @Inject Clock clock;
@@ -78,6 +79,7 @@ public class IcebergCatalogHandlerFactory {
         .catalogHandlerUtils(catalogHandlerUtils)
         .federatedCatalogFactories(federatedCatalogFactories)
         .storageAccessConfigProvider(storageAccessConfigProvider)
+        .capturedConfigHolder(capturedConfigHolder)
         .eventAttributeMap(eventAttributeMap)
         .metricsReporter(metricsReporter)
         .clock(clock)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTFederatedCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTFederatedCatalogFactory.java
@@ -42,7 +42,7 @@ public class IcebergRESTFederatedCatalogFactory implements FederatedCatalogFacto
   private final CapturedConfigHolder capturedConfigHolder;
 
   @Inject
-  public IcebergRESTExternalCatalogFactory(CapturedConfigHolder capturedConfigHolder) {
+  public IcebergRESTFederatedCatalogFactory(CapturedConfigHolder capturedConfigHolder) {
     this.capturedConfigHolder = capturedConfigHolder;
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTFederatedCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRESTFederatedCatalogFactory.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.catalog.iceberg;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Map;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog;
@@ -38,6 +39,13 @@ import org.apache.polaris.core.credentials.PolarisCredentialManager;
 @Identifier(ConnectionType.ICEBERG_REST_FACTORY_IDENTIFIER)
 public class IcebergRESTFederatedCatalogFactory implements FederatedCatalogFactory {
 
+  private final CapturedConfigHolder capturedConfigHolder;
+
+  @Inject
+  public IcebergRESTExternalCatalogFactory(CapturedConfigHolder capturedConfigHolder) {
+    this.capturedConfigHolder = capturedConfigHolder;
+  }
+
   @Override
   public Catalog createCatalog(
       ConnectionConfigInfoDpo connectionConfig,
@@ -54,9 +62,11 @@ public class IcebergRESTFederatedCatalogFactory implements FederatedCatalogFacto
         new RESTCatalog(
             context,
             (config) ->
-                HTTPClient.builder(config)
-                    .uri(config.get(org.apache.iceberg.CatalogProperties.URI))
-                    .build());
+                new ConfigCapturingHTTPClient(
+                    HTTPClient.builder(config)
+                        .uri(config.get(org.apache.iceberg.CatalogProperties.URI))
+                        .build(),
+                    capturedConfigHolder));
 
     // Merge properties with precedence: connection config properties override catalog properties
     // to ensure required settings like URI and authentication cannot be accidentally overwritten.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/S3TablesUtil.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/S3TablesUtil.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods for S3 Tables credential vending in federated catalogs. Handles table ARN
+ * construction, validation, and storage type detection for S3 Tables catalogs.
+ */
+public final class S3TablesUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3TablesUtil.class);
+
+  /** ARN path segment separating the table bucket ARN from the tableId. */
+  static final String TABLE_ARN_SEGMENT = "/table/";
+
+  private S3TablesUtil() {}
+
+  /** Checks whether the resolved catalog entity is configured with S3_TABLES storage type. */
+  public static boolean isS3TablesCatalog(CatalogEntity catalogEntity) {
+    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
+    return storageConfig != null
+        && storageConfig.getStorageType() == PolarisStorageConfigurationInfo.StorageType.S3_TABLES;
+  }
+
+  /**
+   * Constructs an S3 Tables ARN from the catalog's default-base-location and a tableId. The
+   * default-base-location for S3 Tables catalogs is the table bucket ARN (e.g.,
+   * arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket). The resulting table ARN is
+   * bucket-arn/table/tableId.
+   */
+  public static String constructTableArn(CatalogEntity catalogEntity, String tableId) {
+    String baseLocation = catalogEntity.getBaseLocation();
+    return baseLocation + TABLE_ARN_SEGMENT + tableId;
+  }
+
+  /**
+   * Validates that a constructed S3 Tables ARN falls under one of the catalog's allowed locations.
+   * This prevents a malicious remote catalog from returning a tableId that would construct an ARN
+   * outside the catalog's authorized scope.
+   */
+  public static void validateTableArn(
+      TableIdentifier tableIdentifier, String tableArn, CatalogEntity catalogEntity) {
+    PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
+    if (storageConfig == null) {
+      return;
+    }
+    List<String> allowedLocations = storageConfig.getAllowedLocations();
+    boolean isAllowed =
+        allowedLocations.stream().anyMatch(allowed -> tableArn.startsWith(allowed + "/"));
+    if (!isAllowed) {
+      throw new ForbiddenException(
+          "Table '%s' has ARN '%s' which is outside the catalog's allowed locations: %s",
+          tableIdentifier, tableArn, allowedLocations);
+    }
+  }
+
+  /**
+   * Resolves table locations for S3 Tables catalogs. If the catalog is S3_TABLES and a tableId was
+   * captured from the remote loadTable response, replaces the s3:// table locations with the
+   * constructed table ARN. If the catalog is S3_TABLES but no tableId is available, fails closed
+   * with a BadRequestException.
+   *
+   * @param tableIdentifier the table being loaded
+   * @param tableLocations the original s3:// table locations from metadata
+   * @param catalogEntity the resolved catalog entity
+   * @param capturedTableId the tableId captured from the remote catalog response
+   * @return the resolved table locations (ARN for S3_TABLES, original locations otherwise)
+   */
+  public static Set<String> resolveTableLocations(
+      TableIdentifier tableIdentifier,
+      Set<String> tableLocations,
+      CatalogEntity catalogEntity,
+      Optional<String> capturedTableId) {
+
+    if (!isS3TablesCatalog(catalogEntity)) {
+      return tableLocations;
+    }
+
+    if (capturedTableId.isPresent()) {
+      String tableArn = constructTableArn(catalogEntity, capturedTableId.get());
+      validateTableArn(tableIdentifier, tableArn, catalogEntity);
+      LOGGER
+          .atDebug()
+          .addKeyValue("tableIdentifier", tableIdentifier)
+          .addKeyValue("tableArn", tableArn)
+          .log("Replaced table locations with S3 Tables ARN for credential vending");
+      return Set.of(tableArn);
+    }
+
+    // Fail closed: S3 Tables catalogs require a tableId to construct the table ARN
+    // for scoped credential vending. Without it, we cannot generate a properly scoped
+    // IAM session policy.
+    throw new BadRequestException(
+        "Cannot vend credentials for S3 Tables table '%s': "
+            + "no tableId was captured from the remote catalog response. "
+            + "Ensure the remote S3 Tables endpoint returns tableId in the loadTable config.",
+        tableIdentifier);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
@@ -32,7 +32,7 @@ enum StorageTypeFileIO {
 
   FILE("org.apache.iceberg.hadoop.HadoopFileIO", false),
 
-  S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true),
+  S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true, false),
 
   // Iceberg tests
   IN_MEMORY("org.apache.iceberg.inmemory.InMemoryFileIO", false, false),

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
@@ -32,6 +32,8 @@ enum StorageTypeFileIO {
 
   FILE("org.apache.iceberg.hadoop.HadoopFileIO", false),
 
+  S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true),
+
   // Iceberg tests
   IN_MEMORY("org.apache.iceberg.inmemory.InMemoryFileIO", false, false),
   ;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
@@ -26,6 +26,8 @@ import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 enum StorageTypeFileIO {
   S3("org.apache.iceberg.aws.s3.S3FileIO", true),
 
+  // TODO: Refactor discriminator to support S3 Tables without opt-out.
+  // See https://github.com/apache/polaris/issues/4486
   S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true, false),
 
   GCS("org.apache.iceberg.gcp.gcs.GCSFileIO", true),

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/StorageTypeFileIO.java
@@ -26,13 +26,13 @@ import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 enum StorageTypeFileIO {
   S3("org.apache.iceberg.aws.s3.S3FileIO", true),
 
+  S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true, false),
+
   GCS("org.apache.iceberg.gcp.gcs.GCSFileIO", true),
 
   AZURE("org.apache.iceberg.azure.adlsv2.ADLSFileIO", true),
 
   FILE("org.apache.iceberg.hadoop.HadoopFileIO", false),
-
-  S3_TABLES("org.apache.iceberg.aws.s3.S3FileIO", true, false),
 
   // Iceberg tests
   IN_MEMORY("org.apache.iceberg.inmemory.InMemoryFileIO", false, false),

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -41,6 +41,8 @@ import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.aws.AwsS3TablesCredentialsStorageIntegration;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.StsClientProvider;
 import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
@@ -154,6 +156,26 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
                 return Map.of();
               }
             };
+        break;
+      case S3_TABLES:
+        Optional<AwsCredentialsProvider> s3TablesCreds = stsCredentials;
+        if (s3TablesCreds.isEmpty() && storageConfiguration != null) {
+          if (realmConfig != null
+              && realmConfig.getConfig(FeatureConfiguration.RESOLVE_CREDENTIALS_BY_STORAGE_NAME)) {
+            s3TablesCreds =
+                Optional.of(
+                    storageConfiguration.stsCredentials(
+                        polarisStorageConfigurationInfo.getStorageName()));
+          } else {
+            s3TablesCreds = Optional.of(storageConfiguration.stsCredentials());
+          }
+        }
+        storageIntegration =
+            (PolarisStorageIntegration<T>)
+                new AwsS3TablesCredentialsStorageIntegration(
+                    (AwsS3TablesStorageConfigurationInfo) polarisStorageConfigurationInfo,
+                    stsClientProvider,
+                    s3TablesCreds);
         break;
       default:
         throw new IllegalArgumentException(

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -115,6 +115,26 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
                     stsClientProvider,
                     awsCreds);
         break;
+      case S3_TABLES:
+        Optional<AwsCredentialsProvider> s3TablesCreds = stsCredentials;
+        if (s3TablesCreds.isEmpty() && storageConfiguration != null) {
+          if (realmConfig != null
+              && realmConfig.getConfig(FeatureConfiguration.RESOLVE_CREDENTIALS_BY_STORAGE_NAME)) {
+            s3TablesCreds =
+                Optional.of(
+                    storageConfiguration.stsCredentials(
+                        polarisStorageConfigurationInfo.getStorageName()));
+          } else {
+            s3TablesCreds = Optional.of(storageConfiguration.stsCredentials());
+          }
+        }
+        storageIntegration =
+            (PolarisStorageIntegration<T>)
+                new AwsS3TablesCredentialsStorageIntegration(
+                    (AwsS3TablesStorageConfigurationInfo) polarisStorageConfigurationInfo,
+                    stsClientProvider,
+                    s3TablesCreds);
+        break;
       case GCS:
         storageIntegration =
             (PolarisStorageIntegration<T>)
@@ -156,26 +176,6 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
                 return Map.of();
               }
             };
-        break;
-      case S3_TABLES:
-        Optional<AwsCredentialsProvider> s3TablesCreds = stsCredentials;
-        if (s3TablesCreds.isEmpty() && storageConfiguration != null) {
-          if (realmConfig != null
-              && realmConfig.getConfig(FeatureConfiguration.RESOLVE_CREDENTIALS_BY_STORAGE_NAME)) {
-            s3TablesCreds =
-                Optional.of(
-                    storageConfiguration.stsCredentials(
-                        polarisStorageConfigurationInfo.getStorageName()));
-          } else {
-            s3TablesCreds = Optional.of(storageConfiguration.stsCredentials());
-          }
-        }
-        storageIntegration =
-            (PolarisStorageIntegration<T>)
-                new AwsS3TablesCredentialsStorageIntegration(
-                    (AwsS3TablesStorageConfigurationInfo) polarisStorageConfigurationInfo,
-                    stsClientProvider,
-                    s3TablesCreds);
         break;
       default:
         throw new IllegalArgumentException(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CapturedConfigHolderTest {
+
+  @Test
+  void emptyByDefault() {
+    CapturedConfigHolder holder = new CapturedConfigHolder();
+    assertThat(holder.getTableId()).isEmpty();
+  }
+
+  @Test
+  void capturesTableId() {
+    CapturedConfigHolder holder = new CapturedConfigHolder();
+    holder.setCapturedConfig(
+        Map.of(
+            "tableId", "73031312-6e6f-432c-ab35-ae23561f6472",
+            "tableBucketId", "d7290d06-163c-4d10-a193-8d920e9a0cf0"));
+    assertThat(holder.getTableId()).hasValue("73031312-6e6f-432c-ab35-ae23561f6472");
+  }
+
+  @Test
+  void returnsEmptyWhenNoTableIdInConfig() {
+    CapturedConfigHolder holder = new CapturedConfigHolder();
+    holder.setCapturedConfig(Map.of("tableBucketId", "d7290d06"));
+    assertThat(holder.getTableId()).isEmpty();
+  }
+
+  @Test
+  void clearResetsState() {
+    CapturedConfigHolder holder = new CapturedConfigHolder();
+    holder.setCapturedConfig(Map.of("tableId", "abc123"));
+    assertThat(holder.getTableId()).hasValue("abc123");
+    holder.clear();
+    assertThat(holder.getTableId()).isEmpty();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.TABLE_ID_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -36,7 +37,7 @@ class CapturedConfigHolderTest {
     CapturedConfigHolder holder = new CapturedConfigHolder();
     holder.setCapturedConfig(
         Map.of(
-            "tableId", "73031312-6e6f-432c-ab35-ae23561f6472",
+            TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
             "tableBucketId", "d7290d06-163c-4d10-a193-8d920e9a0cf0"));
     assertThat(holder.getTableId()).hasValue("73031312-6e6f-432c-ab35-ae23561f6472");
   }
@@ -51,7 +52,7 @@ class CapturedConfigHolderTest {
   @Test
   void clearResetsState() {
     CapturedConfigHolder holder = new CapturedConfigHolder();
-    holder.setCapturedConfig(Map.of("tableId", "abc123"));
+    holder.setCapturedConfig(Map.of(TABLE_ID_CONFIG_KEY, "abc123"));
     assertThat(holder.getTableId()).hasValue("abc123");
     holder.clear();
     assertThat(holder.getTableId()).isEmpty();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CapturedConfigHolderTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
-import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.TABLE_ID_CONFIG_KEY;
+import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.S3TABLES_TABLE_ID_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -37,7 +37,7 @@ class CapturedConfigHolderTest {
     CapturedConfigHolder holder = new CapturedConfigHolder();
     holder.setCapturedConfig(
         Map.of(
-            TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
+            S3TABLES_TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
             "tableBucketId", "d7290d06-163c-4d10-a193-8d920e9a0cf0"));
     assertThat(holder.getTableId()).hasValue("73031312-6e6f-432c-ab35-ae23561f6472");
   }
@@ -52,7 +52,7 @@ class CapturedConfigHolderTest {
   @Test
   void clearResetsState() {
     CapturedConfigHolder holder = new CapturedConfigHolder();
-    holder.setCapturedConfig(Map.of(TABLE_ID_CONFIG_KEY, "abc123"));
+    holder.setCapturedConfig(Map.of(S3TABLES_TABLE_ID_CONFIG_KEY, "abc123"));
     assertThat(holder.getTableId()).hasValue("abc123");
     holder.clear();
     assertThat(holder.getTableId()).isEmpty();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConfigCapturingHTTPClientTest {
+
+  private RESTClient delegate;
+  private CapturedConfigHolder holder;
+  private ConfigCapturingHTTPClient client;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(RESTClient.class);
+    holder = new CapturedConfigHolder();
+    client = new ConfigCapturingHTTPClient(delegate, holder);
+  }
+
+  @Test
+  void capturesConfigFromLoadTableResponse() {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.location()).thenReturn("s3://test-bucket/table");
+    LoadTableResponse response =
+        LoadTableResponse.builder()
+            .withTableMetadata(metadata)
+            .addAllConfig(
+                Map.of(
+                    "tableId", "73031312-6e6f-432c-ab35-ae23561f6472",
+                    "tableBucketId", "d7290d06"))
+            .build();
+
+    when(delegate.get(
+            any(String.class),
+            any(Map.class),
+            eq(LoadTableResponse.class),
+            any(Map.class),
+            any(java.util.function.Consumer.class)))
+        .thenReturn(response);
+
+    client.get("path", Map.of(), LoadTableResponse.class, Map.of(), (ErrorResponse e) -> {});
+
+    assertThat(holder.getTableId()).hasValue("73031312-6e6f-432c-ab35-ae23561f6472");
+  }
+
+  @Test
+  void doesNotCaptureFromNonLoadTableResponse() {
+    when(delegate.delete(
+            any(String.class),
+            eq(LoadTableResponse.class),
+            any(Map.class),
+            any(java.util.function.Consumer.class)))
+        .thenReturn(null);
+
+    client.delete("path", LoadTableResponse.class, Map.of(), (ErrorResponse e) -> {});
+
+    assertThat(holder.getTableId()).isEmpty();
+  }
+
+  @Test
+  void withAuthSessionDelegatesToInnerClient() {
+    AuthSession session = mock(AuthSession.class);
+    RESTClient wrappedDelegate = mock(RESTClient.class);
+    when(delegate.withAuthSession(session)).thenReturn(wrappedDelegate);
+
+    RESTClient result = client.withAuthSession(session);
+
+    assertThat(result).isInstanceOf(ConfigCapturingHTTPClient.class);
+    verify(delegate).withAuthSession(session);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
-import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.TABLE_ID_CONFIG_KEY;
+import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.S3TABLES_TABLE_ID_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -57,7 +57,7 @@ class ConfigCapturingHTTPClientTest {
             .withTableMetadata(metadata)
             .addAllConfig(
                 Map.of(
-                    TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
+                    S3TABLES_TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
                     "tableBucketId", "d7290d06"))
             .build();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/ConfigCapturingHTTPClientTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.apache.polaris.service.catalog.iceberg.CapturedConfigHolder.TABLE_ID_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -56,7 +57,7 @@ class ConfigCapturingHTTPClientTest {
             .withTableMetadata(metadata)
             .addAllConfig(
                 Map.of(
-                    "tableId", "73031312-6e6f-432c-ab35-ae23561f6472",
+                    TABLE_ID_CONFIG_KEY, "73031312-6e6f-432c-ab35-ae23561f6472",
                     "tableBucketId", "d7290d06"))
             .build();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/S3TablesUtilTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/S3TablesUtilTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.Set;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.CatalogEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.storage.aws.AwsS3TablesStorageConfigurationInfo;
+import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.junit.jupiter.api.Test;
+
+class S3TablesUtilTest {
+
+  private static final String BUCKET_ARN =
+      "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket";
+  private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/polaris-s3tables-role";
+  private static final String S3_BASE_LOCATION = "s3://my-bucket/path";
+  private static final String TABLE_ID = "abc-123";
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a CatalogEntity whose storage config is S3_TABLES. The bucket ARN is used as both the
+   * allowed location and the default-base-location.
+   */
+  private CatalogEntity s3TablesCatalog() {
+    AwsS3TablesStorageConfigurationInfo s3TablesConfig =
+        AwsS3TablesStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(BUCKET_ARN))
+            .roleARN(ROLE_ARN)
+            .region("us-east-1")
+            .build();
+
+    return new CatalogEntity.Builder()
+        .setName("s3tables-catalog")
+        .setDefaultBaseLocation(BUCKET_ARN)
+        .addInternalProperty(
+            PolarisEntityConstants.getStorageConfigInfoPropertyName(), s3TablesConfig.serialize())
+        .build();
+  }
+
+  /**
+   * Builds a CatalogEntity whose storage config is plain S3. The S3 URI is used as both the
+   * allowed location and the default-base-location.
+   */
+  private CatalogEntity s3Catalog() {
+    AwsStorageConfigurationInfo s3Config =
+        AwsStorageConfigurationInfo.builder()
+            .allowedLocations(Set.of(S3_BASE_LOCATION))
+            .roleARN(ROLE_ARN)
+            .build();
+
+    return new CatalogEntity.Builder()
+        .setName("s3-catalog")
+        .setDefaultBaseLocation(S3_BASE_LOCATION)
+        .addInternalProperty(
+            PolarisEntityConstants.getStorageConfigInfoPropertyName(), s3Config.serialize())
+        .build();
+  }
+
+  /** Builds a CatalogEntity with no storage config (internal properties are empty). */
+  private CatalogEntity noStorageConfigCatalog() {
+    return new CatalogEntity.Builder().setName("no-storage-catalog").build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // isS3TablesCatalog
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void isS3TablesCatalog_returnsTrueForS3TablesConfig() {
+    assertThat(S3TablesUtil.isS3TablesCatalog(s3TablesCatalog())).isTrue();
+  }
+
+  @Test
+  void isS3TablesCatalog_returnsFalseForS3Config() {
+    assertThat(S3TablesUtil.isS3TablesCatalog(s3Catalog())).isFalse();
+  }
+
+  @Test
+  void isS3TablesCatalog_returnsFalseWhenNoStorageConfig() {
+    assertThat(S3TablesUtil.isS3TablesCatalog(noStorageConfigCatalog())).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // constructTableArn
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void constructTableArn_appendsTableSegmentToBaseLocation() {
+    CatalogEntity catalog = s3TablesCatalog();
+    String arn = S3TablesUtil.constructTableArn(catalog, TABLE_ID);
+    assertThat(arn).isEqualTo(BUCKET_ARN + "/table/" + TABLE_ID);
+  }
+
+  // ---------------------------------------------------------------------------
+  // validateTableArn
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void validateTableArn_doesNotThrowWhenArnIsUnderAllowedLocation() {
+    CatalogEntity catalog = s3TablesCatalog();
+    TableIdentifier tableId = TableIdentifier.of("ns", "tbl");
+    String tableArn = BUCKET_ARN + "/table/" + TABLE_ID;
+
+    // Should not throw
+    S3TablesUtil.validateTableArn(tableId, tableArn, catalog);
+  }
+
+  @Test
+  void validateTableArn_throwsForbiddenExceptionWhenArnIsOutsideAllowedLocations() {
+    CatalogEntity catalog = s3TablesCatalog();
+    TableIdentifier tableId = TableIdentifier.of("ns", "tbl");
+    // Bucket ARN that is NOT in the allowed locations
+    String outsideArn = "arn:aws:s3tables:us-east-1:999999999999:bucket/other-bucket/table/xyz";
+
+    assertThatThrownBy(() -> S3TablesUtil.validateTableArn(tableId, outsideArn, catalog))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining(outsideArn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // resolveTableLocations
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolveTableLocations_returnsOriginalLocationsForNonS3TablesCatalog() {
+    CatalogEntity catalog = s3Catalog();
+    TableIdentifier tableId = TableIdentifier.of("ns", "tbl");
+    Set<String> originalLocations = Set.of(S3_BASE_LOCATION + "/ns/tbl");
+
+    Set<String> result =
+        S3TablesUtil.resolveTableLocations(
+            tableId, originalLocations, catalog, Optional.of(TABLE_ID));
+
+    assertThat(result).isEqualTo(originalLocations);
+  }
+
+  @Test
+  void resolveTableLocations_returnsArnSetWhenS3TablesAndTableIdPresent() {
+    CatalogEntity catalog = s3TablesCatalog();
+    TableIdentifier tableId = TableIdentifier.of("ns", "tbl");
+    Set<String> originalLocations = Set.of(S3_BASE_LOCATION + "/ns/tbl");
+    String expectedArn = BUCKET_ARN + "/table/" + TABLE_ID;
+
+    Set<String> result =
+        S3TablesUtil.resolveTableLocations(
+            tableId, originalLocations, catalog, Optional.of(TABLE_ID));
+
+    assertThat(result).containsExactly(expectedArn);
+  }
+
+  @Test
+  void resolveTableLocations_throwsBadRequestExceptionWhenS3TablesAndTableIdAbsent() {
+    CatalogEntity catalog = s3TablesCatalog();
+    TableIdentifier tableId = TableIdentifier.of("ns", "tbl");
+    Set<String> originalLocations = Set.of(S3_BASE_LOCATION + "/ns/tbl");
+
+    assertThatThrownBy(
+            () ->
+                S3TablesUtil.resolveTableLocations(
+                    tableId, originalLocations, catalog, Optional.empty()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("no tableId");
+  }
+}

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1095,6 +1095,7 @@ components:
             - GCS
             - AZURE
             - FILE
+            - S3_TABLES
           description: The cloud provider type this storage is built on. FILE is supported for testing purposes only
         allowedLocations:
           type: array
@@ -1113,6 +1114,7 @@ components:
           AZURE: "#/components/schemas/AzureStorageConfigInfo"
           GCS: "#/components/schemas/GcpStorageConfigInfo"
           FILE: "#/components/schemas/FileStorageConfigInfo"
+          S3_TABLES: "#/components/schemas/AwsS3TablesStorageConfigInfo"
 
     AwsStorageConfigInfo:
       type: object
@@ -1182,6 +1184,37 @@ components:
               type: boolean
               description: >-
                 if set to `true`, instructs Polaris Servers to avoid adding KMS key policies.
+
+    AwsS3TablesStorageConfigInfo:
+      type: object
+      description: AWS S3 Tables storage configuration info
+      allOf:
+        - $ref: '#/components/schemas/StorageConfigInfo'
+        - type: object
+          properties:
+            roleArn:
+              type: string
+              description: the AWS IAM role ARN used to assume credentials for S3 Tables access
+              example: "arn:aws:iam::123456789012:role/polaris-s3tables-role"
+            externalId:
+              type: string
+              description: an optional external ID for the STS AssumeRole trust policy
+            region:
+              type: string
+              description: the AWS region where the S3 Tables bucket resides
+              example: "us-east-1"
+            currentKmsKey:
+              type: string
+              description: the AWS KMS key ARN used to encrypt S3 Tables data
+              example: "arn:aws:kms::123456789012:key/01234578"
+            allowedKmsKeys:
+              type: array
+              description: The list of KMS keys that this catalog and its clients are allowed to use for reading S3 Tables data
+              items:
+                type: string
+              example: ["arn:aws:kms::123456789012:key/01234578"]
+          required:
+            - roleArn
 
     AzureStorageConfigInfo:
       type: object


### PR DESCRIPTION
## Summary

When Polaris federates to an S3 Tables Iceberg REST endpoint, the credential vending flow must generate S3 Tables IAM policies (using `s3tables:` actions and table-level ARNs) instead of standard S3 policies.

This is a draft PR to socialize the approach with the community. Feedback on the design is welcome.

Related to #577

## Problem

S3 Tables uses a different IAM action namespace (`s3tables:`) and ARN format (`arn:aws:s3tables:REGION:ACCOUNT:bucket/BUCKET/table/TABLE_ID`) compared to standard S3. When Polaris federates to an S3 Tables Iceberg REST endpoint, the existing credential vending flow generates S3 policies that don't work for S3 Tables data access.

## Approach

- Detect S3 Tables catalogs via the `signingName` property (`"s3tables"`) from the remote endpoint's connection configuration, persisted on the catalog entity
- Capture the `tableId` returned in `loadTable` responses from the remote endpoint using a `ConfigCapturingHTTPClient` wrapper and request-scoped `CapturedConfigHolder`
- Construct proper S3 Tables ARNs from the catalog's base location and captured `tableId`
- Generate per-table scoped session policies with granular read/write actions:
  - Read: `s3tables:GetTableData`, `s3tables:GetTableMetadataLocation`
  - Write (additional): `s3tables:UpdateTableMetadataLocation`, `s3tables:PutTableData`
- Validate at catalog creation time that `signingName: "s3tables"` catalogs use ARN-based `default-base-location` (not `s3://` paths)

## Files Changed (15 files, ~570 lines)

- `AwsCredentialsStorageIntegration` — S3 Tables policy generation, branching on `signingName`
- `CredentialVendingContext` — added `resourceArns` and `signingName` fields
- `AwsStorageConfigurationInfo` — added `signingName` getter
- `CatalogEntity` — `setSigningNameFromConnectionConfig()` + validation
- `CapturedConfigHolder` / `ConfigCapturingHTTPClient` — new classes to capture `tableId` from remote responses
- `IcebergCatalogHandler` — ARN construction from captured config
- `StorageAccessConfigProvider` — pass `resourceArns` through to credential vending
- `IcebergRESTExternalCatalogFactory` — wire in config capture
- `PolarisAdminService` — persist `signingName` at catalog creation
- Test: 3 new unit tests for S3 Tables policy generation (read-only, read-write, fallback)

## AI Disclosure

This implementation was developed with AI assistance (Kiro).

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #577
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
