### PR TITLE
Parse Iceberg client language and version from request headers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/http/IcebergClientInfo.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/http/IcebergClientInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.http;
+
+import java.util.Optional;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+
+/**
+ * Holds parsed information from the Iceberg client HTTP request headers.
+ *
+ * <p>Iceberg REST clients send a standard {@code X-Client-Version} header on every request: a
+ * client-identification string whose format and semantics vary by language implementation (see
+ * below). In addition, all HTTP clients send a standard {@code User-Agent} header, which some
+ * Iceberg client implementations use to carry their library version.
+ *
+ * <p>The following table summarizes the known formats and the source of {@link #icebergVersion()}
+ * for each language:
+ *
+ * <table border="1">
+ *   <tr><th>Language</th><th>{@code X-Client-Version}</th>
+ *       <th>User-Agent</th><th>{@link #icebergVersion()} source</th></tr>
+ *   <tr><td><a href="https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java">Java</a></td>
+ *       <td>{@code Apache Iceberg <lib version> (commit <hash>)}</td>
+ *       <td>{@code Apache-HttpClient/5.x (Java/...)}</td>
+ *       <td>{@code X-Client-Version}</td></tr>
+ *   <tr><td><a href="https://github.com/apache/iceberg-python/blob/main/pyiceberg/catalog/rest/__init__.py">Python (PyIceberg)</a></td>
+ *       <td>{@code PyIceberg <lib version>}</td>
+ *       <td>{@code PyIceberg/<lib version>}</td>
+ *       <td>{@code User-Agent}</td></tr>
+ *   <tr><td><a href="https://github.com/apache/iceberg-go/blob/main/catalog/rest/rest.go">Go (iceberg-go)</a></td>
+ *       <td>a stale hardcoded constant, not the client version</td>
+ *       <td>{@code GoIceberg/<lib version>}</td>
+ *       <td>{@code User-Agent}</td></tr>
+ *   <tr><td><a href="https://github.com/apache/iceberg-rust/blob/main/crates/catalog/rest/src/catalog.rs">Rust (iceberg-rust)</a></td>
+ *       <td>a stale hardcoded constant, not the client version</td>
+ *       <td>{@code iceberg-rs/<lib version>}</td>
+ *       <td>{@code User-Agent}</td></tr>
+ *   <tr><td><a href="https://github.com/apache/iceberg-cpp/blob/main/src/iceberg/catalog/rest/http_client.cc">C++ (iceberg-cpp)</a></td>
+ *       <td>not sent</td>
+ *       <td>{@code iceberg-cpp/<lib version>}</td>
+ *       <td>{@code User-Agent}</td></tr>
+ * </table>
+ */
+@PolarisImmutable
+public interface IcebergClientInfo {
+
+  /** Programming language of an Iceberg REST client, as determined from request headers. */
+  enum Language {
+    JAVA,
+    PYTHON,
+    GO,
+    RUST,
+    CPP
+  }
+
+  /** Returns the Iceberg client library version, or empty if it cannot be determined. */
+  @Value.Parameter(order = 1)
+  Optional<String> icebergVersion();
+
+  /** Returns the client language, or empty if it cannot be determined. */
+  @Value.Parameter(order = 2)
+  Optional<Language> language();
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/http/IcebergClientInfoFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/http/IcebergClientInfoFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.http;
+
+import jakarta.annotation.Nullable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.util.Optional;
+
+/** Parses Iceberg client HTTP request headers into an {@link IcebergClientInfo}. */
+@ApplicationScoped
+public class IcebergClientInfoFactory {
+
+  /** The HTTP header name carrying the client version string. */
+  static final String CLIENT_VERSION_HEADER = "X-Client-Version";
+
+  /** Creates an {@link IcebergClientInfo} by parsing the Iceberg client headers. */
+  @Produces
+  @RequestScoped
+  public IcebergClientInfo create(HttpHeaders httpHeaders) {
+    return create(
+        httpHeaders.getHeaderString(CLIENT_VERSION_HEADER),
+        httpHeaders.getHeaderString(HttpHeaders.USER_AGENT));
+  }
+
+  /** Creates an {@link IcebergClientInfo} from raw header values; exposed for testing. */
+  public IcebergClientInfo create(
+      @Nullable String versionHeader, @Nullable String userAgentHeader) {
+
+    String icebergVersion = null;
+    IcebergClientInfo.Language language = null;
+
+    // 1. Parse X-Client-Version for Java clients
+    if (versionHeader != null && !versionHeader.isEmpty()) {
+
+      if (versionHeader.startsWith("Apache Iceberg")) {
+        // Java: "Apache Iceberg <version> (commit <fullHash>)"
+        int start = "Apache Iceberg ".length();
+        int end = versionHeader.indexOf(' ', start);
+        if (end > start
+            && versionHeader.regionMatches(end, " (commit ", 0, " (commit ".length())
+            && versionHeader.endsWith(")")) {
+          icebergVersion = versionHeader.substring(start, end);
+          language = IcebergClientInfo.Language.JAVA;
+        }
+      }
+    }
+
+    // 2. Parse User-Agent for other clients, which (except for Python) send a stale, hardcoded
+    // constant in X-Client-Version, or do not send it at all.
+    if (icebergVersion == null && userAgentHeader != null && !userAgentHeader.isEmpty()) {
+
+      if (userAgentHeader.startsWith("PyIceberg/")) {
+        // Python: "PyIceberg/<version>"
+        int start = "PyIceberg/".length();
+        icebergVersion = userAgentHeader.substring(start);
+        language = IcebergClientInfo.Language.PYTHON;
+
+      } else if (userAgentHeader.startsWith("GoIceberg/")) {
+        // Go: "GoIceberg/<version>"
+        int start = "GoIceberg/".length();
+        icebergVersion = userAgentHeader.substring(start);
+        language = IcebergClientInfo.Language.GO;
+
+      } else if (userAgentHeader.startsWith("iceberg-rs/")) {
+        // Rust: "iceberg-rs/<version>"
+        int start = "iceberg-rs/".length();
+        icebergVersion = userAgentHeader.substring(start);
+        language = IcebergClientInfo.Language.RUST;
+
+      } else if (userAgentHeader.startsWith("iceberg-cpp/")) {
+        // C++: "iceberg-cpp/<version>"
+        int start = "iceberg-cpp/".length();
+        icebergVersion = userAgentHeader.substring(start);
+        language = IcebergClientInfo.Language.CPP;
+      }
+    }
+
+    return ImmutableIcebergClientInfo.of(
+        Optional.ofNullable(icebergVersion), Optional.ofNullable(language));
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/logging/LoggingMDCFilter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/logging/LoggingMDCFilter.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.service.config.FilterPriorities;
+import org.apache.polaris.service.http.IcebergClientInfo;
 import org.slf4j.MDC;
 
 @PreMatching
@@ -39,8 +40,12 @@ import org.slf4j.MDC;
 public class LoggingMDCFilter implements ContainerRequestFilter {
 
   public static final String REALM_ID_KEY = "realmId";
+  public static final String ICEBERG_CLIENT_INFO_VERSION_KEY = "icebergClientInfoVersion";
+  public static final String ICEBERG_CLIENT_INFO_LANGUAGE_KEY = "icebergClientInfoLanguage";
 
   @Inject LoggingConfiguration loggingConfiguration;
+
+  @Inject IcebergClientInfo icebergClientInfo;
 
   @Override
   public void filter(ContainerRequestContext rc) {
@@ -52,5 +57,9 @@ public class LoggingMDCFilter implements ContainerRequestFilter {
     MDC.put(REQUEST_ID_KEY, (String) rc.getProperty(REQUEST_ID_KEY));
     RealmContext realmContext = (RealmContext) rc.getProperty(REALM_CONTEXT_KEY);
     MDC.put(REALM_ID_KEY, realmContext.getRealmIdentifier());
+    icebergClientInfo.icebergVersion().ifPresent(v -> MDC.put(ICEBERG_CLIENT_INFO_VERSION_KEY, v));
+    icebergClientInfo
+        .language()
+        .ifPresent(l -> MDC.put(ICEBERG_CLIENT_INFO_LANGUAGE_KEY, l.name()));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.tracing;
 import io.opentelemetry.api.trace.Span;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
@@ -28,6 +29,7 @@ import jakarta.ws.rs.ext.Provider;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.service.config.FilterPriorities;
 import org.apache.polaris.service.context.RealmContextFilter;
+import org.apache.polaris.service.http.IcebergClientInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @PreMatching
@@ -38,9 +40,13 @@ public class TracingFilter implements ContainerRequestFilter {
 
   public static final String REQUEST_ID_ATTRIBUTE = "polaris.request.id";
   public static final String REALM_ID_ATTRIBUTE = "polaris.realm.id";
+  public static final String ICEBERG_CLIENT_INFO_VERSION = "polaris.iceberg-client-info.version";
+  public static final String ICEBERG_CLIENT_INFO_LANGUAGE = "polaris.iceberg-client-info.language";
 
   @ConfigProperty(name = "quarkus.otel.sdk.disabled")
   boolean sdkDisabled;
+
+  @Inject IcebergClientInfo icebergClientInfo;
 
   @Override
   public void filter(ContainerRequestContext rc) {
@@ -51,6 +57,12 @@ public class TracingFilter implements ContainerRequestFilter {
       RealmContext realmContext =
           (RealmContext) rc.getProperty(RealmContextFilter.REALM_CONTEXT_KEY);
       span.setAttribute(REALM_ID_ATTRIBUTE, realmContext.getRealmIdentifier());
+      icebergClientInfo
+          .icebergVersion()
+          .ifPresent(v -> span.setAttribute(ICEBERG_CLIENT_INFO_VERSION, v));
+      icebergClientInfo
+          .language()
+          .ifPresent(l -> span.setAttribute(ICEBERG_CLIENT_INFO_LANGUAGE, l.name()));
     }
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/http/IcebergClientInfoFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/http/IcebergClientInfoFactoryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class IcebergClientInfoFactoryTest {
+
+  // --- Java client (org.apache.iceberg.rest.HTTPClient) ---
+  // X-Client-Version: "Apache Iceberg <version> (commit <fullHash>)"
+  // User-Agent:       "Apache-HttpClient/5.x (Java/11.x)" <-- HTTP library, not Iceberg
+
+  @Test
+  void javaClient() {
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory()
+            .create(
+                "Apache Iceberg 1.10.1 (commit abc1234567890abcdef1234567890abcdef123456)",
+                "Apache-HttpClient/5.4 (Java/11.0.25)");
+    assertThat(info.icebergVersion()).hasValue("1.10.1");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.JAVA);
+  }
+
+  @Test
+  void javaClientSnapshotVersion() {
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory()
+            .create(
+                "Apache Iceberg 1.11.0-SNAPSHOT (commit abc1234567890abcdef1234567890abcdef123456)",
+                null);
+    assertThat(info.icebergVersion()).hasValue("1.11.0-SNAPSHOT");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.JAVA);
+  }
+
+  @Test
+  void javaClientUnknownBuildMetadata() {
+    // IcebergBuild returns "unknown" for both fields when build properties cannot be loaded
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory().create("Apache Iceberg unknown (commit unknown)", null);
+    assertThat(info.icebergVersion()).hasValue("unknown");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.JAVA);
+  }
+
+  // --- Python client (PyIceberg) ---
+  // X-Client-Version: "PyIceberg <version>"   (pyiceberg/catalog/rest/__init__.py)
+  // User-Agent:       "PyIceberg/<version>"
+
+  @Test
+  void pythonClient() {
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory().create("PyIceberg 0.9.1", "PyIceberg/0.9.1");
+    assertThat(info.icebergVersion()).hasValue("0.9.1");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.PYTHON);
+  }
+
+  // --- Go client (iceberg-go) ---
+  // X-Client-Version: a stale hardcoded constant — ignored  (catalog/rest/rest.go)
+  // User-Agent:       "GoIceberg/<libVersion>"
+
+  @Test
+  void goClient() {
+    IcebergClientInfo info = new IcebergClientInfoFactory().create("0.14.1", "GoIceberg/0.5.0");
+    assertThat(info.icebergVersion()).hasValue("0.5.0");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.GO);
+  }
+
+  // --- Rust client (iceberg-rust) ---
+  // X-Client-Version: a stale hardcoded constant — ignored  (crates/catalog/rest/src/catalog.rs)
+  // User-Agent:       "iceberg-rs/<libVersion>"
+
+  @Test
+  void rustClient() {
+    IcebergClientInfo info = new IcebergClientInfoFactory().create("0.14.1", "iceberg-rs/0.3.0");
+    assertThat(info.icebergVersion()).hasValue("0.3.0");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.RUST);
+  }
+
+  // --- C++ client (iceberg-cpp) ---
+  // X-Client-Version: not sent  (src/iceberg/catalog/rest/http_client.cc)
+  // User-Agent:       "iceberg-cpp/<libVersion>"
+
+  @Test
+  void cppClient() {
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory().create(null, "iceberg-cpp/0.3.0-SNAPSHOT");
+    assertThat(info.icebergVersion()).hasValue("0.3.0-SNAPSHOT");
+    assertThat(info.language()).hasValue(IcebergClientInfo.Language.CPP);
+  }
+
+  // --- Missing / unrecognized headers ---
+
+  @Test
+  void noHeaders() {
+    IcebergClientInfo info = new IcebergClientInfoFactory().create(null, null);
+    assertThat(info.icebergVersion()).isEmpty();
+    assertThat(info.language()).isEmpty();
+    info = new IcebergClientInfoFactory().create("", "");
+    assertThat(info.icebergVersion()).isEmpty();
+    assertThat(info.language()).isEmpty();
+  }
+
+  @Test
+  void unknownHeaders() {
+    IcebergClientInfo info =
+        new IcebergClientInfoFactory().create("some-unknown-format", "some-unknown-agent");
+    assertThat(info.icebergVersion()).isEmpty();
+    assertThat(info.language()).isEmpty();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/tracing/TracingFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/tracing/TracingFilterTest.java
@@ -23,6 +23,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanContext;
@@ -33,14 +34,20 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.polaris.service.catalog.api.IcebergRestOAuth2Api;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusTest
 @TestProfile(TracingFilterTest.Profile.class)
@@ -62,6 +69,11 @@ public class TracingFilterTest {
   }
 
   @Inject InMemorySpanExporter inMemorySpanExporter;
+
+  @BeforeEach
+  void resetSpanExporter() {
+    inMemorySpanExporter.reset();
+  }
 
   @Test
   void testW3CTraceContextPropagation() {
@@ -113,5 +125,75 @@ public class TracingFilterTest {
     assertThat(parent.getTraceState().asMap())
         .containsEntry("rojo", rojoState)
         .containsEntry("congo", congoState);
+  }
+
+  @ParameterizedTest
+  @MethodSource("icebergClientInfoCases")
+  void testIcebergClientInfoSpanAttributes(
+      String clientVersionHeader,
+      String userAgentHeader,
+      String expectedVersion,
+      String expectedLanguage) {
+
+    RequestSpecification spec =
+        given()
+            .contentType(ContentType.URLENC)
+            .formParam("grant_type", "client_credentials")
+            .formParam("scope", "PRINCIPAL_ROLE:ALL")
+            .formParam("client_id", "test-admin")
+            .formParam("client_secret", "test-secret");
+
+    if (clientVersionHeader != null) {
+      spec = spec.header("X-Client-Version", clientVersionHeader);
+    }
+    if (userAgentHeader != null) {
+      spec = spec.header("User-Agent", userAgentHeader);
+    }
+
+    spec.when().post().then().statusCode(200);
+
+    List<SpanData> spans =
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(inMemorySpanExporter::getFinishedSpanItems, sp -> !sp.isEmpty());
+
+    SpanData span = spans.getFirst();
+    Map<AttributeKey<?>, Object> attributes = span.getAttributes().asMap();
+
+    if (expectedVersion != null) {
+      assertThat(attributes)
+          .containsEntry(stringKey(TracingFilter.ICEBERG_CLIENT_INFO_VERSION), expectedVersion);
+    } else {
+      assertThat(attributes)
+          .doesNotContainKey(stringKey(TracingFilter.ICEBERG_CLIENT_INFO_VERSION));
+    }
+
+    if (expectedLanguage != null) {
+      assertThat(attributes)
+          .containsEntry(stringKey(TracingFilter.ICEBERG_CLIENT_INFO_LANGUAGE), expectedLanguage);
+    } else {
+      assertThat(attributes)
+          .doesNotContainKey(stringKey(TracingFilter.ICEBERG_CLIENT_INFO_LANGUAGE));
+    }
+  }
+
+  static Stream<Arguments> icebergClientInfoCases() {
+    return Stream.of(
+        // Java: version comes from X-Client-Version
+        arguments(
+            "Apache Iceberg 1.10.1 (commit abc1234567890abcdef1234567890abcdef123456)",
+            "Apache-HttpClient/5.4 (Java/11.0.25)",
+            "1.10.1",
+            "JAVA"),
+        // Python (PyIceberg): version comes from User-Agent
+        arguments("PyIceberg 0.9.1", "PyIceberg/0.9.1", "0.9.1", "PYTHON"),
+        // Go (iceberg-go): X-Client-Version is a stale constant; version comes from User-Agent
+        arguments("0.14.1", "GoIceberg/0.5.0", "0.5.0", "GO"),
+        // Rust (iceberg-rust): X-Client-Version is a stale constant; version comes from User-Agent
+        arguments("0.14.1", "iceberg-rs/0.3.0", "0.3.0", "RUST"),
+        // C++ (iceberg-cpp): no X-Client-Version; version comes from User-Agent
+        arguments(null, "iceberg-cpp/0.3.0-SNAPSHOT", "0.3.0-SNAPSHOT", "CPP"),
+        // No Iceberg headers — version and language attributes must be absent from the span
+        arguments(null, null, null, null));
   }
 }


### PR DESCRIPTION
This change introduces a new `IcebergClientInfo` component to identify the Iceberg client library making each REST request.

This information may be useful not only for logging and tracing, but also for future enhancements such as when deciding:

- How to decode path segments (the decoding algorithm is likely to change)
- How to process a remote signing request (the spec is likely to evolve)

The information is sourced from two HTTP headers:

- `X-Client-Version`: carries the client version string for Java and Python.
- `User-Agent`: carries the version for Python, Go, Rust, and C++.

The client info is propagated to:

- OpenTelemetry spans via `TracingFilter`
- SLF4J MDC via `LoggingMDCFilter`

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
