### PR TITLE
NoSQL: revalidate grant entities before grant or revoke

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -284,7 +284,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                     catalogAdminRole, effRole, PolarisPrivilege.CATALOG_ROLE_USAGE));
           }
 
-          persistGrantsOrRevokes(true, grants.toArray(SecurableGranteePrivilegeTuple[]::new));
+          persistGrantsOrRevokes(
+              true, false, grants.toArray(SecurableGranteePrivilegeTuple[]::new));
 
           byName.put(nameKey, objRef(catalogObj));
           byId.put(idKey, nameKey);
@@ -1302,10 +1303,17 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     }
   }
 
-  boolean persistGrantsOrRevokes(boolean doGrant, SecurableGranteePrivilegeTuple... grants) {
+  boolean persistGrantsOrRevokes(
+      boolean doGrant, boolean validateEntityReferences, SecurableGranteePrivilegeTuple... grants) {
     LOGGER.debug("Persisting {} for '{}'", doGrant ? "grants" : "revokes", Arrays.asList(grants));
 
-    return new GrantsMutation(persistence, memoizedIndexedAccess, privileges, doGrant, grants)
+    return new GrantsMutation(
+            persistence,
+            memoizedIndexedAccess,
+            privileges,
+            doGrant,
+            validateEntityReferences,
+            grants)
         .apply();
   }
 

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -20,6 +20,7 @@ package org.apache.polaris.persistence.nosql.metastore;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.ENTITY_NOT_FOUND;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.GRANT_NOT_FOUND;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.SUBSCOPE_CREDS_ERROR;
@@ -77,6 +78,7 @@ import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.core.storage.CredentialVendingContext;
+import org.apache.polaris.persistence.nosql.metastore.mutation.GrantsMutation;
 import org.apache.polaris.persistence.nosql.metastore.privs.SecurableGranteePrivilegeTuple;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -395,11 +397,15 @@ record NoSqlMetaStoreManager(
       PolarisEntityCore grantee,
       PolarisEntityCore securable,
       PolarisPrivilege privilege) {
-    if (!ms(callCtx)
-            .persistGrantsOrRevokes(
-                grant, new SecurableGranteePrivilegeTuple(securable, grantee, privilege))
-        && !grant) {
-      return new PrivilegeResult(GRANT_NOT_FOUND, "");
+    try {
+      if (!ms(callCtx)
+              .persistGrantsOrRevokes(
+                  grant, true, new SecurableGranteePrivilegeTuple(securable, grantee, privilege))
+          && !grant) {
+        return new PrivilegeResult(GRANT_NOT_FOUND, "");
+      }
+    } catch (GrantsMutation.EntityCannotBeResolvedException e) {
+      return new PrivilegeResult(ENTITY_CANNOT_BE_RESOLVED, null);
     }
 
     var grantRecord =

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/GrantsMutation.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/GrantsMutation.java
@@ -26,6 +26,7 @@ import static org.apache.polaris.persistence.nosql.coretypes.realm.RealmGrantsOb
 
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.commit.CommitException;
@@ -52,8 +53,11 @@ public record GrantsMutation(
     MemoizedIndexedAccess memoizedIndexedAccess,
     Privileges privileges,
     boolean doGrant,
+    boolean validateEntityReferences,
     SecurableGranteePrivilegeTuple... grants) {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrantsMutation.class);
+
+  public static final class EntityCannotBeResolvedException extends RuntimeException {}
 
   public boolean apply() {
     try {
@@ -82,6 +86,10 @@ public record GrantsMutation(
 
                   var changed = false;
                   for (var g : grants) {
+                    if (validateEntityReferences && !allEntityReferencesExist(g)) {
+                      throw new EntityCannotBeResolvedException();
+                    }
+
                     var securable = GrantTriplet.forEntity(g.securable());
                     var grantee = GrantTriplet.forEntity(g.grantee());
                     var forSec = grantee.asDirected();
@@ -179,6 +187,22 @@ public record GrantsMutation(
 
                   // aclObj changed
                   return true;
+                }
+
+                private boolean allEntityReferencesExist(SecurableGranteePrivilegeTuple grant) {
+                  return entityReferenceExists(grant.securable())
+                      && entityReferenceExists(grant.grantee());
+                }
+
+                private boolean entityReferenceExists(PolarisEntityCore entity) {
+                  try {
+                    return memoizedIndexedAccess
+                        .indexedAccess(entity.getCatalogId(), entity.getTypeCode())
+                        .nameKeyById(entity.getId())
+                        .isPresent();
+                  } catch (IllegalArgumentException e) {
+                    return false;
+                  }
                 }
               })
           .isPresent();

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -47,6 +47,7 @@ import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
 import org.apache.polaris.ids.api.MonotonicClock;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -297,6 +298,91 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
     // In NoSQL, this should return ENTITY_ALREADY_EXISTS instead of crashing
     assertThat(tableResult.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS);
+  }
+
+  @Test
+  public void testGrantAndRevokeUsageRevalidateGranteeExistenceAndType() {
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStore.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "grantRevalidateCatalog");
+    CreateCatalogResult catalogCreated = metaStore.createCatalog(callContext, catalog, List.of());
+    assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    EntityResult catalogAdminRoleResult =
+        metaStore.readEntityByName(
+            callContext,
+            List.of(catalog),
+            PolarisEntityType.CATALOG_ROLE,
+            PolarisEntitySubType.ANY_SUBTYPE,
+            PolarisEntityConstants.getNameOfCatalogAdminRole());
+    assertThat(catalogAdminRoleResult.isSuccess()).isTrue();
+    PolarisBaseEntity catalogAdminRole = catalogAdminRoleResult.getEntity();
+    assertThat(catalogAdminRole).isNotNull();
+
+    PolarisBaseEntity principalRole =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStore.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "grantRevalidatePrincipalRole");
+    EntityResult principalRoleCreate =
+        metaStore.createEntityIfNotExists(callContext, null, principalRole);
+    assertThat(principalRoleCreate.isSuccess()).isTrue();
+    PolarisBaseEntity createdPrincipalRole = principalRoleCreate.getEntity();
+    assertThat(createdPrincipalRole).isNotNull();
+    long principalRoleId = createdPrincipalRole.getId();
+
+    PolarisBaseEntity mismatchedTypeGrantee =
+        new PolarisBaseEntity.Builder(createdPrincipalRole)
+            .typeCode(PolarisEntityType.CATALOG_ROLE.getCode())
+            .build();
+
+    assertThat(
+            metaStore
+                .grantUsageOnRoleToGrantee(
+                    callContext, catalog, catalogAdminRole, mismatchedTypeGrantee)
+                .getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED);
+    assertThat(
+            metaStore
+                .revokeUsageOnRoleFromGrantee(
+                    callContext, catalog, catalogAdminRole, mismatchedTypeGrantee)
+                .getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED);
+
+    assertThat(
+            metaStore
+                .dropEntityIfExists(callContext, null, createdPrincipalRole, null, false)
+                .isSuccess())
+        .isTrue();
+
+    assertThat(
+            metaStore
+                .grantUsageOnRoleToGrantee(
+                    callContext, catalog, catalogAdminRole, createdPrincipalRole)
+                .getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED);
+    assertThat(
+            metaStore
+                .revokeUsageOnRoleFromGrantee(
+                    callContext, catalog, catalogAdminRole, createdPrincipalRole)
+                .getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED);
+
+    LoadGrantsResult grantsOnCatalogRole =
+        metaStore.loadGrantsOnSecurable(callContext, catalogAdminRole);
+    assertThat(grantsOnCatalogRole.isSuccess()).isTrue();
+    assertThat(grantsOnCatalogRole.getGrantRecords())
+        .noneSatisfy(
+            grantRecord -> assertThat(grantRecord.getGranteeId()).isEqualTo(principalRoleId));
   }
 
   @Override


### PR DESCRIPTION
Before persisting a grant or revoke in the NoSQL metastore, validate that the securable and grantee entity references actually exist and have the correct type. Previously, stale or mismatched entity references could be silently written as grant records.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
