### PR TITLE
Move CallContextCatalogFactory to core module and rename

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/catalog/LocalCatalogFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/catalog/LocalCatalogFactory.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.context.catalog;
+package org.apache.polaris.core.catalog;
 
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 
-public interface CallContextCatalogFactory {
+public interface LocalCatalogFactory {
 
-  Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest);
+  Catalog createCatalog(PolarisResolutionManifest resolvedManifest);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -90,6 +90,7 @@ import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.catalog.FederatedCatalogFactory;
+import org.apache.polaris.core.catalog.LocalCatalogFactory;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
 import org.apache.polaris.core.connection.ConnectionType;
@@ -122,7 +123,6 @@ import org.apache.polaris.service.catalog.common.CatalogHandler;
 import org.apache.polaris.service.catalog.common.CatalogUtils;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.config.ReservedProperties;
-import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
 import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.events.EventAttributes;
 import org.apache.polaris.service.http.IcebergHttpUtil;
@@ -193,7 +193,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
   protected abstract ResolverFactory resolverFactory();
 
-  protected abstract CallContextCatalogFactory catalogFactory();
+  protected abstract LocalCatalogFactory localCatalogFactory();
 
   protected abstract ReservedProperties reservedProperties();
 
@@ -288,7 +288,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       this.baseCatalog = federatedCatalog;
     } else {
       LOGGER.debug("Initializing non-federated catalog");
-      this.baseCatalog = catalogFactory().createCallContextCatalog(resolutionManifest);
+      this.baseCatalog = localCatalogFactory().createCatalog(resolutionManifest);
     }
     this.namespaceCatalog =
         (baseCatalog instanceof SupportsNamespaces) ? (SupportsNamespaces) baseCatalog : null;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFactory.java
@@ -27,6 +27,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.FederatedCatalogFactory;
+import org.apache.polaris.core.catalog.LocalCatalogFactory;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.credentials.PolarisCredentialManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -35,7 +36,6 @@ import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.config.ReservedProperties;
-import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
 import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.reporting.PolarisMetricsReporter;
 
