### PR TITLE
Release management: improve releaseEmailTemplate task

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -201,7 +201,6 @@ jobs:
           exec_process mkdir -p "${version_dir}"
           exec_process cp build/distributions/* "${version_dir}/"
           exec_process cp runtime/distribution/build/distributions/* "${version_dir}/"
-          exec_process rm -f "${version_dir}/*vote-email{-subject,-body}.txt"
 
           exec_process cd "${dist_dev_dir}"
           exec_process svn add "${version_without_rc}"
@@ -585,7 +584,7 @@ jobs:
           You can find the KEYS file here:
           * https://downloads.apache.org/polaris/KEYS
 
-          Convenience binary artifacts are staged on Nexus. The Maven repositories URLs are:
+          Convenience binary artifacts are staged on Nexus. The Maven repository URL is:
           * https://repository.apache.org/content/repositories/${staging_repository_id}/
 
           Please download, verify, and test according to the release verification guide, which can be found at:
@@ -593,7 +592,7 @@ jobs:
 
           Please vote in the next 72 hours.
 
-          [ ] +1 Release this as Apache polaris ${version_without_rc}
+          [ ] +1 Release this as Apache Polaris ${version_without_rc}
           [ ] +0
           [ ] -1 Do not release this because...
 

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperExtension.kt
@@ -20,7 +20,6 @@
 package publishing
 
 import asf.AsfProject
-import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
@@ -82,9 +81,6 @@ constructor(objectFactory: ObjectFactory, project: Project) {
 
   /** List of mailing-lists. */
   val mailingLists = objectFactory.listProperty(String::class.java).convention(emptyList())
