### PR TITLE
JSpecify: Fix target of `@Nullable`

### DIFF
--- a/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/AnotherTestObj.java
+++ b/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/AnotherTestObj.java
@@ -41,7 +41,7 @@ public interface AnotherTestObj extends Obj {
 
   @Nullable String text();
 
-  byte @Nullable [] binary();
+  @Nullable byte[] binary();
 
   @Nullable Number number();
 

--- a/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/CommitTestObj.java
+++ b/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/CommitTestObj.java
@@ -41,7 +41,7 @@ public interface CommitTestObj extends BaseCommitObj {
 
   @Nullable String text();
 
-  byte @Nullable [] binary();
+  @Nullable byte[] binary();
 
   @Nullable Number number();
 

--- a/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/SimpleTestObj.java
+++ b/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/SimpleTestObj.java
@@ -41,7 +41,7 @@ public interface SimpleTestObj extends Obj {
 
   @Nullable String text();
 
-  byte @Nullable [] binary();
+  @Nullable byte[] binary();
 
   @Nullable Number number();
 

--- a/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/VersionedTestObj.java
+++ b/persistence/nosql/persistence/api/src/testFixtures/java/org/apache/polaris/persistence/nosql/api/obj/VersionedTestObj.java
@@ -43,7 +43,7 @@ public interface VersionedTestObj extends Obj {
 
   @Nullable String someValue();
 
-  byte @Nullable [] binary();
+  @Nullable byte[] binary();
 
   final class VersionedTestObjType extends AbstractObjType<VersionedTestObj> {
     public VersionedTestObjType() {


### PR DESCRIPTION
Fixes compilation warnings like `warning: (immutables:from) Generated builder '.from' method will not copy from attribute 'binary' because it has some not-yet-generated type, or different return type in supertype  (we cannot handle generic specialization or covariant overrides yet). Sometimes it is possible to avoid this by providing abstract override method in this value object`.
