### PR TITLE
CLI: preserve optional S3 fields in setup catalog creation

### DIFF
--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -74,48 +74,48 @@ class CatalogsCommand(Command):
 
     catalogs_subcommand: str
     catalog_type: str
-    default_base_location: str
-    storage_type: str
-    allowed_locations: List[str]
-    role_arn: str
-    external_id: str
-    user_arn: str
-    region: str
-    tenant_id: str
-    multi_tenant_app_name: str
+    default_base_location: Optional[str]
+    storage_type: Optional[str]
+    allowed_locations: Optional[List[str]]
+    role_arn: Optional[str]
+    external_id: Optional[str]
+    user_arn: Optional[str]
+    region: Optional[str]
+    tenant_id: Optional[str]
+    multi_tenant_app_name: Optional[str]
     hierarchical: bool
-    consent_url: str
-    service_account: str
+    consent_url: Optional[str]
+    service_account: Optional[str]
     catalog_name: str
     properties: Dict[str, StrictStr]
     set_properties: Dict[str, StrictStr]
     remove_properties: List[str]
-    hadoop_warehouse: str
-    hive_warehouse: str
-    iceberg_remote_catalog_name: str
-    endpoint: str
-    endpoint_internal: str
-    sts_endpoint: str
+    hadoop_warehouse: Optional[str]
+    hive_warehouse: Optional[str]
+    iceberg_remote_catalog_name: Optional[str]
+    endpoint: Optional[str]
+    endpoint_internal: Optional[str]
+    sts_endpoint: Optional[str]
     sts_unavailable: bool
     kms_unavailable: bool
     path_style_access: bool
-    current_kms_key: str
-    allowed_kms_keys: List[str]
-    catalog_connection_type: str
-    catalog_authentication_type: str
-    catalog_service_identity_type: str
-    catalog_service_identity_iam_arn: str
-    catalog_uri: str
-    catalog_token_uri: str
-    catalog_client_id: str
-    catalog_client_secret: str
+    current_kms_key: Optional[str]
+    allowed_kms_keys: Optional[List[str]]
+    catalog_connection_type: Optional[str]
+    catalog_authentication_type: Optional[str]
+    catalog_service_identity_type: Optional[str]
+    catalog_service_identity_iam_arn: Optional[str]
+    catalog_uri: Optional[str]
+    catalog_token_uri: Optional[str]
+    catalog_client_id: Optional[str]
+    catalog_client_secret: Optional[str]
     catalog_client_scopes: List[str]
-    catalog_bearer_token: str
-    catalog_role_arn: str
-    catalog_role_session_name: str
-    catalog_external_id: str
-    catalog_signing_region: str
-    catalog_signing_name: str
+    catalog_bearer_token: Optional[str]
+    catalog_role_arn: Optional[str]
+    catalog_role_session_name: Optional[str]
+    catalog_external_id: Optional[str]
+    catalog_signing_region: Optional[str]
+    catalog_signing_name: Optional[str]
 
     def validate(self) -> None:
         if self.catalogs_subcommand == Subcommands.CREATE:

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -907,71 +907,61 @@ class SetupCommand(Command):
                         ),
                         catalog_name=command_args.get("catalog_name", ""),
                         catalog_type=command_args.get("catalog_type", "INTERNAL"),
-                        default_base_location=command_args.get(
-                            "default_base_location", ""
-                        ),
-                        storage_type=command_args.get("storage_type", ""),
-                        allowed_locations=command_args.get("allowed_locations") or [],
+                        default_base_location=command_args.get("default_base_location"),
+                        storage_type=command_args.get("storage_type"),
+                        allowed_locations=command_args.get("allowed_locations"),
                         properties=command_args.get("properties") or {},
                         set_properties=command_args.get("set_properties") or {},
                         remove_properties=command_args.get("remove_properties") or [],
-                        role_arn=command_args.get("role_arn", ""),
-                        external_id=command_args.get("external_id", ""),
-                        user_arn=command_args.get("user_arn", ""),
-                        region=command_args.get("region", ""),
-                        tenant_id=command_args.get("tenant_id", ""),
-                        multi_tenant_app_name=command_args.get(
-                            "multi_tenant_app_name", ""
-                        ),
-                        consent_url=command_args.get("consent_url", ""),
-                        service_account=command_args.get("service_account", ""),
+                        role_arn=command_args.get("role_arn"),
+                        external_id=command_args.get("external_id"),
+                        user_arn=command_args.get("user_arn"),
+                        region=command_args.get("region"),
+                        tenant_id=command_args.get("tenant_id"),
+                        multi_tenant_app_name=command_args.get("multi_tenant_app_name"),
+                        consent_url=command_args.get("consent_url"),
+                        service_account=command_args.get("service_account"),
                         hierarchical=command_args.get("hierarchical", False),
-                        endpoint=command_args.get("endpoint", ""),
-                        endpoint_internal=command_args.get("endpoint_internal", ""),
-                        sts_endpoint=command_args.get("sts_endpoint", ""),
+                        endpoint=command_args.get("endpoint"),
+                        endpoint_internal=command_args.get("endpoint_internal"),
+                        sts_endpoint=command_args.get("sts_endpoint"),
                         sts_unavailable=command_args.get("sts_unavailable", False),
                         kms_unavailable=command_args.get("kms_unavailable", False),
                         path_style_access=command_args.get("path_style_access", False),
-                        current_kms_key=command_args.get("current_kms_key", ""),
-                        allowed_kms_keys=command_args.get("allowed_kms_keys") or [],
+                        current_kms_key=command_args.get("current_kms_key"),
+                        allowed_kms_keys=command_args.get("allowed_kms_keys"),
                         catalog_connection_type=command_args.get(
-                            "catalog_connection_type", ""
+                            "catalog_connection_type"
                         ),
