### PR TITLE
PolarisConfigurationStoreTest: minor fixes for error-prone update

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/PolarisConfigurationStoreTest.java
@@ -49,9 +49,9 @@ public class PolarisConfigurationStoreTest {
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
-          /**
+          /*
            * Ad-hoc configuration store implementation that just returns the stringified version of
-           * the config's default value
+           * the config's default value.
            */
           @SuppressWarnings("unchecked")
           @Override
@@ -154,10 +154,10 @@ public class PolarisConfigurationStoreTest {
 
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
+          @SuppressWarnings("unchecked")
           @Override
           public <T> @Nullable T getConfiguration(
               @Nonnull RealmContext realmContext, String configName) {
-            //noinspection unchecked
             return (T) Map.of("key2", "config-value2").get(configName);
           }
         };
@@ -179,10 +179,10 @@ public class PolarisConfigurationStoreTest {
   public void testGetConfiguration() {
     PolarisConfigurationStore store =
         new PolarisConfigurationStore() {
+          @SuppressWarnings("unchecked")
           @Override
           public <T> @Nullable T getConfiguration(
               @Nonnull RealmContext realmContext, String configName) {
-            //noinspection unchecked
             return (T) Map.of("key3", "config-value3").get(configName);
           }
         };


### PR DESCRIPTION
The `// noinspection ...` comment isn't standard and not recognized by error-prone, fixed by using `@SuppressWarnings`.

Error-prone also complains about the Javadoc comment at L52, because it can never make it into a generated javadoc (anonymous inner class), so it's converted to an inline block comment.

This PR unblocks #4131