@@ -49,7 +49,7 @@ public class IcebergCatalogHandlerFactory {
   @Inject ResolutionManifestFactory resolutionManifestFactory;
   @Inject PolarisMetaStoreManager metaStoreManager;
   @Inject PolarisCredentialManager credentialManager;
-  @Inject CallContextCatalogFactory catalogFactory;
+  @Inject LocalCatalogFactory localCatalogFactory;
   @Inject PolarisAuthorizer authorizer;
   @Inject ReservedProperties reservedProperties;
   @Inject CatalogHandlerUtils catalogHandlerUtils;
@@ -70,7 +70,7 @@ public class IcebergCatalogHandlerFactory {
         .resolutionManifestFactory(resolutionManifestFactory)
         .metaStoreManager(metaStoreManager)
         .credentialManager(credentialManager)
-        .catalogFactory(catalogFactory)
+        .localCatalogFactory(localCatalogFactory)
         .authorizer(authorizer)
         .reservedProperties(reservedProperties)
         .catalogHandlerUtils(catalogHandlerUtils)

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.catalog.LocalCatalogFactory;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -41,9 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @RequestScoped
-public class PolarisCallContextCatalogFactory implements CallContextCatalogFactory {
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(PolarisCallContextCatalogFactory.class);
+public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PolarisLocalCatalogFactory.class);
 
   private final PolarisDiagnostics diagnostics;
   private final TaskExecutor taskExecutor;
@@ -57,7 +57,7 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
   private final PolarisPrincipal principal;
 
   @Inject
-  public PolarisCallContextCatalogFactory(
+  public PolarisLocalCatalogFactory(
       PolarisDiagnostics diagnostics,
       ResolverFactory resolverFactory,
       TaskExecutor taskExecutor,
@@ -81,7 +81,7 @@ public class PolarisCallContextCatalogFactory implements CallContextCatalogFacto
   }
 
   @Override
-  public Catalog createCallContextCatalog(final PolarisResolutionManifest resolvedManifest) {
+  public Catalog createCatalog(final PolarisResolutionManifest resolvedManifest) {
     CatalogEntity catalog = resolvedManifest.getResolvedCatalogEntity();
     String catalogName = catalog.getName();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -82,7 +82,7 @@ import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.catalog.policy.PolicyCatalog;
 import org.apache.polaris.service.config.ReservedProperties;
-import org.apache.polaris.service.context.catalog.PolarisCallContextCatalogFactory;
+import org.apache.polaris.service.context.catalog.PolarisLocalCatalogFactory;
 import org.apache.polaris.service.context.catalog.RealmContextHolder;
 import org.apache.polaris.service.events.PolarisEventDispatcher;
 import org.apache.polaris.service.events.PolarisEventMetadataFactory;
@@ -104,7 +104,7 @@ public abstract class PolarisAuthzTestBase {
 
     @Override
     public Set<Class<?>> getEnabledAlternatives() {
-      return Set.of(TestPolarisCallContextCatalogFactory.class);
+      return Set.of(TestPolarisLocalCatalogFactory.class);
     }
 
     @Override
@@ -500,16 +500,15 @@ public abstract class PolarisAuthzTestBase {
 
   @Alternative
   @RequestScoped
-  public static class TestPolarisCallContextCatalogFactory
-      extends PolarisCallContextCatalogFactory {
+  public static class TestPolarisLocalCatalogFactory extends PolarisLocalCatalogFactory {
 
     @SuppressWarnings("unused") // Required by CDI
-    protected TestPolarisCallContextCatalogFactory() {
+    protected TestPolarisLocalCatalogFactory() {
       this(null, null, null, null, null, null, null, null, null, null);
     }
 
     @Inject
-    public TestPolarisCallContextCatalogFactory(
+    public TestPolarisLocalCatalogFactory(
         PolarisDiagnostics diagnostics,
         ResolverFactory resolverFactory,
         TaskExecutor taskExecutor,
@@ -534,10 +533,10 @@ public abstract class PolarisAuthzTestBase {
     }
 
     @Override
-    public Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest) {
+    public Catalog createCatalog(PolarisResolutionManifest resolvedManifest) {
       // This depends on the BasePolarisCatalog allowing calling initialize multiple times
       // to override the previous config.
-      Catalog catalog = super.createCallContextCatalog(resolvedManifest);
+      Catalog catalog = super.createCatalog(resolvedManifest);
       catalog.initialize(
           CATALOG_NAME,
           ImmutableMap.of(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -64,6 +64,7 @@ import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.catalog.LocalCatalogFactory;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.PolarisConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
@@ -75,8 +76,7 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.service.admin.PolarisAuthzTestBase;
-import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
-import org.apache.polaris.service.context.catalog.PolarisCallContextCatalogFactory;
+import org.apache.polaris.service.context.catalog.PolarisLocalCatalogFactory;
 import org.apache.polaris.service.http.IfNoneMatch;
 import org.apache.polaris.service.types.NotificationRequest;
 import org.apache.polaris.service.types.NotificationType;
@@ -103,7 +103,7 @@ import org.mockito.Mockito;
 @SuppressWarnings("resource")
 public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
 
-  @Inject CallContextCatalogFactory callContextCatalogFactory;
+  @Inject LocalCatalogFactory localCatalogFactory;
   @Inject IcebergCatalogHandlerFactory icebergCatalogHandlerFactory;
 
   protected IcebergCatalogHandler newHandler() {
@@ -111,19 +111,22 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
   }
 
   private IcebergCatalogHandler newHandler(Set<String> activatedPrincipalRoles) {
-    return newHandler(activatedPrincipalRoles, CATALOG_NAME, callContextCatalogFactory);
+    return newHandler(activatedPrincipalRoles, CATALOG_NAME, localCatalogFactory);
   }
 
   private IcebergCatalogHandler newHandler(
-      Set<String> activatedPrincipalRoles, String catalogName, CallContextCatalogFactory factory) {
+      Set<String> activatedPrincipalRoles, String catalogName, LocalCatalogFactory factory) {
     PolarisPrincipal authenticatedPrincipal =
         PolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
     IcebergCatalogHandler handler =
         icebergCatalogHandlerFactory.createHandler(catalogName, authenticatedPrincipal);
-    if (factory == callContextCatalogFactory) {
+    if (factory == localCatalogFactory) {
       return handler;
     }
-    return ImmutableIcebergCatalogHandler.builder().from(handler).catalogFactory(factory).build();
+    return ImmutableIcebergCatalogHandler.builder()
+        .from(handler)
+        .localCatalogFactory(factory)
+        .build();
   }
 
   @TestFactory
@@ -1168,7 +1171,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         "file:///tmp/send_notification_sufficient_privileges_" + System.nanoTime();
 
     createExternalCatalog(externalCatalog, storageLocation);
-    PolarisCallContextCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
+    PolarisLocalCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
 
     Namespace namespace = Namespace.of("extns1", "extns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
@@ -1231,7 +1234,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         "file:///tmp/send_notification_sufficient_privileges_" + System.nanoTime();
 
     createExternalCatalog(externalCatalog, storageLocation);
-    PolarisCallContextCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
+    PolarisLocalCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
 
     Namespace namespace = Namespace.of("extns1", "extns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
@@ -1280,7 +1283,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         "file:///tmp/send_notification_sufficient_privileges_" + System.nanoTime();
 
     createExternalCatalog(externalCatalog, storageLocation);
-    PolarisCallContextCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
+    PolarisLocalCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
 
     Namespace namespace = Namespace.of("extns1", "extns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
@@ -1329,7 +1332,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         "file:///tmp/send_notification_sufficient_privileges_" + System.nanoTime();
 
     createExternalCatalog(externalCatalog, storageLocation);
-    PolarisCallContextCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
+    PolarisLocalCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
 
     Namespace namespace = Namespace.of("extns1", "extns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
@@ -1381,7 +1384,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         "file:///tmp/send_notification_sufficient_privileges_" + System.nanoTime();
 
     createExternalCatalog(externalCatalog, storageLocation);
-    PolarisCallContextCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
+    PolarisLocalCatalogFactory factory = createExternalCatalogFactory(externalCatalog);
 
     Namespace namespace = Namespace.of("extns1", "extns2");
     TableIdentifier table = TableIdentifier.of(namespace, "tbl1");
@@ -1450,8 +1453,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
             externalCatalog, CATALOG_ROLE2, PolarisPrivilege.CATALOG_MANAGE_CONTENT));
   }
 
-  private PolarisCallContextCatalogFactory createExternalCatalogFactory(String externalCatalog) {
-    return new PolarisCallContextCatalogFactory(
+  private PolarisLocalCatalogFactory createExternalCatalogFactory(String externalCatalog) {
+    return new PolarisLocalCatalogFactory(
         diagServices,
         resolverFactory,
         Mockito.mock(),
@@ -1463,8 +1466,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         callContext,
         authenticatedRoot) {
       @Override
-      public Catalog createCallContextCatalog(PolarisResolutionManifest resolvedManifest) {
-        Catalog catalog = super.createCallContextCatalog(resolvedManifest);
+      public Catalog createCatalog(PolarisResolutionManifest resolvedManifest) {
+        Catalog catalog = super.createCatalog(resolvedManifest);
         String fileIoImpl = "org.apache.iceberg.inmemory.InMemoryFileIO";
         catalog.initialize(
             externalCatalog, ImmutableMap.of(CatalogProperties.FILE_IO_IMPL, fileIoImpl));

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -39,6 +39,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.FederatedCatalogFactory;
+import org.apache.polaris.core.catalog.LocalCatalogFactory;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.config.RealmConfigurationSource;
 import org.apache.polaris.core.context.CallContext;
@@ -80,8 +81,7 @@ import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.config.ReservedProperties;
-import org.apache.polaris.service.context.catalog.CallContextCatalogFactory;
-import org.apache.polaris.service.context.catalog.PolarisCallContextCatalogFactory;
+import org.apache.polaris.service.context.catalog.PolarisLocalCatalogFactory;
 import org.apache.polaris.service.credentials.DefaultPolarisCredentialManager;
 import org.apache.polaris.service.credentials.connection.SigV4ConnectionCredentialVendor;
 import org.apache.polaris.service.events.EventAttributeMap;
@@ -299,8 +299,8 @@ public record TestServices(
       TaskExecutor taskExecutor = Mockito.mock(TaskExecutor.class);
 
       PolarisEventDispatcher polarisEventDispatcher = new InMemoryEventCollector();
-      CallContextCatalogFactory callContextFactory =
-          new PolarisCallContextCatalogFactory(
+      LocalCatalogFactory localCatalogFactory =
+          new PolarisLocalCatalogFactory(
               diagnostics,
               resolverFactory,
               taskExecutor,
@@ -338,7 +338,7 @@ public record TestServices(
                   .resolutionManifestFactory(resolutionManifestFactory)
                   .metaStoreManager(metaStoreManager)
                   .credentialManager(credentialManager)
-                  .catalogFactory(callContextFactory)
+                  .localCatalogFactory(localCatalogFactory)
                   .authorizer(authorizer)
                   .reservedProperties(reservedProperties)
                   .catalogHandlerUtils(catalogHandlerUtils)


### PR DESCRIPTION
Polaris currently uses external catalog for two different ideas: the broad concept of catalogs whose source of truth lives outside Polaris, and the narrower runtime path where Polaris builds a remote catalog client from ConnectionConfigInfo and delegates operations to it. That makes the current SPI name misleading, since notification-synced catalogs are also external in the broad sense but do not use this factory. Likewise, CallContextCatalogFactory describes an implementation detail rather than the role of the abstraction.

This PR makes that split explicit by renaming the remote delegation path to `FederatedCatalogFactory` and the Polaris-managed path to `LocalCatalogFactory`. That gives us clearer terminology: external stays the umbrella concept, federated refers to remote-backed execution, and local refers to the in-process Polaris-backed path. No behavioral change is intended.

This PR also moves the interface into `polaris-core`. Keeping it in core should make future SPI enforcement simpler if we treat interfaces in `polaris-core` as the supported SPI surface.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
