### PR TITLE
fix: reduce AWS STS inline policy size by merging read+write actions

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Nonnull;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.policybuilder.iam.IamStatement;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.PackedPolicyTooLargeException;
 import software.amazon.awssdk.services.sts.model.Tag;
 
 /** Credential vendor that supports generating */
@@ -151,7 +153,17 @@ public class AwsCredentialsStorageIntegration
       StsClient stsClient =
           stsClientProvider.stsClient(StsDestination.of(storageConfig.getStsEndpointUri(), region));
 
-      AssumeRoleResponse response = stsClient.assumeRole(request.build());
+      AssumeRoleResponse response;
+      try {
+        response = stsClient.assumeRole(request.build());
+      } catch (PackedPolicyTooLargeException e) {
+        throw new RuntimeException(
+            "AWS STS rejected the session policy: it exceeds the 2048-character packed-policy"
+                + " limit. This commonly happens with deeply nested namespace hierarchies or"
+                + " long namespace names. Consider shortening the namespace path or splitting"
+                + " the hierarchy.",
+            e);
+      }
       accessConfig.put(StorageAccessProperty.AWS_KEY_ID, response.credentials().accessKeyId());
       accessConfig.put(
           StorageAccessProperty.AWS_SECRET_KEY, response.credentials().secretAccessKey());
