### PR TITLE
fix: enforce single expiration timestamp per credential bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The ExternalCatalogFactory interface has been renamed to FederatedCatalogFactory. Its createCatalog() and createGenericCatalog() method signatures have been extended to include a `catalogProperties` parameter of type `Map<String, String>` for passing through proxy and timeout settings to federated catalog HTTP clients.
 - Metrics reporting now requires the `TABLE_READ_DATA` privilege on the target table for read (scan) metrics and `TABLE_WRITE_DATA` for write (commit) metrics.
 - The `REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE` operation no longer requires the `PRINCIPAL_ROLE_MANAGE_GRANTS_FOR_GRANTEE` privilege. Only `CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE` on the catalog role is now required, making revoke symmetric with assign. This allows catalog administrators to fully manage catalog role assignments without requiring elevated privileges on principal roles.
-- The `ConnectionCredentials.of()` method now throws an exception when multiple expiration timestamp properties are present in the credentials map, instead of silently using one of them.
+- The `ConnectionCredentials.of()` method now throws an exception when more than one expiration timestamp property is present in the credentials map. Only a single expiration timestamp is allowed per credentials bundle.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The ExternalCatalogFactory interface has been renamed to FederatedCatalogFactory. Its createCatalog() and createGenericCatalog() method signatures have been extended to include a `catalogProperties` parameter of type `Map<String, String>` for passing through proxy and timeout settings to federated catalog HTTP clients.
 - Metrics reporting now requires the `TABLE_READ_DATA` privilege on the target table for read (scan) metrics and `TABLE_WRITE_DATA` for write (commit) metrics.
 - The `REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE` operation no longer requires the `PRINCIPAL_ROLE_MANAGE_GRANTS_FOR_GRANTEE` privilege. Only `CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE` on the catalog role is now required, making revoke symmetric with assign. This allows catalog administrators to fully manage catalog role assignments without requiring elevated privileges on principal roles.
