### PR TITLE
Verify image builds with -PNonRESTCatalogs=HIVE,HADOOP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Image build
         env: *gradle_env_vars
-        run: ./gradlew :polaris-server:assemble -Dquarkus.container-image.build=true
+        run: ./gradlew :polaris-server:assemble -PNonRESTCatalogs=HIVE,HADOOP -Dquarkus.container-image.build=true
       - name: Save image to tar
         run: |
           docker save apache/polaris:latest | zstd -T0 > polaris-image.tar.zst


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR adds `-PNonRESTCatalogs=HIVE,HADOOP` parameters to the `docker-image-build` CI job to verify, that Docker image build succeeds with Hive and Hadoop federated catalog extensions. We can avoid merging PRs, which can break the build with these extensions.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
