### PR TITLE
Clean SVN directories before adding artifacts

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -185,6 +185,13 @@ jobs:
           exec_process_with_retries 5 60 "${dist_dev_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"
 
           version_dir="${dist_dev_dir}/${version_without_rc}"
+
+          # If the version directory already exists in SVN (e.g. re-running the workflow),
+          # delete it so we can re-add fresh artifacts without "already versioned" errors.
+          if svn info "${version_dir}" &>/dev/null 2>&1; then
+            exec_process svn delete "${version_dir}"
+          fi
+
           exec_process mkdir -p "${version_dir}"
           exec_process cp build/distributions/* "${version_dir}/"
           exec_process cp runtime/distribution/build/distributions/* "${version_dir}/"
@@ -392,8 +399,16 @@ jobs:
           # Retry logic for SVN checkout (Apache SVN can have transient connectivity issues)
           exec_process_with_retries 5 60 "${dist_dev_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"
 
-          exec_process mkdir -p "${dist_dev_dir}/helm-chart/${version_without_rc}"
-          exec_process cp helm/polaris-${version_without_rc}.tgz* "${dist_dev_dir}/helm-chart/${version_without_rc}/"
+          helm_version_dir="${dist_dev_dir}/helm-chart/${version_without_rc}"
+
+          # If the helm version directory already exists in SVN (e.g. re-running the workflow),
+          # delete it so we can re-add fresh artifacts without "already versioned" errors.
+          if svn info "${helm_version_dir}" &>/dev/null 2>&1; then
+            exec_process svn delete "${helm_version_dir}"
+          fi
+
+          exec_process mkdir -p "${helm_version_dir}"
+          exec_process cp helm/polaris-${version_without_rc}.tgz* "${helm_version_dir}/"
 
           exec_process cd "${dist_dev_dir}"
           exec_process svn add --parents "helm-chart/${version_without_rc}"


### PR DESCRIPTION
When attempting to create a new RC, the existing artifacts within the SVN repo clash when trying to commit the new files. We should always clean first before attempting to push new artifacts to the same release branch.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
