### PR TITLE
feat(helm): add termination and lifecycle options

### DIFF
--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -72,11 +72,18 @@ spec:
       initContainers:
         {{- tpl (toYaml .Values.extraInitContainers) . | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
             {{- tpl (toYaml .Values.containerSecurityContext) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.containerLifecycle }}
+          lifecycle:
+            {{- tpl (toYaml .Values.containerLifecycle) . | nindent 12 }}
           {{- end }}
           image: "{{ tpl .Values.image.repository . }}:{{ tpl .Values.image.tag . | default .Chart.Version }}"
           imagePullPolicy: {{ tpl .Values.image.pullPolicy . }}

--- a/helm/polaris/templates/deployment.yaml
+++ b/helm/polaris/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       initContainers:
         {{- tpl (toYaml .Values.extraInitContainers) . | nindent 8 }}
       {{- end }}
-      {{- if .Values.terminationGracePeriodSeconds }}
+      {{- if ne .Values.terminationGracePeriodSeconds nil }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
       containers:

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -338,6 +338,42 @@ tests:
             runAsNonRoot: false
             runAsUser: 1234
 
+  # spec.template.spec.containers[0].lifecycle
+  - it: should not set container lifecycle by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+  - it: should set container lifecycle with preStop hook
+    template: deployment.yaml
+    set:
+      containerLifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 60"]
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].lifecycle
+          content:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 60"]
+
+  # spec.template.spec.terminationGracePeriodSeconds
+  - it: should not set terminationGracePeriodSeconds by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+  - it: should set terminationGracePeriodSeconds
+    template: deployment.yaml
+    set:
+      terminationGracePeriodSeconds: 90
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 90
+
   # spec.template.spec.containers[0].image
   - it: should set container image
     template: deployment.yaml

--- a/helm/polaris/tests/deployment_test.yaml
+++ b/helm/polaris/tests/deployment_test.yaml
@@ -373,6 +373,14 @@ tests:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 90
+  - it: should set terminationGracePeriodSeconds to zero
+    template: deployment.yaml
+    set:
+      terminationGracePeriodSeconds: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 0
 
   # spec.template.spec.containers[0].image
   - it: should set container image

--- a/helm/polaris/values.schema.json
+++ b/helm/polaris/values.schema.json
@@ -134,6 +134,13 @@
                 "type": "string"
             }
         },
+        "containerLifecycle": {
+            "description": "Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/). Use this to configure a preStop hook for graceful shutdown, e.g.: containerLifecycle: preStop: exec: command: [\"/bin/sh\", \"-c\", \"sleep 30\"]",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
         "containerSecurityContext": {
             "description": "Security context for the polaris container. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
             "type": "object"
@@ -1351,6 +1358,14 @@
                     "type": "integer"
                 }
             }
+        },
+        "terminationGracePeriodSeconds": {
+            "description": "Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration. See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination). When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time.",
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1
         },
         "tolerations": {
             "description": "A list of tolerations to apply to polaris pods. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).",

--- a/helm/polaris/values.schema.json
+++ b/helm/polaris/values.schema.json
@@ -136,10 +136,7 @@
         },
         "containerLifecycle": {
             "description": "Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/). Use this to configure a preStop hook for graceful shutdown, e.g.: containerLifecycle: preStop: exec: command: [\"/bin/sh\", \"-c\", \"sleep 30\"]",
-            "type": [
-                "object",
-                "null"
-            ]
+            "type": "object"
         },
         "containerSecurityContext": {
             "description": "Security context for the polaris container. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
@@ -1365,7 +1362,7 @@
                 "integer",
                 "null"
             ],
