### PR TITLE
Core: Catch number format exception in PolarisObjectMapperUtil

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtil.java
@@ -163,7 +163,7 @@ public final class PolarisObjectMapperUtil {
         }
       }
       return new TaskExecutionState(executorId, lastAttemptStartTime, attemptCount);
-    } catch (IOException e) {
+    } catch (IOException | NumberFormatException e) {
       LOGGER
           .atWarn()
           .addKeyValue("json", entity.getProperties())

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisObjectMapperUtilTest.java
@@ -92,4 +92,46 @@ class PolarisObjectMapperUtilTest {
         PolarisObjectMapperUtil.parseTaskState(entity);
     Assertions.assertThat(state).isNull();
   }
+
+  @Test
+  public void testParseTaskStateWithInvalidLastAttemptStartTime() {
+    PolarisBaseEntity entity =
+        new PolarisBaseEntity.Builder()
+            .catalogId(0L)
+            .id(1L)
+            .typeCode(PolarisEntityType.TASK.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(0L)
+            .name("task")
+            .properties(
+                "{\"name\": \"my name\", \"lastAttemptExecutorId\": \"executor1\", "
+                    + "\"lastAttemptStartTime\": \"not-a-number\", \"attemptCount\": \"5\"}")
+            .build();
+
+    // Should return null and log warning instead of throwing NumberFormatException
+    PolarisObjectMapperUtil.TaskExecutionState state =
+        PolarisObjectMapperUtil.parseTaskState(entity);
+    Assertions.assertThat(state).isNull();
+  }
+
+  @Test
+  public void testParseTaskStateWithInvalidAttemptCount() {
+    PolarisBaseEntity entity =
+        new PolarisBaseEntity.Builder()
+            .catalogId(0L)
+            .id(1L)
+            .typeCode(PolarisEntityType.TASK.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(0L)
+            .name("task")
+            .properties(
+                "{\"name\": \"my name\", \"lastAttemptExecutorId\": \"executor2\", "
+                    + "\"lastAttemptStartTime\": \"12345\", \"attemptCount\": \"invalid-count\"}")
+            .build();
+
+    // Should return null and log warning instead of throwing NumberFormatException
+    PolarisObjectMapperUtil.TaskExecutionState state =
+        PolarisObjectMapperUtil.parseTaskState(entity);
+    Assertions.assertThat(state).isNull();
+  }
 }


### PR DESCRIPTION
The original catch block only caught IOException, not NumberFormatException.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
