### PR TITLE
Add a few common AI agents to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,14 @@ venv
 # to override default properties for local development.
 # And then use `./gradlew run -Dquarkus.profile=local` to run Polaris with dev profile.
 application-local.properties
+
+# AI / Agentic Development Tools
+.agents/
+.aider/
+.aider.chat.history.md
+.aider.input.history
+.codex/
+.claude/
+.cursor/
+.opencode/
+skills-lock.json


### PR DESCRIPTION
This PR adds hidden files and folders related to agentic-driven development to .gitignore:

- Generic agents
- Aider
- Claude
- Codex
- Cursor
- OpenCode
- skills.sh

Note: `skills-lock.json` is actually meant to be committed, but it doesn't make sense for an Apache project to have this file in version control.

Also, according to Cursor docs, `.cursor/` is meant to be committed as well, which is surprising for a hidden folder. It also doesn't make sense to have it in version control for this project.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
