### PR TITLE
Releasey: fix missing index.yaml in dist/dev Helm repo (#4154)

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -496,7 +496,9 @@ jobs:
           exec_process cp "helm/polaris/artifacthub-repo.yml" "${dist_dev_dir}/helm-chart/artifacthub-repo.yml"
 
           exec_process cd "${dist_dev_dir}"
-          # Add artifacthub-repo.yml if not already versioned
+          # Add index.yaml and artifacthub-repo.yml if not already versioned
+          # (they are removed from dist dev by workflow 4 after each release)
+          exec_process svn add helm-chart/index.yaml || true
           exec_process svn add helm-chart/artifacthub-repo.yml || true
           # Commit the updated index and artifacthub-repo.yml
           exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Update Helm index and artifacthub-repo.yml for ${version_without_rc} RC${rc_number}"


### PR DESCRIPTION
Backporting a1b3192 to 1.4.0.

This PR fixes a missing index.yaml file in the `dist/dev` Helm chart repository when using the automated release process.

The release-3 workflow currently performs the following steps:

1. Copies the generated `index.yaml` into the SVN working copy
2. Copies `artifacthub-repo.yml` into the SVN working copy
3. Runs `svn add` for `artifacthub-repo.yml`
4. Runs `svn commit`

But it never runs `svn add` for `index.yaml`. This worked before because `index.yaml` was already tracked by SVN.

But now, when the release-4 workflow runs `svn mv` to move `index.yaml` from `dist/dev` to `dist/release`, the file is no longer tracked in `dist/dev`. The next release-3 workflow run copies a new `index.yaml` into the working directory, but since it's untracked, `svn commit` silently ignores it.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
