### PR TITLE
NoSQL: filter ACL entries by direction in loadGrants

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1152,8 +1152,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     //   - reverse ('r/...'): grants where that entity is the grantee
     //   - directed ('d/...'): grants where that entity is the securable
     // Filter by direction so callers receive only the requested perspective.
-    Predicate<GrantTriplet> entryFilter =
-        onSecurable ? triplet -> !triplet.reverseOrKey() : GrantTriplet::reverseOrKey;
+    Predicate<GrantTriplet> entryFilter = GrantTriplet::reverseOrKey;
+    entryFilter = onSecurable ? entryFilter.negate() : entryFilter;
 
     collectGrantRecords(
         catalogId,

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1148,11 +1148,17 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     var collector = new GrantRecordsCollector();
     var entities = new ArrayList<PolarisBaseEntity>();
     var ids = new HashSet<Long>();
+    // ACLs for a given entity contain two directional entry flavors:
+    //   - reverse ('r/...'): grants where that entity is the grantee
+    //   - directed ('d/...'): grants where that entity is the securable
+    // Filter by direction so callers receive only the requested perspective.
+    Predicate<GrantTriplet> entryFilter =
+        onSecurable ? triplet -> !triplet.reverseOrKey() : GrantTriplet::reverseOrKey;
 
     collectGrantRecords(
         catalogId,
         aclName,
-        ((securableAndGrantee, granted) -> {
+        (securableAndGrantee, granted) -> {
           var targetCatalogId =
               onSecurable
                   ? securableAndGrantee.granteeCatalogId()
@@ -1182,7 +1188,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
           } else {
             LOGGER.trace("    Not returning stale entity reference");
           }
-        }));
+        },
+        entryFilter);
 
     LOGGER.trace(
         "Returning {} grant records for loadGrants for catalog:{}, id:{}, entityType:{}({})",
@@ -1225,7 +1232,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
 
           collector.handle(securableAndGrantee, granted);
         },
-        securablesIndex);
+        securablesIndex,
+        triplet -> true);
     return collector.grantRecords;
   }
 
