### PR TITLE
Core: Add null check and exception handling in ConnectionCredentials

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
@@ -70,7 +70,20 @@ public interface ConnectionCredentials {
 
     default Builder put(CatalogAccessProperty key, String value) {
       if (key.isExpirationTimestamp()) {
-        expiresAt(Instant.ofEpochMilli(Long.parseLong(value)));
+        if (value == null) {
+          throw new IllegalArgumentException(
+              "Expiration timestamp value cannot be null for key: " + key.getPropertyName());
+        }
+        try {
+          expiresAt(Instant.ofEpochMilli(Long.parseLong(value)));
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+              "Invalid expiration timestamp value for key "
+                  + key.getPropertyName()
+                  + ": "
+                  + value,
+              e);
+        }
       }
 
       if (key.isCredential()) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
@@ -78,10 +78,7 @@ public interface ConnectionCredentials {
           expiresAt(Instant.ofEpochMilli(Long.parseLong(value)));
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException(
-              "Invalid expiration timestamp value for key "
-                  + key.getPropertyName()
-                  + ": "
-                  + value,
+              "Invalid expiration timestamp value for key " + key.getPropertyName() + ": " + value,
               e);
         }
       }

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -26,10 +26,6 @@ import org.junit.jupiter.api.Test;
 
 class ConnectionCredentialsTest {
 
-  /**
-   * Test that validates Bug #3 fix: Null check for expiration timestamp value prevents
-   * NullPointerException.
-   */
   @Test
   public void testPutWithNullExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -40,10 +36,6 @@ class ConnectionCredentialsTest {
         .hasMessageContaining("rest.expires-at-ms");
   }
 
-  /**
-   * Test that validates Bug #3 fix: NumberFormatException is caught and wrapped in
-   * IllegalArgumentException when expiration timestamp contains invalid non-numeric value.
-   */
   @Test
   public void testPutWithInvalidExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -55,10 +47,6 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
-   * contains an empty string.
-   */
   @Test
   public void testPutWithEmptyStringExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -69,10 +57,6 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
-   * contains a decimal value.
-   */
   @Test
   public void testPutWithDecimalExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -84,10 +68,6 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
-   * contains alphanumeric characters.
-   */
   @Test
   public void testPutWithAlphanumericExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -99,10 +79,6 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
-   * is a number that's too large for Long.
-   */
   @Test
   public void testPutWithOverflowExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -116,9 +92,6 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix: Valid expiration timestamp works correctly after the fix.
-   */
   @Test
   public void testPutWithValidExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -127,14 +100,9 @@ class ConnectionCredentialsTest {
     builder.put(CatalogAccessProperty.EXPIRES_AT_MS, String.valueOf(expectedMillis));
 
     ConnectionCredentials credentials = builder.build();
-    assertThat(credentials.expiresAt())
-        .isPresent()
-        .hasValue(Instant.ofEpochMilli(expectedMillis));
+    assertThat(credentials.expiresAt()).isPresent().hasValue(Instant.ofEpochMilli(expectedMillis));
   }
 
-  /**
-   * Test that validates non-expiration properties still work after the fix.
-   */
   @Test
   public void testPutWithCredentialProperty() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -145,10 +113,6 @@ class ConnectionCredentialsTest {
     assertThat(credentials.get(CatalogAccessProperty.BEARER_TOKEN)).isEqualTo("my-secret-token");
   }
 
-  /**
-   * Test that validates Bug #3 fix: Negative timestamp values are accepted (valid for dates
-   * before epoch).
-   */
   @Test
   public void testPutWithNegativeExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -157,14 +121,9 @@ class ConnectionCredentialsTest {
     builder.put(CatalogAccessProperty.EXPIRES_AT_MS, String.valueOf(expectedMillis));
 
     ConnectionCredentials credentials = builder.build();
-    assertThat(credentials.expiresAt())
-        .isPresent()
-        .hasValue(Instant.ofEpochMilli(expectedMillis));
+    assertThat(credentials.expiresAt()).isPresent().hasValue(Instant.ofEpochMilli(expectedMillis));
   }
 
-  /**
-   * Test that validates Bug #3 fix: Zero timestamp value is accepted.
-   */
   @Test
   public void testPutWithZeroExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -175,9 +134,6 @@ class ConnectionCredentialsTest {
     assertThat(credentials.expiresAt()).isPresent().hasValue(Instant.ofEpochMilli(0L));
   }
 
-  /**
-   * Test that validates whitespace in timestamp is not handled (should throw exception).
-   */
   @Test
   public void testPutWithWhitespaceExpirationTimestamp() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
@@ -188,25 +144,18 @@ class ConnectionCredentialsTest {
         .hasCauseInstanceOf(NumberFormatException.class);
   }
 
-  /**
-   * Test that validates Bug #3 fix works with AWS session token expiration timestamp.
-   */
   @Test
   public void testPutWithAWSSessionTokenExpiresAt() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
 
     long expectedMillis = 1711234567890L;
-    builder.put(CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expectedMillis));
+    builder.put(
+        CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expectedMillis));
 
     ConnectionCredentials credentials = builder.build();
-    assertThat(credentials.expiresAt())
-        .isPresent()
-        .hasValue(Instant.ofEpochMilli(expectedMillis));
+    assertThat(credentials.expiresAt()).isPresent().hasValue(Instant.ofEpochMilli(expectedMillis));
   }
 
