### PR TITLE
NoSQL: improve test coverage on index-value-serializers

### DIFF
--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
@@ -793,6 +793,138 @@ public class TestIndexImpl {
     soft.assertThatCode(() -> index.divide(3)).doesNotThrowAnyException();
   }
 
+  /**
+   * Verifies that an index containing null-valued elements (tombstones) can be serialized and
+   * deserialized without data corruption. This is a test for a potential bug where {@code
+   * IndexValueSerializer.serialize(null, target)} could write to a different buffer instead of
+   * {@code target}, causing the serialized byte stream to be shifted and subsequent deserialization
+   * to fail with a {@link java.nio.BufferUnderflowException}.
+   */
+  @Test
+  void serializeDeserializeWithNullValues() {
+    var index = newStoreIndex(OBJ_REF_SERIALIZER);
+    var key1 = key("table1");
+    var key2 = key("table2");
+    var key3 = key("table3");
+    var key4 = key("table4");
+
+    var value1 = randomObjId();
+    var value3 = randomObjId();
+
+    index.add(indexElement(key1, value1));
+    index.add(indexElement(key2, (ObjRef) null)); // tombstone
+    index.add(indexElement(key3, value3));
+    index.add(indexElement(key4, (ObjRef) null)); // tombstone
+
+    var serialized = index.serialize();
+    var deserialized = deserializeStoreIndex(serialized, OBJ_REF_SERIALIZER);
+
+    soft.assertThat(deserialized.estimatedSerializedSize()).isEqualTo(serialized.remaining());
+
+    var el1 = deserialized.getElement(key1);
+    var el2 = deserialized.getElement(key2);
+    var el3 = deserialized.getElement(key3);
+    var el4 = deserialized.getElement(key4);
+
+    soft.assertThat(el1).isNotNull();
+    soft.assertThat(el1.key()).isEqualTo(key1);
+    soft.assertThat(el1.valueNullable()).isEqualTo(value1);
+
+    soft.assertThat(el2).isNotNull();
+    soft.assertThat(el2.key()).isEqualTo(key2);
+    soft.assertThat(el2.valueNullable()).isNull();
+
+    soft.assertThat(el3).isNotNull();
+    soft.assertThat(el3.key()).isEqualTo(key3);
+    soft.assertThat(el3.valueNullable()).isEqualTo(value3);
+
+    soft.assertThat(el4).isNotNull();
+    soft.assertThat(el4.key()).isEqualTo(key4);
+    soft.assertThat(el4.valueNullable()).isNull();
+
+    // Verify that the deserialized index can be re-serialized and deserialized again.
+    // Add an element to force re-serialization (modified flag).
+    var key5 = key("table5");
+    var value5 = randomObjId();
+    deserialized.add(indexElement(key5, value5));
+    var reserialized = deserialized.serialize();
+    var redeserialized = deserializeStoreIndex(reserialized, OBJ_REF_SERIALIZER);
+
+    soft.assertThat(redeserialized.getElement(key1).valueNullable()).isEqualTo(value1);
+    soft.assertThat(redeserialized.getElement(key2).valueNullable()).isNull();
+    soft.assertThat(redeserialized.getElement(key3).valueNullable()).isEqualTo(value3);
+    soft.assertThat(redeserialized.getElement(key4).valueNullable()).isNull();
+  }
+
+  @Test
+  void serializeDeserializeWithNullValuesObjTest() {
+    var index = newStoreIndex(OBJ_TEST_SERIALIZER);
+    var key1 = key("a");
+    var key2 = key("b");
+    var key3 = key("c");
+
+    index.add(indexElement(key1, objTestValueFromString("cafe")));
+    index.add(indexElement(key2, (ObjTestValue) null)); // tombstone
+    index.add(indexElement(key3, objTestValueFromString("babe")));
+
+    var serialized = index.serialize();
+    var deserialized = deserializeStoreIndex(serialized, OBJ_TEST_SERIALIZER);
+
+    soft.assertThat(deserialized.getElement(key1).valueNullable())
+        .isEqualTo(objTestValueFromString("cafe"));
+    soft.assertThat(deserialized.getElement(key2).valueNullable()).isNull();
+    soft.assertThat(deserialized.getElement(key3).valueNullable())
+        .isEqualTo(objTestValueFromString("babe"));
+  }
+
+  /** Tests that replacing a non-null value with null (tombstone) round-trips correctly. */
+  @Test
+  void replaceValueWithNull() {
+    var index = newStoreIndex(OBJ_REF_SERIALIZER);
+    var key1 = key("table1");
+    var key2 = key("table2");
+
+    var value1 = randomObjId();
+    var value2 = randomObjId();
+
+    index.add(indexElement(key1, value1));
+    index.add(indexElement(key2, value2));
+
+    // Serialize, deserialize, then replace key2 with null (tombstone)
+    var serialized = index.serialize();
+    var deserialized = deserializeStoreIndex(serialized, OBJ_REF_SERIALIZER);
+
+    deserialized.add(indexElement(key2, (ObjRef) null));
+
+    var reserialized = deserialized.serialize();
+    var final_ = deserializeStoreIndex(reserialized, OBJ_REF_SERIALIZER);
+
+    soft.assertThat(final_.getElement(key1).valueNullable()).isEqualTo(value1);
+    soft.assertThat(final_.getElement(key2).valueNullable()).isNull();
+  }
+
+  /**
+   * Tests that an index with only null-valued elements (all tombstones) round-trips correctly. This
+   * is an edge case where every serialized value is the null marker.
+   */
+  @Test
+  void allNullValues() {
+    var index = newStoreIndex(OBJ_REF_SERIALIZER);
+
+    for (var i = 0; i < 10; i++) {
+      index.add(indexElement(key("key" + i), (ObjRef) null));
+    }
+
+    var serialized = index.serialize();
+    var deserialized = deserializeStoreIndex(serialized, OBJ_REF_SERIALIZER);
+
+    for (var i = 0; i < 10; i++) {
+      var el = deserialized.getElement(key("key" + i));
+      soft.assertThat(el).describedAs("Element for key%d", i).isNotNull();
+      soft.assertThat(el.valueNullable()).describedAs("Value for key%d", i).isNull();
+    }
+  }
+
   // The following multithreaded "tests" are only there to verify that no ByteBuffer related
   // exceptions are thrown.
 

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/catalog/TestEntityIdSet.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/catalog/TestEntityIdSet.java
@@ -94,4 +94,24 @@ public class TestEntityIdSet {
         EntityIdSet.entityIdSet(
             LongStream.range(MAX_VALUE - 1000, MAX_VALUE).boxed().collect(Collectors.toSet())));
   }
