### PR TITLE
Isolate encode/decode logic used in Polaris entities

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/NamespaceEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/NamespaceEntity.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import jakarta.annotation.Nullable;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
 
 /**
@@ -30,7 +29,7 @@ import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
  * internalProperties specific to the NAMESPACE type.
  */
 public class NamespaceEntity extends PolarisEntity implements LocationBasedEntity {
-  // RESTUtil-encoded parent namespace.
+  // Encoded parent namespace.
   public static final String PARENT_NAMESPACE_KEY = "parent-namespace";
 
   public NamespaceEntity(PolarisBaseEntity sourceEntity) {
@@ -55,7 +54,7 @@ public class NamespaceEntity extends PolarisEntity implements LocationBasedEntit
     if (encodedNamespace == null) {
       return Namespace.empty();
     }
-    return RESTUtil.decodeNamespace(encodedNamespace);
+    return PolarisEntityUtils.decodeNamespace(encodedNamespace);
   }
 
   public Namespace asNamespace() {
@@ -89,7 +88,7 @@ public class NamespaceEntity extends PolarisEntity implements LocationBasedEntit
 
     public Builder setParentNamespace(Namespace namespace) {
       if (namespace != null && !namespace.isEmpty()) {
-        internalProperties.put(PARENT_NAMESPACE_KEY, RESTUtil.encodeNamespace(namespace));
+        internalProperties.put(PARENT_NAMESPACE_KEY, PolarisEntityUtils.encodeNamespace(namespace));
       }
       return this;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityUtils.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityUtils.java
@@ -18,16 +18,30 @@
  */
 package org.apache.polaris.core.entity;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
 
+/**
+ * Polaris-owned encoding/decoding for namespaces stored in entity internal properties.
+ *
+ * <p>This logic is isolated from {@link RESTUtil} to ensure the storage format remains stable even
+ * if Iceberg's REST utilities change behavior in future versions, preventing potential data
+ * corruption in Polaris metastores.
+ */
 public final class PolarisEntityUtils {
 
   private static final String NAMESPACE_SEPARATOR_ENCODED = "%1F";
+
+  private static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR_ENCODED);
+
+  private static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR_ENCODED);
 
   private PolarisEntityUtils() {}
 
@@ -44,7 +58,7 @@ public final class PolarisEntityUtils {
     for (int i = 0; i < levels.length; i++) {
       encodedLevels[i] = URLEncoder.encode(levels[i], StandardCharsets.UTF_8);
     }
-    return String.join(NAMESPACE_SEPARATOR_ENCODED, encodedLevels);
+    return NAMESPACE_JOINER.join(encodedLevels);
   }
 
   /**
@@ -55,7 +69,7 @@ public final class PolarisEntityUtils {
    */
   public static Namespace decodeNamespace(String encodedNs) {
     Preconditions.checkArgument(encodedNs != null, "Invalid namespace: null");
-    String[] levels = encodedNs.split(NAMESPACE_SEPARATOR_ENCODED, -1);
+    String[] levels = Iterables.toArray(NAMESPACE_SPLITTER.split(encodedNs), String.class);
     for (int i = 0; i < levels.length; i++) {
       levels[i] = URLDecoder.decode(levels[i], StandardCharsets.UTF_8);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityUtils.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.entity;
+
+import com.google.common.base.Preconditions;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.RESTUtil;
+
+public final class PolarisEntityUtils {
+
+  private static final String NAMESPACE_SEPARATOR_ENCODED = "%1F";
+
+  private PolarisEntityUtils() {}
+
+  /**
+   * Returns a String representation of a namespace that is suitable for storage in entity internal
+   * properties.
+   *
+   * <p>This method is similar to {@link RESTUtil#encodeNamespace(Namespace)}.
+   */
+  public static String encodeNamespace(Namespace ns) {
+    Preconditions.checkArgument(ns != null, "Invalid namespace: null");
+    String[] levels = ns.levels();
+    String[] encodedLevels = new String[levels.length];
+    for (int i = 0; i < levels.length; i++) {
+      encodedLevels[i] = URLEncoder.encode(levels[i], StandardCharsets.UTF_8);
+    }
+    return String.join(NAMESPACE_SEPARATOR_ENCODED, encodedLevels);
+  }
+
+  /**
+   * Returns a Namespace object from a String representation that was encoded using {@link
+   * #encodeNamespace(Namespace)}.
+   *
+   * <p>This method is similar to {@link RESTUtil#decodeNamespace(String)}.
+   */
+  public static Namespace decodeNamespace(String encodedNs) {
+    Preconditions.checkArgument(encodedNs != null, "Invalid namespace: null");
+    String[] levels = encodedNs.split(NAMESPACE_SEPARATOR_ENCODED, -1);
+    for (int i = 0; i < levels.length; i++) {
+      levels[i] = URLDecoder.decode(levels[i], StandardCharsets.UTF_8);
+    }
+    return Namespace.of(levels);
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/table/GenericTableEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/table/GenericTableEntity.java
@@ -23,13 +23,13 @@ import com.google.common.base.Preconditions;
 import jakarta.annotation.Nullable;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisEntityUtils;
 
 /**
  * A {@link TableLikeEntity} implementation for generic tables. These tables are not Iceberg-like in
@@ -107,7 +107,7 @@ public class GenericTableEntity extends TableLikeEntity {
     public GenericTableEntity.Builder setParentNamespace(Namespace namespace) {
       if (namespace != null && !namespace.isEmpty()) {
         internalProperties.put(
-            NamespaceEntity.PARENT_NAMESPACE_KEY, RESTUtil.encodeNamespace(namespace));
+            NamespaceEntity.PARENT_NAMESPACE_KEY, PolarisEntityUtils.encodeNamespace(namespace));
       }
       return this;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/table/IcebergTableLikeEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/table/IcebergTableLikeEntity.java
@@ -27,13 +27,13 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisEntityUtils;
 
 /**
  * An entity type for {@link TableLikeEntity} instances that conform to iceberg semantics around
@@ -166,7 +166,7 @@ public class IcebergTableLikeEntity extends TableLikeEntity {
     public Builder setParentNamespace(Namespace namespace) {
       if (namespace != null && !namespace.isEmpty()) {
         internalProperties.put(
-            NamespaceEntity.PARENT_NAMESPACE_KEY, RESTUtil.encodeNamespace(namespace));
+            NamespaceEntity.PARENT_NAMESPACE_KEY, PolarisEntityUtils.encodeNamespace(namespace));
       }
       return this;
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/table/TableLikeEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/table/TableLikeEntity.java
@@ -23,12 +23,12 @@ import com.google.common.base.Preconditions;
 import jakarta.annotation.Nonnull;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisEntityUtils;
 
 /**
  * An entity type for all table-like entities including Iceberg tables, Iceberg views, and generic
@@ -55,6 +55,6 @@ public abstract class TableLikeEntity extends PolarisEntity implements LocationB
     if (encodedNamespace == null) {
       return Namespace.empty();
     }
-    return RESTUtil.decodeNamespace(encodedNamespace);
+    return PolarisEntityUtils.decodeNamespace(encodedNamespace);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolicyEntity.java
@@ -22,12 +22,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import jakarta.annotation.Nullable;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.rest.RESTUtil;
 import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisEntityUtils;
 
 public class PolicyEntity extends PolarisEntity {
 
@@ -84,7 +84,7 @@ public class PolicyEntity extends PolarisEntity {
   public Namespace getParentNamespace() {
     String parentNamespace = getInternalPropertiesAsMap().get(NamespaceEntity.PARENT_NAMESPACE_KEY);
     if (parentNamespace != null) {
-      return RESTUtil.decodeNamespace(parentNamespace);
+      return PolarisEntityUtils.decodeNamespace(parentNamespace);
     }
     return null;
   }
@@ -114,7 +114,7 @@ public class PolicyEntity extends PolarisEntity {
     public Builder setParentNamespace(Namespace namespace) {
       if (namespace != null && !namespace.isEmpty()) {
         internalProperties.put(
-            NamespaceEntity.PARENT_NAMESPACE_KEY, RESTUtil.encodeNamespace(namespace));
+            NamespaceEntity.PARENT_NAMESPACE_KEY, PolarisEntityUtils.encodeNamespace(namespace));
       }
       return this;
     }

--- a/polaris-core/src/test/java/org/apache/polaris/core/entity/PolarisEntityUtilsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/entity/PolarisEntityUtilsTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.polaris.core.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.stream.Stream;
 import org.apache.iceberg.catalog.Namespace;
-import org.assertj.core.api.Assertions;
+import org.apache.iceberg.rest.RESTUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,13 +52,15 @@ public class PolarisEntityUtilsTest {
   @ParameterizedTest
   @MethodSource("encodeNamespaceCases")
   public void testEncodeNamespace(Namespace ns, String expected) {
-    Assertions.assertThat(PolarisEntityUtils.encodeNamespace(ns)).isEqualTo(expected);
+    assertThat(PolarisEntityUtils.encodeNamespace(ns))
+        .isEqualTo(RESTUtil.encodeNamespace(ns))
+        .isEqualTo(expected);
   }
 
   @ParameterizedTest
   @NullSource
   public void testEncodeNamespaceNullInput(Namespace ns) {
-    Assertions.assertThatThrownBy(() -> PolarisEntityUtils.encodeNamespace(ns))
+    assertThatThrownBy(() -> PolarisEntityUtils.encodeNamespace(ns))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid namespace: null");
   }
@@ -81,35 +86,36 @@ public class PolarisEntityUtilsTest {
   @ParameterizedTest
   @MethodSource("decodeNamespaceCases")
   public void testDecodeNamespace(String encoded, Namespace expected) {
-    Assertions.assertThat(PolarisEntityUtils.decodeNamespace(encoded)).isEqualTo(expected);
+    assertThat(PolarisEntityUtils.decodeNamespace(encoded))
+        .isEqualTo(RESTUtil.decodeNamespace(encoded))
+        .isEqualTo(expected);
   }
 
   @ParameterizedTest
   @NullSource
   public void testDecodeNamespaceNullInput(String encoded) {
-    Assertions.assertThatThrownBy(() -> PolarisEntityUtils.decodeNamespace(encoded))
+    assertThatThrownBy(() -> PolarisEntityUtils.decodeNamespace(encoded))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid namespace: null");
   }
 
-  static Stream<Arguments> roundTripCases() {
+  static Stream<Namespace> roundTripCases() {
     return Stream.of(
-        Arguments.of(Namespace.of("a")),
-        Arguments.of(Namespace.of("a", "b")),
-        Arguments.of(Namespace.of("a", "b", "c")),
-        Arguments.of(Namespace.of("hello world")),
-        Arguments.of(Namespace.of("a/b", "c")),
+        Namespace.of("a"),
+        Namespace.of("a", "b"),
+        Namespace.of("a", "b", "c"),
+        Namespace.of("hello world"),
+        Namespace.of("a/b", "c"),
         // literal %1F in a level name must survive the round-trip
-        Arguments.of(Namespace.of("%1F")),
-        Arguments.of(Namespace.of("a", "", "b")),
-        Arguments.of(Namespace.of("unicode \u4e2d\u6587")));
+        Namespace.of("%1F"),
+        Namespace.of("a", "", "b"),
+        Namespace.of("unicode \u4e2d\u6587"));
   }
 
   @ParameterizedTest
   @MethodSource("roundTripCases")
   public void testRoundTrip(Namespace ns) {
-    Assertions.assertThat(
-            PolarisEntityUtils.decodeNamespace(PolarisEntityUtils.encodeNamespace(ns)))
+    assertThat(PolarisEntityUtils.decodeNamespace(PolarisEntityUtils.encodeNamespace(ns)))
         .isEqualTo(ns);
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/entity/PolarisEntityUtilsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/entity/PolarisEntityUtilsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.entity;
+
+import java.util.stream.Stream;
+import org.apache.iceberg.catalog.Namespace;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+public class PolarisEntityUtilsTest {
+
+  static Stream<Arguments> encodeNamespaceCases() {
+    return Stream.of(
+        // empty namespace encodes to empty string
+        Arguments.of(Namespace.empty(), ""),
+        // single-level namespaces
+        Arguments.of(Namespace.of("a"), "a"),
+        Arguments.of(Namespace.of("hello world"), "hello+world"),
+        Arguments.of(Namespace.of("a/b"), "a%2Fb"),
+        // literal "%1F" in a level name is double-encoded so it can't be confused with separator
+        Arguments.of(Namespace.of("%1F"), "%251F"),
+        // multi-level namespaces: levels are joined with %1F separator
+        Arguments.of(Namespace.of("a", "b"), "a%1Fb"),
+        Arguments.of(Namespace.of("a", "b", "c"), "a%1Fb%1Fc"),
+        Arguments.of(Namespace.of("a/b", "c"), "a%2Fb%1Fc"),
+        // empty level in a multi-level namespace
+        Arguments.of(Namespace.of("a", "", "b"), "a%1F%1Fb"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("encodeNamespaceCases")
+  public void testEncodeNamespace(Namespace ns, String expected) {
+    Assertions.assertThat(PolarisEntityUtils.encodeNamespace(ns)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  public void testEncodeNamespaceNullInput(Namespace ns) {
+    Assertions.assertThatThrownBy(() -> PolarisEntityUtils.encodeNamespace(ns))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace: null");
+  }
+
+  static Stream<Arguments> decodeNamespaceCases() {
+    return Stream.of(
+        // empty string decodes to a single empty-string level (not Namespace.empty())
+        Arguments.of("", Namespace.of("")),
+        // single-level namespaces
+        Arguments.of("a", Namespace.of("a")),
+        Arguments.of("hello+world", Namespace.of("hello world")),
+        Arguments.of("a%2Fb", Namespace.of("a/b")),
+        // double-encoded %25 decodes back to literal %1F level
+        Arguments.of("%251F", Namespace.of("%1F")),
+        // multi-level namespaces: split on %1F separator
+        Arguments.of("a%1Fb", Namespace.of("a", "b")),
+        Arguments.of("a%1Fb%1Fc", Namespace.of("a", "b", "c")),
+        Arguments.of("a%2Fb%1Fc", Namespace.of("a/b", "c")),
+        // empty level in a multi-level namespace
+        Arguments.of("a%1F%1Fb", Namespace.of("a", "", "b")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("decodeNamespaceCases")
+  public void testDecodeNamespace(String encoded, Namespace expected) {
+    Assertions.assertThat(PolarisEntityUtils.decodeNamespace(encoded)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  public void testDecodeNamespaceNullInput(String encoded) {
+    Assertions.assertThatThrownBy(() -> PolarisEntityUtils.decodeNamespace(encoded))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace: null");
+  }
+
+  static Stream<Arguments> roundTripCases() {
+    return Stream.of(
+        Arguments.of(Namespace.of("a")),
+        Arguments.of(Namespace.of("a", "b")),
+        Arguments.of(Namespace.of("a", "b", "c")),
+        Arguments.of(Namespace.of("hello world")),
+        Arguments.of(Namespace.of("a/b", "c")),
+        // literal %1F in a level name must survive the round-trip
+        Arguments.of(Namespace.of("%1F")),
+        Arguments.of(Namespace.of("a", "", "b")),
+        Arguments.of(Namespace.of("unicode \u4e2d\u6587")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("roundTripCases")
+  public void testRoundTrip(Namespace ns) {
+    Assertions.assertThat(
+            PolarisEntityUtils.decodeNamespace(PolarisEntityUtils.encodeNamespace(ns)))
+        .isEqualTo(ns);
+  }
+}


### PR DESCRIPTION
This change replaces calls to `RESTUtil` in Polaris entity code when serializing or deserializing namespaces stored in internal properties.

It replaces those calls with calls to a new utility class, `PolarisEntityUtils`. The logic used there for encoding and decoding namespaces is in fact identical to `RESTUtil` as of today, but having our own logic protects Polaris from future behavioral changes in `RESTUtil` that could potentially cause data corruption in Polaris metastores.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