-                        catalog_uri=command_args.get("catalog_uri", ""),
-                        hadoop_warehouse=command_args.get("hadoop_warehouse", ""),
-                        hive_warehouse=command_args.get("hive_warehouse", ""),
+                        catalog_uri=command_args.get("catalog_uri"),
+                        hadoop_warehouse=command_args.get("hadoop_warehouse"),
+                        hive_warehouse=command_args.get("hive_warehouse"),
                         iceberg_remote_catalog_name=command_args.get(
-                            "iceberg_remote_catalog_name", ""
+                            "iceberg_remote_catalog_name"
                         ),
                         catalog_authentication_type=command_args.get(
-                            "catalog_authentication_type", ""
+                            "catalog_authentication_type"
                         ),
-                        catalog_token_uri=command_args.get("catalog_token_uri", ""),
-                        catalog_client_id=command_args.get("catalog_client_id", ""),
-                        catalog_client_secret=command_args.get(
-                            "catalog_client_secret", ""
-                        ),
+                        catalog_token_uri=command_args.get("catalog_token_uri"),
+                        catalog_client_id=command_args.get("catalog_client_id"),
+                        catalog_client_secret=command_args.get("catalog_client_secret"),
                         catalog_client_scopes=command_args.get("catalog_client_scopes")
                         or [],
-                        catalog_bearer_token=command_args.get(
-                            "catalog_bearer_token", ""
-                        ),
-                        catalog_role_arn=command_args.get("catalog_role_arn", ""),
+                        catalog_bearer_token=command_args.get("catalog_bearer_token"),
+                        catalog_role_arn=command_args.get("catalog_role_arn"),
                         catalog_role_session_name=command_args.get(
-                            "catalog_role_session_name", ""
+                            "catalog_role_session_name"
                         ),
-                        catalog_external_id=command_args.get("catalog_external_id", ""),
+                        catalog_external_id=command_args.get("catalog_external_id"),
                         catalog_signing_region=command_args.get(
-                            "catalog_signing_region", ""
+                            "catalog_signing_region"
                         ),
-                        catalog_signing_name=command_args.get(
-                            "catalog_signing_name", ""
-                        ),
+                        catalog_signing_name=command_args.get("catalog_signing_name"),
                         catalog_service_identity_type=command_args.get(
-                            "catalog_service_identity_type", ""
+                            "catalog_service_identity_type"
                         ),
                         catalog_service_identity_iam_arn=command_args.get(
-                            "catalog_service_identity_iam_arn", ""
+                            "catalog_service_identity_iam_arn"
                         ),
                     )
                     cmd.validate()

--- a/client/python/test/test_setup_command.py
+++ b/client/python/test/test_setup_command.py
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from unittest.mock import MagicMock
+
+from apache_polaris.cli.command import Command
+from apache_polaris.cli.command.setup import SetupCommand
+from apache_polaris.cli.options.parser import Parser
+from apache_polaris.sdk.management import PolarisDefaultApi
+
+
+class TestSetupCommand(unittest.TestCase):
+    def test_setup_apply_matches_direct_catalog_create_for_optional_s3_fields(
+        self,
+    ) -> None:
+        direct_api = MagicMock(spec=PolarisDefaultApi)
+        direct_command = Command.from_options(
+            Parser.parse(
+                [
+                    "catalogs",
+                    "create",
+                    "catalog_name",
+                    "--storage-type",
+                    "s3",
+                    "--default-base-location",
+                    "s3://bucket/catalog_name/",
+                    "--allowed-location",
+                    "s3://bucket/catalog_name/",
+                    "--region",
+                    "us-east-1",
+                    "--endpoint",
+                    "http://localhost:9000/",
+                    "--endpoint-internal",
+                    "http://rustfs:9000",
+                    "--path-style-access",
+                    "--no-sts",
+                ]
+            )
+        )
+        direct_command.execute(direct_api)
+        direct_request = direct_api.create_catalog.call_args.args[0].to_dict()
+
+        setup_api = MagicMock(spec=PolarisDefaultApi)
+        setup_api.list_catalogs.return_value.catalogs = []
+        setup_command = SetupCommand("apply")
+        success = setup_command._create_catalogs(
+            setup_api,
+            [
+                {
+                    "name": "catalog_name",
+                    "storage_type": "s3",
+                    "type": "internal",
+                    "default_base_location": "s3://bucket/catalog_name/",
+                    "allowed_locations": ["s3://bucket/catalog_name/"],
+                    "region": "us-east-1",
+                    "endpoint": "http://localhost:9000/",
+                    "endpoint_internal": "http://rustfs:9000",
+                    "path_style_access": True,
+                    "sts_unavailable": True,
+                }
+            ],
+        )
+
+        self.assertTrue(success)
+        setup_request = setup_api.create_catalog.call_args.args[0].to_dict()
+
+        self.assertEqual(direct_request, setup_request)
+        storage_config = setup_request["catalog"]["storageConfigInfo"]
+        self.assertNotIn("roleArn", storage_config)
+        self.assertTrue(storage_config["stsUnavailable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`polaris setup apply` was rebuilding `CatalogsCommand` instances with empty-string defaults for omitted optional storage and authentication fields. The direct CLI path passes `None` for those fields instead.

For S3 catalogs this caused setup-driven catalog creation to serialize an empty `roleArn`, which the server rejects, and it diverged from the behavior of the working `polaris catalogs create` command. This change aligns the setup path with the direct CLI semantics, updates `CatalogsCommand` annotations to reflect that these inputs are optional, and adds a regression test that compares the direct CLI and setup-apply request payloads for the same S3 catalog definition.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4076
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (not needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed)

Validation:
- `./.venv/bin/python -m pytest client/python/test -q`
- `make client-lint`