@@ -208,11 +220,16 @@ public class AwsCredentialsStorageIntegration
   }
 
   /**
-   * generate an IamPolicy from the input readLocations and writeLocations, optionally with list
+   * Generate an IamPolicy from the input readLocations and writeLocations, optionally with list
    * support. Credentials will be scoped to exactly the resources provided. If read and write
    * locations are empty, a non-empty policy will be generated that grants GetObject and optionally
    * ListBucket privileges with no resources. This prevents us from sending an empty policy to AWS
    * and just assuming the role with full privileges.
+   *
+   * <p>Write locations are emitted in a single combined statement that grants both read and write
+   * actions, rather than in a separate write-only statement that duplicates the resource ARN
+   * already listed in the read statement. This keeps the packed inline policy within AWS STS's
+   * 2048-character limit for deeply nested namespace hierarchies.
    */
   private IamPolicy policyString(
       AwsStorageConfigurationInfo storageConfigurationInfo,
@@ -221,25 +238,24 @@ public class AwsCredentialsStorageIntegration
       Set<String> writeLocations,
       String region) {
     IamPolicy.Builder policyBuilder = IamPolicy.builder();
-    IamStatement.Builder allowGetObjectStatementBuilder =
-        IamStatement.builder()
-            .effect(IamEffect.ALLOW)
-            .addAction("s3:GetObject")
-            .addAction("s3:GetObjectVersion");
-    Map<String, IamStatement.Builder> bucketListStatementBuilder = new HashMap<>();
-    Map<String, IamStatement.Builder> bucketGetLocationStatementBuilder = new HashMap<>();
-
     String arnPrefix = arnPrefixForPartition(storageConfigurationInfo.getAwsPartition());
     String currentKmsKey = storageConfigurationInfo.getCurrentKmsKey();
     List<String> allowedKmsKeys = storageConfigurationInfo.getAllowedKmsKeys();
+
+    // Locations readable but not writable receive only read actions; everything in writeLocations
+    // receives read and write actions from a single combined statement below. Splitting this way
+    // avoids listing every write-location ARN twice.
+    Set<String> readOnlyLocations = new HashSet<>(readLocations);
+    readOnlyLocations.removeAll(writeLocations);
+    boolean canWrite = !writeLocations.isEmpty();
+
+    Map<String, IamStatement.Builder> bucketListStatementBuilder = new HashMap<>();
+    Map<String, IamStatement.Builder> bucketGetLocationStatementBuilder = new HashMap<>();
     Stream.concat(readLocations.stream(), writeLocations.stream())
         .distinct()
         .forEach(
             location -> {
               URI uri = URI.create(location);
-              allowGetObjectStatementBuilder.addResource(
-                  IamResource.create(
-                      arnPrefix + StorageUtil.concatFilePrefixes(parseS3Path(uri), "*", "/")));
               final var bucket = arnPrefix + StorageUtil.getBucket(uri);
               if (allowList) {
                 bucketListStatementBuilder
@@ -264,21 +280,22 @@ public class AwsCredentialsStorageIntegration
                           .addResource(key));
             });
 
-    boolean canWrite = !writeLocations.isEmpty();
     if (canWrite) {
-      IamStatement.Builder allowPutObjectStatementBuilder =
+      IamStatement.Builder allowReadWriteStatementBuilder =
           IamStatement.builder()
               .effect(IamEffect.ALLOW)
+              .addAction("s3:GetObject")
+              .addAction("s3:GetObjectVersion")
               .addAction("s3:PutObject")
               .addAction("s3:DeleteObject");
       writeLocations.forEach(
           location -> {
             URI uri = URI.create(location);
-            allowPutObjectStatementBuilder.addResource(
+            allowReadWriteStatementBuilder.addResource(
                 IamResource.create(
                     arnPrefix + StorageUtil.concatFilePrefixes(parseS3Path(uri), "*", "/")));
           });
-      policyBuilder.addStatement(allowPutObjectStatementBuilder.build());
+      policyBuilder.addStatement(allowReadWriteStatementBuilder.build());
     }
     if (shouldUseKms(storageConfigurationInfo)) {
       addKmsKeyPolicy(
@@ -302,7 +319,26 @@ public class AwsCredentialsStorageIntegration
     bucketGetLocationStatementBuilder
         .values()
         .forEach(statementBuilder -> policyBuilder.addStatement(statementBuilder.build()));
-    return policyBuilder.addStatement(allowGetObjectStatementBuilder.build()).build();
+
+    // Emit a read-only statement when there are read-only locations, or as a fallback with no
+    // resources when no combined read+write statement was emitted — ensuring the inline policy is
+    // always non-empty.
+    if (!readOnlyLocations.isEmpty() || !canWrite) {
+      IamStatement.Builder allowGetObjectStatementBuilder =
+          IamStatement.builder()
+              .effect(IamEffect.ALLOW)
+              .addAction("s3:GetObject")
+              .addAction("s3:GetObjectVersion");
+      readOnlyLocations.forEach(
+          location -> {
+            URI uri = URI.create(location);
+            allowGetObjectStatementBuilder.addResource(
+                IamResource.create(
+                    arnPrefix + StorageUtil.concatFilePrefixes(parseS3Path(uri), "*", "/")));
+          });
+      policyBuilder.addStatement(allowGetObjectStatementBuilder.build());
+    }
+    return policyBuilder.build();
   }
 
   private static void addKmsKeyPolicy(

--- a/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.PackedPolicyTooLargeException;
 import software.amazon.awssdk.services.sts.model.StsException;
 
 class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
@@ -92,6 +93,9 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   public static final String AWS_PARTITION = "aws";
   public static final PolarisPrincipal POLARIS_PRINCIPAL =
       PolarisPrincipal.of("test-principal", Map.of(), Set.of());
+
+  /** AWS STS inline session policy size limit (packed), in characters. */
+  private static final int STS_PACKED_POLICY_LIMIT = 2048;
 
   @SafeVarargs
   private static RealmConfig enabledFeatures(FeatureConfiguration<Boolean>... enabledOptions) {
@@ -256,6 +260,8 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                                             IamStatement::resources)
                                         .returns(
                                             List.of(
+                                                IamAction.create("s3:GetObject"),
+                                                IamAction.create("s3:GetObjectVersion"),
                                                 IamAction.create("s3:PutObject"),
                                                 IamAction.create("s3:DeleteObject")),
                                             IamStatement::actions),
@@ -306,15 +312,11 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                                 statement ->
                                     assertThat(statement)
                                         .returns(IamEffect.ALLOW, IamStatement::effect)
-                                        .satisfies(
-                                            st ->
-                                                assertThat(st.resources())
-                                                    .containsExactlyInAnyOrder(
-                                                        IamResource.create(
-                                                            s3Arn(awsPartition, bucket, firstPath)),
-                                                        IamResource.create(
-                                                            s3Arn(
-                                                                awsPartition, bucket, secondPath))))
+                                        .returns(
+                                            List.of(
+                                                IamResource.create(
+                                                    s3Arn(awsPartition, bucket, secondPath))),
+                                            IamStatement::resources)
                                         .returns(
                                             List.of(
                                                 IamAction.create("s3:GetObject"),
@@ -392,6 +394,8 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                                             IamStatement::resources)
                                         .returns(
                                             List.of(
+                                                IamAction.create("s3:GetObject"),
+                                                IamAction.create("s3:GetObjectVersion"),
                                                 IamAction.create("s3:PutObject"),
                                                 IamAction.create("s3:DeleteObject")),
                                             IamStatement::actions),
@@ -410,18 +414,11 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                                 statement ->
                                     assertThat(statement)
                                         .returns(IamEffect.ALLOW, IamStatement::effect)
-                                        .satisfies(
-                                            st ->
-                                                assertThat(st.resources())
-                                                    .containsExactlyInAnyOrder(
-                                                        IamResource.create(
-                                                            s3Arn(
-                                                                AWS_PARTITION, bucket, firstPath)),
-                                                        IamResource.create(
-                                                            s3Arn(
-                                                                AWS_PARTITION,
-                                                                bucket,
-                                                                secondPath))))
+                                        .returns(
+                                            List.of(
+                                                IamResource.create(
+                                                    s3Arn(AWS_PARTITION, bucket, secondPath))),
+                                            IamStatement::resources)
                                         .returns(
                                             List.of(
                                                 IamAction.create("s3:GetObject"),
@@ -1635,6 +1632,184 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                         context))
         .isInstanceOf(software.amazon.awssdk.services.sts.model.StsException.class)
         .hasMessageContaining("sts:TagSession");
+  }
+
+  /**
+   * Regression test for issue #3243: read and write actions for shared locations are emitted in a
+   * single statement, eliminating the duplicated ARN that previously inflated the policy.
+   */
+  @Test
+  public void testReadWriteLocationsMergedIntoSingleStatement() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
+    String externalId = "externalId";
+    String bucket = "bucket";
+    String tablePath = "path/to/warehouse/ns/table";
+    Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              assertThat(invocation.getArguments()[0])
+                  .isInstanceOf(AssumeRoleRequest.class)
+                  .asInstanceOf(InstanceOfAssertFactories.type(AssumeRoleRequest.class))
+                  .extracting(AssumeRoleRequest::policy)
+                  .extracting(IamPolicy::fromJson)
+                  .satisfies(
+                      policy -> {
+                        List<IamStatement> objectStatements =
+                            policy.statements().stream()
+                                .filter(
+                                    s ->
+                                        s.actions().stream()
+                                            .anyMatch(a -> a.value().startsWith("s3:GetObject")))
+                                .toList();
+                        // Exactly one object-access statement when read and write sets match,
+                        // carrying both read and write actions on the shared resource.
+                        assertThat(objectStatements)
+                            .singleElement()
+                            .returns(
+                                List.of(
+                                    IamAction.create("s3:GetObject"),
+                                    IamAction.create("s3:GetObjectVersion"),
+                                    IamAction.create("s3:PutObject"),
+                                    IamAction.create("s3:DeleteObject")),
+                                IamStatement::actions)
+                            .returns(
+                                List.of(
+                                    IamResource.create(s3Arn(AWS_PARTITION, bucket, tablePath))),
+                                IamStatement::resources);
+                      });
+              return ASSUME_ROLE_RESPONSE;
+            });
+    new AwsCredentialsStorageIntegration(
+            AwsStorageConfigurationInfo.builder()
+                .addAllowedLocation(s3Path(bucket, tablePath))
+                .roleARN(roleARN)
+                .externalId(externalId)
+                .build(),
+            stsClient)
+        .getSubscopedCreds(
+            EMPTY_REALM_CONFIG,
+            true,
+            Set.of(s3Path(bucket, tablePath)),
+            Set.of(s3Path(bucket, tablePath)),
+            POLARIS_PRINCIPAL,
+            Optional.empty(),
+            CredentialVendingContext.empty());
+  }
+
+  /**
+   * Deeply-nested namespace paths (15 nested 32-char namespaces, mirroring the benchmark repro)
+   * would previously exceed the AWS STS packed-policy limit because each write location's ARN was
+   * listed in both the read and the write statement. With the merged statement, the policy stays
+   * well within the limit.
+   */
+  @Test
+  public void testDeepNestedNamespaceStaysWithinPackedPolicyLimit() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
+    String externalId = "externalId";
+    String bucket = "my-very-long-s3-bucket";
+    String[] namespaces = {
+      "f5a4d86558ed1f7fddec42ce11d8ee3a",
+      "e3fa7fd44796b949fce728cb334f3c15",
+      "f031eb9dc709150a3e1e9a76e9af550a",
+      "5598924229adee97260cda483d70674c",
+      "0857633d48470f538d1fc4cdc789c753",
+      "c4c06b9b673a710f7ce865690ff8797b",
+      "9594c7f9e8a1cd28054ff71b933fdc3b",
+      "0018c223e978d13aeec87488bc333c70",
+      "d4c484ca41745b69286372286f3f30aa",
+      "362f8d6579892af8a9c5f38b4e664b07",
+      "f28f3a8b846271c68bdbc09992d88d28",
+      "915107073e394e3471173ec4633137fa",
+      "5eac9dac6dd84afcb35f4805af9d8b34",
+      "e1a24630cbf9ced9dffcc123b70b2e43",
+      "ab4ffa55f688360e0c12aef543c18351"
+    };
+    String deepPath = "catalog/" + String.join("/", namespaces);
+    Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              AssumeRoleRequest req = invocation.getArgument(0);
+              assertThat(req.policy().length())
+                  .as("inline policy JSON length for deep-nested namespace")
+                  .isLessThan(STS_PACKED_POLICY_LIMIT);
+              IamPolicy policy = IamPolicy.fromJson(req.policy());
+              long statementsReferencingDeepPath =
+                  policy.statements().stream()
+                      .filter(
+                          s ->
+                              s.resources().stream()
+                                  .anyMatch(r -> r.value().endsWith(deepPath + "/*")))
+                      .count();
+              assertThat(statementsReferencingDeepPath).isEqualTo(1);
+              return ASSUME_ROLE_RESPONSE;
+            });
+    new AwsCredentialsStorageIntegration(
+            AwsStorageConfigurationInfo.builder()
+                .addAllowedLocation(s3Path(bucket, "catalog"))
+                .roleARN(roleARN)
+                .externalId(externalId)
+                .build(),
+            stsClient)
+        .getSubscopedCreds(
+            EMPTY_REALM_CONFIG,
+            true,
+            Set.of(s3Path(bucket, deepPath)),
+            Set.of(s3Path(bucket, deepPath)),
+            POLARIS_PRINCIPAL,
+            Optional.empty(),
+            CredentialVendingContext.empty());
+  }
+
+  /**
+   * When the generated policy is still too large for STS despite the merging optimizations, the raw
+   * AWS SDK exception is rewrapped with an actionable message pointing at namespace path length.
+   */
+  @Test
+  public void testPackedPolicyTooLargeExceptionIsRewrapped() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
+    String externalId = "externalId";
+    String bucket = "bucket";
+    String warehouseKeyPrefix = "path/to/warehouse";
+
+    PackedPolicyTooLargeException packedPolicyException =
+        (PackedPolicyTooLargeException)
+            PackedPolicyTooLargeException.builder()
+                .message("Packed policy consumes 118% of allotted space, please use smaller policy")
+                .awsErrorDetails(
+                    AwsErrorDetails.builder()
+                        .errorCode("PackedPolicyTooLarge")
+                        .serviceName("STS")
+                        .build())
+                .statusCode(400)
+                .build();
+
+    Mockito.when(stsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+        .thenThrow(packedPolicyException);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                new AwsCredentialsStorageIntegration(
+                        AwsStorageConfigurationInfo.builder()
+                            .addAllowedLocation(s3Path(bucket, warehouseKeyPrefix))
+                            .roleARN(roleARN)
+                            .externalId(externalId)
+                            .build(),
+                        stsClient)
+                    .getSubscopedCreds(
+                        EMPTY_REALM_CONFIG,
+                        true,
+                        Set.of(s3Path(bucket, warehouseKeyPrefix)),
+                        Set.of(s3Path(bucket, warehouseKeyPrefix)),
+                        POLARIS_PRINCIPAL,
+                        Optional.empty(),
+                        CredentialVendingContext.empty()))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(String.valueOf(STS_PACKED_POLICY_LIMIT))
+        .hasMessageContaining("namespace")
+        .hasCauseInstanceOf(PackedPolicyTooLargeException.class);
   }
 
   @Test


### PR DESCRIPTION
Writable locations previously appeared in two separate statements:
1. Read statement covering every location
2. Write statement covering only writable ones.

This listed the resource ARN twice for every writable location, which pushed deeply nested namespace paths past the 2048-character STS policy limit.

This change emits a single combined statement granting both read and write actions for writable locations, and keep the read-only statement only for locations not already covered.

Also wraps the assumeRole call to rewrap `PackedPolicyTooLargeException` with a descriptive error msg.

Example:

Before (2 statements, ARN duplicated):
```
  {"Action": ["s3:GetObject", "s3:GetObjectVersion"],
   "Resource": ["...bucket/path/*"]}
  {"Action": ["s3:PutObject", "s3:DeleteObject"],
   "Resource": ["...bucket/path/*"]}
```

After (1 statement):
```
  {"Action": ["s3:GetObject", "s3:GetObjectVersion",
              "s3:PutObject", "s3:DeleteObject"],
   "Resource": ["...bucket/path/*"]}
```

Fixes #3243

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
