### PR TITLE
NoSQL: Change to detect a theoretically possible recursive call, which must not happen at all.

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/SupplyOnce.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/SupplyOnce.java
@@ -47,20 +47,22 @@ final class SupplyOnce {
       return switch (loaded) {
         case 1 -> (T) result;
         case 2 -> throw (RuntimeException) result;
+        case 3 -> throw new IllegalStateException("Recursive call to SupplyOnce.get() detected");
         case 0 -> load();
         default -> throw new IllegalStateException();
       };
     }
 
     private T load() {
+      loaded = 3;
       try {
-        loaded = 1;
         T obj = loader.get();
         result = obj;
+        loaded = 1;
         return obj;
       } catch (RuntimeException re) {
-        loaded = 2;
         result = re;
+        loaded = 2;
         throw re;
       }
     }


### PR DESCRIPTION
Adds explicit recursion detection — load() now sets loaded = 3 as a sentinel before invoking the supplier. If `get()` re-enters during loading, it hits the new case 3 and throws a clear `IllegalStateException` ("Recursive call to SupplyOnce.get() detected") instead of silently misbehaving.