### PR TITLE
chore: Less descriptive OPA Exception message

### DIFF
--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -184,9 +184,7 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
                 toResourceEntitiesFromResolvedPaths(targets),
                 toResourceEntitiesFromResolvedPaths(secondaries)));
     if (!allowed) {
-      throw new ForbiddenException(
-          "OPA denied authorization for operation=%s principal=%s targets=%s secondaries=%s",
-          authzOp, polarisPrincipal.getName(), targets, secondaries);
+      throw new ForbiddenException("OPA denied authorization");
     }
   }
 


### PR DESCRIPTION
As pointed out in https://github.com/apache/polaris/pull/3999#discussion_r3077112696 `ForbiddenException` is propagated to Polaris response through the `IcebergExceptionMapper`. It would best to remove information about Polaris internals from the exception message sent back to the Polaris user.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
