### PR TITLE
NoSQL: fix phantom grants for dropped/non-existent entities

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1137,13 +1137,26 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
   }
 
   LoadGrantsResult loadGrants(long catalogId, long id, int entityTypeCode, boolean onSecurable) {
+    PolarisEntityType entityType = PolarisEntityType.fromCode(entityTypeCode);
     LOGGER.debug(
         "loadGrants on {} for catalog:{}, id:{}, entityType:{}({})",
         onSecurable ? "securable" : "grantee",
         catalogId,
         id,
-        PolarisEntityType.fromCode(entityTypeCode),
+        entityType,
         entityTypeCode);
+
+    var anchorEntity = lookupEntity(catalogId, id, entityTypeCode);
+    if (anchorEntity == null) {
+      LOGGER.trace(
+          "Anchor entity for loadGrants does not exist, returning ENTITY_NOT_FOUND: catalog:{}, id:{}, entityType:{}({})",
+          catalogId,
+          id,
+          entityType,
+          entityTypeCode);
+      return new LoadGrantsResult(ENTITY_NOT_FOUND, null);
+    }
+
     var aclName = new GrantTriplet(true, catalogId, id, entityTypeCode).toRoleName();
 
     var collector = new GrantRecordsCollector();
@@ -1164,6 +1177,20 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               onSecurable
                   ? securableAndGrantee.granteeTypeCode()
                   : securableAndGrantee.securableTypeCode();
+
+          // Skip self-referencing entries where the target is the anchor entity itself.
+          // The bidirectional ACL model produces these when securable == grantee.
+          if (targetId == id && targetTypeCode == entityTypeCode) {
+            if (LOGGER.isTraceEnabled()) {
+              LOGGER.trace(
+                  "    Skipping self-referencing grant entry for catalog:{}, id:{}, entityType:{}({})",
+                  targetCatalogId,
+                  targetId,
+                  PolarisEntityType.fromCode(targetTypeCode),
+                  targetTypeCode);
+            }
+            return;
+          }
 
           var indexedAccess = memoizedIndexedAccess.indexedAccess(targetCatalogId, targetTypeCode);
           var entityOptional =
@@ -1190,10 +1217,11 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
         collector.grantRecords.size(),
         catalogId,
         id,
-        PolarisEntityType.fromCode(entityTypeCode),
+        entityType,
         entityTypeCode);
 
-    return new LoadGrantsResult(1, collector.grantRecords, entities);
+    return new LoadGrantsResult(
+        anchorEntity.getGrantRecordsVersion(), collector.grantRecords, entities);
   }
 
   private List<PolarisGrantRecord> collectGrantRecords(

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -385,6 +385,29 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
             grantRecord -> assertThat(grantRecord.getGranteeId()).isEqualTo(principalRoleId));
   }
 
+  @Test
+  public void testLoadGrantsReturnsEntityNotFoundForMissingAnchor() {
+    long missingId = metaStore.generateNewEntityId(callContext).getId();
+    PolarisBaseEntity missingPrincipalRole =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            missingId,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "missingPrincipalRole");
+
+    LoadGrantsResult grantsToMissing =
+        metaStore.loadGrantsToGrantee(callContext, missingPrincipalRole);
+    assertThat(grantsToMissing.getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_NOT_FOUND);
+
+    LoadGrantsResult grantsOnMissing =
+        metaStore.loadGrantsOnSecurable(callContext, missingPrincipalRole);
+    assertThat(grantsOnMissing.getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_NOT_FOUND);
+  }
+
   @Override
   @Test
   @Disabled(

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -21,6 +21,7 @@ package org.apache.polaris.persistence.nosql.metastore;
 import static org.apache.polaris.core.entity.PolarisEntityConstants.ENTITY_BASE_LOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 
 import io.smallrye.common.annotation.Identifier;
@@ -39,6 +40,7 @@ import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -406,6 +408,46 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
         metaStore.loadGrantsOnSecurable(callContext, missingPrincipalRole);
     assertThat(grantsOnMissing.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.ENTITY_NOT_FOUND);
+  }
+
+  @Test
+  public void testLoadGrantsSkipsSelfReferencingEntries() {
+    PolarisBaseEntity principalRole =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStore.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "selfReferencingPrincipalRole");
+
+    EntityResult createResult = metaStore.createEntityIfNotExists(callContext, null, principalRole);
+    assertThat(createResult.isSuccess()).isTrue();
+    PolarisBaseEntity createdPrincipalRole = createResult.getEntity();
+    assertThat(createdPrincipalRole).isNotNull();
+
+    assertThat(
+            metaStore
+                .grantPrivilegeOnSecurableToRole(
+                    callContext,
+                    createdPrincipalRole,
+                    null,
+                    createdPrincipalRole,
+                    PolarisPrivilege.PRINCIPAL_ROLE_USAGE)
+                .isSuccess())
+        .isTrue();
+
+    assertThat(
+            List.of(
+                metaStore.loadGrantsOnSecurable(callContext, createdPrincipalRole),
+                metaStore.loadGrantsToGrantee(callContext, createdPrincipalRole)))
+        .extracting(
+            LoadGrantsResult::isSuccess,
+            LoadGrantsResult::getGrantRecords,
+            LoadGrantsResult::getEntities)
+        .containsExactly( //
+            tuple(true, List.of(), List.of()), //
+            tuple(true, List.of(), List.of()));
   }
 
   @Override


### PR DESCRIPTION
The `loadGrants()` method never verified the anchor entity exists, always returning `SUCCESS` with a hardcoded version of 1. This violated the `PolarisGrantManager` contract which requires `ENTITY_NOT_FOUND` when the entity is missing, and allowed stale ACLs to surface as valid grants.

Additionally, the bidirectional ACL model produced self-referencing  entries when `securable == grantee`, causing an entity to appear in its own grant list. These are now filtered out on read.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
