### PR TITLE
Add PyPI Publishing to Automated Release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
           make client-nightly-build
 
       - name: Publish Python client to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: client/python/dist/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/polaris'
     permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing to PyPI
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,8 @@ jobs:
   nightly_build_python_client:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/polaris'
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -93,8 +95,13 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Publish Python client to Test PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+      - name: Build Python client nightly
         run: |
-          make client-nightly-publish
+          make client-nightly-build
+
+      - name: Publish Python client to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: client/python/dist/
+          skip-existing: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,6 @@ jobs:
 
   nightly_build_python_client:
     runs-on: ubuntu-latest
-    if: github.repository == 'apache/polaris'
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,7 @@ jobs:
 
   nightly_build_python_client:
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/polaris'
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
           make client-nightly-build
 
       - name: Publish Python client to Test PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: client/python/dist/

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -529,6 +529,7 @@ jobs:
     needs: [prerequisite-checks]
     permissions:
       contents: read
+      # IMPORTANT: this permission is mandatory for Trusted Publishing to PyPI
       id-token: write
     env:
       DRY_RUN: ${{ needs.prerequisite-checks.outputs.dry_run }}
@@ -578,7 +579,12 @@ jobs:
   generate-release-email:
     name: Generate Release Email Body
     runs-on: ubuntu-latest
-    needs: [prerequisite-checks, build-and-publish-artifacts, build-docker, build-and-stage-helm-chart, publish-python-client-rc]
+    needs:
+      - prerequisite-checks
+      - build-and-publish-artifacts
+      - build-docker
+      - build-and-stage-helm-chart
+      - publish-python-client-rc
     permissions:
       contents: read
     env:

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -523,10 +523,55 @@ jobs:
           | Artifact Hub metadata | ✅ Committed to dist dev |
           EOT
 
