### PR TITLE
fix(iceberg): preserve table-default properties for staged creates

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1319,6 +1319,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
     public PolarisIcebergCatalogTableBuilder(TableIdentifier identifier, Schema schema) {
       super(identifier, schema);
+      withProperties(
+          PropertyUtil.propertiesWithPrefix(IcebergCatalog.this.properties(), "table-default."));
       this.identifier = identifier;
     }
 
@@ -1531,12 +1533,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               : resolvedTableEntities;
 
       // refresh credentials because we need to read the metadata file to validate its location
+      Map<String, String> commitFileIoProperties = new HashMap<>(tableDefaultProperties);
+      commitFileIoProperties.putAll(metadata.properties());
       tableFileIO =
           loadFileIOForTableLike(
               tableIdentifier,
               StorageUtil.getLocationsUsedByTable(metadata),
               resolvedStorageEntity,
-              new HashMap<>(metadata.properties()),
+              commitFileIoProperties,
               Set.of(
                   PolarisStorageActions.READ,
                   PolarisStorageActions.WRITE,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1319,6 +1319,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
     public PolarisIcebergCatalogTableBuilder(TableIdentifier identifier, Schema schema) {
       super(identifier, schema);
+      withProperties(new HashMap<>(tableDefaultProperties));
       this.identifier = identifier;
     }
 
@@ -1535,12 +1536,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               : resolvedTableEntities;
 
       // refresh credentials because we need to read the metadata file to validate its location
+      Map<String, String> commitFileIoProperties = new HashMap<>(tableDefaultProperties);
+      commitFileIoProperties.putAll(metadata.properties());
       tableFileIO =
           loadFileIOForTableLike(
               tableIdentifier,
               StorageUtil.getLocationsUsedByTable(metadata),
               resolvedStorageEntity,
-              new HashMap<>(metadata.properties()),
+              commitFileIoProperties,
               Set.of(
                   PolarisStorageActions.READ,
                   PolarisStorageActions.WRITE,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -1536,14 +1536,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
               : resolvedTableEntities;
 
       // refresh credentials because we need to read the metadata file to validate its location
-      Map<String, String> commitFileIoProperties = new HashMap<>(tableDefaultProperties);
-      commitFileIoProperties.putAll(metadata.properties());
       tableFileIO =
           loadFileIOForTableLike(
               tableIdentifier,
               StorageUtil.getLocationsUsedByTable(metadata),
               resolvedStorageEntity,
-              commitFileIoProperties,
+              new HashMap<>(metadata.properties()),
               Set.of(
                   PolarisStorageActions.READ,
                   PolarisStorageActions.WRITE,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SnapshotRef;
@@ -89,6 +90,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.catalog.FederatedCatalogFactory;
@@ -517,6 +519,11 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     Map<String, String> properties = Maps.newHashMap();
     properties.put("created-at", OffsetDateTime.now(ZoneOffset.UTC).toString());
+    if (baseCatalog instanceof IcebergCatalog polarisCatalog) {
+      properties.putAll(
+          PropertyUtil.propertiesWithPrefix(
+              polarisCatalog.properties(), CatalogProperties.TABLE_DEFAULT_PREFIX));
+    }
     properties.putAll(reservedProperties().removeReservedProperties(request.properties()));
 
     String location;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SnapshotRef;
@@ -89,6 +91,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.catalog.FederatedCatalogFactory;
@@ -475,6 +478,11 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     Map<String, String> properties = Maps.newHashMap();
     properties.put("created-at", OffsetDateTime.now(ZoneOffset.UTC).toString());
+    if (baseCatalog instanceof IcebergCatalog polarisCatalog) {
+      properties.putAll(
+          PropertyUtil.propertiesWithPrefix(
+              polarisCatalog.properties(), CatalogProperties.TABLE_DEFAULT_PREFIX));
+    }
     properties.putAll(reservedProperties().removeReservedProperties(request.properties()));
 
     Table table =
@@ -535,7 +543,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
               .buildTable(ident, request.schema())
               .withPartitionSpec(request.spec())
               .withSortOrder(request.writeOrder())
-              .withProperties(properties)
+              .withProperties(new HashMap<>(properties))
               .createTransaction()
               .table()
               .location();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
@@ -499,6 +500,45 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_CONTENT)
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_METADATA)
         .createTests();
+  }
+
+  @Test
+  void testCreateTableStagedIncludesTableDefaultProperties() throws Exception {
+    CreateTableRequest createStagedRequest =
+        CreateTableRequest.builder()
+            .withName("staged-defaults")
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    LocalCatalogFactory defaultPropertiesFactory =
+        resolvedManifest -> {
+          Catalog catalog = localCatalogFactory.createCatalog(resolvedManifest);
+          catalog.initialize(
+              CATALOG_NAME,
+              ImmutableMap.of(
+                  CatalogProperties.FILE_IO_IMPL,
+                  "org.apache.iceberg.inmemory.InMemoryFileIO",
+                  CatalogProperties.TABLE_DEFAULT_PREFIX + "default-key1",
+                  "catalog-default-key1",
+                  CatalogProperties.TABLE_DEFAULT_PREFIX + "default-key2",
+                  "catalog-default-key2"));
+          return catalog;
+        };
+
+    IcebergCatalogHandler rootHandler =
+        icebergCatalogHandlerFactory.createHandler(CATALOG_NAME, authenticatedRoot);
+    try (IcebergCatalogHandler handler =
+        ImmutableIcebergCatalogHandler.builder()
+            .from(rootHandler)
+            .localCatalogFactory(defaultPropertiesFactory)
+            .build()) {
+      LoadTableResponse response = handler.createTableStaged(NS2, createStagedRequest);
+
+      Assertions.assertThat(response.tableMetadata().properties())
+          .containsEntry("default-key1", "catalog-default-key1")
+          .containsEntry("default-key2", "catalog-default-key2");
+    }
   }
 
   @TestFactory

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -417,6 +418,19 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
         fileIOFactory,
         polarisEventDispatcher,
         eventMetadataFactory);
+  }
+
+  private IcebergCatalog newConfiguredIcebergCatalog(
+      String catalogName, FileIOFactory fileIOFactory, Map<String, String> additionalProperties) {
+    IcebergCatalog icebergCatalog = newIcebergCatalog(catalogName, metaStoreManager, fileIOFactory);
+    icebergCatalog.setCatalogFileIo(new InMemoryFileIO());
+    ImmutableMap.Builder<String, String> propertiesBuilder =
+        ImmutableMap.<String, String>builder()
+            .put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO")
+            .putAll(TABLE_PREFIXES)
+            .putAll(additionalProperties);
+    icebergCatalog.initialize(catalogName, propertiesBuilder.buildKeepingLast());
+    return icebergCatalog;
   }
 
   @Test
@@ -982,6 +996,91 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
     Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Fake failure applying downscoped credentials");
+  }
+
+  @Test
+  public void testDirectCreatePassesTableDefaultPropertiesToFileIO() {
+    Namespace namespace = Namespace.of("fileio-defaults-create");
+    TableIdentifier table = TableIdentifier.of(namespace, "table");
+    AtomicReference<Map<String, String>> capturedProperties = new AtomicReference<>();
+    FileIOFactory capturingFileIOFactory = spy(this.fileIOFactory);
+    doAnswer(
+            invocation -> {
+              capturedProperties.set(Map.copyOf(invocation.getArgument(2)));
+              return invocation.callRealMethod();
+            })
+        .when(capturingFileIOFactory)
+        .loadFileIO(any(), any(), any());
+
+    IcebergCatalog catalog =
+        newConfiguredIcebergCatalog(
+            CATALOG_NAME,
+            capturingFileIOFactory,
+            Map.of(
+                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.endpoint",
+                "http://minio.local",
+                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.path-style-access",
+                "true"));
+
+    try {
+      catalog.createNamespace(namespace);
+      catalog.buildTable(table, SCHEMA).create();
+
+      assertThat(capturedProperties.get())
+          .containsEntry("s3.endpoint", "http://minio.local")
+          .containsEntry("s3.path-style-access", "true");
+    } finally {
+      if (catalog.tableExists(table)) {
+        catalog.dropTable(table, true);
+      }
+    }
+  }
+
+  @Test
+  public void testSparseCreateCommitPassesTableDefaultPropertiesToFileIO() {
+    Namespace namespace = Namespace.of("fileio-defaults-commit");
+    TableIdentifier table = TableIdentifier.of(namespace, "table");
+    AtomicReference<Map<String, String>> capturedProperties = new AtomicReference<>();
+    FileIOFactory capturingFileIOFactory = spy(this.fileIOFactory);
+    doAnswer(
+            invocation -> {
+              capturedProperties.set(Map.copyOf(invocation.getArgument(2)));
+              return invocation.callRealMethod();
+            })
+        .when(capturingFileIOFactory)
+        .loadFileIO(any(), any(), any());
+
+    IcebergCatalog catalog =
+        newConfiguredIcebergCatalog(
+            CATALOG_NAME,
+            capturingFileIOFactory,
+            Map.of(
+                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.endpoint",
+                "http://minio.local",
+                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.path-style-access",
+                "true"));
+
+    try {
+      catalog.createNamespace(namespace);
+
+      TableMetadata metadata =
+          TableMetadata.newTableMetadata(
+              SCHEMA,
+              PartitionSpec.unpartitioned(),
+              SortOrder.unsorted(),
+              catalog.transformTableLikeLocation(table, baseTableLocation(table)),
+              Map.of("created-at", "now"));
+
+      catalog.newTableOps(table, false).commit(null, metadata);
+
+      assertThat(capturedProperties.get())
+          .containsEntry("s3.endpoint", "http://minio.local")
+          .containsEntry("s3.path-style-access", "true");
+    } finally {
+      if (catalog.tableExists(table)) {
+        catalog.dropTable(table, true);
+      }
+    }
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -1037,53 +1037,6 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
   }
 
   @Test
