### PR TITLE
Docs generator: do not print all enum constants for all enums

### DIFF
--- a/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authentication.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authentication.md
@@ -25,7 +25,7 @@ build:
 
 | Property | Default Value | Type | Description |
 |----------|---------------|------|-------------|
-| `polaris.authentication.type` | `internal` | `INTERNAL, EXTERNAL, MIXED` | The type of authentication to use.  |
+| `polaris.authentication.type` | `internal` | `enum (INTERNAL, EXTERNAL, MIXED)` | The type of authentication to use.  |
 | `polaris.authentication.authenticator.type` | `default` | `string` | The type of the identity provider. Must be a registered (`Authenticator`) identifier.  |
 | `polaris.authentication.token-service.type` | `default` | `string` | The type of the OAuth2 service. Must be a registered (`IcebergRestOAuth2ApiService`) identifier.  |
 | `polaris.authentication.token-broker.max-token-generation` | `PT1H` | `duration` | The maximum token duration.  |
@@ -34,7 +34,7 @@ build:
 | `polaris.authentication.token-broker.rsa-key-pair.private-key-file` |  | `path` | The path to the private key file.  |
 | `polaris.authentication.token-broker.symmetric-key.secret` |  | `string` | The secret to use for both signing and verifying signatures. Either this option of (`#file()`) must be provided.  |
 | `polaris.authentication.token-broker.symmetric-key.file` |  | `path` | The file to read the secret from. Either this option of (`#secret()`) must be provided.  |
-| `polaris.authentication.`_`<realm>`_`.type` | `internal` | `INTERNAL, EXTERNAL, MIXED` | The type of authentication to use.  |
+| `polaris.authentication.`_`<realm>`_`.type` | `internal` | `enum (INTERNAL, EXTERNAL, MIXED)` | The type of authentication to use.  |
 | `polaris.authentication.`_`<realm>`_`.authenticator.type` | `default` | `string` | The type of the identity provider. Must be a registered (`Authenticator`) identifier.  |
 | `polaris.authentication.`_`<realm>`_`.token-service.type` | `default` | `string` | The type of the OAuth2 service. Must be a registered (`IcebergRestOAuth2ApiService`) identifier.  |
 | `polaris.authentication.`_`<realm>`_`.token-broker.max-token-generation` | `PT1H` | `duration` | The maximum token duration.  |

--- a/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authorization_opa.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authorization_opa.md
@@ -30,7 +30,7 @@ Beta Feature: OPA authorization is currently in Beta and is not a stable  releas
 | Property | Default Value | Type | Description |
 |----------|---------------|------|-------------|
 | `polaris.authorization.opa.policy-uri` |  | `uri` |  |
-| `polaris.authorization.opa.auth.type` | `none` | `NONE, BEARER` | Type of authentication  |
+| `polaris.authorization.opa.auth.type` | `none` | `enum (NONE, BEARER)` | Type of authentication  |
 | `polaris.authorization.opa.auth.bearer.static-token.value` |  | `string` | Static bearer token value  |
 | `polaris.authorization.opa.auth.bearer.file-based.path` |  | `path` | Path to file containing bearer token  |
 | `polaris.authorization.opa.auth.bearer.file-based.refresh-interval` |  | `duration` | How often to refresh file-based bearer tokens (defaults to 5 minutes if not specified)  |

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/MarkdownPropertyFormatter.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/MarkdownPropertyFormatter.java
@@ -33,6 +33,14 @@ public class MarkdownPropertyFormatter extends MarkdownFormatter {
   }
 
   public String propertyType() {
+    String tooltip = propertyInfo.enumTooltipText();
+    if (tooltip != null) {
+      return "<span title=\""
+          + tooltip
+          + "\"><code>"
+          + propertyInfo.simplifiedTypeName()
+          + "</code></span>";
+    }
     return '`' + propertyInfo.simplifiedTypeName() + '`';
   }
 }

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/SmallRyeConfigPropertyInfo.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/SmallRyeConfigPropertyInfo.java
@@ -102,6 +102,11 @@ public class SmallRyeConfigPropertyInfo implements PropertyInfo {
     return simplifiedTypeName(property);
   }
 
+  @Override
+  public String enumTooltipText() {
+    return enumTooltipText(property);
+  }
+
   public boolean isSettableType() {
     return isSettableType(property);
   }
