### PR TITLE
CI: Restrict CodeQL to `apache` GitHub org

### DIFF
--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -33,6 +33,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Code-QL is not enabled by default in all GitHub repos and can fail CI in those repos, hence restricting the workflow to only run in the `apache` GitHub org.
