### PR TITLE
Add Swagger UI for interactive API documentation

### DIFF
--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -45,7 +45,6 @@ quarkus.otel.enabled=true
 #quarkus.mongodb.connection-string=mongodb://localhost:27017
 quarkus.datasource.db-kind=postgresql
 quarkus.smallrye-openapi.store-schema-directory=build/openapi
-quarkus.swagger-ui.always-include=true
 
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -44,6 +44,8 @@ quarkus.otel.enabled=true
 #quarkus.mongodb.metrics.enabled=true
 #quarkus.mongodb.connection-string=mongodb://localhost:27017
 quarkus.datasource.db-kind=postgresql
+quarkus.smallrye-openapi.store-schema-directory=build/openapi
+quarkus.swagger-ui.always-include=true
 
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -335,6 +335,8 @@ This product bundles Quarkus.
 * Maven group:artifact IDs: io.quarkus:quarkus-smallrye-fault-tolerance
 * Maven group:artifact IDs: io.quarkus:quarkus-smallrye-health
 * Maven group:artifact IDs: io.quarkus:quarkus-smallrye-jwt-build
+* Maven group:artifact IDs: io.quarkus:quarkus-smallrye-openapi
+* Maven group:artifact IDs: io.quarkus:quarkus-swagger-ui
 * Maven group:artifact IDs: io.quarkus:quarkus-tls-registry
 * Maven group:artifact IDs: io.quarkus:quarkus-tls-registry-spi
 * Maven group:artifact IDs: io.quarkus:quarkus-transaction-annotations
@@ -383,6 +385,7 @@ This product bundles several SmallRye project artifacts.
 * Maven group:artifact IDs: io.smallrye.reactive:smallrye-reactive-converter-api
 * Maven group:artifact IDs: io.smallrye.reactive:smallrye-reactive-converter-mutiny
 * Maven group:artifact IDs: io.smallrye.reactive:vertx-mutiny-generator
+* Maven group:artifact IDs: io.smallrye:jandex
 * Maven group:artifact IDs: io.smallrye:smallrye-context-propagation
 * Maven group:artifact IDs: io.smallrye:smallrye-context-propagation-api
 * Maven group:artifact IDs: io.smallrye:smallrye-context-propagation-jta
@@ -399,6 +402,8 @@ This product bundles several SmallRye project artifacts.
 * Maven group:artifact IDs: io.smallrye:smallrye-health-api
 * Maven group:artifact IDs: io.smallrye:smallrye-health-provided-checks
 * Maven group:artifact IDs: io.smallrye:smallrye-jwt
+* Maven group:artifact IDs: io.smallrye:smallrye-open-api-core
+* Maven group:artifact IDs: io.smallrye:smallrye-open-api-model
 * Maven group:artifact IDs: io.smallrye:smallrye-jwt-build
 * Maven group:artifact IDs: io.smallrye:smallrye-jwt-common
 
@@ -1618,6 +1623,7 @@ This product bundles Microprofile.
 * Maven group:artifact IDs: org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api
 * Maven group:artifact IDs: org.eclipse.microprofile.health:microprofile-health-api
 * Maven group:artifact IDs: org.eclipse.microprofile.jwt:microprofile-jwt-auth-api
+* Maven group:artifact IDs: org.eclipse.microprofile.openapi:microprofile-openapi-api
 * Maven group:artifact IDs: org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api
 * Maven group:artifact IDs: org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core
 

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
   implementation("io.quarkus:quarkus-reactive-routes")
   implementation("io.quarkus:quarkus-hibernate-validator")
   implementation("io.quarkus:quarkus-smallrye-health")
+  implementation("io.quarkus:quarkus-smallrye-openapi")
   implementation("io.quarkus:quarkus-micrometer")
   implementation("io.quarkus:quarkus-micrometer-registry-prometheus")
   implementation("io.quarkus:quarkus-oidc")


### PR DESCRIPTION
## Summary

- Add `quarkus-smallrye-openapi` extension to expose the OpenAPI spec at `/q/openapi` and Swagger UI at `/q/swagger-ui` in dev mode
- Polaris already uses Swagger annotations (`swagger.jaxrs`, `swagger.annotations`) throughout the codebase but does not serve API docs to developers

## Motivation

Polaris currently requires developers to reference external OpenAPI spec files or read source code to understand the REST API surface. This change improves API discoverability for developers evaluating or integrating with Polaris.

## Changes

- `runtime/service/build.gradle.kts` — add `quarkus-smallrye-openapi` dependency
- `runtime/defaults/src/main/resources/application.properties` — configure schema output directory
- `runtime/server/distribution/LICENSE` — add license entries for transitive dependencies

Swagger UI is auto-enabled by Quarkus in dev mode only. With `quarkus.management.enabled=true`, both endpoints are served on the management port (8182):
- `http://localhost:8182/q/swagger-ui/`
- `http://localhost:8182/q/openapi`

Production builds do not include Swagger UI unless users explicitly opt in with `quarkus.swagger-ui.always-include=true` at build time.


## Test plan

- [x] `./gradlew :polaris-runtime-service:compileJava :polaris-server:compileJava` — builds successfully
- [x] `./gradlew :polaris-server:generateLicenseReport` — license check passes
- [x] `./gradlew :polaris-runtime-service:spotlessCheck` — formatting passes
- [x] `./gradlew quarkusDev` → verified Swagger UI at `http://localhost:8182/q/swagger-ui/`
- [x] Verified `/q/openapi` returns the OpenAPI spec in YAML format on port 8182
- [x] CI passes