### PR TITLE
Update s3mock from 4.12.x to 5.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,7 @@ picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "pico
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.10" }
 quarkus-amazon-services-bom = { module = "io.quarkus.platform:quarkus-amazon-services-bom", version.ref="quarkus" }
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
-s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "4.12.4" }
+s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "5.0.0" }
 scala212-lang-library = { module = "org.scala-lang:scala-library", version.ref = "scala212" }
 scala212-lang-reflect = { module = "org.scala-lang:scala-reflect", version.ref = "scala212" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version = "2.0.17" }

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/s3mock/S3Mock.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/s3mock/S3Mock.java
@@ -23,26 +23,37 @@ import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import java.util.Map;
 import org.apache.polaris.containerspec.ContainerSpecHelper;
 
-public class S3Mock extends S3MockContainer {
+public class S3Mock {
 
   private static final String DEFAULT_BUCKETS = "my-bucket,my-old-bucket";
   private static final String DEFAULT_ACCESS_KEY = "ap1";
   private static final String DEFAULT_SECRET_KEY = "s3cr3t";
+
+  private final S3MockContainer s3Mock;
 
   public S3Mock() {
     this(DEFAULT_BUCKETS);
   }
 
   public S3Mock(String initialBuckets) {
-    super(
-        ContainerSpecHelper.containerSpecHelper("s3mock", S3Mock.class)
-            .dockerImageName(null)
-            .asCompatibleSubstituteFor("adobe/s3mock"));
-    this.withInitialBuckets(initialBuckets);
+    this.s3Mock =
+        new S3MockContainer(
+            ContainerSpecHelper.containerSpecHelper("s3mock", S3Mock.class)
+                .dockerImageName(null)
+                .asCompatibleSubstituteFor("adobe/s3mock"));
+    this.s3Mock.withInitialBuckets(initialBuckets);
+  }
+
+  public void start() {
+    s3Mock.start();
+  }
+
+  public void stop() {
+    s3Mock.stop();
   }
 
   public Map<String, String> getS3ConfigProperties() {
-    String endpoint = this.getHttpEndpoint();
+    String endpoint = this.s3Mock.getHttpEndpoint();
     return Map.of(
         "table-default.s3.endpoint", endpoint,
         "table-default.s3.path-style-access", "true",

--- a/runtime/test-common/src/main/resources/org/apache/polaris/test/commons/s3mock/Dockerfile-s3mock-version
+++ b/runtime/test-common/src/main/resources/org/apache/polaris/test/commons/s3mock/Dockerfile-s3mock-version
@@ -19,4 +19,4 @@
 
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/adobe/s3mock:4.12.4
+FROM docker.io/adobe/s3mock:5.0.0


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR addressed failure in https://github.com/apache/polaris/pull/4137. The failure is due to S3MockContainer is now a final  class in 5.0.0.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
