### PR TITLE
CI: Use Zizmor defaults

### DIFF
--- a/.github/workflows/ci-zizmor.yml
+++ b/.github/workflows/ci-zizmor.yml
@@ -46,15 +46,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Run Zizmor (SARIF upload)
+      - name: Run Zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          min-severity: medium
-          min-confidence: medium
-      - name: Run Zizmor (PR annotations)
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
-        with:
-          min-severity: medium
-          min-confidence: medium
-          advanced-security: false
-          annotations: true
+          # Intentionally leave the defaults, which is to report even informational/low
+          # severity/confidence findings.
+          #min-severity:
+          #min-confidence:
+          advanced-security: ${{ github.event_name != 'pull_request' }}
+          annotations: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Zizmor is a static analysis toll, which, by the nature of such tools, does not consider the context of a finding, but judges on using static patters. Users can either deal with false positives or silence a lot to a level that they don't report much by default. Hiding those can, in case of security issues, be dangerous.

'low' confidence doesn't mean that the risk does not exist nor that the issue is not exploitable.

'informational'/'low' severity issues today can become 'high' or even 'critical' ones tomorrow. Hiding those can easily give a false sense of security.

Chains of informational/low severity/confidence issues have led to exactly the recent tj-actions incident. Some of these are:

* unpinned actions: this is _still_ a risk, just look at the [approved wildcard patterns](https://github.com/apache/infrastructure-actions/blob/8a059befd17ed98f4942c5cf3a67b7378045b669/approved_patterns.yml).
* no explicitly declared workflow/job permissions - this is even just _informational_
* similarly: excessive workflow/job permissions
* (some) template injections

As the workflows and actions work with Zizmor's default severity/confidence, I'd advocate to use its default and not silence a lot.