+  publish-python-client-rc:
+    name: Publish Python Client RC to PyPI
+    runs-on: ubuntu-latest
+    needs: [prerequisite-checks]
+    permissions:
+      contents: read
+    env:
+      DRY_RUN: ${{ needs.prerequisite-checks.outputs.dry_run }}
+      version_without_rc: ${{ needs.prerequisite-checks.outputs.version_without_rc }}
+      rc_number: ${{ needs.prerequisite-checks.outputs.rc_number }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up JDK for openapi-generator-cli
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Publish Python client RC to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+        run: |
+          make client-rc-publish RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
+
+          echo "## Python Client RC" >> $GITHUB_STEP_SUMMARY
+          cat <<EOT >> $GITHUB_STEP_SUMMARY
+          🎉 Python client RC published successfully:
+
+          | Property | Value |
+          | --- | --- |
+          | Version | \`${version_without_rc}rc${rc_number}\` |
+          | Registry | PyPI |
+          EOT
+
   generate-release-email:
     name: Generate Release Email Body
     runs-on: ubuntu-latest
-    needs: [prerequisite-checks, build-and-publish-artifacts, build-docker, build-and-stage-helm-chart]
+    needs: [prerequisite-checks, build-and-publish-artifacts, build-docker, build-and-stage-helm-chart, publish-python-client-rc]
     permissions:
       contents: read
     env:

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -558,7 +558,7 @@ jobs:
           make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
       - name: Publish Python client RC to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: client/python/dist/

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -529,6 +529,7 @@ jobs:
     needs: [prerequisite-checks]
     permissions:
       contents: read
+      id-token: write
     env:
       DRY_RUN: ${{ needs.prerequisite-checks.outputs.dry_run }}
       version_without_rc: ${{ needs.prerequisite-checks.outputs.version_without_rc }}
@@ -552,12 +553,18 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Publish Python client RC to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+      - name: Build Python client RC
         run: |
-          make client-rc-publish RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
+          make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
+      - name: Publish Python client RC to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: client/python/dist/
+
+      - name: Update step summary
+        run: |
           echo "## Python Client RC" >> $GITHUB_STEP_SUMMARY
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           🎉 Python client RC published successfully:
@@ -565,7 +572,7 @@ jobs:
           | Property | Value |
           | --- | --- |
           | Version | \`${version_without_rc}rc${rc_number}\` |
-          | Registry | PyPI |
+          | Registry | Test PyPI |
           EOT
 
   generate-release-email:

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -558,7 +558,7 @@ jobs:
           make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
       - name: Publish Python client RC to Test PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: client/python/dist/

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -633,6 +633,9 @@ jobs:
 
           NB: you have to build the Docker images locally in order to test Helm charts.
 
+          The Python CLI RC is available on Test PyPI:
+          * https://test.pypi.org/project/apache-polaris/${version_without_rc}rc${rc_number}/
+
           You can find the KEYS file here:
           * https://downloads.apache.org/polaris/KEYS
 

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -543,6 +543,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up environment variables
+        run: |
+          echo "RELEASEY_DIR=$(pwd)/releasey" >> $GITHUB_ENV
+          echo "LIBS_DIR=$(pwd)/releasey/libs" >> $GITHUB_ENV
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -554,15 +559,68 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.POLARIS_GPG_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Build Python client RC
         run: |
           make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
+
+      - name: Sign and checksum Python wheel
+        run: |
+          source "${LIBS_DIR}/_exec.sh"
+
+          wheel_file=$(ls client/python/dist/*.whl)
+          calculate_sha512 "${wheel_file}"
+          exec_process gpg --armor --output "${wheel_file}.asc" --detach-sig "${wheel_file}"
 
       - name: Publish Python client RC to Test PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: client/python/dist/
+
+      - name: Stage Python wheel to Apache dist dev repository
+        env:
+          SVN_USERNAME: ${{ secrets.POLARIS_SVN_DEV_USERNAME }} # zizmor: ignore[secrets-outside-env]
+          SVN_PASSWORD: ${{ secrets.POLARIS_SVN_DEV_PASSWORD }} # zizmor: ignore[secrets-outside-env]
+        run: |
+          echo "::add-mask::$SVN_PASSWORD"
+
+          source "${LIBS_DIR}/_constants.sh"
+          source "${LIBS_DIR}/_exec.sh"
+
+          dist_dev_dir=${RELEASEY_DIR}/polaris-dist-dev
+
+          # Retry logic for SVN checkout (Apache SVN can have transient connectivity issues)
+          exec_process_with_retries 5 60 "${dist_dev_dir}" svn checkout --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${APACHE_DIST_URL}${APACHE_DIST_PATH}" "${dist_dev_dir}"
+
+          python_client_version_dir="${dist_dev_dir}/python-client/${version_without_rc}"
+
+          # If the python-client version directory already exists in SVN (e.g. re-running the workflow),
+          # delete it so we can re-add fresh artifacts without "already versioned" errors.
+          if svn info "${python_client_version_dir}" &>/dev/null 2>&1; then
+            exec_process svn delete "${python_client_version_dir}"
+          fi
+
+          exec_process mkdir -p "${python_client_version_dir}"
+          exec_process cp client/python/dist/*.whl "${python_client_version_dir}/"
+          exec_process cp client/python/dist/*.whl.sha512 "${python_client_version_dir}/"
+          exec_process cp client/python/dist/*.whl.asc "${python_client_version_dir}/"
+
+          exec_process cd "${dist_dev_dir}"
+          exec_process svn add --parents "python-client/${version_without_rc}"
+
+          exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Stage Apache Polaris Python client ${version_without_rc} RC${rc_number}"
 
       - name: Update step summary
         run: |
@@ -574,6 +632,7 @@ jobs:
           | --- | --- |
           | Version | \`${version_without_rc}rc${rc_number}\` |
           | Registry | Test PyPI |
+          | Apache dist dev | \`python-client/${version_without_rc}\` |
           EOT
 
   generate-release-email:
@@ -639,7 +698,10 @@ jobs:
 
           NB: you have to build the Docker images locally in order to test Helm charts.
 
-          The Python CLI RC is available on Test PyPI:
+          The Python CLI RC wheel is available on:
+          * https://dist.apache.org/repos/dist/dev/polaris/python-client/${version_without_rc}
+
+          The Python CLI RC is also available on Test PyPI:
           * https://test.pypi.org/project/apache-polaris/${version_without_rc}rc${rc_number}/
 
           You can find the KEYS file here:

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -575,13 +575,14 @@ jobs:
         run: |
           make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
-      - name: Sign and checksum Python wheel
+      - name: Sign and checksum Python distributions
         run: |
           source "${LIBS_DIR}/_exec.sh"
 
-          wheel_file=$(ls client/python/dist/*.whl)
-          calculate_sha512 "${wheel_file}"
-          exec_process gpg --armor --output "${wheel_file}.asc" --detach-sig "${wheel_file}"
+          for dist_file in client/python/dist/*.whl client/python/dist/*.tar.gz; do
+            calculate_sha512 "${dist_file}"
+            exec_process gpg --armor --output "${dist_file}.asc" --detach-sig "${dist_file}"
+          done
 
       - name: Publish Python client RC to Test PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
@@ -613,9 +614,7 @@ jobs:
           fi
 
           exec_process mkdir -p "${python_client_version_dir}"
-          exec_process cp client/python/dist/*.whl "${python_client_version_dir}/"
-          exec_process cp client/python/dist/*.whl.sha512 "${python_client_version_dir}/"
-          exec_process cp client/python/dist/*.whl.asc "${python_client_version_dir}/"
+          exec_process cp client/python/dist/* "${python_client_version_dir}/"
 
           exec_process cd "${dist_dev_dir}"
           exec_process svn add --parents "python-client/${version_without_rc}"

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -571,24 +571,17 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Build Python client RC
+      - name: Build Python client RC for SVN
         run: |
           make client-rc-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
-      - name: Sign and checksum Python distributions
+      - name: Sign and checksum Python wheel
         run: |
           source "${LIBS_DIR}/_exec.sh"
 
-          for dist_file in client/python/dist/*.whl client/python/dist/*.tar.gz; do
-            calculate_sha512 "${dist_file}"
-            exec_process gpg --armor --output "${dist_file}.asc" --detach-sig "${dist_file}"
-          done
-
-      - name: Publish Python client RC to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: client/python/dist/
+          wheel_file=$(ls client/python/dist/*.whl)
+          calculate_sha512 "${wheel_file}"
+          exec_process gpg --armor --output "${wheel_file}.asc" --detach-sig "${wheel_file}"
 
       - name: Stage Python wheel to Apache dist dev repository
         env:
@@ -621,6 +614,16 @@ jobs:
 
           exec_process svn commit --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive -m "Stage Apache Polaris Python client ${version_without_rc} RC${rc_number}"
 
+      - name: Build Python client RC for Test PyPI
+        run: |
+          make client-rc-testpypi-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
+
+      - name: Publish Python client RC to Test PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: client/python/dist/
+
       - name: Update step summary
         run: |
           echo "## Python Client RC" >> $GITHUB_STEP_SUMMARY
@@ -629,9 +632,9 @@ jobs:
 
           | Property | Value |
           | --- | --- |
-          | Version | \`${version_without_rc}rc${rc_number}\` |
-          | Registry | Test PyPI |
+          | Version | \`${version_without_rc}\` |
           | Apache dist dev | \`python-client/${version_without_rc}\` |
+          | Registry | Test PyPI |
           EOT
 
   generate-release-email:
@@ -697,10 +700,10 @@ jobs:
 
           NB: you have to build the Docker images locally in order to test Helm charts.
 
-          The Python CLI RC wheel is available on:
+          The Python CLI wheel is available on:
           * https://dist.apache.org/repos/dist/dev/polaris/python-client/${version_without_rc}
 
-          The Python CLI RC is also available on Test PyPI:
+          The Python CLI is also available on Test PyPI:
           * https://test.pypi.org/project/apache-polaris/${version_without_rc}rc${rc_number}/
 
           You can find the KEYS file here:

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -38,7 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
+    outputs:
+      version_without_rc: ${{ steps.release-params.outputs.version_without_rc }}
 
     steps:
       - name: Checkout repository
@@ -88,6 +89,7 @@ jobs:
           sudo apt-get install -y subversion
 
       - name: Auto-determine release parameters from branch and Git state
+        id: release-params
         env:
           GIT_REF: ${{ github.ref }}
         run: |
@@ -172,6 +174,7 @@ jobs:
           echo "rc_tag=${rc_tag}" >> $GITHUB_ENV
           echo "final_release_tag=${final_release_tag}" >> $GITHUB_ENV
           echo "release_branch=${current_branch}" >> $GITHUB_ENV
+          echo "version_without_rc=${version_without_rc}" >> $GITHUB_OUTPUT
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           | Parameter | Value |
@@ -437,27 +440,6 @@ jobs:
           ✅ Nexus staging repository released
           EOT
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.13"
-
-      - name: Build Python client release
-        run: |
-          make client-release-build RELEASE_VERSION="${version_without_rc}"
-
-      - name: Publish Python client release to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          packages-dir: client/python/dist/
-
-      - name: Update step summary
-        run: |
-          cat <<EOT >> $GITHUB_STEP_SUMMARY
-          ## Python Client
-          ✅ Python client \`${version_without_rc}\` published to PyPI
-          EOT
-
       - name: Release summary
         run: |
           cat <<EOT >> $GITHUB_STEP_SUMMARY
@@ -473,7 +455,51 @@ jobs:
           | GitHub release | ✅ Created with artifacts attached |
           | Docker images | ✅ Published to Docker Hub |
           | Nexus repository | ✅ Released |
-          | Python client | ✅ Published to PyPI |
           | Version | \`${version_without_rc}\` |
           | Final release tag | \`${final_release_tag}\` |
+          EOT
+
+  publish-python-client:
+    name: Publish Python Client to PyPI
+    runs-on: ubuntu-latest
+    needs: [publish-release]
+    permissions:
+      contents: read
+      # IMPORTANT: this permission is mandatory for Trusted Publishing to PyPI
+      id-token: write
+    env:
+      version_without_rc: ${{ needs.publish-release.outputs.version_without_rc }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up JDK for openapi-generator-cli
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Build Python client release
+        run: |
+          make client-release-build RELEASE_VERSION="${version_without_rc}"
+
+      - name: Publish Python client release to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: client/python/dist/
+
+      - name: Update step summary
+        run: |
+          cat <<EOT >> $GITHUB_STEP_SUMMARY
+          ## Python Client
+          ✅ Python client \`${version_without_rc}\` published to PyPI
           EOT

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -432,6 +432,29 @@ jobs:
           exec_process ./gradlew releaseApacheStagingRepository --staging-repository-id "${STAGING_REPOSITORY_ID}"
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY
+          ## Nexus
+          ✅ Nexus staging repository released
+          EOT
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Publish Python client release to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+        run: |
+          make client-release-publish RELEASE_VERSION="${version_without_rc}"
+
+          cat <<EOT >> $GITHUB_STEP_SUMMARY
+          ## Python Client
+          ✅ Python client \`${version_without_rc}\` published to PyPI
+          EOT
+
+      - name: Release summary
+        run: |
+          cat <<EOT >> $GITHUB_STEP_SUMMARY
           ## Summary
           🎉 Release published successfully:
 
@@ -444,6 +467,7 @@ jobs:
           | GitHub release | ✅ Created with artifacts attached |
           | Docker images | ✅ Published to Docker Hub |
           | Nexus repository | ✅ Released |
+          | Python client | ✅ Published to PyPI |
           | Version | \`${version_without_rc}\` |
           | Final release tag | \`${final_release_tag}\` |
           EOT

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -447,7 +447,7 @@ jobs:
           make client-release-build RELEASE_VERSION="${version_without_rc}"
 
       - name: Publish Python client release to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: client/python/dist/
 

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -447,7 +447,7 @@ jobs:
           make client-release-build RELEASE_VERSION="${version_without_rc}"
 
       - name: Publish Python client release to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: client/python/dist/
 

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -441,12 +442,17 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Publish Python client release to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+      - name: Build Python client release
         run: |
-          make client-release-publish RELEASE_VERSION="${version_without_rc}"
+          make client-release-build RELEASE_VERSION="${version_without_rc}"
 
+      - name: Publish Python client release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: client/python/dist/
+
+      - name: Update step summary
+        run: |
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           ## Python Client
           ✅ Python client \`${version_without_rc}\` published to PyPI

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -203,6 +203,9 @@ jobs:
           dev_helm_url="${APACHE_DIST_URL}/dev/polaris/helm-chart/${version_without_rc}"
           release_helm_url="${APACHE_DIST_URL}/release/polaris/helm-chart/${version_without_rc}"
 
+          dev_python_client_url="${APACHE_DIST_URL}/dev/polaris/python-client/${version_without_rc}"
+          release_python_client_url="${APACHE_DIST_URL}/release/polaris/python-client/${version_without_rc}"
+
           exec_process svn mv --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
             "${dev_artifacts_url}" "${release_artifacts_url}" \
             -m "Release Apache Polaris ${version_without_rc}"
@@ -211,9 +214,13 @@ jobs:
             "${dev_helm_url}" "${release_helm_url}" \
             -m "Release Apache Polaris Helm chart ${version_without_rc}"
 
+          exec_process svn mv --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+            "${dev_python_client_url}" "${release_python_client_url}" \
+            -m "Release Apache Polaris Python client ${version_without_rc}"
+
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           ## Distribution
-          Artifacts and Helm chart moved from dist dev to dist release
+          Artifacts, Helm chart, and Python client moved from dist dev to dist release
           EOT
 
       - name: Clean up old releases from dist release repository
@@ -267,6 +274,27 @@ jobs:
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "No old Helm chart versions found to remove" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # List and remove old Python client versions
+          release_python_client_url="${APACHE_DIST_URL}/release/polaris/python-client"
+          old_python_client_versions=$(svn list --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_python_client_url}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-incubating)?/$' | sed 's|/$||' | grep -v "^${version_without_rc}$" || true)
+
+          if [[ -n "${old_python_client_versions}" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Removing old Python client versions:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${old_python_client_versions}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+
+            for old_python_client_version in ${old_python_client_versions}; do
+              exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+                "${release_python_client_url}/${old_python_client_version}" \
+                -m "Remove old Python client ${old_python_client_version} (superseded by ${version_without_rc})"
+            done
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No old Python client versions found to remove" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Transfer Helm index and artifacthub-repo.yml from dev to release
@@ -477,25 +505,35 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.13"
-
-      - name: Set up JDK for openapi-generator-cli
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Build Python client release
+      - name: Set up environment variables
         run: |
-          make client-release-build RELEASE_VERSION="${version_without_rc}"
+          echo "RELEASEY_DIR=$(pwd)/releasey" >> $GITHUB_ENV
+          echo "LIBS_DIR=$(pwd)/releasey/libs" >> $GITHUB_ENV
+
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion
+
+      - name: Download Python wheel from Apache dist release repository
+        env:
+          SVN_USERNAME: ${{ secrets.POLARIS_SVN_DEV_USERNAME }} # zizmor: ignore[secrets-outside-env]
+          SVN_PASSWORD: ${{ secrets.POLARIS_SVN_DEV_PASSWORD }} # zizmor: ignore[secrets-outside-env]
+        run: |
+          echo "::add-mask::$SVN_PASSWORD"
+
+          source "${LIBS_DIR}/_constants.sh"
+          source "${LIBS_DIR}/_exec.sh"
+
+          release_python_client_url="${APACHE_DIST_URL}/release/polaris/python-client/${version_without_rc}"
+
+          exec_process svn export --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+            "${release_python_client_url}" dist/
 
       - name: Publish Python client release to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
-          packages-dir: client/python/dist/
+          packages-dir: dist/
 
       - name: Update step summary
         run: |

--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -171,10 +171,10 @@ jobs:
 
           # Export variables for next steps
           echo "version_without_rc=${version_without_rc}" >> $GITHUB_ENV
+          echo "version_without_rc=${version_without_rc}" >> $GITHUB_OUTPUT
           echo "rc_tag=${rc_tag}" >> $GITHUB_ENV
           echo "final_release_tag=${final_release_tag}" >> $GITHUB_ENV
           echo "release_branch=${current_branch}" >> $GITHUB_ENV
-          echo "version_without_rc=${version_without_rc}" >> $GITHUB_OUTPUT
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           | Parameter | Value |

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,30 @@ client-nightly-publish: client-setup-env ## Build and publish nightly version to
 	uv publish --index testpypi
 	@echo "--- Nightly publish complete ---"
 
+.PHONY: client-rc-publish
+client-rc-publish: client-setup-env ## Build and publish RC version to PyPI (requires RC_VERSION and RC_NUMBER)
+	@echo "--- Starting RC publish ---"
+	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
+	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
+	@$(ACTIVATE_AND_CD) && \
+	RC_PYPI_VERSION="$(RC_VERSION)rc$(RC_NUMBER)" && \
+	echo "Publishing RC version: $${RC_PYPI_VERSION}" && \
+	uv version "$${RC_PYPI_VERSION}" && \
+	uv build --clear && \
+	uv publish --index testpypi
+	@echo "--- RC publish complete ---"
+
+.PHONY: client-release-publish
+client-release-publish: client-setup-env ## Build and publish final release version to PyPI (requires RELEASE_VERSION)
+	@echo "--- Starting release publish ---"
+	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
+	@$(ACTIVATE_AND_CD) && \
+	echo "Publishing release version: $(RELEASE_VERSION)" && \
+	uv version "$(RELEASE_VERSION)" && \
+	uv build --clear && \
+	uv publish
+	@echo "--- Release publish complete ---"
+
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code
 	@echo "--- Regenerating client code ---"

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ _client-build: client-setup-env
 	uv build --clear
 
 .PHONY: client-nightly-build
-client-nightly-build: ## Build nightly version for publishing to Test PyPI
+client-nightly-build: client-setup-env ## Build nightly version for publishing to Test PyPI
 	@$(MAKE) _client-build BUILD_VERSION="$$(cd $(PYTHON_CLIENT_DIR) && uv version --short).dev$$(date -u +%Y%m%d%H%M%S)"
 	@echo "--- Nightly build complete ---"
 

--- a/Makefile
+++ b/Makefile
@@ -188,42 +188,39 @@ client-lint: client-setup-env ## Run linting checks for Polaris client
 	@$(ACTIVATE_AND_CD) && uv run --active pre-commit run --files integration_tests/* generate_clients.py apache_polaris/cli/* apache_polaris/cli/command/* apache_polaris/cli/options/* test/*
 	@echo "--- Client linting checks complete ---"
 
-.PHONY: client-nightly-publish
-client-nightly-publish: client-setup-env ## Build and publish nightly version to Test PyPI
-	@echo "--- Starting nightly publish ---"
+.PHONY: client-nightly-build
+client-nightly-build: client-setup-env ## Build nightly version for publishing to Test PyPI
+	@echo "--- Starting nightly build ---"
 	@$(ACTIVATE_AND_CD) && \
 	CURRENT_VERSION=$$(uv version --short) && \
 	DATE_SUFFIX=$$(date -u +%Y%m%d%H%M%S) && \
 	NIGHTLY_VERSION="$${CURRENT_VERSION}.dev$${DATE_SUFFIX}" && \
-	echo "Publishing nightly version: $${NIGHTLY_VERSION}" && \
+	echo "Building nightly version: $${NIGHTLY_VERSION}" && \
 	uv version "$${NIGHTLY_VERSION}" && \
-	uv build --clear && \
-	uv publish --index testpypi
-	@echo "--- Nightly publish complete ---"
+	uv build --clear
+	@echo "--- Nightly build complete ---"
 
-.PHONY: client-rc-publish
-client-rc-publish: client-setup-env ## Build and publish RC version to PyPI (requires RC_VERSION and RC_NUMBER)
-	@echo "--- Starting RC publish ---"
+.PHONY: client-rc-build
+client-rc-build: client-setup-env ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
+	@echo "--- Starting RC build ---"
 	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
 	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
 	@$(ACTIVATE_AND_CD) && \
 	RC_PYPI_VERSION="$(RC_VERSION)rc$(RC_NUMBER)" && \
-	echo "Publishing RC version: $${RC_PYPI_VERSION}" && \
+	echo "Building RC version: $${RC_PYPI_VERSION}" && \
 	uv version "$${RC_PYPI_VERSION}" && \
-	uv build --clear && \
-	uv publish --index testpypi
-	@echo "--- RC publish complete ---"
+	uv build --clear
+	@echo "--- RC build complete ---"
 
-.PHONY: client-release-publish
-client-release-publish: client-setup-env ## Build and publish final release version to PyPI (requires RELEASE_VERSION)
-	@echo "--- Starting release publish ---"
+.PHONY: client-release-build
+client-release-build: client-setup-env ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
+	@echo "--- Starting release build ---"
 	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
 	@$(ACTIVATE_AND_CD) && \
-	echo "Publishing release version: $(RELEASE_VERSION)" && \
+	echo "Building release version: $(RELEASE_VERSION)" && \
 	uv version "$(RELEASE_VERSION)" && \
-	uv build --clear && \
-	uv publish
-	@echo "--- Release publish complete ---"
+	uv build --clear
+	@echo "--- Release build complete ---"
 
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code

--- a/Makefile
+++ b/Makefile
@@ -188,38 +188,30 @@ client-lint: client-setup-env ## Run linting checks for Polaris client
 	@$(ACTIVATE_AND_CD) && uv run --active pre-commit run --files integration_tests/* generate_clients.py apache_polaris/cli/* apache_polaris/cli/command/* apache_polaris/cli/options/* test/*
 	@echo "--- Client linting checks complete ---"
 
-.PHONY: client-nightly-build
-client-nightly-build: client-setup-env ## Build nightly version for publishing to Test PyPI
-	@echo "--- Starting nightly build ---"
+# Internal target: stamp version and build. Requires BUILD_VERSION to be set.
+.PHONY: _client-build
+_client-build: client-setup-env
 	@$(ACTIVATE_AND_CD) && \
-	CURRENT_VERSION=$$(uv version --short) && \
-	DATE_SUFFIX=$$(date -u +%Y%m%d%H%M%S) && \
-	NIGHTLY_VERSION="$${CURRENT_VERSION}.dev$${DATE_SUFFIX}" && \
-	echo "Building nightly version: $${NIGHTLY_VERSION}" && \
-	uv version "$${NIGHTLY_VERSION}" && \
+	echo "Building version: $(BUILD_VERSION)" && \
+	uv version "$(BUILD_VERSION)" && \
 	uv build --clear
+
+.PHONY: client-nightly-build
+client-nightly-build: ## Build nightly version for publishing to Test PyPI
+	@$(MAKE) _client-build BUILD_VERSION="$$(cd $(PYTHON_CLIENT_DIR) && uv version --short).dev$$(date -u +%Y%m%d%H%M%S)"
 	@echo "--- Nightly build complete ---"
 
 .PHONY: client-rc-build
-client-rc-build: client-setup-env ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
-	@echo "--- Starting RC build ---"
+client-rc-build: ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
 	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
 	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
-	@$(ACTIVATE_AND_CD) && \
-	RC_PYPI_VERSION="$(RC_VERSION)rc$(RC_NUMBER)" && \
-	echo "Building RC version: $${RC_PYPI_VERSION}" && \
-	uv version "$${RC_PYPI_VERSION}" && \
-	uv build --clear
+	@$(MAKE) _client-build BUILD_VERSION="$(RC_VERSION)rc$(RC_NUMBER)"
 	@echo "--- RC build complete ---"
 
 .PHONY: client-release-build
-client-release-build: client-setup-env ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
-	@echo "--- Starting release build ---"
+client-release-build: ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
 	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
-	@$(ACTIVATE_AND_CD) && \
-	echo "Building release version: $(RELEASE_VERSION)" && \
-	uv version "$(RELEASE_VERSION)" && \
-	uv build --clear
+	@$(MAKE) _client-build BUILD_VERSION="$(RELEASE_VERSION)"
 	@echo "--- Release build complete ---"
 
 .PHONY: client-regenerate

--- a/Makefile
+++ b/Makefile
@@ -127,18 +127,21 @@ client-install-dependencies: $(VENV_DIR)
 client-setup-env: $(VENV_DIR) client-install-dependencies
 
 .PHONY: client-build
-client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist or FORMAT=wheel to build a specific format.
+client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist or FORMAT=wheel to build a specific format, and VERSION to stamp the version before building.
 	@echo "--- Building client distribution ---"
+	@if [ -n "$(VERSION)" ]; then \
+		$(ACTIVATE_AND_CD) && uv version "$(VERSION)"; \
+	fi
 	@if [ -n "$(FORMAT)" ]; then \
 		if [ "$(FORMAT)" != "sdist" ] && [ "$(FORMAT)" != "wheel" ]; then \
 			echo "Error: Invalid format '$(FORMAT)'. Supported formats are 'sdist' and 'wheel'." >&2; \
 			exit 1; \
 		fi; \
 		echo "Building with format: $(FORMAT)"; \
-		$(ACTIVATE_AND_CD) && uv build --format $(FORMAT); \
+		$(ACTIVATE_AND_CD) && uv build --clear --format $(FORMAT); \
 	else \
 		echo "Building default distribution (sdist and wheel)"; \
-		$(ACTIVATE_AND_CD) && uv build; \
+		$(ACTIVATE_AND_CD) && uv build --clear; \
 	fi
 	@echo "--- Client distribution build complete ---"
 
@@ -188,31 +191,22 @@ client-lint: client-setup-env ## Run linting checks for Polaris client
 	@$(ACTIVATE_AND_CD) && uv run --active pre-commit run --files integration_tests/* generate_clients.py apache_polaris/cli/* apache_polaris/cli/command/* apache_polaris/cli/options/* test/*
 	@echo "--- Client linting checks complete ---"
 
-# Internal target: stamp version and build. Requires BUILD_VERSION to be set.
-.PHONY: _client-build
-_client-build: client-setup-env
-	@$(ACTIVATE_AND_CD) && \
-	echo "Building version: $(BUILD_VERSION)" && \
-	uv version "$(BUILD_VERSION)" && \
-	uv build --clear
-
 .PHONY: client-nightly-build
 client-nightly-build: client-setup-env ## Build nightly version for publishing to Test PyPI
-	@$(MAKE) _client-build BUILD_VERSION="$$($(VENV_DIR)/bin/uv --directory $(PYTHON_CLIENT_DIR) version --short).dev$$(date -u +%Y%m%d%H%M%S)"
-	@echo "--- Nightly build complete ---"
+	@$(MAKE) client-build \
+		VERSION="$$($(VENV_DIR)/bin/uv --directory $(PYTHON_CLIENT_DIR) version --short).dev$$(date -u +%Y%m%d%H%M%S)" \
+		FORMAT=wheel
 
 .PHONY: client-rc-build
 client-rc-build: ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
 	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
 	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
-	@$(MAKE) _client-build BUILD_VERSION="$(RC_VERSION)rc$(RC_NUMBER)"
-	@echo "--- RC build complete ---"
+	@$(MAKE) client-build VERSION="$(RC_VERSION)rc$(RC_NUMBER)" FORMAT=wheel
 
 .PHONY: client-release-build
 client-release-build: ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
 	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
-	@$(MAKE) _client-build BUILD_VERSION="$(RELEASE_VERSION)"
-	@echo "--- Release build complete ---"
+	@$(MAKE) client-build VERSION="$(RELEASE_VERSION)" FORMAT=wheel
 
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist o
 			exit 1; \
 		fi; \
 		echo "Building with format: $(FORMAT)"; \
-		$(ACTIVATE_AND_CD) && uv build --clear --format $(FORMAT); \
+		$(ACTIVATE_AND_CD) && uv build --clear --$(FORMAT); \
 	else \
 		echo "Building default distribution (sdist and wheel)"; \
 		$(ACTIVATE_AND_CD) && uv build --clear; \

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ _client-build: client-setup-env
 
 .PHONY: client-nightly-build
 client-nightly-build: client-setup-env ## Build nightly version for publishing to Test PyPI
-	@$(MAKE) _client-build BUILD_VERSION="$$(cd $(PYTHON_CLIENT_DIR) && uv version --short).dev$$(date -u +%Y%m%d%H%M%S)"
+	@$(MAKE) _client-build BUILD_VERSION="$$($(VENV_DIR)/bin/uv --directory $(PYTHON_CLIENT_DIR) version --short).dev$$(date -u +%Y%m%d%H%M%S)"
 	@echo "--- Nightly build complete ---"
 
 .PHONY: client-rc-build

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist o
 			exit 1; \
 		fi; \
 		echo "Building with format: $(FORMAT)"; \
-		$(ACTIVATE_AND_CD) && uv build --clear --$(FORMAT); \
+		$(ACTIVATE_AND_CD) && uv build --$(FORMAT); \
 	else \
 		echo "Building default distribution (sdist and wheel)"; \
 		$(ACTIVATE_AND_CD) && uv build --clear; \
@@ -198,15 +198,20 @@ client-nightly-build: client-setup-env ## Build nightly version for publishing t
 		FORMAT=wheel
 
 .PHONY: client-rc-build
-client-rc-build: ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
+client-rc-build: client-setup-env ## Build RC wheel for staging to Apache dist dev (requires RC_VERSION and RC_NUMBER)
 	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
 	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
-	@$(MAKE) client-build VERSION="$(RC_VERSION)rc$(RC_NUMBER)"
+	@echo "--- Building RC wheel for version $(RC_VERSION) RC$(RC_NUMBER) ---"
+	@$(ACTIVATE_AND_CD) && uv version "$(RC_VERSION)" && uv build --wheel
+	@echo "--- RC wheel build complete ---"
 
-.PHONY: client-release-build
-client-release-build: ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
-	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
-	@$(MAKE) client-build VERSION="$(RELEASE_VERSION)"
+.PHONY: client-rc-testpypi-build
+client-rc-testpypi-build: client-setup-env ## Build RC wheel with rc suffix for Test PyPI (requires RC_VERSION and RC_NUMBER)
+	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
+	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
+	@echo "--- Building RC wheel for Test PyPI: $(RC_VERSION)rc$(RC_NUMBER) ---"
+	@$(ACTIVATE_AND_CD) && uv version "$(RC_VERSION)rc$(RC_NUMBER)" && uv build --wheel
+	@echo "--- RC wheel build for Test PyPI complete ---"
 
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code

--- a/Makefile
+++ b/Makefile
@@ -201,12 +201,12 @@ client-nightly-build: client-setup-env ## Build nightly version for publishing t
 client-rc-build: ## Build RC version for publishing to Test PyPI (requires RC_VERSION and RC_NUMBER)
 	@if [ -z "$(RC_VERSION)" ]; then echo "ERROR: RC_VERSION is not set"; exit 1; fi
 	@if [ -z "$(RC_NUMBER)" ]; then echo "ERROR: RC_NUMBER is not set"; exit 1; fi
-	@$(MAKE) client-build VERSION="$(RC_VERSION)rc$(RC_NUMBER)" FORMAT=wheel
+	@$(MAKE) client-build VERSION="$(RC_VERSION)rc$(RC_NUMBER)"
 
 .PHONY: client-release-build
 client-release-build: ## Build final release version for publishing to PyPI (requires RELEASE_VERSION)
 	@if [ -z "$(RELEASE_VERSION)" ]; then echo "ERROR: RELEASE_VERSION is not set"; exit 1; fi
-	@$(MAKE) client-build VERSION="$(RELEASE_VERSION)" FORMAT=wheel
+	@$(MAKE) client-build VERSION="$(RELEASE_VERSION)"
 
 .PHONY: client-regenerate
 client-regenerate: client-setup-env ## Regenerate the client code

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -18,7 +18,7 @@
 #
 
 [project]
-name = "ahemani-apache-polaris"
+name = "apache-polaris"
 version = "1.4.0"
 description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -19,12 +19,12 @@
 
 [project]
 name = "apache-polaris"
-version = "1.4.0"
+version = "1.4.0rc2"
 description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]
 requires-python = ">=3.10,<3.14"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE"]
 keywords = [
     "Apache Polaris",

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -18,7 +18,7 @@
 #
 
 [project]
-name = "apache-polaris"
+name = "ahemani-apache-polaris"
 version = "1.4.0"
 description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -18,8 +18,8 @@
 #
 
 [project]
-name = "apache-polaris"
-version = "1.4.0"
+name = "ahemani-apache-polaris"
+version = "1.4.0.dev20260416065624"
 description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]
 requires-python = ">=3.10,<3.14"

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -19,7 +19,7 @@
 
 [project]
 name = "ahemani-apache-polaris"
-version = "1.4.0.dev20260416065624"
+version = "1.4.0"
 description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]
 requires-python = ">=3.10,<3.14"

--- a/client/python/uv.lock
+++ b/client/python/uv.lock
@@ -3,8 +3,17 @@ revision = 3
 requires-python = ">=3.10, <3.14"
 
 [[package]]
-name = "ahemani-apache-polaris"
-version = "1.4.0.dev20260416065624"
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "apache-polaris"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -51,15 +60,6 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=2.8.1" },
     { name = "types-python-dateutil", specifier = ">=2.8.19.14" },
-]
-
-[[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]

--- a/client/python/uv.lock
+++ b/client/python/uv.lock
@@ -3,17 +3,8 @@ revision = 3
 requires-python = ">=3.10, <3.14"
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "apache-polaris"
-version = "1.4.0"
+name = "ahemani-apache-polaris"
+version = "1.4.0.dev20260416065624"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -60,6 +51,15 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=2.8.1" },
     { name = "types-python-dateutil", specifier = ">=2.8.19.14" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]

--- a/releasey/libs/_exec.sh
+++ b/releasey/libs/_exec.sh
@@ -70,13 +70,15 @@ function exec_process_with_retries {
 
 function calculate_sha512 {
   local source_file="$1"
+  local source_dir source_base
+  source_dir="$(dirname "${source_file}")"
+  source_base="$(basename "${source_file}")"
   local target_file="${source_file}.sha512"
-  # This function is only there for dry-run support.  Because of the
-  # redirection, we cannot use exec_process with the exact command that will be
-  # executed.
+  # Run shasum from the file's directory so the checksum file contains only
+  # the filename, not the full path (required for standard sha512sum -c verification).
   if [[ ${DRY_RUN:-1} -ne 1 ]]; then
-    exec_process shasum -a 512 "${source_file}" > "${target_file}"
+    (cd "${source_dir}" && shasum -a 512 "${source_base}") > "${target_file}"
   else
-    exec_process "shasum -a 512 ${source_file} > ${target_file}"
+    exec_process "cd ${source_dir} && shasum -a 512 ${source_base} > ${target_file}"
   fi
 }


### PR DESCRIPTION
Changes the PyPI nightly build script to use Trusted Publishers, as well as adding publishing scripts when generating a new release candidate and publishing new Polaris versions. 

I've tested this from my fork: https://github.com/adnanhemani/polaris/actions/runs/24500027607/

I've already set up Trusted Publishers for both PyPI and TestPyPI:

<img width="1918" height="1011" alt="Screenshot 2026-04-16 at 1 06 56 AM" src="https://github.com/user-attachments/assets/3e4fae07-b3f6-49f4-878b-18a8876316e5" />

<img width="1923" height="1010" alt="Screenshot 2026-04-16 at 1 07 18 AM" src="https://github.com/user-attachments/assets/b4d7fa25-cd4d-42f8-b755-7ac0efda8c96" />

Result:

<img width="1920" height="1009" alt="Screenshot 2026-04-16 at 1 27 18 AM" src="https://github.com/user-attachments/assets/1beb79a6-11c8-4589-a5fb-113d5eed88e8" />


## Checklist
- [X] 🛡️ Don't disclose security issues!
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
