### PR TITLE
Improve namespace decoding

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
@@ -22,7 +22,6 @@ import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Joiner;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
@@ -36,12 +35,12 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.ErrorHandler;
 import org.apache.iceberg.rest.ErrorHandlers;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.polaris.core.rest.NamespaceUtils;
 
 /**
  * A simple, non-exhaustive set of helper methods for accessing the Iceberg REST API.
@@ -68,9 +67,9 @@ public class CatalogApi extends PolarisRestApi {
   public List<Namespace> listNamespaces(String catalog, Namespace parent) {
     Map<String, String> queryParams = new HashMap<>();
     if (!parent.isEmpty()) {
-      // TODO change this for Iceberg 1.7.2:
-      //   queryParams.put("parent", RESTUtil.encodeNamespace(parent));
-      queryParams.put("parent", Joiner.on('\u001f').join(parent.levels()));
+      queryParams.put(
+          "parent",
+          NamespaceUtils.joinNamespace(parent, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR));
     }
     try (Response response =
         request("v1/{cat}/namespaces", Map.of("cat", catalog), queryParams).get()) {
@@ -84,9 +83,9 @@ public class CatalogApi extends PolarisRestApi {
       String catalog, Namespace parent, String pageToken, String pageSize) {
     Map<String, String> queryParams = new HashMap<>();
     if (!parent.isEmpty()) {
-      // TODO change this for Iceberg 1.7.2:
-      //   queryParams.put("parent", RESTUtil.encodeNamespace(parent));
-      queryParams.put("parent", Joiner.on('\u001f').join(parent.levels()));
+      queryParams.put(
+          "parent",
+          NamespaceUtils.joinNamespace(parent, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR));
     }
     queryParams.put("pageToken", pageToken);
     queryParams.put("pageSize", pageSize);
@@ -113,9 +112,9 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public void deleteNamespace(String catalog, Namespace namespace) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response response =
-        request("v1/{cat}/namespaces/" + ns, Map.of("cat", catalog)).delete()) {
+        request("v1/{cat}/namespaces/{ns}", Map.of("cat", catalog, "ns", ns)).delete()) {
       assertThat(response.getStatus()).isEqualTo(NO_CONTENT.getStatusCode());
     }
   }
@@ -131,9 +130,9 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public List<TableIdentifier> listTables(String catalog, Namespace namespace) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
-        request("v1/{cat}/namespaces/" + ns + "/tables", Map.of("cat", catalog)).get()) {
+        request("v1/{cat}/namespaces/{ns}/tables", Map.of("cat", catalog, "ns", ns)).get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class).identifiers();
     }
@@ -141,12 +140,12 @@ public class CatalogApi extends PolarisRestApi {
 
   public ListTablesResponse listTables(
       String catalog, Namespace namespace, String pageToken, String pageSize) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("pageToken", pageToken);
     queryParams.put("pageSize", pageSize);
     try (Response res =
-        request("v1/{cat}/namespaces/" + ns + "/tables", Map.of("cat", catalog), queryParams)
+        request("v1/{cat}/namespaces/{ns}/tables", Map.of("cat", catalog, "ns", ns), queryParams)
             .get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class);
@@ -154,11 +153,12 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public void dropTable(String catalog, TableIdentifier id) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
-                "v1/{cat}/namespaces/" + ns + "/tables/{table}",
-                Map.of("cat", catalog, "table", id.name()))
+                "v1/{cat}/namespaces/{ns}/tables/{table}",
+                Map.of("cat", catalog, "ns", ns, "table", id.name()))
             .delete()) {
       assertThat(res.getStatus()).isEqualTo(NO_CONTENT.getStatusCode());
     }
@@ -175,11 +175,12 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public LoadCredentialsResponse loadCredentials(String catalog, TableIdentifier id) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
-                "v1/{cat}/namespaces/" + ns + "/tables/{table}/credentials",
-                Map.of("cat", catalog, "table", id.name()))
+                "v1/{cat}/namespaces/{ns}/tables/{table}/credentials",
+                Map.of("cat", catalog, "ns", ns, "table", id.name()))
             .get()) {
       assertThat(res.getStatus()).isEqualTo(OK.getStatusCode());
       return res.readEntity(LoadCredentialsResponse.class);
@@ -191,11 +192,12 @@ public class CatalogApi extends PolarisRestApi {
     HashMap<String, String> allHeaders = new HashMap<>(defaultHeaders());
     allHeaders.putAll(headers);
 
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
-                "v1/{cat}/namespaces/" + ns + "/tables/{table}",
-                Map.of("cat", catalog, "table", id.name()),
+                "v1/{cat}/namespaces/{ns}/tables/{table}",
+                Map.of("cat", catalog, "ns", ns, "table", id.name()),
                 snapshots == null ? Map.of() : Map.of("snapshots", snapshots),
                 allHeaders)
             .get()) {
@@ -210,9 +212,9 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public List<TableIdentifier> listViews(String catalog, Namespace namespace) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
-        request("v1/{cat}/namespaces/" + ns + "/views", Map.of("cat", catalog)).get()) {
+        request("v1/{cat}/namespaces/{ns}/views", Map.of("cat", catalog, "ns", ns)).get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class).identifiers();
     }
@@ -220,12 +222,12 @@ public class CatalogApi extends PolarisRestApi {
 
   public ListTablesResponse listViews(
       String catalog, Namespace namespace, String pageToken, String pageSize) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("pageToken", pageToken);
     queryParams.put("pageSize", pageSize);
     try (Response res =
-        request("v1/{cat}/namespaces/" + ns + "/views", Map.of("cat", catalog), queryParams)
+        request("v1/{cat}/namespaces/{ns}/views", Map.of("cat", catalog, "ns", ns), queryParams)
             .get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class);
@@ -233,11 +235,12 @@ public class CatalogApi extends PolarisRestApi {
   }
 
   public void dropView(String catalog, TableIdentifier id) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
-                "v1/{cat}/namespaces/" + ns + "/views/{view}",
-                Map.of("cat", catalog, "view", id.name()))
+                "v1/{cat}/namespaces/{ns}/views/{view}",
+                Map.of("cat", catalog, "ns", ns, "view", id.name()))
             .delete()) {
       assertThat(res.getStatus()).isEqualTo(NO_CONTENT.getStatusCode());
     }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/GenericTableApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/GenericTableApi.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTUtil;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.service.types.CreateGenericTableRequest;
 import org.apache.polaris.service.types.GenericTable;
 import org.apache.polaris.service.types.ListGenericTablesResponse;
@@ -50,7 +50,7 @@ public class GenericTableApi extends PolarisRestApi {
   }
 
   public List<TableIdentifier> listGenericTables(String catalog, Namespace namespace) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request("polaris/v1/{cat}/namespaces/{ns}/generic-tables", Map.of("cat", catalog, "ns", ns))
             .get()) {
@@ -60,7 +60,8 @@ public class GenericTableApi extends PolarisRestApi {
   }
 
   public void dropGenericTable(String catalog, TableIdentifier id) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
                 "polaris/v1/{cat}/namespaces/{ns}/generic-tables/{table}",
@@ -71,7 +72,8 @@ public class GenericTableApi extends PolarisRestApi {
   }
 
   public GenericTable getGenericTable(String catalog, TableIdentifier id) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
                 "polaris/v1/{cat}/namespaces/{ns}/generic-tables/{table}",
@@ -83,7 +85,8 @@ public class GenericTableApi extends PolarisRestApi {
 
   public GenericTable createGenericTable(
       String catalog, TableIdentifier id, String format, Map<String, String> properties) {
-    String ns = RESTUtil.encodeNamespace(id.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(id.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
                 "polaris/v1/{cat}/namespaces/{ns}/generic-tables/",

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolicyApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/PolicyApi.java
@@ -26,9 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.service.types.ApplicablePolicy;
 import org.apache.polaris.service.types.AttachPolicyRequest;
 import org.apache.polaris.service.types.CreatePolicyRequest;
@@ -56,7 +56,7 @@ public class PolicyApi extends PolarisRestApi {
   }
 
   public List<PolicyIdentifier> listPolicies(String catalog, Namespace namespace, PolicyType type) {
-    String ns = RESTUtil.encodeNamespace(namespace);
+    String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     Map<String, String> queryParams = new HashMap<>();
     if (type != null) {
       queryParams.put("policyType", type.getName());
@@ -77,7 +77,9 @@ public class PolicyApi extends PolarisRestApi {
   }
 
   public void dropPolicy(String catalog, PolicyIdentifier policyIdentifier, Boolean detachAll) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     Map<String, String> queryParams = new HashMap<>();
     if (detachAll != null) {
       queryParams.put("detach-all", detachAll.toString());
@@ -96,7 +98,9 @@ public class PolicyApi extends PolarisRestApi {
   }
 
   public Policy loadPolicy(String catalog, PolicyIdentifier policyIdentifier) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     try (Response res =
         request(
                 "polaris/v1/{cat}/namespaces/{ns}/policies/{policy}",
@@ -113,7 +117,9 @@ public class PolicyApi extends PolarisRestApi {
       PolicyType policyType,
       String content,
       String description) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     CreatePolicyRequest request =
         CreatePolicyRequest.builder()
             .setType(policyType.getName())
@@ -135,7 +141,9 @@ public class PolicyApi extends PolarisRestApi {
       String newContent,
       String newDescription,
       int currentPolicyVersion) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     UpdatePolicyRequest request =
         UpdatePolicyRequest.builder()
             .setContent(newContent)
@@ -157,7 +165,9 @@ public class PolicyApi extends PolarisRestApi {
       PolicyIdentifier policyIdentifier,
       PolicyAttachmentTarget target,
       Map<String, String> parameters) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     AttachPolicyRequest request =
         AttachPolicyRequest.builder().setTarget(target).setParameters(parameters).build();
     try (Response res =
@@ -171,7 +181,9 @@ public class PolicyApi extends PolarisRestApi {
 
   public void detachPolicy(
       String catalog, PolicyIdentifier policyIdentifier, PolicyAttachmentTarget target) {
-    String ns = RESTUtil.encodeNamespace(policyIdentifier.namespace());
+    String ns =
+        NamespaceUtils.joinNamespace(
+            policyIdentifier.namespace(), NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     DetachPolicyRequest request = DetachPolicyRequest.builder().setTarget(target).build();
     try (Response res =
         request(
@@ -184,7 +196,10 @@ public class PolicyApi extends PolarisRestApi {
 
   public List<ApplicablePolicy> getApplicablePolicies(
       String catalog, Namespace namespace, String targetName, PolicyType policyType) {
-    String ns = namespace != null ? RESTUtil.encodeNamespace(namespace) : null;
+    String ns =
+        namespace != null
+            ? NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR)
+            : null;
     Map<String, String> queryParams = new HashMap<>();
     if (ns != null) {
       queryParams.put("namespace", ns);

--- a/polaris-core/src/main/java/org/apache/polaris/core/rest/NamespaceUtils.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/rest/NamespaceUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.rest;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import org.apache.iceberg.catalog.Namespace;
+
+/** Utility methods for encoding and decoding {@link Namespace} values. */
+public final class NamespaceUtils {
+
+  /**
+   * The default namespace separator: the ASCII Unit Separator character (U+001F).
+   *
+   * <p>This is the same separator declared in Iceberg's {@link org.apache.iceberg.rest.RESTUtil}
+   * class, but it's private there and cannot be referenced.
+   */
+  public static final String DEFAULT_NAMESPACE_SEPARATOR = "\u001f";
+
+  private NamespaceUtils() {}
+
+  /** Joins the levels of a namespace into a single string using the given {@code separator}. */
+  public static String joinNamespace(Namespace namespace, String separator) {
+    return Joiner.on(separator).join(namespace.levels());
+  }
+
+  /**
+   * Splits the string using the given {@code separator} and returns the corresponding namespace.
+   */
+  public static Namespace splitNamespace(String namespace, String separator) {
+    return Namespace.of(Iterables.toArray(Splitter.on(separator).split(namespace), String.class));
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/rest/NamespaceUtilsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/rest/NamespaceUtilsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.iceberg.catalog.Namespace;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class NamespaceUtilsTest {
+
+  static Stream<Arguments> joinNamespaceCases() {
+    return Stream.of(
+        // empty namespace
+        Arguments.of(Namespace.of(), ""),
+        // single level
+        Arguments.of(Namespace.of("simple"), "simple"),
+        // multi-level
+        Arguments.of(Namespace.of("foo", "bar", "baz"), "foo\u001fbar\u001fbaz"),
+        // spaces
+        Arguments.of(Namespace.of("foo bar"), "foo bar"),
+        Arguments.of(Namespace.of("foo bar", "baz qux"), "foo bar\u001fbaz qux"),
+        // plus sign
+        Arguments.of(Namespace.of("foo+bar"), "foo+bar"),
+        Arguments.of(Namespace.of("a+b", "c+d"), "a+b\u001fc+d"),
+        // percent-encoded sequences (treated as literals, not decoded)
+        Arguments.of(Namespace.of("foo%20bar"), "foo%20bar"),
+        Arguments.of(Namespace.of("%2F"), "%2F"),
+        // slash in level names (safe with the default \u001f separator)
+        Arguments.of(Namespace.of("a/b"), "a/b"),
+        Arguments.of(Namespace.of("foo/bar", "baz/qux"), "foo/bar\u001fbaz/qux"),
+        Arguments.of(Namespace.of("path/to/resource"), "path/to/resource"),
+        // non-ASCII characters
+        Arguments.of(Namespace.of("café"), "café"),
+        Arguments.of(Namespace.of("日本語"), "日本語"),
+        Arguments.of(Namespace.of("日本語", "namespace"), "日本語\u001fnamespace"),
+        // combination of various special characters
+        Arguments.of(
+            Namespace.of("foo bar", "baz+qux", "café", "%20"),
+            "foo bar\u001fbaz+qux\u001fcafé\u001f%20"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("joinNamespaceCases")
+  void joinNamespace(Namespace namespace, String expected) {
+    assertThat(NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR))
+        .isEqualTo(expected);
+  }
+
+  static Stream<Arguments> splitNamespaceCases() {
+    return Stream.of(
+        // single level
+        Arguments.of("simple", Namespace.of("simple")),
+        // multi-level
+        Arguments.of("foo\u001fbar\u001fbaz", Namespace.of("foo", "bar", "baz")),
+        // spaces
+        Arguments.of("foo bar", Namespace.of("foo bar")),
+        Arguments.of("foo bar\u001fbaz qux", Namespace.of("foo bar", "baz qux")),
+        // plus sign
+        Arguments.of("foo+bar", Namespace.of("foo+bar")),
+        Arguments.of("a+b\u001fc+d", Namespace.of("a+b", "c+d")),
+        // percent-encoded sequences (treated as literals, not decoded)
+        Arguments.of("foo%20bar", Namespace.of("foo%20bar")),
+        Arguments.of("%2F", Namespace.of("%2F")),
+        // slash in level names (safe with the default \u001f separator)
+        Arguments.of("a/b", Namespace.of("a/b")),
+        Arguments.of("foo/bar\u001fbaz/qux", Namespace.of("foo/bar", "baz/qux")),
+        Arguments.of("path/to/resource", Namespace.of("path/to/resource")),
+        // non-ASCII characters
+        Arguments.of("café", Namespace.of("café")),
+        Arguments.of("日本語", Namespace.of("日本語")),
+        Arguments.of("日本語\u001fnamespace", Namespace.of("日本語", "namespace")),
+        // combination of various special characters
+        Arguments.of(
+            "foo bar\u001fbaz+qux\u001fcafé\u001f%20",
+            Namespace.of("foo bar", "baz+qux", "café", "%20")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("splitNamespaceCases")
+  void splitNamespace(String joined, Namespace expected) {
+    assertThat(NamespaceUtils.splitNamespace(joined, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR))
+        .isEqualTo(expected);
+  }
+
+  // Round-trip cases: namespace levels contain none of the tested separators (\u001f, /, |, --).
+  static Stream<Arguments> roundTripCases() {
+    List<Namespace> namespaces =
+        List.of(
+            Namespace.of("simple"),
+            Namespace.of("foo", "bar", "baz"),
+            Namespace.of("foo bar"),
+            Namespace.of("foo bar", "baz qux"),
+            Namespace.of("foo+bar"),
+            Namespace.of("a+b", "c+d"),
+            Namespace.of("foo%20bar"),
+            Namespace.of("%2F"),
+            Namespace.of("café"),
+            Namespace.of("日本語"),
+            Namespace.of("日本語", "namespace"),
+            Namespace.of("foo bar", "baz+qux", "café", "%20"));
+    List<String> separators = List.of("\u001f", "/", "|", "--");
+    return namespaces.stream().flatMap(ns -> separators.stream().map(sep -> Arguments.of(ns, sep)));
+  }
+
+  // Round-trip cases for namespaces whose levels contain "/": only non-"/" separators are valid.
+  static Stream<Arguments> roundTripCasesWithSlash() {
+    List<Namespace> namespaces =
+        List.of(
+            Namespace.of("a/b"),
+            Namespace.of("foo/bar", "baz/qux"),
+            Namespace.of("path/to/resource"),
+            Namespace.of("a/b", "c+d", "café"));
+    List<String> separators = List.of("\u001f", "|", "--");
+    return namespaces.stream().flatMap(ns -> separators.stream().map(sep -> Arguments.of(ns, sep)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("roundTripCases")
+  void roundTrip(Namespace namespace, String separator) {
+    assertThat(
+            NamespaceUtils.splitNamespace(
+                NamespaceUtils.joinNamespace(namespace, separator), separator))
+        .isEqualTo(namespace);
+  }
+
+  @ParameterizedTest
+  @MethodSource("roundTripCasesWithSlash")
+  void roundTripWithSlash(Namespace namespace, String separator) {
+    assertThat(
+            NamespaceUtils.splitNamespace(
+                NamespaceUtils.joinNamespace(namespace, separator), separator))
+        .isEqualTo(namespace);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
@@ -19,16 +19,11 @@
 
 package org.apache.polaris.service.catalog.common;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
@@ -99,9 +94,5 @@ public class CatalogUtils {
                 }
               }
             });
-  }
-
-  public static Namespace decodeNamespace(String namespace) {
-    return RESTUtil.decodeNamespace(URLEncoder.encode(namespace, UTF_8));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogAdapter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.service.catalog.generic;
 
-import static org.apache.polaris.service.catalog.common.CatalogUtils.decodeNamespace;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -30,6 +28,7 @@ import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.api.PolarisCatalogGenericTableApiService;
 import org.apache.polaris.service.catalog.common.CatalogAdapter;
@@ -78,7 +77,10 @@ public class GenericTableCatalogAdapter
     GenericTableCatalogHandler handler = newHandler(securityContext, prefix);
     LoadGenericTableResponse response =
         handler.createGenericTable(
-            TableIdentifier.of(decodeNamespace(namespace), createGenericTableRequest.getName()),
+            TableIdentifier.of(
+                NamespaceUtils.splitNamespace(
+                    namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR),
+                createGenericTableRequest.getName()),
             createGenericTableRequest.getFormat(),
             createGenericTableRequest.getBaseLocation(),
             createGenericTableRequest.getDoc(),
@@ -95,7 +97,10 @@ public class GenericTableCatalogAdapter
       RealmContext realmContext,
       SecurityContext securityContext) {
     GenericTableCatalogHandler handler = newHandler(securityContext, prefix);
-    handler.dropGenericTable(TableIdentifier.of(decodeNamespace(namespace), genericTable));
+    handler.dropGenericTable(
+        TableIdentifier.of(
+            NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR),
+            genericTable));
     return Response.noContent().build();
   }
 
@@ -108,7 +113,9 @@ public class GenericTableCatalogAdapter
       RealmContext realmContext,
       SecurityContext securityContext) {
     GenericTableCatalogHandler handler = newHandler(securityContext, prefix);
-    ListGenericTablesResponse response = handler.listGenericTables(decodeNamespace(namespace));
+    ListGenericTablesResponse response =
+        handler.listGenericTables(
+            NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR));
     return Response.ok(response).build();
   }
 
@@ -122,7 +129,11 @@ public class GenericTableCatalogAdapter
       SecurityContext securityContext) {
     GenericTableCatalogHandler handler = newHandler(securityContext, prefix);
     LoadGenericTableResponse response =
-        handler.loadGenericTable(TableIdentifier.of(decodeNamespace(namespace), genericTable));
+        handler.loadGenericTable(
+            TableIdentifier.of(
+                NamespaceUtils.splitNamespace(
+                    namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR),
+                genericTable));
     return Response.ok(response).build();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
-import static org.apache.polaris.service.catalog.common.CatalogUtils.decodeNamespace;
 import static org.apache.polaris.service.catalog.validation.IcebergPropertiesValidation.validateIcebergProperties;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -50,13 +49,13 @@ import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.core.rest.PolarisResourcePaths;
 import org.apache.polaris.service.catalog.AccessDelegationMode;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.api.IcebergRestCatalogApiService;
 import org.apache.polaris.service.catalog.api.IcebergRestConfigurationApiService;
 import org.apache.polaris.service.catalog.common.CatalogAdapter;
-import org.apache.polaris.service.catalog.common.CatalogUtils;
 import org.apache.polaris.service.config.ReservedProperties;
 import org.apache.polaris.service.http.IcebergHttpUtil;
 import org.apache.polaris.service.http.IfNoneMatch;
@@ -148,7 +147,11 @@ public class IcebergCatalogAdapter
       RealmContext realmContext,
       SecurityContext securityContext) {
     Optional<Namespace> namespaceOptional =
-        Optional.ofNullable(parent).map(CatalogUtils::decodeNamespace);
+        Optional.ofNullable(parent)
+            .map(
+                namespace ->
+                    NamespaceUtils.splitNamespace(
+                        namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR));
     return withCatalog(
         securityContext,
         prefix,
@@ -162,7 +165,8 @@ public class IcebergCatalogAdapter
   @Override
   public Response loadNamespaceMetadata(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext, prefix, catalog -> Response.ok(catalog.loadNamespaceMetadata(ns)).build());
   }
@@ -195,7 +199,8 @@ public class IcebergCatalogAdapter
   @Override
   public Response namespaceExists(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -208,7 +213,8 @@ public class IcebergCatalogAdapter
   @Override
   public Response dropNamespace(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -226,7 +232,8 @@ public class IcebergCatalogAdapter
       RealmContext realmContext,
       SecurityContext securityContext) {
     validateIcebergProperties(realmConfig, updateNamespacePropertiesRequest.updates());
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     UpdateNamespacePropertiesRequest revisedRequest =
         UpdateNamespacePropertiesRequest.builder()
             .removeAll(
@@ -259,7 +266,8 @@ public class IcebergCatalogAdapter
     validateIcebergProperties(realmConfig, createTableRequest.properties());
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -293,7 +301,8 @@ public class IcebergCatalogAdapter
       Integer pageSize,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -312,7 +321,8 @@ public class IcebergCatalogAdapter
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
 
     IfNoneMatch ifNoneMatch = IfNoneMatch.fromHeader(ifNoneMatchString);
@@ -358,7 +368,8 @@ public class IcebergCatalogAdapter
       String table,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     return withCatalog(
         securityContext,
@@ -377,7 +388,8 @@ public class IcebergCatalogAdapter
       Boolean purgeRequested,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     return withCatalog(
         securityContext,
@@ -399,7 +411,8 @@ public class IcebergCatalogAdapter
       RegisterTableRequest registerTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -446,7 +459,8 @@ public class IcebergCatalogAdapter
             commitTableRequest.updates().stream()
                 .map(reservedProperties::removeReservedProperties)
                 .toList());
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     return withCatalog(
         securityContext,
@@ -474,7 +488,8 @@ public class IcebergCatalogAdapter
         ImmutableCreateViewRequest.copyOf(createViewRequest)
             .withProperties(
                 reservedProperties.removeReservedProperties(createViewRequest.properties()));
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -489,7 +504,8 @@ public class IcebergCatalogAdapter
       Integer pageSize,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
         securityContext,
         prefix,
@@ -503,7 +519,8 @@ public class IcebergCatalogAdapter
       String table,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     Optional<String> refreshEndpoint =
         Optional.of(new PolarisResourcePaths(prefix).credentialsPath(tableIdentifier));
@@ -520,7 +537,8 @@ public class IcebergCatalogAdapter
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     return withCatalog(
         securityContext, prefix, catalog -> Response.ok(catalog.loadView(tableIdentifier)).build());
@@ -533,7 +551,8 @@ public class IcebergCatalogAdapter
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     return withCatalog(
         securityContext,
@@ -551,7 +570,8 @@ public class IcebergCatalogAdapter
       String view,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     return withCatalog(
         securityContext,
@@ -592,7 +612,8 @@ public class IcebergCatalogAdapter
             commitViewRequest.updates().stream()
                 .map(reservedProperties::removeReservedProperties)
                 .toList());
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(view));
     return withCatalog(
         securityContext,
@@ -642,7 +663,8 @@ public class IcebergCatalogAdapter
       ReportMetricsRequest reportMetricsRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     return withCatalog(
         securityContext,
@@ -661,7 +683,8 @@ public class IcebergCatalogAdapter
       NotificationRequest notificationRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     TableIdentifier tableIdentifier = TableIdentifier.of(ns, RESTUtil.decodeString(table));
     return withCatalog(
         securityContext,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
@@ -19,8 +19,6 @@
 
 package org.apache.polaris.service.catalog.iceberg;
 
-import static org.apache.polaris.service.catalog.common.CatalogUtils.decodeNamespace;
-
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Priority;
 import jakarta.decorator.Decorator;
@@ -46,6 +44,7 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.api.IcebergRestCatalogApiService;
 import org.apache.polaris.service.catalog.common.CatalogAdapter;
@@ -154,7 +153,10 @@ public class IcebergRestCatalogEventServiceDelegator
             eventMetadataFactory.create(),
             new EventAttributeMap()
                 .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
+                .put(
+                    EventAttributes.NAMESPACE,
+                    NamespaceUtils.splitNamespace(
+                        namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR))));
     Response resp =
         delegate.loadNamespaceMetadata(prefix, namespace, realmContext, securityContext);
     GetNamespaceResponse getNamespaceResponse = (GetNamespaceResponse) resp.getEntity();
@@ -173,7 +175,8 @@ public class IcebergRestCatalogEventServiceDelegator
   public Response namespaceExists(
       String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_CHECK_EXISTS_NAMESPACE,
@@ -202,7 +205,10 @@ public class IcebergRestCatalogEventServiceDelegator
             eventMetadataFactory.create(),
             new EventAttributeMap()
                 .put(EventAttributes.CATALOG_NAME, catalogName)
-                .put(EventAttributes.NAMESPACE, decodeNamespace(namespace))));
+                .put(
+                    EventAttributes.NAMESPACE,
+                    NamespaceUtils.splitNamespace(
+                        namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR))));
     Response resp = delegate.dropNamespace(prefix, namespace, realmContext, securityContext);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
@@ -222,7 +228,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_UPDATE_NAMESPACE_PROPERTIES,
@@ -258,7 +265,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_CREATE_TABLE,
@@ -299,7 +307,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_LIST_TABLES,
@@ -330,7 +339,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_TABLE,
@@ -373,7 +383,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_CHECK_EXISTS_TABLE,
@@ -403,7 +414,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_DROP_TABLE,
@@ -435,7 +447,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_REGISTER_TABLE,
@@ -493,7 +506,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_UPDATE_TABLE,
@@ -529,7 +543,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_CREATE_VIEW,
@@ -561,7 +576,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_LIST_VIEWS,
@@ -589,7 +605,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_CREDENTIALS,
@@ -619,7 +636,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_LOAD_VIEW,
@@ -649,7 +667,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_CHECK_EXISTS_VIEW,
@@ -678,7 +697,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_DROP_VIEW,
@@ -733,7 +753,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_REPLACE_VIEW,
@@ -836,7 +857,8 @@ public class IcebergRestCatalogEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    Namespace namespaceObj = decodeNamespace(namespace);
+    Namespace namespaceObj =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     polarisEventDispatcher.dispatch(
         new PolarisEvent(
             PolarisEventType.BEFORE_SEND_NOTIFICATION,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.service.catalog.policy;
 
-import static org.apache.polaris.service.catalog.common.CatalogUtils.decodeNamespace;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -32,6 +30,7 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.policy.PolicyType;
+import org.apache.polaris.core.rest.NamespaceUtils;
 import org.apache.polaris.service.catalog.CatalogPrefixParser;
 import org.apache.polaris.service.catalog.api.PolarisCatalogPolicyApiService;
 import org.apache.polaris.service.catalog.common.CatalogAdapter;
@@ -76,7 +75,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       CreatePolicyRequest createPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     LoadPolicyResponse response = handler.createPolicy(ns, createPolicyRequest);
     return Response.ok(response).build();
@@ -91,7 +91,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       String policyType,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyType type =
         policyType != null ? PolicyType.fromName(RESTUtil.decodeString(policyType)) : null;
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
@@ -106,7 +107,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       String policyName,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyIdentifier identifier = new PolicyIdentifier(ns, RESTUtil.decodeString(policyName));
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     LoadPolicyResponse response = handler.loadPolicy(identifier);
@@ -121,7 +123,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       UpdatePolicyRequest updatePolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyIdentifier identifier = new PolicyIdentifier(ns, RESTUtil.decodeString(policyName));
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     LoadPolicyResponse response = handler.updatePolicy(identifier, updatePolicyRequest);
@@ -136,7 +139,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       Boolean detachAll,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyIdentifier identifier = new PolicyIdentifier(ns, RESTUtil.decodeString(policyName));
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     handler.dropPolicy(identifier, detachAll != null && detachAll);
@@ -151,7 +155,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       AttachPolicyRequest attachPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyIdentifier identifier = new PolicyIdentifier(ns, RESTUtil.decodeString(policyName));
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     handler.attachPolicy(identifier, attachPolicyRequest);
@@ -166,7 +171,8 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       DetachPolicyRequest detachPolicyRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = decodeNamespace(namespace);
+    Namespace ns =
+        NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     PolicyIdentifier identifier = new PolicyIdentifier(ns, RESTUtil.decodeString(policyName));
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     handler.detachPolicy(identifier, detachPolicyRequest);
@@ -183,7 +189,10 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       String policyType,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    Namespace ns = namespace != null ? decodeNamespace(namespace) : null;
+    Namespace ns =
+        namespace != null
+            ? NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR)
+            : null;
     String target = targetName != null ? RESTUtil.decodeString(targetName) : null;
     PolicyType type =
         policyType != null ? PolicyType.fromName(RESTUtil.decodeString(policyType)) : null;


### PR DESCRIPTION
This change removes calls to Iceberg `RESTUtil.decodeNamespace()` almost entirely, and replaces those with methods that are more suitable for use in Quarkus/Jersey.

The REST framework (Jersey) already URL-decodes path segments. For example, when a REST resource method such as `IcebergRestCatalogApi.loadTable` is invoked, the parameters `namespace` and `table` are already URL-decoded.

But since `RESTUtil.decodeNamespace()` expects *encoded* inputs, we were forced to re-encode the namespace name before passing it to `decodeNamespace()`.

This change does NOT remove calls to `RESTUtil.decodeNamespace()` in the Polaris entity code – this will be addressed later.

This change also does NOT change calls to `RESTUtil.encodeNamespace()` – these are problematic but will be addressed later as well.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