+- The `ConnectionCredentials.of()` method now throws an exception when multiple expiration timestamp properties are present in the credentials map, instead of silently using one of them.
 
 ### New Features
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
@@ -41,6 +41,10 @@ public record ConnectionCredentials(Map<String, String> credentials, Optional<In
   /**
    * Creates ConnectionCredentials from a map of catalog access properties. Expiration timestamps
    * are extracted and stored separately; credential properties are stored in the credentials map.
+   *
+   * <p>Only a single shared expiration timestamp is supported for a credentials bundle. If multiple
+   * expiration timestamp properties are present, they must all represent the same instant or an
+   * {@link IllegalArgumentException} is thrown.
    */
   public static ConnectionCredentials of(Map<CatalogAccessProperty, String> properties) {
     Map<String, String> credentials = new HashMap<>();
@@ -48,7 +52,16 @@ public record ConnectionCredentials(Map<String, String> credentials, Optional<In
     for (var entry : properties.entrySet()) {
       CatalogAccessProperty key = entry.getKey();
       if (key.isExpirationTimestamp()) {
-        expiresAt = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
+        Instant current = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
+        if (expiresAt == null) {
+          expiresAt = current;
+        } else if (!current.equals(expiresAt)) {
+          throw new IllegalArgumentException(
+              "Multiple distinct expiration timestamps found while building ConnectionCredentials: "
+                  + expiresAt.toEpochMilli()
+                  + " and "
+                  + current.toEpochMilli());
+        }
       }
       if (key.isCredential()) {
         credentials.put(key.getPropertyName(), entry.getValue());

--- a/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
@@ -42,9 +42,8 @@ public record ConnectionCredentials(Map<String, String> credentials, Optional<In
    * Creates ConnectionCredentials from a map of catalog access properties. Expiration timestamps
    * are extracted and stored separately; credential properties are stored in the credentials map.
    *
-   * <p>Only a single shared expiration timestamp is supported for a credentials bundle. If multiple
-   * expiration timestamp properties are present, they must all represent the same instant or an
-   * {@link IllegalArgumentException} is thrown.
+   * <p>Only a single expiration timestamp is supported per credentials bundle. If multiple
+   * expiration timestamp properties are present, an {@link IllegalArgumentException} is thrown.
    */
   public static ConnectionCredentials of(Map<CatalogAccessProperty, String> properties) {
     Map<String, String> credentials = new HashMap<>();
@@ -53,21 +52,16 @@ public record ConnectionCredentials(Map<String, String> credentials, Optional<In
     for (var entry : properties.entrySet()) {
       CatalogAccessProperty key = entry.getKey();
       if (key.isExpirationTimestamp()) {
-        Instant current = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
-        if (expiresAt == null) {
-          expiresAt = current;
-          expiresAtKey = key;
-        } else if (!current.equals(expiresAt)) {
+        if (expiresAtKey != null) {
           throw new IllegalArgumentException(
-              "Multiple distinct expiration timestamps found while building ConnectionCredentials: "
+              "Multiple expiration timestamp properties found while building ConnectionCredentials: "
                   + expiresAtKey.getPropertyName()
-                  + "="
-                  + expiresAt.toEpochMilli()
                   + " and "
                   + key.getPropertyName()
-                  + "="
-                  + current.toEpochMilli());
+                  + ". Only a single expiration timestamp is allowed per credentials bundle.");
         }
+        expiresAt = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
+        expiresAtKey = key;
       }
       if (key.isCredential()) {
         credentials.put(key.getPropertyName(), entry.getValue());

--- a/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/credentials/connection/ConnectionCredentials.java
@@ -49,17 +49,23 @@ public record ConnectionCredentials(Map<String, String> credentials, Optional<In
   public static ConnectionCredentials of(Map<CatalogAccessProperty, String> properties) {
     Map<String, String> credentials = new HashMap<>();
     Instant expiresAt = null;
+    CatalogAccessProperty expiresAtKey = null;
     for (var entry : properties.entrySet()) {
       CatalogAccessProperty key = entry.getKey();
       if (key.isExpirationTimestamp()) {
         Instant current = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
         if (expiresAt == null) {
           expiresAt = current;
+          expiresAtKey = key;
         } else if (!current.equals(expiresAt)) {
           throw new IllegalArgumentException(
               "Multiple distinct expiration timestamps found while building ConnectionCredentials: "
+                  + expiresAtKey.getPropertyName()
+                  + "="
                   + expiresAt.toEpochMilli()
                   + " and "
+                  + key.getPropertyName()
+                  + "="
                   + current.toEpochMilli());
         }
       }

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -53,7 +53,9 @@ public class ConnectionCredentialsTest {
 
     assertThatThrownBy(() -> ConnectionCredentials.of(properties))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Multiple distinct expiration timestamps");
+        .hasMessageContaining("Multiple distinct expiration timestamps")
+        .hasMessageContaining("rest.session-token-expires-at-ms")
+        .hasMessageContaining("rest.expires-at-ms");
   }
 
   @Test

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.credentials.connection;
+
+import static org.apache.polaris.core.credentials.connection.CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS;
+import static org.apache.polaris.core.credentials.connection.CatalogAccessProperty.EXPIRES_AT_MS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ConnectionCredentialsTest {
+
+  @Test
+  public void testSameExpirationTs() {
+    Map<CatalogAccessProperty, String> properties = new HashMap<>();
+    Instant expireAt = Instant.ofEpochMilli(1);
+    String expireAtStr = String.valueOf(expireAt.toEpochMilli());
+
+    properties.put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, expireAtStr);
+    properties.put(EXPIRES_AT_MS, expireAtStr);
+
+    ConnectionCredentials credentials = ConnectionCredentials.of(properties);
+
+    assertThat(credentials.expiresAt()).hasValue(expireAt);
+  }
+
+  @Test
+  public void testDifferentExpirationTs() {
+    Map<CatalogAccessProperty, String> properties = new HashMap<>();
+    properties.put(
+        AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli()));
+    properties.put(EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(2).toEpochMilli()));
+
+    assertThatThrownBy(() -> ConnectionCredentials.of(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Multiple distinct expiration timestamps");
+  }
+
+  @Test
+  public void testSingleExpirationTs() {
+    Instant expireAt = Instant.ofEpochMilli(1);
+    ConnectionCredentials credentials =
+        ConnectionCredentials.of(
+            Map.of(AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expireAt.toEpochMilli())));
+    assertThat(credentials.expiresAt()).hasValue(expireAt);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.credentials.connection;
 
+import static org.apache.polaris.core.credentials.connection.CatalogAccessProperty.AWS_ACCESS_KEY_ID;
 import static org.apache.polaris.core.credentials.connection.CatalogAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS;
 import static org.apache.polaris.core.credentials.connection.CatalogAccessProperty.EXPIRES_AT_MS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,29 +32,15 @@ import org.junit.jupiter.api.Test;
 public class ConnectionCredentialsTest {
 
   @Test
-  public void testSameExpirationTs() {
-    Map<CatalogAccessProperty, String> properties = new HashMap<>();
-    Instant expireAt = Instant.ofEpochMilli(1);
-    String expireAtStr = String.valueOf(expireAt.toEpochMilli());
-
-    properties.put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, expireAtStr);
-    properties.put(EXPIRES_AT_MS, expireAtStr);
-
-    ConnectionCredentials credentials = ConnectionCredentials.of(properties);
-
-    assertThat(credentials.expiresAt()).hasValue(expireAt);
-  }
-
-  @Test
-  public void testDifferentExpirationTs() {
+  public void testMultipleExpirationTsThrows() {
     Map<CatalogAccessProperty, String> properties = new HashMap<>();
     properties.put(
         AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli()));
-    properties.put(EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(2).toEpochMilli()));
+    properties.put(EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli()));
 
     assertThatThrownBy(() -> ConnectionCredentials.of(properties))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Multiple distinct expiration timestamps")
+        .hasMessageContaining("Multiple expiration timestamp properties")
         .hasMessageContaining("rest.session-token-expires-at-ms")
         .hasMessageContaining("rest.expires-at-ms");
   }
@@ -63,7 +50,11 @@ public class ConnectionCredentialsTest {
     Instant expireAt = Instant.ofEpochMilli(1);
     ConnectionCredentials credentials =
         ConnectionCredentials.of(
-            Map.of(AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expireAt.toEpochMilli())));
+            Map.of(
+                AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                String.valueOf(expireAt.toEpochMilli()),
+                AWS_ACCESS_KEY_ID,
+                "test-key"));
     assertThat(credentials.expiresAt()).hasValue(expireAt);
   }
 }


### PR DESCRIPTION
ConnectionCredentials.of() silently overwrites the expiresAt field when multiple expiration timestamp props are present. This produces non-deterministic results since the input is a HashMap (no order).

Instead, this change fails fast by throwing an exception when multiple timestamps are found.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
