### PR TITLE
Fix entity name overlap handling and tests (#4168)

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -59,6 +59,7 @@ import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.RESTException;
@@ -1433,6 +1434,101 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
     managementApi.updateCatalog(catalog, catalogProps);
 
     assertThatCode(() -> restCatalog.dropView(id)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testCreateTableNameThatCollidesWithNamespace() {
+    Namespace parentNamespace = Namespace.of("ns1");
+    restCatalog.createNamespace(parentNamespace);
+    restCatalog.createNamespace(Namespace.of("ns1", "clash"));
+
+    assertThatThrownBy(
+            () ->
+                restCatalog
+                    .buildTable(TableIdentifier.of(parentNamespace, "clash"), SCHEMA)
+                    .create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCreateViewNameThatCollidesWithNamespace() {
+    Namespace parentNamespace = Namespace.of("ns1");
+    restCatalog.createNamespace(parentNamespace);
+    restCatalog.createNamespace(Namespace.of("ns1", "clash"));
+
+    assertThatThrownBy(
+            () ->
+                restCatalog
+                    .buildView(TableIdentifier.of(parentNamespace, "clash"))
+                    .withSchema(SCHEMA)
+                    .withDefaultNamespace(parentNamespace)
+                    .withQuery("spark", VIEW_QUERY)
+                    .create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCreateNamespaceNameThatCollidesWithTable() {
+    Namespace parentNamespace = Namespace.of("ns1");
+    restCatalog.createNamespace(parentNamespace);
+    restCatalog.buildTable(TableIdentifier.of(parentNamespace, "clash"), SCHEMA).create();
+
+    assertThatThrownBy(() -> restCatalog.createNamespace(Namespace.of("ns1", "clash")))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCreateNamespaceNameThatCollidesWithView() {
+    Namespace parentNamespace = Namespace.of("ns1");
+    restCatalog.createNamespace(parentNamespace);
+    restCatalog
+        .buildView(TableIdentifier.of(parentNamespace, "clash"))
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(parentNamespace)
+        .withQuery("spark", VIEW_QUERY)
+        .create();
+
+    assertThatThrownBy(() -> restCatalog.createNamespace(Namespace.of("ns1", "clash")))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCreateViewNameThatCollidesWithTable() {
+    Namespace namespace = Namespace.of("ns1");
+    restCatalog.createNamespace(namespace);
+    restCatalog.buildTable(TableIdentifier.of(namespace, "clash"), SCHEMA).create();
+
+    assertThatThrownBy(
+            () ->
+                restCatalog
+                    .buildView(TableIdentifier.of(namespace, "clash"))
+                    .withSchema(SCHEMA)
+                    .withDefaultNamespace(namespace)
+                    .withQuery("spark", VIEW_QUERY)
+                    .create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCreateTableNameThatCollidesWithView() {
+    Namespace namespace = Namespace.of("ns1");
+    restCatalog.createNamespace(namespace);
+    restCatalog
+        .buildView(TableIdentifier.of(namespace, "clash"))
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(namespace)
+        .withQuery("spark", VIEW_QUERY)
+        .create();
+
+    assertThatThrownBy(
+            () -> restCatalog.buildTable(TableIdentifier.of(namespace, "clash"), SCHEMA).create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
   }
 
   @Test

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -648,8 +648,30 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   private boolean namespaceWithSameNameExists(TableIdentifier identifier) {
-    return listNamespaces(identifier.namespace()).stream()
-        .anyMatch(namespace -> namespace.level(namespace.length() - 1).equals(identifier.name()));
+    PolarisResolvedPathWrapper resolvedEntities =
+        resolvedEntityView.getResolvedPath(ResolvedPathKey.ofNamespace(identifier.namespace()));
+    if (resolvedEntities == null) {
+      return false;
+    }
+
+    List<PolarisEntity> catalogPath = resolvedEntities.getRawFullPath();
+    EntityResult lookupResult =
+        getMetaStoreManager()
+            .readEntityByName(
+                getCurrentPolarisContext(),
+                PolarisEntity.toCoreList(catalogPath),
+                PolarisEntityType.NAMESPACE,
+                PolarisEntitySubType.NULL_SUBTYPE,
+                identifier.name());
+    if (lookupResult.isSuccess()) {
+      return true;
+    }
+    if (lookupResult.getReturnStatus() != BaseResult.ReturnStatus.ENTITY_NOT_FOUND) {
+      throw new ServiceFailureException(
+          "Failed to check existing namespace for '%s'. Status: %s ExtraInfo: %s",
+          identifier.name(), lookupResult.getReturnStatus(), lookupResult.getExtraInformation());
+    }
+    return false;
   }
 
   private PolarisResolvedPathWrapper getResolvedParentNamespace(Namespace namespace) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -513,6 +513,24 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       PolarisResolvedPathWrapper resolvedParent) {
     String baseLocation = resolveNamespaceLocation(namespace, metadata);
 
+    // Prevent namespace creation when a table or view with the same name already exists.
+    Namespace parentNamespace = PolarisCatalogHelpers.getParentNamespace(namespace);
+    String namespaceName = namespace.level(namespace.length() - 1);
+    Optional<PolarisEntitySubType> conflictingSubType =
+        Stream.of(PolarisEntitySubType.ICEBERG_TABLE, PolarisEntitySubType.ICEBERG_VIEW)
+            .filter(
+                subType ->
+                    listTableLike(subType, parentNamespace, PageToken.readEverything())
+                        .items()
+                        .stream()
+                        .anyMatch(identifier -> identifier.name().equals(namespaceName)))
+            .findFirst();
+    if (conflictingSubType.isPresent()) {
+      TableIdentifier tableLikeIdentifier = TableIdentifier.of(parentNamespace, namespaceName);
+      throw alreadyExistsExceptionWithSameNameForTableLikeEntity(
+          tableLikeIdentifier, conflictingSubType.get());
+    }
+
     // Set / suffix
     boolean requireTrailingSlash =
         realmConfig.getConfig(FeatureConfiguration.ADD_TRAILING_SLASH_TO_LOCATION);
@@ -628,6 +646,18 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     } else {
       return location;
     }
+  }
+
+  private static Namespace tableLikeIdentifierAsNamespace(TableIdentifier identifier) {
+    String[] namespaceLevels =
+        Arrays.copyOf(identifier.namespace().levels(), identifier.namespace().length() + 1);
+    namespaceLevels[identifier.namespace().length()] = identifier.name();
+    return Namespace.of(namespaceLevels);
+  }
+
+  private boolean namespaceWithSameNameExists(TableIdentifier identifier) {
+    return listNamespaces(identifier.namespace()).stream()
+        .anyMatch(namespace -> namespace.level(namespace.length() - 1).equals(identifier.name()));
   }
 
   private PolarisResolvedPathWrapper getResolvedParentNamespace(Namespace namespace) {
@@ -1517,6 +1547,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
             tableIdentifier, tableIdentifier.namespace());
       }
 
+      if (base == null && namespaceWithSameNameExists(tableIdentifier)) {
+        throw new AlreadyExistsException(
+            "Cannot create table '%s'. Namespace already exists: '%s'",
+            tableIdentifier, tableLikeIdentifierAsNamespace(tableIdentifier));
+      }
+
       PolarisResolvedPathWrapper resolvedTableEntities =
           resolvedEntityView.getPassthroughResolvedPath(
               ResolvedPathKey.ofTableLike(tableIdentifier), PolarisEntitySubType.ICEBERG_TABLE);
@@ -1940,6 +1976,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
         throw new NoSuchNamespaceException(
             "Cannot create view '%s'. Namespace does not exist: '%s'",
             identifier, identifier.namespace());
+      }
+
+      if (base == null && namespaceWithSameNameExists(identifier)) {
+        throw new AlreadyExistsException(
+            "Cannot create view '%s'. Namespace already exists: '%s'",
+            identifier, tableLikeIdentifierAsNamespace(identifier));
       }
 
       PolarisResolvedPathWrapper resolvedTable =

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -504,6 +504,16 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       throw new NoSuchNamespaceException(
           "Cannot create namespace %s. Parent namespace does not exist.", namespace);
     }
+
+    String namespaceName = namespace.level(namespace.length() - 1);
+    Optional<PolarisEntitySubType> conflictingSubType =
+        conflictingTableLikeSubtype(resolvedParent.getRawFullPath(), namespaceName);
+    if (conflictingSubType.isPresent()) {
+      TableIdentifier tableLikeIdentifier = TableIdentifier.of(parentNamespace, namespaceName);
+      throw alreadyExistsExceptionWithSameNameForTableLikeEntity(
+          tableLikeIdentifier, conflictingSubType.get());
+    }
+
     createNamespaceInternal(namespace, metadata, resolvedParent);
   }
 
@@ -512,24 +522,6 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       Map<String, String> metadata,
       PolarisResolvedPathWrapper resolvedParent) {
     String baseLocation = resolveNamespaceLocation(namespace, metadata);
-
-    // Prevent namespace creation when a table or view with the same name already exists.
-    Namespace parentNamespace = PolarisCatalogHelpers.getParentNamespace(namespace);
-    String namespaceName = namespace.level(namespace.length() - 1);
-    Optional<PolarisEntitySubType> conflictingSubType =
-        Stream.of(PolarisEntitySubType.ICEBERG_TABLE, PolarisEntitySubType.ICEBERG_VIEW)
-            .filter(
-                subType ->
-                    listTableLike(subType, parentNamespace, PageToken.readEverything())
-                        .items()
-                        .stream()
-                        .anyMatch(identifier -> identifier.name().equals(namespaceName)))
-            .findFirst();
-    if (conflictingSubType.isPresent()) {
-      TableIdentifier tableLikeIdentifier = TableIdentifier.of(parentNamespace, namespaceName);
-      throw alreadyExistsExceptionWithSameNameForTableLikeEntity(
-          tableLikeIdentifier, conflictingSubType.get());
-    }
 
     // Set / suffix
     boolean requireTrailingSlash =
@@ -2740,6 +2732,30 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     return listResult
         .getPage()
         .map(record -> TableIdentifier.of(parentNamespace, record.getName()));
+  }
+
+  private Optional<PolarisEntitySubType> conflictingTableLikeSubtype(
+      List<PolarisEntity> catalogPath, String entityName) {
+    for (PolarisEntitySubType subType :
+        List.of(PolarisEntitySubType.ICEBERG_TABLE, PolarisEntitySubType.ICEBERG_VIEW)) {
+      EntityResult lookupResult =
+          getMetaStoreManager()
+              .readEntityByName(
+                  getCurrentPolarisContext(),
+                  PolarisEntity.toCoreList(catalogPath),
+                  PolarisEntityType.TABLE_LIKE,
+                  subType,
+                  entityName);
+      if (lookupResult.isSuccess()) {
+        return Optional.of(subType);
+      }
+      if (lookupResult.getReturnStatus() != BaseResult.ReturnStatus.ENTITY_NOT_FOUND) {
+        throw new ServiceFailureException(
+            "Failed to check existing table-like entities for '%s'. Status: %s ExtraInfo: %s",
+            entityName, lookupResult.getReturnStatus(), lookupResult.getExtraInformation());
+      }
+    }
+    return Optional.empty();
   }
 
   private int getMaxMetadataRefreshRetries() {


### PR DESCRIPTION
Fixes #4168 by adding shared integration tests for namespace/table/view name collisions and enforcing consistent [AlreadyExistsException](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) behavior across backends. Verified with [RestCatalogFileIT](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [NoSqlCatalogIT](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).