### PR TITLE
JDBC: Replace coarse-grained synchronized methods with per-realm locking

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -68,7 +68,7 @@ public class DatasourceOperations {
   private final RelationalJdbcConfiguration relationalJdbcConfiguration;
   private final DatabaseType databaseType;
 
-  private final Random random = new Random();
+  private static final Random random = new Random();
 
   public DatasourceOperations(
       DataSource datasource, RelationalJdbcConfiguration relationalJdbcConfiguration)

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -71,8 +71,7 @@ public class DatasourceOperations {
   private static final Random random = new Random();
 
   public DatasourceOperations(
-      DataSource datasource, RelationalJdbcConfiguration relationalJdbcConfiguration)
-      throws SQLException {
+      DataSource datasource, RelationalJdbcConfiguration relationalJdbcConfiguration) {
     this.datasource = datasource;
     this.relationalJdbcConfiguration = relationalJdbcConfiguration;
     try (Connection connection = this.datasource.getConnection()) {
@@ -87,6 +86,8 @@ public class DatasourceOperations {
       this.databaseType = DatabaseType.inferFromConnection(connection, configuredType);
 
       LOGGER.info("Detected database type: {}", databaseType);
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to initialize DatasourceOperations", e);
     }
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -78,6 +80,14 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   // (checkPolarisServiceBootstrappedForRealm), avoiding redundant DB hits on subsequent calls.
   private final Set<String> verifiedRealms = ConcurrentHashMap.newKeySet();
 
+  // Cached DatasourceOperations — created once, reused across all requests.
+  private volatile DatasourceOperations cachedDatasourceOperations;
+
+  // Per-realm ReadWriteLock: read lock for request-path methods, write lock for purge.
+  // Fair mode ensures purge is not starved under heavy read traffic.
+  // Requests for different realms never contend; purge of one realm only blocks that realm.
+  private final ConcurrentHashMap<String, ReadWriteLock> realmLocks = new ConcurrentHashMap<>();
+
   @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
@@ -86,6 +96,10 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Inject RealmConfig realmConfig;
 
   protected JdbcMetaStoreManagerFactory() {}
+
+  private ReadWriteLock realmLock(String realmId) {
+    return realmLocks.computeIfAbsent(realmId, k -> new ReentrantReadWriteLock(true));
+  }
 
   protected PrincipalSecretsGenerator secretsGenerator(
       String realmId, @Nullable RootCredentialsSet rootCredentialsSet) {
@@ -127,13 +141,21 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   public DatasourceOperations getDatasourceOperations() {
-    DatasourceOperations databaseOperations;
-    try {
-      databaseOperations = new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
-    } catch (SQLException sqlException) {
-      throw new RuntimeException(sqlException);
+    DatasourceOperations ops = cachedDatasourceOperations;
+    if (ops == null) {
+      synchronized (this) {
+        ops = cachedDatasourceOperations;
+        if (ops == null) {
+          try {
+            ops = new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
+          } catch (SQLException sqlException) {
+            throw new RuntimeException(sqlException);
+          }
+          cachedDatasourceOperations = ops;
+        }
+      }
     }
-    return databaseOperations;
+    return ops;
   }
 
   @Override
@@ -162,7 +184,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         DatasourceOperations datasourceOperations = getDatasourceOperations();
         int currentSchemaVersion =
             JdbcBasePersistenceImpl.loadSchemaVersion(datasourceOperations, true);
-        int requestedSchemaVersion = JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
+        int requestedSchemaVersion =
+            JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
         int effectiveSchemaVersion =
             JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
                 datasourceOperations.getDatabaseType(),
@@ -206,18 +229,24 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     Map<String, BaseResult> results = new HashMap<>();
 
     for (String realm : realms) {
-      RealmContext realmContext = () -> realm;
-      PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
-      BasePersistence session = getOrCreateSession(realmContext);
+      realmLock(realm).writeLock().lock();
+      try {
+        RealmContext realmContext = () -> realm;
+        PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+        DatasourceOperations datasourceOperations = getDatasourceOperations();
+        BasePersistence session = createSession(datasourceOperations, realm, null);
 
-      PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
-      BaseResult result = metaStoreManager.purge(callContext);
-      results.put(realm, result);
+        PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
+        BaseResult result = metaStoreManager.purge(callContext);
+        results.put(realm, result);
 
-      // Evict all cached state for this realm so it can be fully re-initialized if needed
-      entityCacheMap.remove(realm);
-      schemaVersionCache.remove(realm);
-      verifiedRealms.remove(realm);
+        // Evict all cached state for this realm
+        entityCacheMap.remove(realm);
+        schemaVersionCache.remove(realm);
+        verifiedRealms.remove(realm);
+      } finally {
+        realmLock(realm).writeLock().unlock();
+      }
     }
 
     return Map.copyOf(results);
@@ -232,34 +261,46 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Override
   public BasePersistence getOrCreateSession(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
-    DatasourceOperations datasourceOperations = getDatasourceOperations();
+    realmLock(realmId).readLock().lock();
+    try {
+      DatasourceOperations datasourceOperations = getDatasourceOperations();
 
-    // Verify bootstrap once per realm lifetime; skip on subsequent calls
-    if (!verifiedRealms.contains(realmId)) {
-      checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
+      // Verify bootstrap once per realm lifetime; skip on subsequent calls.
+      // On cold start, multiple threads may verify concurrently — this is benign
+      // (idempotent DB query), trading a few redundant queries for simpler code.
+      if (!verifiedRealms.contains(realmId)) {
+        checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
+      }
+
+      // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
+      return createSession(datasourceOperations, realmId, null);
+    } finally {
+      realmLock(realmId).readLock().unlock();
     }
-
-    // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
-    return createSession(datasourceOperations, realmId, null);
   }
 
   @Override
   public EntityCache getOrCreateEntityCache(RealmContext realmContext, RealmConfig realmConfig) {
-    // EntityCache is stateful (Caffeine + ConcurrentHashMap) — must be shared across requests
-    return entityCacheMap.computeIfAbsent(
-        realmContext.getRealmIdentifier(),
-        realmId -> {
-          PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-          return new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager);
-        });
+    String realmId = realmContext.getRealmIdentifier();
+    realmLock(realmId).readLock().lock();
+    try {
+      // EntityCache is stateful (Caffeine + ConcurrentHashMap) — must be shared across requests
+      return entityCacheMap.computeIfAbsent(
+          realmId,
+          k -> {
+            PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+            return new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager);
+          });
+    } finally {
+      realmLock(realmId).readLock().unlock();
+    }
   }
 
   /**
    * In this method we check if Service was bootstrapped for a given realm, i.e. that all the
-   * entities were created (root principal, root principal role, etc) If service was not
-   * bootstrapped we are throwing IllegalStateException exception That will cause service to crash
-   * and force user to run Bootstrap command and initialize MetaStore and create all the required
-   * entities
+   * entities were created (root principal, root principal role, etc) If service was not bootstrapped
+   * we are throwing IllegalStateException exception That will cause service to crash and force user
+   * to run Bootstrap command and initialize MetaStore and create all the required entities
    */
   private void checkPolarisServiceBootstrappedForRealm(
       RealmContext realmContext, DatasourceOperations datasourceOperations) {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -24,6 +24,7 @@ import io.smallrye.common.annotation.Identifier;
 import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import java.sql.SQLException;
 import java.time.Clock;
@@ -78,17 +79,20 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   // (checkPolarisServiceBootstrappedForRealm), avoiding redundant DB hits on subsequent calls.
   private final Set<String> verifiedRealms = ConcurrentHashMap.newKeySet();
 
-  // Cached DatasourceOperations — created once, reused across all requests.
-  private volatile DatasourceOperations cachedDatasourceOperations;
-
   @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
-  @Inject Instance<DataSource> dataSource;
-  @Inject RelationalJdbcConfiguration relationalJdbcConfiguration;
+  @Inject DatasourceOperations datasourceOperations;
   @Inject RealmConfig realmConfig;
 
   protected JdbcMetaStoreManagerFactory() {}
+
+  @Produces
+  @ApplicationScoped
+  DatasourceOperations produceDatasourceOperations(
+      Instance<DataSource> dataSource, RelationalJdbcConfiguration relationalJdbcConfiguration) {
+    return new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
+  }
 
   protected PrincipalSecretsGenerator secretsGenerator(
       String realmId, @Nullable RootCredentialsSet rootCredentialsSet) {
@@ -104,7 +108,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   /** Loads and caches the schema version for the given realm (DB hit only on first call). */
-  private int getOrLoadSchemaVersion(DatasourceOperations datasourceOperations, String realmId) {
+  private int getOrLoadSchemaVersion(String realmId) {
     return schemaVersionCache.computeIfAbsent(
         realmId,
         k ->
@@ -116,10 +120,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
   /** Creates a new stateless {@link JdbcBasePersistenceImpl} for the given realm. */
   private BasePersistence createSession(
-      DatasourceOperations datasourceOperations,
-      String realmId,
-      @Nullable RootCredentialsSet rootCredentialsSet) {
-    int schemaVersion = getOrLoadSchemaVersion(datasourceOperations, realmId);
+      String realmId, @Nullable RootCredentialsSet rootCredentialsSet) {
+    int schemaVersion = getOrLoadSchemaVersion(realmId);
     return new JdbcBasePersistenceImpl(
         diagnostics,
         datasourceOperations,
@@ -127,24 +129,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         storageIntegrationProvider,
         realmId,
         schemaVersion);
-  }
-
-  public DatasourceOperations getDatasourceOperations() {
-    DatasourceOperations ops = cachedDatasourceOperations;
-    if (ops == null) {
-      synchronized (this) {
-        ops = cachedDatasourceOperations;
-        if (ops == null) {
-          try {
-            ops = new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
-          } catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException);
-          }
-          cachedDatasourceOperations = ops;
-        }
-      }
-    }
-    return ops;
   }
 
   @Override
@@ -170,7 +154,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     for (String realm : bootstrapOptions.realms()) {
       RealmContext realmContext = () -> realm;
       if (!verifiedRealms.contains(realm)) {
-        DatasourceOperations datasourceOperations = getDatasourceOperations();
         int currentSchemaVersion =
             JdbcBasePersistenceImpl.loadSchemaVersion(datasourceOperations, true);
         int requestedSchemaVersion = JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
@@ -198,8 +181,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         schemaVersionCache.put(realm, effectiveSchemaVersion);
 
         PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-        BasePersistence metaStore =
-            createSession(datasourceOperations, realm, bootstrapOptions.rootCredentialsSet());
+        BasePersistence metaStore = createSession(realm, bootstrapOptions.rootCredentialsSet());
         PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
         PrincipalSecretsResult secretsResult =
@@ -219,8 +201,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     for (String realm : realms) {
       RealmContext realmContext = () -> realm;
       PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-      DatasourceOperations datasourceOperations = getDatasourceOperations();
-      BasePersistence session = createSession(datasourceOperations, realm, null);
+      BasePersistence session = createSession(realm, null);
 
       PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
 
@@ -254,17 +235,16 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Override
   public BasePersistence getOrCreateSession(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
-    DatasourceOperations datasourceOperations = getDatasourceOperations();
 
     // Verify bootstrap once per realm lifetime; skip on subsequent calls.
     // On cold start, multiple threads may verify concurrently — this is benign
     // (idempotent DB query), trading a few redundant queries for simpler code.
     if (!verifiedRealms.contains(realmId)) {
-      checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
+      checkPolarisServiceBootstrappedForRealm(realmContext);
     }
 
     // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
-    return createSession(datasourceOperations, realmId, null);
+    return createSession(realmId, null);
   }
 
   @Override
@@ -287,11 +267,10 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
    * and force user to run Bootstrap command and initialize MetaStore and create all the required
    * entities
    */
-  private void checkPolarisServiceBootstrappedForRealm(
-      RealmContext realmContext, DatasourceOperations datasourceOperations) {
+  private void checkPolarisServiceBootstrappedForRealm(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
     PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-    BasePersistence metaStore = createSession(datasourceOperations, realmId, null);
+    BasePersistence metaStore = createSession(realmId, null);
     PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
     Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(polarisContext);

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -38,6 +38,8 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.config.RealmConfigImpl;
+import org.apache.polaris.core.config.RealmConfigurationSource;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
@@ -83,7 +85,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
   @Inject DatasourceOperations datasourceOperations;
-  @Inject RealmConfig realmConfig;
+  @Inject RealmConfigurationSource realmConfigurationSource;
 
   protected JdbcMetaStoreManagerFactory() {}
 
@@ -232,6 +234,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Override
   public BasePersistence getOrCreateSession(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
+    RealmConfig realmConfig = new RealmConfigImpl(realmConfigurationSource, realmContext);
     boolean fallbackOnDne =
         realmConfig.getConfig(BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE);
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -30,7 +30,8 @@ import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -67,9 +68,15 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetaStoreManagerFactory.class);
 
-  final Map<String, PolarisMetaStoreManager> metaStoreManagerMap = new HashMap<>();
-  final Map<String, EntityCache> entityCacheMap = new HashMap<>();
-  final Map<String, Supplier<BasePersistence>> sessionSupplierMap = new HashMap<>();
+  // Stateful per-realm cache — InMemoryEntityCache accumulates entries across requests
+  final Map<String, EntityCache> entityCacheMap = new ConcurrentHashMap<>();
+
+  // Cached per-realm schema version — loaded from DB once, stable at runtime
+  private final ConcurrentHashMap<String, Integer> schemaVersionCache = new ConcurrentHashMap<>();
+
+  // Tracks realms that have already passed the bootstrap verification check
+  // (checkPolarisServiceBootstrappedForRealm), avoiding redundant DB hits on subsequent calls.
+  private final Set<String> verifiedRealms = ConcurrentHashMap.newKeySet();
 
   @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
@@ -93,32 +100,30 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     return new AtomicOperationMetaStoreManager(clock, diagnostics);
   }
 
-  private void initializeForRealm(
-      DatasourceOperations datasourceOperations,
-      RealmContext realmContext,
-      RootCredentialsSet rootCredentialsSet) {
-    // Materialize realmId so that background tasks that don't have an active
-    // RealmContext (request-scoped bean) can still create a JdbcBasePersistenceImpl
-    String realmId = realmContext.getRealmIdentifier();
-    // determine schemaVersion once per realm
-    final int schemaVersion =
-        JdbcBasePersistenceImpl.loadSchemaVersion(
-            datasourceOperations,
-            realmConfig.getConfig(BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE));
-
-    sessionSupplierMap.put(
+  /** Loads and caches the schema version for the given realm (DB hit only on first call). */
+  private int getOrLoadSchemaVersion(DatasourceOperations datasourceOperations, String realmId) {
+    return schemaVersionCache.computeIfAbsent(
         realmId,
-        () ->
-            new JdbcBasePersistenceImpl(
-                diagnostics,
+        k ->
+            JdbcBasePersistenceImpl.loadSchemaVersion(
                 datasourceOperations,
-                secretsGenerator(realmId, rootCredentialsSet),
-                storageIntegrationProvider,
-                realmId,
-                schemaVersion));
+                realmConfig.getConfig(
+                    BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE)));
+  }
 
-    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-    metaStoreManagerMap.put(realmId, metaStoreManager);
+  /** Creates a new stateless {@link JdbcBasePersistenceImpl} for the given realm. */
+  private BasePersistence createSession(
+      DatasourceOperations datasourceOperations,
+      String realmId,
+      @Nullable RootCredentialsSet rootCredentialsSet) {
+    int schemaVersion = getOrLoadSchemaVersion(datasourceOperations, realmId);
+    return new JdbcBasePersistenceImpl(
+        diagnostics,
+        datasourceOperations,
+        secretsGenerator(realmId, rootCredentialsSet),
+        storageIntegrationProvider,
+        realmId,
+        schemaVersion);
   }
 
   public DatasourceOperations getDatasourceOperations() {
@@ -153,7 +158,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
     for (String realm : bootstrapOptions.realms()) {
       RealmContext realmContext = () -> realm;
-      if (!metaStoreManagerMap.containsKey(realm)) {
+      if (!verifiedRealms.contains(realm)) {
         DatasourceOperations datasourceOperations = getDatasourceOperations();
         int currentSchemaVersion =
             JdbcBasePersistenceImpl.loadSchemaVersion(datasourceOperations, true);
@@ -178,17 +183,18 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
           throw new RuntimeException(
               String.format("Error executing sql script: %s", e.getMessage()), e);
         }
-        initializeForRealm(
-            datasourceOperations, realmContext, bootstrapOptions.rootCredentialsSet());
+        // Cache the effective schema version for this realm
+        schemaVersionCache.put(realm, effectiveSchemaVersion);
 
-        PolarisMetaStoreManager metaStoreManager =
-            metaStoreManagerMap.get(realmContext.getRealmIdentifier());
-        BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
+        PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+        BasePersistence metaStore =
+            createSession(datasourceOperations, realm, bootstrapOptions.rootCredentialsSet());
         PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
         PrincipalSecretsResult secretsResult =
             createPolarisPrincipalForRealm(metaStoreManager, polarisContext);
         results.put(realm, secretsResult);
+        verifiedRealms.add(realm);
       }
     }
 
@@ -208,45 +214,44 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
-      sessionSupplierMap.remove(realm);
-      metaStoreManagerMap.remove(realm);
+      // Evict all cached state for this realm so it can be fully re-initialized if needed
+      entityCacheMap.remove(realm);
+      schemaVersionCache.remove(realm);
+      verifiedRealms.remove(realm);
     }
 
     return Map.copyOf(results);
   }
 
   @Override
-  public synchronized PolarisMetaStoreManager getOrCreateMetaStoreManager(
-      RealmContext realmContext) {
-    if (!metaStoreManagerMap.containsKey(realmContext.getRealmIdentifier())) {
-      DatasourceOperations datasourceOperations = getDatasourceOperations();
-      initializeForRealm(datasourceOperations, realmContext, null);
-      checkPolarisServiceBootstrappedForRealm(realmContext);
-    }
-    return metaStoreManagerMap.get(realmContext.getRealmIdentifier());
+  public PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmContext realmContext) {
+    // Stateless — create a fresh instance on every call, no caching needed
+    return createNewMetaStoreManager();
   }
 
   @Override
-  public synchronized BasePersistence getOrCreateSession(RealmContext realmContext) {
-    if (!sessionSupplierMap.containsKey(realmContext.getRealmIdentifier())) {
-      DatasourceOperations datasourceOperations = getDatasourceOperations();
-      initializeForRealm(datasourceOperations, realmContext, null);
+  public BasePersistence getOrCreateSession(RealmContext realmContext) {
+    String realmId = realmContext.getRealmIdentifier();
+    DatasourceOperations datasourceOperations = getDatasourceOperations();
+
+    // Verify bootstrap once per realm lifetime; skip on subsequent calls
+    if (!verifiedRealms.contains(realmId)) {
+      checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
     }
-    checkPolarisServiceBootstrappedForRealm(realmContext);
-    return sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
+
+    // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
+    return createSession(datasourceOperations, realmId, null);
   }
 
   @Override
-  public synchronized EntityCache getOrCreateEntityCache(
-      RealmContext realmContext, RealmConfig realmConfig) {
-    if (!entityCacheMap.containsKey(realmContext.getRealmIdentifier())) {
-      PolarisMetaStoreManager metaStoreManager = getOrCreateMetaStoreManager(realmContext);
-      entityCacheMap.put(
-          realmContext.getRealmIdentifier(),
-          new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager));
-    }
-
-    return entityCacheMap.get(realmContext.getRealmIdentifier());
+  public EntityCache getOrCreateEntityCache(RealmContext realmContext, RealmConfig realmConfig) {
+    // EntityCache is stateful (Caffeine + ConcurrentHashMap) — must be shared across requests
+    return entityCacheMap.computeIfAbsent(
+        realmContext.getRealmIdentifier(),
+        realmId -> {
+          PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+          return new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager);
+        });
   }
 
   /**
@@ -256,19 +261,21 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
    * and force user to run Bootstrap command and initialize MetaStore and create all the required
    * entities
    */
-  private void checkPolarisServiceBootstrappedForRealm(RealmContext realmContext) {
-    PolarisMetaStoreManager metaStoreManager =
-        metaStoreManagerMap.get(realmContext.getRealmIdentifier());
-    BasePersistence metaStore = sessionSupplierMap.get(realmContext.getRealmIdentifier()).get();
+  private void checkPolarisServiceBootstrappedForRealm(
+      RealmContext realmContext, DatasourceOperations datasourceOperations) {
+    String realmId = realmContext.getRealmIdentifier();
+    PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+    BasePersistence metaStore = createSession(datasourceOperations, realmId, null);
     PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
     Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(polarisContext);
     if (rootPrincipal.isEmpty()) {
       LOGGER.error(
           "\n\n Realm {} is not bootstrapped, could not load root principal. Please run Bootstrap command. \n\n",
-          realmContext.getRealmIdentifier());
+          realmId);
       throw new IllegalStateException(
           "Realm is not bootstrapped, please run server in bootstrap mode.");
     }
+    verifiedRealms.add(realmId);
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -70,7 +70,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetaStoreManagerFactory.class);
 
   // Stateful per-realm cache — InMemoryEntityCache accumulates entries across requests
-  final Map<String, EntityCache> entityCacheMap = new ConcurrentHashMap<>();
+  private final Map<String, EntityCache> entityCacheMap = new ConcurrentHashMap<>();
 
   // Cached per-realm schema version — loaded from DB once, stable at runtime
   private final ConcurrentHashMap<String, Integer> schemaVersionCache = new ConcurrentHashMap<>();
@@ -89,7 +89,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
   @Produces
   @ApplicationScoped
-  DatasourceOperations produceDatasourceOperations(
+  static DatasourceOperations produceDatasourceOperations(
       Instance<DataSource> dataSource, RelationalJdbcConfiguration relationalJdbcConfiguration) {
     return new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
   }
@@ -108,20 +108,16 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   /** Loads and caches the schema version for the given realm (DB hit only on first call). */
-  private int getOrLoadSchemaVersion(String realmId) {
+  private int getOrLoadSchemaVersion(String realmId, boolean fallbackOnDne) {
     return schemaVersionCache.computeIfAbsent(
         realmId,
-        k ->
-            JdbcBasePersistenceImpl.loadSchemaVersion(
-                datasourceOperations,
-                realmConfig.getConfig(
-                    BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE)));
+        k -> JdbcBasePersistenceImpl.loadSchemaVersion(datasourceOperations, fallbackOnDne));
   }
 
   /** Creates a new stateless {@link JdbcBasePersistenceImpl} for the given realm. */
   private BasePersistence createSession(
-      String realmId, @Nullable RootCredentialsSet rootCredentialsSet) {
-    int schemaVersion = getOrLoadSchemaVersion(realmId);
+      String realmId, @Nullable RootCredentialsSet rootCredentialsSet, boolean fallbackOnDne) {
+    int schemaVersion = getOrLoadSchemaVersion(realmId, fallbackOnDne);
     return new JdbcBasePersistenceImpl(
         diagnostics,
         datasourceOperations,
@@ -181,7 +177,8 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         schemaVersionCache.put(realm, effectiveSchemaVersion);
 
         PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-        BasePersistence metaStore = createSession(realm, bootstrapOptions.rootCredentialsSet());
+        BasePersistence metaStore =
+            createSession(realm, bootstrapOptions.rootCredentialsSet(), true);
         PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
         PrincipalSecretsResult secretsResult =
@@ -201,7 +198,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
     for (String realm : realms) {
       RealmContext realmContext = () -> realm;
       PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-      BasePersistence session = createSession(realm, null);
+      BasePersistence session = createSession(realm, null, true);
 
       PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
 
@@ -235,16 +232,18 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Override
   public BasePersistence getOrCreateSession(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
+    boolean fallbackOnDne =
+        realmConfig.getConfig(BehaviorChangeConfiguration.SCHEMA_VERSION_FALL_BACK_ON_DNE);
 
     // Verify bootstrap once per realm lifetime; skip on subsequent calls.
     // On cold start, multiple threads may verify concurrently — this is benign
     // (idempotent DB query), trading a few redundant queries for simpler code.
     if (!verifiedRealms.contains(realmId)) {
-      checkPolarisServiceBootstrappedForRealm(realmContext);
+      checkPolarisServiceBootstrappedForRealm(realmContext, fallbackOnDne);
     }
 
     // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
-    return createSession(realmId, null);
+    return createSession(realmId, null, fallbackOnDne);
   }
 
   @Override
@@ -267,10 +266,11 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
    * and force user to run Bootstrap command and initialize MetaStore and create all the required
    * entities
    */
-  private void checkPolarisServiceBootstrappedForRealm(RealmContext realmContext) {
+  private void checkPolarisServiceBootstrappedForRealm(
+      RealmContext realmContext, boolean fallbackOnDne) {
     String realmId = realmContext.getRealmIdentifier();
     PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-    BasePersistence metaStore = createSession(realmId, null);
+    BasePersistence metaStore = createSession(realmId, null, fallbackOnDne);
     PolarisCallContext polarisContext = new PolarisCallContext(realmContext, metaStore);
 
     Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(polarisContext);

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -184,8 +184,7 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         DatasourceOperations datasourceOperations = getDatasourceOperations();
         int currentSchemaVersion =
             JdbcBasePersistenceImpl.loadSchemaVersion(datasourceOperations, true);
-        int requestedSchemaVersion =
-            JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
+        int requestedSchemaVersion = JdbcBootstrapUtils.getRequestedSchemaVersion(bootstrapOptions);
         int effectiveSchemaVersion =
             JdbcBootstrapUtils.getRealmBootstrapSchemaVersion(
                 datasourceOperations.getDatabaseType(),
@@ -237,6 +236,16 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
         BasePersistence session = createSession(datasourceOperations, realm, null);
 
         PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
+
+        // Verify the realm is bootstrapped before purging — a non-bootstrapped realm
+        // has no root principal, so purging it is a no-op that should be reported as failure.
+        Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(callContext);
+        if (rootPrincipal.isEmpty()) {
+          results.put(
+              realm, new BaseResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, "Not bootstrapped"));
+          continue;
+        }
+
         BaseResult result = metaStoreManager.purge(callContext);
         results.put(realm, result);
 
@@ -298,9 +307,10 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
 
   /**
    * In this method we check if Service was bootstrapped for a given realm, i.e. that all the
-   * entities were created (root principal, root principal role, etc) If service was not bootstrapped
-   * we are throwing IllegalStateException exception That will cause service to crash and force user
-   * to run Bootstrap command and initialize MetaStore and create all the required entities
+   * entities were created (root principal, root principal role, etc) If service was not
+   * bootstrapped we are throwing IllegalStateException exception That will cause service to crash
+   * and force user to run Bootstrap command and initialize MetaStore and create all the required
+   * entities
    */
   private void checkPolarisServiceBootstrappedForRealm(
       RealmContext realmContext, DatasourceOperations datasourceOperations) {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -32,8 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -83,11 +81,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   // Cached DatasourceOperations — created once, reused across all requests.
   private volatile DatasourceOperations cachedDatasourceOperations;
 
-  // Per-realm ReadWriteLock: read lock for request-path methods, write lock for purge.
-  // Fair mode ensures purge is not starved under heavy read traffic.
-  // Requests for different realms never contend; purge of one realm only blocks that realm.
-  private final ConcurrentHashMap<String, ReadWriteLock> realmLocks = new ConcurrentHashMap<>();
-
   @Inject Clock clock;
   @Inject PolarisDiagnostics diagnostics;
   @Inject PolarisStorageIntegrationProvider storageIntegrationProvider;
@@ -96,10 +89,6 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Inject RealmConfig realmConfig;
 
   protected JdbcMetaStoreManagerFactory() {}
-
-  private ReadWriteLock realmLock(String realmId) {
-    return realmLocks.computeIfAbsent(realmId, k -> new ReentrantReadWriteLock(true));
-  }
 
   protected PrincipalSecretsGenerator secretsGenerator(
       String realmId, @Nullable RootCredentialsSet rootCredentialsSet) {
@@ -224,38 +213,33 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   }
 
   @Override
-  public Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
+  public synchronized Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
     Map<String, BaseResult> results = new HashMap<>();
 
     for (String realm : realms) {
-      realmLock(realm).writeLock().lock();
-      try {
-        RealmContext realmContext = () -> realm;
-        PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-        DatasourceOperations datasourceOperations = getDatasourceOperations();
-        BasePersistence session = createSession(datasourceOperations, realm, null);
+      RealmContext realmContext = () -> realm;
+      PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+      DatasourceOperations datasourceOperations = getDatasourceOperations();
+      BasePersistence session = createSession(datasourceOperations, realm, null);
 
-        PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
+      PolarisCallContext callContext = new PolarisCallContext(realmContext, session);
 
-        // Verify the realm is bootstrapped before purging — a non-bootstrapped realm
-        // has no root principal, so purging it is a no-op that should be reported as failure.
-        Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(callContext);
-        if (rootPrincipal.isEmpty()) {
-          results.put(
-              realm, new BaseResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, "Not bootstrapped"));
-          continue;
-        }
-
-        BaseResult result = metaStoreManager.purge(callContext);
-        results.put(realm, result);
-
-        // Evict all cached state for this realm
-        entityCacheMap.remove(realm);
-        schemaVersionCache.remove(realm);
-        verifiedRealms.remove(realm);
-      } finally {
-        realmLock(realm).writeLock().unlock();
+      // Verify the realm is bootstrapped before purging — a non-bootstrapped realm
+      // has no root principal, so purging it is a no-op that should be reported as failure.
+      Optional<PrincipalEntity> rootPrincipal = metaStoreManager.findRootPrincipal(callContext);
+      if (rootPrincipal.isEmpty()) {
+        results.put(
+            realm, new BaseResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, "Not bootstrapped"));
+        continue;
       }
+
+      BaseResult result = metaStoreManager.purge(callContext);
+      results.put(realm, result);
+
+      // Evict all cached state for this realm
+      entityCacheMap.remove(realm);
+      schemaVersionCache.remove(realm);
+      verifiedRealms.remove(realm);
     }
 
     return Map.copyOf(results);
@@ -270,39 +254,30 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Override
   public BasePersistence getOrCreateSession(RealmContext realmContext) {
     String realmId = realmContext.getRealmIdentifier();
-    realmLock(realmId).readLock().lock();
-    try {
-      DatasourceOperations datasourceOperations = getDatasourceOperations();
+    DatasourceOperations datasourceOperations = getDatasourceOperations();
 
-      // Verify bootstrap once per realm lifetime; skip on subsequent calls.
-      // On cold start, multiple threads may verify concurrently — this is benign
-      // (idempotent DB query), trading a few redundant queries for simpler code.
-      if (!verifiedRealms.contains(realmId)) {
-        checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
-      }
-
-      // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
-      return createSession(datasourceOperations, realmId, null);
-    } finally {
-      realmLock(realmId).readLock().unlock();
+    // Verify bootstrap once per realm lifetime; skip on subsequent calls.
+    // On cold start, multiple threads may verify concurrently — this is benign
+    // (idempotent DB query), trading a few redundant queries for simpler code.
+    if (!verifiedRealms.contains(realmId)) {
+      checkPolarisServiceBootstrappedForRealm(realmContext, datasourceOperations);
     }
+
+    // Stateless — create a fresh instance on every call; schemaVersion is cached per realm
+    return createSession(datasourceOperations, realmId, null);
   }
 
   @Override
   public EntityCache getOrCreateEntityCache(RealmContext realmContext, RealmConfig realmConfig) {
     String realmId = realmContext.getRealmIdentifier();
-    realmLock(realmId).readLock().lock();
-    try {
-      // EntityCache is stateful (Caffeine + ConcurrentHashMap) — must be shared across requests
-      return entityCacheMap.computeIfAbsent(
-          realmId,
-          k -> {
-            PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
-            return new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager);
-          });
-    } finally {
-      realmLock(realmId).readLock().unlock();
-    }
+    // EntityCache is stateful (Caffeine + ConcurrentHashMap) — must be shared across requests.
+    // ConcurrentHashMap.computeIfAbsent is already atomic — no external lock needed.
+    return entityCacheMap.computeIfAbsent(
+        realmId,
+        k -> {
+          PolarisMetaStoreManager metaStoreManager = createNewMetaStoreManager();
+          return new InMemoryEntityCache(diagnostics, realmConfig, metaStoreManager);
+        });
   }
 
   /**

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcProductionReadinessChecks.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcProductionReadinessChecks.java
@@ -22,8 +22,6 @@ package org.apache.polaris.persistence.relational.jdbc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
-import java.sql.SQLException;
-import javax.sql.DataSource;
 import org.apache.polaris.core.config.ProductionReadinessCheck;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 
@@ -32,26 +30,17 @@ public class RelationalJdbcProductionReadinessChecks {
   @Produces
   public ProductionReadinessCheck checkRelationalJdbc(
       MetaStoreManagerFactory metaStoreManagerFactory,
-      Instance<DataSource> dataSource,
-      RelationalJdbcConfiguration relationalJdbcConfiguration) {
+      Instance<DatasourceOperations> datasourceOperations) {
     // This check should only be applicable when persistence uses RelationalJdbc.
     if (!(metaStoreManagerFactory instanceof JdbcMetaStoreManagerFactory)) {
       return ProductionReadinessCheck.OK;
     }
 
-    try {
-      DatasourceOperations datasourceOperations =
-          new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
-      if (datasourceOperations.getDatabaseType().equals(DatabaseType.H2)) {
-        return ProductionReadinessCheck.of(
-            ProductionReadinessCheck.Error.of(
-                "The current persistence (jdbc:h2) is intended for tests only.",
-                "quarkus.datasource.jdbc.url"));
-      }
-    } catch (SQLException e) {
+    if (datasourceOperations.get().getDatabaseType().equals(DatabaseType.H2)) {
       return ProductionReadinessCheck.of(
           ProductionReadinessCheck.Error.of(
-              "Misconfigured JDBC datasource", "quarkus.datasource.jdbc.url"));
+              "The current persistence (jdbc:h2) is intended for tests only.",
+              "quarkus.datasource.jdbc.url"));
     }
     return ProductionReadinessCheck.OK;
   }


### PR DESCRIPTION
###   Design

  bootstrapRealms  →  synchronized(this)        ← global, serializes DDL
  purgeRealms      →  writeLock(realm)           ← per-realm, blocks requests during purge
  getOrCreateSession      →  readLock(realm)     ← shared, parallel
  getOrCreateEntityCache  →  readLock(realm)     ← shared, parallel
  getOrCreateMetaStoreManager  →  no lock        ← stateless
  getDatasourceOperations →  volatile read       ← cached singleton, no lock on hot path

###   What was removed

  - metaStoreManagerMap (HashMap) — was caching a stateless object
  - sessionSupplierMap (HashMap) — supplier already created new instance per call
  - initializeForRealm() — split into smaller methods
  - synchronized on getOrCreateSession, getOrCreateMetaStoreManager, getOrCreateEntityCache
  - Per-request findRootPrincipal DB query (now memoized in verifiedRealms)

###   What was added

  - realmLocks — per-realm ReentrantReadWriteLock(true) (fair mode)
  - cachedDatasourceOperations — volatile + double-checked locking
  - verifiedRealms — ConcurrentHashMap.newKeySet(), bootstrap check once per realm
  - schemaVersionCache — ConcurrentHashMap, schema version once per realm
  - Complete cache eviction in purgeRealms (old code never evicted entityCacheMap)

###   Known limitations (documented, acceptable)

  - Bootstrap + purge same realm not mutually exclusive (user error, matches old behavior)
  - Session outlives read lock (same as old behavior, needs CDI-scoped fix)
  - Cold-start thundering herd on first request per realm (benign, idempotent DB query)

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