+
+  /**
+   * Verifies that {@code serialize(null, target)} writes the null marker directly into {@code
+   * target} and does not return a different buffer.
+   */
+  @Test
+  void serializeNullWritesToTarget() {
+    var target = ByteBuffer.allocate(64);
+    var returned = ENTITY_ID_SET_SERIALIZER.serialize(null, target);
+
+    // Must return the same target buffer
+    soft.assertThat(returned).isSameAs(target);
+    // Must have advanced the position
+    soft.assertThat(target.position()).isGreaterThan(0);
+
+    // Verify that the bytes written to target actually round-trip via deserialize
+    target.flip();
+    var deserialized = ENTITY_ID_SET_SERIALIZER.deserialize(target);
+    soft.assertThat(deserialized).isNull();
+  }
 }

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/changes/TestChanges.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/changes/TestChanges.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -77,5 +78,18 @@ public class TestChanges {
         ChangeRename.builder().renameFrom(key("foo")).build(),
         ChangeRename.builder().renameFrom(key(42L)).build(),
         ChangeUpdate.builder().build());
+  }
+
+  @Test
+  void serializeNullWritesToTarget() {
+    var target = ByteBuffer.allocate(256);
+    var returned = CHANGE_SERIALIZER.serialize(null, target);
+
+    soft.assertThat(returned).isSameAs(target);
+    soft.assertThat(target.position()).isGreaterThan(0);
+
+    target.flip();
+    var deserialized = CHANGE_SERIALIZER.deserialize(target);
+    soft.assertThat(deserialized).isNull();
   }
 }

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/realm/TestPolicyMapping.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/realm/TestPolicyMapping.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -81,5 +82,18 @@ public class TestPolicyMapping {
                     .boxed()
                     .collect(Collectors.toMap(v -> "k" + v, v -> "v" + v)))
             .build());
+  }
+
+  @Test
+  void serializeNullWritesToTarget() {
+    var target = ByteBuffer.allocate(64);
+    var returned = POLICY_MAPPING_SERIALIZER.serialize(null, target);
+
+    soft.assertThat(returned).isSameAs(target);
+    soft.assertThat(target.position()).isGreaterThan(0);
+
+    target.flip();
+    var deserialized = POLICY_MAPPING_SERIALIZER.deserialize(target);
+    soft.assertThat(deserialized).isEqualTo(PolicyMapping.EMPTY);
   }
 }


### PR DESCRIPTION
This change only adds new tests covering the specific `null`-value scenario in combination with an actual index, and vice versa.