-  /**
-   * Test that validates Bug #3 fix catches invalid AWS session token expiration timestamp.
-   */
   @Test
   public void testPutWithInvalidAWSSessionTokenExpiresAt() {
     ConnectionCredentials.Builder builder = ConnectionCredentials.builder();

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.credentials.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ConnectionCredentialsTest {
+
+  /**
+   * Test that validates Bug #3 fix: Null check for expiration timestamp value prevents
+   * NullPointerException.
+   */
+  @Test
+  public void testPutWithNullExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Expiration timestamp value cannot be null")
+        .hasMessageContaining("rest.expires-at-ms");
+  }
+
+  /**
+   * Test that validates Bug #3 fix: NumberFormatException is caught and wrapped in
+   * IllegalArgumentException when expiration timestamp contains invalid non-numeric value.
+   */
+  @Test
+  public void testPutWithInvalidExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, "not-a-number"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasMessageContaining("not-a-number")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
+   * contains an empty string.
+   */
+  @Test
+  public void testPutWithEmptyStringExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
+   * contains a decimal value.
+   */
+  @Test
+  public void testPutWithDecimalExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, "1234.567"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasMessageContaining("1234.567")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
+   * contains alphanumeric characters.
+   */
+  @Test
+  public void testPutWithAlphanumericExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, "abc123xyz"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasMessageContaining("abc123xyz")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix: NumberFormatException is caught when expiration timestamp
+   * is a number that's too large for Long.
+   */
+  @Test
+  public void testPutWithOverflowExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(
+            () ->
+                builder.put(
+                    CatalogAccessProperty.EXPIRES_AT_MS, "999999999999999999999999999999999999"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix: Valid expiration timestamp works correctly after the fix.
+   */
+  @Test
+  public void testPutWithValidExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    long expectedMillis = 1234567890000L;
+    builder.put(CatalogAccessProperty.EXPIRES_AT_MS, String.valueOf(expectedMillis));
+
+    ConnectionCredentials credentials = builder.build();
+    assertThat(credentials.expiresAt())
+        .isPresent()
+        .hasValue(Instant.ofEpochMilli(expectedMillis));
+  }
+
+  /**
+   * Test that validates non-expiration properties still work after the fix.
+   */
+  @Test
+  public void testPutWithCredentialProperty() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    builder.put(CatalogAccessProperty.BEARER_TOKEN, "my-secret-token");
+
+    ConnectionCredentials credentials = builder.build();
+    assertThat(credentials.get(CatalogAccessProperty.BEARER_TOKEN)).isEqualTo("my-secret-token");
+  }
+
+  /**
+   * Test that validates Bug #3 fix: Negative timestamp values are accepted (valid for dates
+   * before epoch).
+   */
+  @Test
+  public void testPutWithNegativeExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    long expectedMillis = -1234567890000L;
+    builder.put(CatalogAccessProperty.EXPIRES_AT_MS, String.valueOf(expectedMillis));
+
+    ConnectionCredentials credentials = builder.build();
+    assertThat(credentials.expiresAt())
+        .isPresent()
+        .hasValue(Instant.ofEpochMilli(expectedMillis));
+  }
+
+  /**
+   * Test that validates Bug #3 fix: Zero timestamp value is accepted.
+   */
+  @Test
+  public void testPutWithZeroExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    builder.put(CatalogAccessProperty.EXPIRES_AT_MS, "0");
+
+    ConnectionCredentials credentials = builder.build();
+    assertThat(credentials.expiresAt()).isPresent().hasValue(Instant.ofEpochMilli(0L));
+  }
+
+  /**
+   * Test that validates whitespace in timestamp is not handled (should throw exception).
+   */
+  @Test
+  public void testPutWithWhitespaceExpirationTimestamp() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(() -> builder.put(CatalogAccessProperty.EXPIRES_AT_MS, "  12345  "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+
+  /**
+   * Test that validates Bug #3 fix works with AWS session token expiration timestamp.
+   */
+  @Test
+  public void testPutWithAWSSessionTokenExpiresAt() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    long expectedMillis = 1711234567890L;
+    builder.put(CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expectedMillis));
+
+    ConnectionCredentials credentials = builder.build();
+    assertThat(credentials.expiresAt())
+        .isPresent()
+        .hasValue(Instant.ofEpochMilli(expectedMillis));
+  }
+
+  /**
+   * Test that validates Bug #3 fix catches invalid AWS session token expiration timestamp.
+   */
+  @Test
+  public void testPutWithInvalidAWSSessionTokenExpiresAt() {
+    ConnectionCredentials.Builder builder = ConnectionCredentials.builder();
+
+    assertThatThrownBy(
+            () ->
+                builder.put(CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, "invalid-time"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid expiration timestamp value")
+        .hasMessageContaining("invalid-time")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+}


### PR DESCRIPTION
Issue: Unhandled NumberFormatException could crash at runtime

It adds null check before parsing the timestamp and wraps Long.parseLong() in try-catch to handle NumberFormatException, The fix throws IllegalArgumentException with clear error message for invalid values. The fix prevents uncaught runtime exceptions when credentials contain malformed data.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