-  public void testSparseCreateCommitPassesTableDefaultPropertiesToFileIO() {
-    Namespace namespace = Namespace.of("fileio-defaults-commit");
-    TableIdentifier table = TableIdentifier.of(namespace, "table");
-    AtomicReference<Map<String, String>> capturedProperties = new AtomicReference<>();
-    FileIOFactory capturingFileIOFactory = spy(this.fileIOFactory);
-    doAnswer(
-            invocation -> {
-              capturedProperties.set(Map.copyOf(invocation.getArgument(2)));
-              return invocation.callRealMethod();
-            })
-        .when(capturingFileIOFactory)
-        .loadFileIO(any(), any(), any());
-
-    IcebergCatalog catalog =
-        newConfiguredIcebergCatalog(
-            CATALOG_NAME,
-            capturingFileIOFactory,
-            Map.of(
-                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.endpoint",
-                "http://minio.local",
-                CatalogProperties.TABLE_DEFAULT_PREFIX + "s3.path-style-access",
-                "true"));
-
-    try {
-      catalog.createNamespace(namespace);
-
-      TableMetadata metadata =
-          TableMetadata.newTableMetadata(
-              SCHEMA,
-              PartitionSpec.unpartitioned(),
-              SortOrder.unsorted(),
-              catalog.transformTableLikeLocation(table, baseTableLocation(table)),
-              Map.of("created-at", "now"));
-
-      catalog.newTableOps(table, false).commit(null, metadata);
-
-      assertThat(capturedProperties.get())
-          .containsEntry("s3.endpoint", "http://minio.local")
-          .containsEntry("s3.path-style-access", "true");
-    } finally {
-      if (catalog.tableExists(table)) {
-        catalog.dropTable(table, true);
-      }
-    }
-  }
-
-  @Test
   public void testUpdateNotificationWhenTableAndNamespacesDontExist() {
     Assumptions.assumeTrue(
         requiresNamespaceCreate(),


### PR DESCRIPTION
Ensure catalog-level `table-default.*` properties survive all table creation paths. The table builder now inherits them during direct creates, staged metadata construction adds them before returning table metadata to the client, and sparse staged commits use them as the baseline when FileIO is reinitialized during commit.

The accompanying tests cover staged create metadata plus FileIO initialization in both relational and NoSQL catalog variants.

## Testing
- `export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 && ./gradlew format`
- `export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 && ./gradlew :polaris-runtime-service:test --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogRelationalTest.testDirectCreatePassesTableDefaultPropertiesToFileIO' --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogRelationalTest.testSparseCreateCommitPassesTableDefaultPropertiesToFileIO' --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogNoSqlInMemTest.testDirectCreatePassesTableDefaultPropertiesToFileIO' --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogNoSqlInMemTest.testSparseCreateCommitPassesTableDefaultPropertiesToFileIO' --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandlerAuthzTest.testCreateTableStagedIncludesTableDefaultProperties' --tests 'org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandlerNoSqlAuthzTest.testCreateTableStagedIncludesTableDefaultProperties'`\n\n## Checklist\n- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)\n- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4062\n- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)\n- [ ] 💡 Added comments for complex logic\n- [ ] 🧾 Updated `CHANGELOG.md` (if needed)\n- [ ] 📚 Updated `site/content/in-dev/unreleased` documentation (if needed)