@@ -1235,12 +1243,16 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
   }
 
   private void collectGrantRecords(
-      long catalogStableId, String aclName, AclEntryHandler aclEntryConsumer) {
+      long catalogStableId,
+      String aclName,
+      AclEntryHandler aclEntryConsumer,
+      Predicate<GrantTriplet> tripletFilter) {
     LOGGER.debug("Checking ACL '{}'", aclName);
 
     var securablesIndex = memoizedIndexedAccess.grantsIndex();
     if (securablesIndex.isPresent()) {
-      collectGrantRecords(catalogStableId, aclName, aclEntryConsumer, securablesIndex.get());
+      collectGrantRecords(
+          catalogStableId, aclName, aclEntryConsumer, securablesIndex.get(), tripletFilter);
     } else {
       LOGGER.trace("ACL {} does not exist", aclName);
     }
@@ -1250,7 +1262,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
       long catalogStableId,
       String aclName,
       AclEntryHandler aclEntryConsumer,
-      Index<ObjRef> securablesIndex) {
+      Index<ObjRef> securablesIndex,
+      Predicate<GrantTriplet> tripletFilter) {
     var securableKey = IndexKey.key(aclName);
 
     LOGGER.trace("Processing existing ACL {}", aclName);
@@ -1263,6 +1276,10 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               acl.forEach(
                   (role, entry) -> {
                     var triplet = GrantTriplet.fromRoleName(role);
+                    if (!tripletFilter.test(triplet)) {
+                      LOGGER.trace("  Skipping ACL entry role '{}' due to direction filter", role);
+                      return;
+                    }
                     LOGGER
                         .atTrace()
                         .setMessage("  ACL has securable {} ({}) with privileges {}")

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -295,6 +295,15 @@ public abstract class BasePolarisMetaStoreManagerTest {
     polarisTestMetaStoreManager.testLoadResolvedEntitySkipsDroppedGranteeReferences();
   }
 
+  /**
+   * Test that loadGrantsToGrantee/loadGrantsOnSecurable return only grants where the entity plays
+   * the expected role — regression test for entities that are both grantee and securable.
+   */
+  @Test
+  protected void testLoadGrantsGranteeVsSecurableRecords() {
+    polarisTestMetaStoreManager.testLoadGrantsGranteeVsSecurableRecords();
+  }
+
   /** Test the set of functions for the entity cache */
   @Test
   protected void testEntityCache() {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2963,6 +2963,108 @@ public class PolarisTestMetaStoreManager {
                 Assertions.assertThat(grantRecord.getGranteeId()).isEqualTo(principalRoleId));
   }
 
+  /**
+   * Verify that loadGrantsToGrantee and loadGrantsOnSecurable return only grants where the entity
+   * plays the expected role (grantee or securable).
+   */
+  public void testLoadGrantsGranteeVsSecurableRecords() {
+    // create a catalog — this also creates the catalog_admin role, which is automatically
+    // both a grantee (it has grants on the catalog) and a securable (it gets granted to the
+    // catalog owner).
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            polarisMetaStoreManager.generateNewEntityId(this.polarisCallContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "load_grants_test");
+    CreateCatalogResult catalogCreated =
+        polarisMetaStoreManager.createCatalog(this.polarisCallContext, catalog, List.of());
+    Assertions.assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    EntityResult catalogAdminResult =
+        polarisMetaStoreManager.readEntityByName(
+            this.polarisCallContext,
+            List.of(catalog),
+            PolarisEntityType.CATALOG_ROLE,
+            PolarisEntitySubType.ANY_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogAdminRole());
+    Assertions.assertThat(catalogAdminResult.isSuccess()).isTrue();
+    PolarisBaseEntity catalogAdmin = catalogAdminResult.getEntity();
+
+    // none of the returned entities should be a CATALOG_ROLE — the securables should be
+    // catalogs, namespaces, etc., not the role itself
+    LoadGrantsResult catalogAdminAsGrantee =
+        polarisMetaStoreManager.loadGrantsToGrantee(this.polarisCallContext, catalogAdmin);
+    Assertions.assertThat(catalogAdminAsGrantee.isSuccess()).isTrue();
+    Assertions.assertThat(catalogAdminAsGrantee.getGrantRecords())
+        .isNotEmpty()
+        .allSatisfy(
+            g -> {
+              Assertions.assertThat(g.getGranteeCatalogId()).isEqualTo(catalogAdmin.getCatalogId());
+              Assertions.assertThat(g.getGranteeId()).isEqualTo(catalogAdmin.getId());
+            });
+    Assertions.assertThat(catalogAdminAsGrantee.getEntities())
+        .allSatisfy(
+            entity ->
+                Assertions.assertThat(entity.getType())
+                    .isNotEqualTo(PolarisEntityType.CATALOG_ROLE));
+
+    // now set up an explicit scenario to validate both directions thoroughly:
+    // create a namespace and a catalog role CR1 with grants in both directions
+    PolarisBaseEntity N1 = createEntity(List.of(catalog), PolarisEntityType.NAMESPACE, "N1");
+    PolarisBaseEntity CR1 = createEntity(List.of(catalog), PolarisEntityType.CATALOG_ROLE, "CR1");
+
+    // grant a privilege TO CR1 on N1 (CR1 is the grantee)
+    grantPrivilege(CR1, List.of(catalog, N1), N1, PolarisPrivilege.TABLE_READ_DATA);
+
+    // create a principal role and grant CR1 usage to it (CR1 is the securable)
+    PolarisBaseEntity PR1 = createEntity(null, PolarisEntityType.PRINCIPAL_ROLE, "PR1");
+    grantToGrantee(catalog, CR1, PR1, PolarisPrivilege.CATALOG_ROLE_USAGE);
+
+    // loadGrantsToGrantee(CR1): all records must have granteeId == CR1
+    LoadGrantsResult granteeResult =
+        polarisMetaStoreManager.loadGrantsToGrantee(this.polarisCallContext, CR1);
+    Assertions.assertThat(granteeResult.getGrantRecords())
+        .isNotEmpty()
+        .allSatisfy(
+            g -> {
+              Assertions.assertThat(g.getGranteeId()).isEqualTo(CR1.getId());
+              Assertions.assertThat(g.getSecurableId()).isNotEqualTo(CR1.getId());
+            });
+    Assertions.assertThat(granteeResult.getGrantRecords())
+        .anySatisfy(
+            g -> {
+              Assertions.assertThat(g.getSecurableId()).isEqualTo(N1.getId());
+              Assertions.assertThat(g.getPrivilegeCode())
+                  .isEqualTo(PolarisPrivilege.TABLE_READ_DATA.getCode());
+            });
+
+    // loadGrantsOnSecurable(CR1): all records must have securableId == CR1
+    LoadGrantsResult securableResult =
+        polarisMetaStoreManager.loadGrantsOnSecurable(this.polarisCallContext, CR1);
+    Assertions.assertThat(securableResult.getGrantRecords())
+        .isNotEmpty()
+        .allSatisfy(
+            g -> {
+              Assertions.assertThat(g.getSecurableId()).isEqualTo(CR1.getId());
+              Assertions.assertThat(g.getGranteeId()).isNotEqualTo(CR1.getId());
+            });
+    Assertions.assertThat(securableResult.getGrantRecords())
+        .anySatisfy(
+            g -> {
+              Assertions.assertThat(g.getGranteeId()).isEqualTo(PR1.getId());
+              Assertions.assertThat(g.getPrivilegeCode())
+                  .isEqualTo(PolarisPrivilege.CATALOG_ROLE_USAGE.getCode());
+            });
+
+    // the two result sets must not overlap
+    Assertions.assertThat(granteeResult.getGrantRecords())
+        .doesNotContainAnyElementsOf(securableResult.getGrantRecords());
+  }
+
   private static PolarisEntityCore getEntityCore(PolarisBaseEntity entity) {
     return new PolarisEntityCore.Builder<>(entity).build();
   }


### PR DESCRIPTION
Fixes #4219.

The NoSQL persistence layer stores both directional entry flavors in a single ACL document: reverse ('r/') entries where the entity is the grantee, and directed ('d/') entries where it is the securable. When loading grants for a specific perspective (grantee or securable), both flavors were returned, causing entities like `catalog_admin` — which appear as both grantee and securable — to produce incorrect grant records and trigger "Unexpected entity type 'CATALOG_ROLE'" errors.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
