### PR TITLE
NoSQL: filter stale grants with deleted grantees from resolved entities

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1203,17 +1203,35 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
         catalogId,
         aclName,
         (securableAndGrantee, granted) -> {
-          var indexedAccess =
-              memoizedIndexedAccess.indexedAccess(
+          var securableExists =
+              entityExists(
                   securableAndGrantee.securableCatalogId(),
+                  securableAndGrantee.securableId(),
                   securableAndGrantee.securableTypeCode());
-          var existing = indexedAccess.nameKeyById(securableAndGrantee.securableId());
-          if (existing.isPresent()) {
-            collector.handle(securableAndGrantee, granted);
+          if (!securableExists) {
+            LOGGER.trace("Skipping stale grant record due to missing securable reference");
+            return;
           }
+
+          var granteeExists =
+              entityExists(
+                  securableAndGrantee.granteeCatalogId(),
+                  securableAndGrantee.granteeId(),
+                  securableAndGrantee.granteeTypeCode());
+          if (!granteeExists) {
+            LOGGER.trace("Skipping stale grant record due to missing grantee reference");
+            return;
+          }
+
+          collector.handle(securableAndGrantee, granted);
         },
         securablesIndex);
     return collector.grantRecords;
+  }
+
+  private boolean entityExists(long catalogId, long id, int typeCode) {
+    var indexedAccess = memoizedIndexedAccess.indexedAccess(catalogId, typeCode);
+    return indexedAccess.nameKeyById(id).isPresent();
   }
 
   private void collectGrantRecords(

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -289,6 +289,12 @@ public abstract class BasePolarisMetaStoreManagerTest {
     polarisTestMetaStoreManager.testLoadResolvedEntitiesGranteeVsSecurableRecords();
   }
 
+  /** test that resolved entities do not include grant records referencing dropped grantees */
+  @Test
+  protected void testLoadResolvedEntitySkipsDroppedGranteeReferences() {
+    polarisTestMetaStoreManager.testLoadResolvedEntitySkipsDroppedGranteeReferences();
+  }
+
   /** Test the set of functions for the entity cache */
   @Test
   protected void testEntityCache() {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2873,6 +2873,96 @@ public class PolarisTestMetaStoreManager {
         .doesNotContainAnyElementsOf(resolved.getGrantRecordsAsSecurable());
   }
 
+  public void testLoadResolvedEntitySkipsDroppedGranteeReferences() {
+    // create a catalog
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            polarisMetaStoreManager.generateNewEntityId(this.polarisCallContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "staleGrantCatalog");
+    CreateCatalogResult catalogCreated =
+        polarisMetaStoreManager.createCatalog(this.polarisCallContext, catalog, List.of());
+    Assertions.assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    // read the built-in catalog_admin role (will be the securable)
+    EntityResult catalogAdminRoleResult =
+        polarisMetaStoreManager.readEntityByName(
+            this.polarisCallContext,
+            List.of(catalog),
+            PolarisEntityType.CATALOG_ROLE,
+            PolarisEntitySubType.ANY_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogAdminRole());
+    Assertions.assertThat(catalogAdminRoleResult.isSuccess()).isTrue();
+    PolarisBaseEntity catalogAdminRole = catalogAdminRoleResult.getEntity();
+    Assertions.assertThat(catalogAdminRole).isNotNull();
+
+    // create a principal role (will be the grantee)
+    PolarisBaseEntity principalRole =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            polarisMetaStoreManager.generateNewEntityId(this.polarisCallContext).getId(),
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "staleGrantPrincipalRole");
+    EntityResult principalRoleCreate =
+        polarisMetaStoreManager.createEntityIfNotExists(
+            this.polarisCallContext, null, principalRole);
+    Assertions.assertThat(principalRoleCreate.isSuccess()).isTrue();
+    PolarisBaseEntity createdPrincipalRole = principalRoleCreate.getEntity();
+    Assertions.assertThat(createdPrincipalRole).isNotNull();
+    long principalRoleId = createdPrincipalRole.getId();
+
+    // grant usage on catalog_admin role to the principal role
+    Assertions.assertThat(
+            polarisMetaStoreManager
+                .grantUsageOnRoleToGrantee(
+                    this.polarisCallContext, catalog, catalogAdminRole, createdPrincipalRole)
+                .isSuccess())
+        .isTrue();
+
+    // verify the grant appears in the catalog_admin role's resolved entity
+    ResolvedEntityResult beforeDrop =
+        polarisMetaStoreManager.loadResolvedEntityById(
+            this.polarisCallContext,
+            catalogAdminRole.getCatalogId(),
+            catalogAdminRole.getId(),
+            PolarisEntityType.CATALOG_ROLE);
+    Assertions.assertThat(beforeDrop.isSuccess()).isTrue();
+    Assertions.assertThat(beforeDrop.getEntityGrantRecords())
+        .anySatisfy(
+            grantRecord -> {
+              Assertions.assertThat(grantRecord.getSecurableId())
+                  .isEqualTo(catalogAdminRole.getId());
+              Assertions.assertThat(grantRecord.getGranteeId()).isEqualTo(principalRoleId);
+            });
+
+    // drop the principal role (grantee)
+    Assertions.assertThat(
+            polarisMetaStoreManager
+                .dropEntityIfExists(
+                    this.polarisCallContext, null, createdPrincipalRole, null, false)
+                .isSuccess())
+        .isTrue();
+
+    // verify the stale grant is filtered out from the catalog_admin role's resolved entity
+    ResolvedEntityResult afterDrop =
+        polarisMetaStoreManager.loadResolvedEntityById(
+            this.polarisCallContext,
+            catalogAdminRole.getCatalogId(),
+            catalogAdminRole.getId(),
+            PolarisEntityType.CATALOG_ROLE);
+    Assertions.assertThat(afterDrop.isSuccess()).isTrue();
+    Assertions.assertThat(afterDrop.getEntityGrantRecords())
+        .noneSatisfy(
+            grantRecord ->
+                Assertions.assertThat(grantRecord.getGranteeId()).isEqualTo(principalRoleId));
+  }
+
   private static PolarisEntityCore getEntityCore(PolarisBaseEntity entity) {
     return new PolarisEntityCore.Builder<>(entity).build();
   }


### PR DESCRIPTION
The `allGrantRecords()` method only checked securable existence when filtering stale grants. For directed entries (d/...) the securable is the current entity itself, so deleted grantees were never filtered and leaked into resolved-entity grant sets.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