@@ -172,10 +177,14 @@ public class SmallRyeConfigPropertyInfo implements PropertyInfo {
       var leaf = property.asLeaf();
       var rawType = leaf.getValueRawType();
       if (rawType.isEnum()) {
-        return Arrays.stream(rawType.getEnumConstants())
-            .map(Enum.class::cast)
-            .map(Enum::name)
-            .collect(Collectors.joining(", "));
+        Object[] constants = rawType.getEnumConstants();
+        String firstThree =
+            Arrays.stream(constants)
+                .limit(3)
+                .map(Enum.class::cast)
+                .map(Enum::name)
+                .collect(Collectors.joining(", "));
+        return "enum (" + firstThree + (constants.length > 3 ? ", ..." : "") + ")";
       }
       if (property.hasConvertWith()) {
         // A smallrye-config converter always takes a string.
@@ -237,6 +246,31 @@ public class SmallRyeConfigPropertyInfo implements PropertyInfo {
       return "";
     }
     throw new UnsupportedOperationException("Don't know how to handle " + property);
+  }
+
+  public static String enumTooltipText(Property property) {
+    if (property.isOptional()) {
+      return enumTooltipText(property.asOptional().getNestedProperty());
+    }
+    if (property.isCollection()) {
+      return enumTooltipText(property.asCollection().getElement());
+    }
+    if (property.isMap()) {
+      return enumTooltipText(property.asMap().getValueProperty());
+    }
+    if (property.isLeaf()) {
+      var rawType = property.asLeaf().getValueRawType();
+      if (rawType.isEnum()) {
+        Object[] constants = rawType.getEnumConstants();
+        if (constants.length > 3) {
+          return Arrays.stream(constants)
+              .map(Enum.class::cast)
+              .map(Enum::name)
+              .collect(Collectors.joining(", "));
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
+++ b/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
@@ -143,10 +143,13 @@ public class TestDocGenTool {
                     | `my.types.float-prim` |  | `float` |  |
                     | `my.types.bool-boxed` |  | `boolean` |  |
                     | `my.types.bool-prim` |  | `boolean` |  |
-                    | `my.types.enum-thing` |  | `ONE, TWO, THREE` |  |
-                    | `my.types.optional-enum` |  | `ONE, TWO, THREE` |  |
-                    | `my.types.list-of-enum` |  | `list of ONE, TWO, THREE` |  |
-                    | `my.types.map-to-enum.`_`<name>`_ |  | `ONE, TWO, THREE` |  |
+                    | `my.types.enum-thing` |  | `enum (ONE, TWO, THREE)` |  |
+                    | `my.types.optional-enum` |  | `enum (ONE, TWO, THREE)` |  |
+                    | `my.types.list-of-enum` |  | `list of enum (ONE, TWO, THREE)` |  |
+                    | `my.types.map-to-enum.`_`<name>`_ |  | `enum (ONE, TWO, THREE)` |  |
+                    | `my.types.large-enum` |  | <span title="ONE, TWO, THREE, FOUR"><code>enum (ONE, TWO, THREE, ...)</code></span> |  |
+                    | `my.types.optional-large-enum` |  | <span title="ONE, TWO, THREE, FOUR"><code>enum (ONE, TWO, THREE, ...)</code></span> |  |
+                    | `my.types.list-of-large-enum` |  | <span title="ONE, TWO, THREE, FOUR"><code>list of enum (ONE, TWO, THREE, ...)</code></span> |  |
                     | `my.types.optional-bool` |  | `boolean` |  |
                     | `my.types.mapped-a.some-weird-name` | `some-default` | `string` | Something that configures something.  |
                     | `my.types.mapped-a.some-duration` |  | `duration` | A duration of something.  |

--- a/tools/config-docs/generator/src/test/java/tests/smallrye/AllTypes.java
+++ b/tools/config-docs/generator/src/test/java/tests/smallrye/AllTypes.java
@@ -97,6 +97,12 @@ public interface AllTypes extends InterfaceOne {
 
   Map<String, SomeEnum> mapToEnum();
 
+  LargeEnum largeEnum();
+
+  Optional<LargeEnum> optionalLargeEnum();
+
+  List<LargeEnum> listOfLargeEnum();
+
   Optional<Boolean> optionalBool();
 
   /** My {@code MappedA}. */

--- a/tools/config-docs/generator/src/test/java/tests/smallrye/LargeEnum.java
+++ b/tools/config-docs/generator/src/test/java/tests/smallrye/LargeEnum.java
@@ -13,28 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.polaris.docs.generator;
+package tests.smallrye;
 
-import com.sun.source.doctree.DocCommentTree;
-import java.util.Optional;
-import javax.lang.model.element.Element;
-
-public interface PropertyInfo {
-  Element propertyElement();
-
-  String propertyName();
-
-  String propertySuffix();
-
-  String simplifiedTypeName();
-
-  String defaultValue();
-
-  DocCommentTree doc();
-
-  Optional<Class<?>> groupType();
-
-  default String enumTooltipText() {
-    return null;
-  }
+public enum LargeEnum {
+  ONE,
+  TWO,
+  THREE,
+  FOUR
 }


### PR DESCRIPTION
For enums with more than 3 constants, we are now printing just the first 3, in order to avoid messing up the HTML table rendering. The full list of names is still viewable through an HTML tooltip.

The format also now includes the token `enum` before the list of enum names, for clarity.

This PR will make HTML rendering hopefully much better when #4064 is merged (it will bring a new field of type `PolarisEventType` with 150+ enum constants).

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