-
-  fun distributionFile(ext: String): File =
-    distributionDir.get().file("${baseName.get()}.$ext").asFile
 }
 
 /**

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -93,12 +93,14 @@ internal fun configureOnRootProject(project: Project) =
       val rootProject = project.rootProject
       val gradle = project.gradle
       val projectVersion = project.version
-      val projectDir = project.projectDir
 
       doFirst {
         val asfName = publishingHelperExt.asfProjectId.get()
 
-        val gitCommitId = GitInfo.memoized(rootProject).gitHead
+        val gitInfo = GitInfo.memoized(rootProject)
+        val gitCommitId = gitInfo.gitHead
+        val gitTag = gitInfo.gitDescribe
+        val rcNumber = Regex("-rc(\\d+)$").find(gitTag)?.groupValues?.get(1) ?: "<RC_NUMBER>"
 
         val repos = nexusPublishExt.repositories
         val repo = repos.iterator().next()
@@ -109,7 +111,7 @@ internal fun configureOnRootProject(project: Project) =
           >(
             "stagingRepositoryUrlRegistry"
           )
-        val staginRepoUrl =
+        val stagingRepoUrl =
           if (stagingRepositoryUrlRegistryRegistration.isPresent) {
             val stagingRepositoryUrlRegistryBuildServiceRegistration =
               stagingRepositoryUrlRegistryRegistration.get()
@@ -135,50 +137,51 @@ internal fun configureOnRootProject(project: Project) =
         val asfProjectName =
           publishingHelperExt.overrideName.orElse("Apache ${asfProject.name}").get()
 
-        val versionNoRc = projectVersion.toString().replace("-rc-?[0-9]+".toRegex(), "")
-
+        val emailTemplatesDir = project.layout.buildDirectory.dir("email-templates").get().asFile
+        emailTemplatesDir.mkdirs()
         val subjectFile =
-          publishingHelperExt.distributionFile("vote-email-subject.txt").relativeTo(projectDir)
+          emailTemplatesDir.resolve("${publishingHelperExt.baseName.get()}.vote-email-subject.txt")
         val bodyFile =
-          publishingHelperExt.distributionFile("vote-email-body.txt").relativeTo(projectDir)
+          emailTemplatesDir.resolve("${publishingHelperExt.baseName.get()}.vote-email-body.txt")
 
-        val emailSubject = "[VOTE] Release $asfProjectName $projectVersion"
+        val emailSubject = "[VOTE] Release $asfProjectName $projectVersion (rc$rcNumber)"
         subjectFile.writeText(emailSubject)
 
         val emailBody =
           """
               Hi everyone,
 
-              I propose that we release the following RC as the official
-              $asfProjectName $versionNoRc release.
+              I propose that we release the following RC as the official $asfProjectName $version release.
 
-              * This corresponds to the tag: apache-$asfName-$projectVersion
-              * https://github.com/apache/$asfName/commits/apache-$asfName-$projectVersion
+              This corresponds to the tag: $gitTag
+              * https://github.com/apache/$asfName/commits/$gitTag
               * https://github.com/apache/$asfName/tree/$gitCommitId
 
               The release tarball, signature, and checksums are here:
-              * https://dist.apache.org/repos/dist/dev/$asfName/apache-$asfName-$projectVersion
+              * https://dist.apache.org/repos/dist/dev/$asfName/$projectVersion
+
+              Helm charts are available on:
+              * https://dist.apache.org/repos/dist/dev/$asfName/helm-chart/$projectVersion
+
+              NB: you have to build the Docker images locally in order to test Helm charts.
 
               You can find the KEYS file here:
               * https://downloads.apache.org/$asfName/KEYS
 
               Convenience binary artifacts are staged on Nexus. The Maven repository URL is:
-              * $staginRepoUrl
+              * $stagingRepoUrl
 
-              Please download, verify, and test.
+              Please download, verify, and test according to the release verification guide, which can be found at:
+              * https://polaris.apache.org/community/release-guides/release-verification-guide/
 
               Please vote in the next 72 hours.
 
-              [ ] +1 Release this as Apache $asfName $projectVersion
+              [ ] +1 Release this as Apache Polaris $projectVersion
               [ ] +0
               [ ] -1 Do not release this because...
 
-              Only PMC members have binding votes, but other community members are
-              encouraged to cast non-binding votes. This vote will pass if there are
-              3 binding +1 votes and more binding +1 votes than -1 votes.
-
-              Thanks
-              Regards
+              Only PMC members have binding votes, but other community members are encouraged to cast non-binding votes.
+              This vote will pass if there are 3 binding +1 votes and more binding +1 votes than -1 votes.
             """
 
         logger.lifecycle(

--- a/site/content/community/release-guides/manual-release-guide.md
+++ b/site/content/community/release-guides/manual-release-guide.md
@@ -300,7 +300,7 @@ Next, you have to close the staging repository:
 
 The last step for a release candidate is to create a VOTE thread on the dev mailing list.
 
-A generated email template is available in the `build/distribution` folder.
+A generated email template is available in the `build/email-templates` folder.
 
 Example title subject:
 
@@ -313,10 +313,9 @@ Example content:
 ```
 Hi everyone,
 
-I propose that we release the following RC as the official
-Apache Polaris x.y.z release.
+I propose that we release the following RC as the official Apache Polaris x.y.z release.
 
-* This corresponds to the tag: apache-polaris-x.y.z-rci
+This corresponds to the tag: apache-polaris-x.y.z-rci
 * https://github.com/apache/polaris/commits/apache-polaris-x.y.z-rci
 * https://github.com/apache/polaris/tree/<SHA1>
 
@@ -324,28 +323,27 @@ The release tarball, signature, and checksums are here:
 * https://dist.apache.org/repos/dist/dev/polaris/x.y.z
 
 Helm charts are available on:
-* https://dist.apache.org/repos/dist/dev/polaris/helm-chart
+* https://dist.apache.org/repos/dist/dev/polaris/helm-chart/x.y.z
+
 NB: you have to build the Docker images locally in order to test Helm charts.
 
 You can find the KEYS file here:
 * https://downloads.apache.org/polaris/KEYS
 
-Convenience binary artifacts are staged on Nexus. The Maven
-repositories URLs are:
+Convenience binary artifacts are staged on Nexus. The Maven repository URL is:
 * https://repository.apache.org/content/repositories/orgapachepolaris-<ID>/
 
-Please download, verify, and test.
+Please download, verify, and test according to the release verification guide, which can be found at:
+* https://polaris.apache.org/community/release-guides/release-verification-guide/
 
 Please vote in the next 72 hours.
 
-[ ] +1 Release this as Apache polaris x.y.z
+[ ] +1 Release this as Apache Polaris x.y.z
 [ ] +0
 [ ] -1 Do not release this because...
 
-Only PMC members have binding votes, but other community
-members are encouraged to cast non-binding votes.
-This vote will pass if there are 3 binding +1 votes and
-more binding +1 votes than -1 votes.
+Only PMC members have binding votes, but other community members are encouraged to cast non-binding votes.
+This vote will pass if there are 3 binding +1 votes and more binding +1 votes than -1 votes.
 ```
 
 When a candidate is passed or rejected, reply with the vote result:


### PR DESCRIPTION
The `releaseEmailTemplate` Gradle task wrote vote email files into `build/distributions/`, which were then copied to the Apache dist dev SVN repository by the release workflow. The cleanup `rm` command never worked due to shell quoting preventing glob/brace expansion.

This change moves the email template output to `build/email-templates/` so it is never swept up by the bulk cp of distribution artifacts.

It also harmonizes the vote email template across the Gradle task, the release workflow, and the manual release guide.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
