### PR TITLE
fix: enforce single expiration timestamp per storage credential bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Metrics reporting now requires the `TABLE_READ_DATA` privilege on the target table for read (scan) metrics and `TABLE_WRITE_DATA` for write (commit) metrics.
 - The `REVOKE_CATALOG_ROLE_FROM_PRINCIPAL_ROLE` operation no longer requires the `PRINCIPAL_ROLE_MANAGE_GRANTS_FOR_GRANTEE` privilege. Only `CATALOG_ROLE_MANAGE_GRANTS_ON_SECURABLE` on the catalog role is now required, making revoke symmetric with assign. This allows catalog administrators to fully manage catalog role assignments without requiring elevated privileges on principal roles.
 - The `ConnectionCredentials.of()` method now throws an exception when more than one expiration timestamp property is present in the credentials map. Only a single expiration timestamp is allowed per credentials bundle.
+- The `StorageAccessConfig.Builder.put()` method now throws an exception when more than one expiration timestamp property is on the same builder. Only a single expiration timestamp is allowed per credential bundle.
 
 ### New Features
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessConfig.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessConfig.java
@@ -58,7 +58,7 @@ public interface StorageAccessConfig {
   }
 
   static StorageAccessConfig.Builder builder() {
-    return ImmutableStorageAccessConfig.builder();
+    return new ValidatingBuilder(ImmutableStorageAccessConfig.builder());
   }
 
   interface Builder {
@@ -90,5 +90,77 @@ public interface StorageAccessConfig {
     }
 
     StorageAccessConfig build();
+  }
+
+  /**
+   * A decorator around {@link ImmutableStorageAccessConfig.Builder} that enforces at most one
+   * expiration timestamp property per {@link StorageAccessConfig}. Without this guard, multiple
+   * calls to {@link Builder#put} with different expiration timestamp properties silently overwrite
+   * {@link StorageAccessConfig#expiresAt()}.
+   */
+  class ValidatingBuilder implements Builder {
+    private final ImmutableStorageAccessConfig.Builder delegate;
+    private StorageAccessProperty expiresAtKey;
+
+    ValidatingBuilder(ImmutableStorageAccessConfig.Builder delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Builder put(StorageAccessProperty key, String value) {
+      if (key.isExpirationTimestamp()) {
+        if (expiresAtKey != null) {
+          throw new IllegalArgumentException(
+              "Multiple expiration timestamp properties found while building StorageAccessConfig: "
+                  + expiresAtKey.getPropertyName()
+                  + " and "
+                  + key.getPropertyName()
+                  + ". Only a single expiration timestamp is allowed per StorageAccessConfig.");
+        }
+        expiresAtKey = key;
+      }
+      Builder.super.put(key, value);
+      return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Builder putCredential(String key, String value) {
+      delegate.putCredential(key, value);
+      return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Builder putExtraProperty(String key, String value) {
+      delegate.putExtraProperty(key, value);
+      return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Builder putInternalProperty(String key, String value) {
+      delegate.putInternalProperty(key, value);
+      return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Builder expiresAt(Instant expiresAt) {
+      delegate.expiresAt(expiresAt);
+      return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Builder supportsCredentialVending(boolean supportsCredentialVending) {
+      delegate.supportsCredentialVending(supportsCredentialVending);
+      return this;
+    }
+
+    @Override
+    public StorageAccessConfig build() {
+      return delegate.build();
+    }
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -160,8 +160,6 @@ public class AwsCredentialsStorageIntegration
           .ifPresent(
               i -> {
                 accessConfig.put(
-                    StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
-                accessConfig.put(
                     StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
                     String.valueOf(i.toEpochMilli()));
               });

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageAccessConfigTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageAccessConfigTest.java
@@ -25,6 +25,7 @@ import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_SESSION_
 import static org.apache.polaris.core.storage.StorageAccessProperty.EXPIRATION_TIME;
 import static org.apache.polaris.core.storage.StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.util.Map;
@@ -79,15 +80,38 @@ public class StorageAccessConfigTest {
 
   @Test
   public void testExpiresAt() {
-    StorageAccessConfig.Builder b = StorageAccessConfig.builder();
-    assertThat(b.build().expiresAt()).isEmpty();
-    b.put(GCS_ACCESS_TOKEN_EXPIRES_AT, "111");
-    assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(111));
-    b.put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, "222");
-    assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(222));
-    b.put(EXPIRATION_TIME, "333");
-    assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(333));
-    b.expiresAt(Instant.ofEpochMilli(444));
-    assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(444));
+    assertThat(StorageAccessConfig.builder().build().expiresAt()).isEmpty();
+
+    assertThat(
+            StorageAccessConfig.builder()
+                .put(GCS_ACCESS_TOKEN_EXPIRES_AT, "111")
+                .build()
+                .expiresAt())
+        .hasValue(Instant.ofEpochMilli(111));
+
+    assertThat(
+            StorageAccessConfig.builder()
+                .put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, "222")
+                .build()
+                .expiresAt())
+        .hasValue(Instant.ofEpochMilli(222));
+
+    assertThat(StorageAccessConfig.builder().put(EXPIRATION_TIME, "333").build().expiresAt())
+        .hasValue(Instant.ofEpochMilli(333));
+
+    assertThat(
+            StorageAccessConfig.builder().expiresAt(Instant.ofEpochMilli(444)).build().expiresAt())
+        .hasValue(Instant.ofEpochMilli(444));
+  }
+
+  @Test
+  public void testMultipleExpirationTimestampsThrows() {
+    StorageAccessConfig.Builder b =
+        StorageAccessConfig.builder().put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, "1");
+
+    assertThatThrownBy(() -> b.put(EXPIRATION_TIME, "2"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(AWS_SESSION_TOKEN_EXPIRES_AT_MS.getPropertyName())
+        .hasMessageContaining(EXPIRATION_TIME.getPropertyName());
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -509,7 +509,6 @@ public class StorageCredentialCacheTest {
                   .put(StorageAccessProperty.AWS_KEY_ID, "key_id_" + finalI)
                   .put(StorageAccessProperty.AWS_SECRET_KEY, "key_secret_" + finalI)
                   .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, expireTime)
-                  .put(StorageAccessProperty.EXPIRATION_TIME, expireTime)
                   .build()));
       if (res.size() == number) return res;
       res.add(


### PR DESCRIPTION
`StorageAccessConfig.Builder.put()` silently overwrites `expiresAt` when multiple expiration timestamp properties are set. Only a single expiration timestamp is valid per credential bundle. Multiple timestamps indicate incorrect behavior that should fail fast rather than silently picking one. 

This mirrors the same fix applied to `ConnectionCredentials.of()` in https://github.com/apache/polaris/pull/4173.

Also fixes `AwsCredentialsStorageIntegration` which was the only production caller setting two expiration timestamps (`EXPIRATION_TIME` and `AWS_SESSION_TOKEN_EXPIRES_AT_MS`).

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
