### PR TITLE
CLI: Fix text for host and port with profile update

### DIFF
--- a/client/python/apache_polaris/cli/command/profiles.py
+++ b/client/python/apache_polaris/cli/command/profiles.py
@@ -124,8 +124,8 @@ class ProfilesCommand(Command):
                 input(f"Polaris Client Secret [{current_client_secret}]: ")
                 or current_client_secret
             )
-            host = input(f"Polaris Client ID [{current_host}]: ") or current_host
-            port = input(f"Polaris Client Secret [{current_port}]: ") or current_port
+            host = input(f"Polaris Host [{current_host}]: ") or current_host
+            port = input(f"Polaris Port [{current_port}]: ") or current_port
             realm = input(f"Polaris Context Realm [{current_realm}]: ") or current_realm
             header = (
                 input(f"Polaris Context Header Name [{current_header}]: ")


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Found a copy/paste issue with text when promoting users for profile update around host/port.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
