### PR TITLE
Add BSD-2-Clause to license allow list

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -94,7 +94,7 @@ default-groups = [
 
 [tool.pip-licenses]
 partial-match = true
-allow-only = "Apache;BSD License;BSD-3-Clause;ISC;MIT;Mozilla Public License;PSF-2.0;Python Software Foundation License;The Unlicense"
+allow-only = "Apache;BSD License;BSD-2-Clause;BSD-3-Clause;ISC;MIT;Mozilla Public License;PSF-2.0;Python Software Foundation License;The Unlicense"
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
To fix CI failure in https://github.com/apache/polaris/pull/4084. Per this page, https://www.apache.org/legal/resolved.html#category-a, BSD-2-Clause is allowed in an ASF Project.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