-            "minimum": 1
+            "minimum": 0
         },
         "tolerations": {
             "description": "A list of tolerations to apply to polaris pods. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).",

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -141,6 +141,24 @@ containerSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# @schema type: [object, "null"]
+# -- Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).
+# Use this to configure a preStop hook for graceful shutdown, e.g.:
+# containerLifecycle:
+#   preStop:
+#     exec:
+#       command: ["/bin/sh", "-c", "sleep 30"]
+# @section -- Pod Configuration
+containerLifecycle: {}
+
+# @schema type: [integer, "null"]
+# @schema minimum: 1
+# -- Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration.
+# See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
+# When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time.
+# @section -- Pod Configuration
+terminationGracePeriodSeconds: ~
+
 # Polaris main service settings.
 service:
   # @schema enum: [ExternalName, ClusterIP, NodePort, LoadBalancer]

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -141,7 +141,7 @@ containerSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# @schema type: [object, "null"]
+# @schema type: object
 # -- Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).
 # Use this to configure a preStop hook for graceful shutdown, e.g.:
 # containerLifecycle:
@@ -152,7 +152,7 @@ containerSecurityContext:
 containerLifecycle: {}
 
 # @schema type: [integer, "null"]
-# @schema minimum: 1
+# @schema minimum: 0
 # -- Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration.
 # See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
 # When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time.

--- a/helm/polaris/values.yaml
+++ b/helm/polaris/values.yaml
@@ -153,7 +153,7 @@ containerLifecycle: {}
 
 # @schema type: [integer, "null"]
 # @schema minimum: 0
-# -- Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration.
+# -- (int) Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration.
 # See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
 # When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time.
 # @section -- Pod Configuration

--- a/site/content/in-dev/unreleased/helm-chart/reference.md
+++ b/site/content/in-dev/unreleased/helm-chart/reference.md
@@ -63,7 +63,7 @@ weight: 900
 | podSecurityContext | object | `{"fsGroup":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris pod. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":10000,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris container. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | containerLifecycle | object | `{}` | Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/). Use this to configure a preStop hook for graceful shutdown, e.g.: containerLifecycle:   preStop:     exec:       command: ["/bin/sh", "-c", "sleep 30"] |
-| terminationGracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration. See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination). When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time. |
+| terminationGracePeriodSeconds | int | `nil` | Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration. See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination). When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time. |
 
 ### Service
 

--- a/site/content/in-dev/unreleased/helm-chart/reference.md
+++ b/site/content/in-dev/unreleased/helm-chart/reference.md
@@ -62,6 +62,8 @@ weight: 900
 | podDisruptionBudget.annotations | object | `{}` | Annotations to add to the pod disruption budget. |
 | podSecurityContext | object | `{"fsGroup":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris pod. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":10000,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the polaris container. See [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
+| containerLifecycle | object | `{}` | Lifecycle hooks for the polaris container. See [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/). Use this to configure a preStop hook for graceful shutdown, e.g.: containerLifecycle:   preStop:     exec:       command: ["/bin/sh", "-c", "sleep 30"] |
+| terminationGracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully. Must be greater than the preStop hook duration. See [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination). When using a preStop hook, set this to at least the preStop sleep time plus the expected request completion time. |
 
 ### Service
 


### PR DESCRIPTION
## Summary

  This PR adds two optional Helm chart settings for Kubernetes termination handling:

  - `terminationGracePeriodSeconds` at the pod spec level
  - `containerLifecycle` for rendering container lifecycle hooks such as `preStop`

  The change is intentionally capability-only and does not change default behavior.

  ## Motivation

  The chart already exposes probe configuration, but it does not currently expose the pod-level termination grace period or container lifecycle hooks.

  These settings are useful for operators who need to coordinate graceful termination with connection draining during rollouts or pod eviction, for example by:

  - allowing more time for in-flight requests to complete
  - delaying container shutdown briefly via `preStop` so endpoint removal can propagate before termination begins

  Without these chart-level knobs, users need to fork or patch the deployment template.

  ## What changed

  - added `terminationGracePeriodSeconds` to `values.yaml`
  - added `containerLifecycle` to `values.yaml`
  - rendered both into `helm/polaris/templates/deployment.yaml`
  - updated `values.schema.json`
  - added Helm unit tests
  - regenerated Helm chart reference docs

  ## Behavior

  - defaults remain unchanged
  - the new settings are optional
  - no runtime behavior changes unless users explicitly configure them

  ## Example

  ```yaml
  terminationGracePeriodSeconds: 330

  containerLifecycle:
    preStop:
      exec:
        command:
          - /bin/sh
          - -c
          - sleep 30
```
  ## Verification

  - make helm-schema-generate
  - make helm-doc-generate
  - make helm-unittest
  - helm lint helm/polaris
  - helm template polaris-release helm/polaris


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
