### PR TITLE
fix: pass signing region to STS client

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
@@ -146,7 +146,8 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
     // Get STS client from the provider (potentially pooled)
     // The Polaris service identity credentials are set on the AssumeRole request via
     // overrideConfiguration, not on the STS client itself
-    // TODO: Configure proper StsDestination with region/endpoint from sigv4Params
-    return stsClientProvider.stsClient(StsClientProvider.StsDestination.of(null, null));
+    // TODO: Configure proper StsDestination with endpoint from sigv4Params
+    return stsClientProvider.stsClient(
+        StsClientProvider.StsDestination.of(null, sigv4Params.getSigningRegion()));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.polaris.core.connection.SigV4AuthenticationParametersDpo;
 import org.apache.polaris.core.connection.iceberg.IcebergRestConnectionConfigInfoDpo;
 import org.apache.polaris.core.credentials.connection.CatalogAccessProperty;
@@ -34,6 +35,7 @@ import org.apache.polaris.core.identity.dpo.AwsIamServiceIdentityInfoDpo;
 import org.apache.polaris.core.identity.dpo.ServiceIdentityInfoDpo;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.secrets.SecretReference;
+import org.apache.polaris.core.storage.aws.StsClientProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,11 +54,13 @@ public class SigV4ConnectionCredentialVendorTest {
   private SigV4ConnectionCredentialVendor vendor;
   private StsClient mockStsClient;
   private ServiceIdentityProvider mockServiceIdentityProvider;
+  private AtomicReference<StsClientProvider.StsDestination> capturedDestination;
 
   @BeforeEach
   void setup() {
     mockStsClient = mock(StsClient.class);
     mockServiceIdentityProvider = Mockito.mock(ServiceIdentityProvider.class);
+    capturedDestination = new AtomicReference<>();
 
     // Mock STS AssumeRole response
     Credentials stsCredentials =
@@ -81,10 +85,14 @@ public class SigV4ConnectionCredentialVendorTest {
     when(mockServiceIdentityProvider.getServiceIdentityCredential(any()))
         .thenReturn(Optional.of(mockCredential));
 
-    // Create vendor with mocked dependencies
+    // Create vendor with lambda that captures the destination
     vendor =
         new SigV4ConnectionCredentialVendor(
-            (destination) -> mockStsClient, mockServiceIdentityProvider);
+            (destination) -> {
+              capturedDestination.set(destination);
+              return mockStsClient;
+            },
+            mockServiceIdentityProvider);
   }
 
   @Test
@@ -170,5 +178,58 @@ public class SigV4ConnectionCredentialVendorTest {
         .isEqualTo("arn:aws:iam::123456789012:role/customer-role");
     Assertions.assertThat(capturedRequest.roleSessionName()).isEqualTo("polaris");
     Assertions.assertThat(capturedRequest.externalId()).isNull();
+  }
+
+  @Test
+  public void testStsDestinationUsesSigningRegion() {
+    ServiceIdentityInfoDpo serviceIdentity =
+        new AwsIamServiceIdentityInfoDpo(
+            new SecretReference("urn:polaris-secret:test:my-realm:AWS_IAM", Map.of()));
+
+    SigV4AuthenticationParametersDpo authParams =
+        new SigV4AuthenticationParametersDpo(
+            "arn:aws:iam::123456789012:role/customer-role",
+            "my-session",
+            "external-id-123",
+            "eu-west-1",
+            "glue");
+
+    IcebergRestConnectionConfigInfoDpo connectionConfig =
+        new IcebergRestConnectionConfigInfoDpo(
+            "https://test-catalog.example.com", authParams, serviceIdentity, "test-catalog");
+
+    vendor.getConnectionCredentials(connectionConfig);
+
+    // Verify the STS client was created with the correct region from sigV4 params
+    Assertions.assertThat(capturedDestination.get().region())
+        .isPresent()
+        .hasValue("eu-west-1");
+    Assertions.assertThat(capturedDestination.get().endpoint()).isEmpty();
+  }
+
+  @Test
+  public void testStsDestinationUsesDifferentRegions() {
+    ServiceIdentityInfoDpo serviceIdentity =
+        new AwsIamServiceIdentityInfoDpo(
+            new SecretReference("urn:polaris-secret:test:my-realm:AWS_IAM", Map.of()));
+
+    SigV4AuthenticationParametersDpo authParams =
+        new SigV4AuthenticationParametersDpo(
+            "arn:aws:iam::123456789012:role/customer-role",
+            null,
+            null,
+            "ap-southeast-1",
+            null);
+
+    IcebergRestConnectionConfigInfoDpo connectionConfig =
+        new IcebergRestConnectionConfigInfoDpo(
+            "https://test-catalog.example.com", authParams, serviceIdentity, "test-catalog");
+
+    vendor.getConnectionCredentials(connectionConfig);
+
+    Assertions.assertThat(capturedDestination.get().region())
+        .isPresent()
+        .hasValue("ap-southeast-1");
+    Assertions.assertThat(capturedDestination.get().endpoint()).isEmpty();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
@@ -201,9 +201,7 @@ public class SigV4ConnectionCredentialVendorTest {
     vendor.getConnectionCredentials(connectionConfig);
 
     // Verify the STS client was created with the correct region from sigV4 params
-    Assertions.assertThat(capturedDestination.get().region())
-        .isPresent()
-        .hasValue("eu-west-1");
+    Assertions.assertThat(capturedDestination.get().region()).isPresent().hasValue("eu-west-1");
     Assertions.assertThat(capturedDestination.get().endpoint()).isEmpty();
   }
 
@@ -215,11 +213,7 @@ public class SigV4ConnectionCredentialVendorTest {
 
     SigV4AuthenticationParametersDpo authParams =
         new SigV4AuthenticationParametersDpo(
-            "arn:aws:iam::123456789012:role/customer-role",
-            null,
-            null,
-            "ap-southeast-1",
-            null);
+            "arn:aws:iam::123456789012:role/customer-role", null, null, "ap-southeast-1", null);
 
     IcebergRestConnectionConfigInfoDpo connectionConfig =
         new IcebergRestConnectionConfigInfoDpo(


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Passes signing region to `StsDestination` instead of null so the STS client targets the right regional endpoint when assuming IAM roles.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
