### PR TITLE
Verify-release: check LICENSE/NOTICE in both root and META-INF of jars

### DIFF
--- a/tools/verify-release/verify-release.sh
+++ b/tools/verify-release/verify-release.sh
@@ -537,13 +537,16 @@ if [[ $reproducible_builds -eq 1 ]]; then
   done < "${temp_dir}/maven-local-files"
 fi
 # verify that the "main" and sources jars contain LICENSE + NOTICE files
-# (Spark JARs are excluded as they do not contain META-INF/LICENSE and META-INF/NOTICE)
 echo "Checking for mandatory jar file content..."
 while read -r fn ; do
-  [[ $(zipinfo -1 "${maven_repo_dir}/${fn}" | grep --extended-regexp --count "^META-INF/(LICENSE|NOTICE)$") -ne 2 ]] && \
-    log_fatal "${fn}: Mandatory LICENSE/NOTICE files not in META-INF/"
-done < <(grep --extended-regexp ".*-$version(-sources)?[.]jar$" < "${temp_dir}/maven-local-files" \
-  | grep -v -- "polaris-spark")
+  jar_entries=$(zipinfo -1 "${maven_repo_dir}/${fn}")
+  has_license=0
+  has_notice=0
+  echo "${jar_entries}" | grep --extended-regexp --quiet "^(META-INF/)?LICENSE$" && has_license=1
+  echo "${jar_entries}" | grep --extended-regexp --quiet "^(META-INF/)?NOTICE$" && has_notice=1
+  [[ ${has_license} -eq 0 ]] && log_fatal "${fn}: Mandatory LICENSE file not found in root or META-INF/"
+  [[ ${has_notice} -eq 0 ]] && log_fatal "${fn}: Mandatory NOTICE file not found in root or META-INF/"
+done < <(grep --extended-regexp ".*-$version(-sources)?[.]jar$" < "${temp_dir}/maven-local-files")
 log_part_end
 
 log_part_start "Checking main distribution artifact content"


### PR DESCRIPTION
As discussed on dev@, the verify-release.s script should check that LICENSE/NOTICE exist in either root or META-INF.