### PR TITLE
docs: clarify remove_orphan_files with vended credentials

### DIFF
--- a/site/content/in-dev/unreleased/_index.md
+++ b/site/content/in-dev/unreleased/_index.md
@@ -151,10 +151,9 @@ To secure interactions with service connections, Polaris vends temporary storage
 execution. These credentials allow the query engine to run the query without requiring access to your cloud storage for
 Iceberg tables. This process is called credential vending.
 
-As of now, the following limitation is known regarding Apache Iceberg support:
+The following applies to Apache Iceberg with Apache Spark:
 
-- **remove_orphan_files:** Apache Spark can't use credential vending
-  for this due to a known issue. See [apache/iceberg#7914](https://github.com/apache/iceberg/pull/7914) for details.
+- **remove_orphan_files**: By default this procedure lists storage through Spark's Hadoop layer, not Iceberg, so Polaris vended credentials may not apply to that step. From **Iceberg 1.10**, use **`prefix_listing => true`** in `CALL ... remove_orphan_files(...)` (or **`.usePrefixListing(true)`** on `SparkActions.deleteOrphanFiles`) so listing uses Iceberg's file client and vended credentials apply. See [apache/iceberg#12254](https://github.com/apache/iceberg/pull/12254). Note: Listing runs on the driver for this mode and can be slow for very large file sets.
 
 ### Identity and access management (IAM)
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

`remove_orphan_files` can be used with credential vending starting with Iceberg 1.10 if `prefix_listing` is set to `true`. This change updates the documentation to reflect this with a note calling out performance degradation since listing occurs on the driver.

For more details, see https://github.com/apache/iceberg/pull/12254

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
