### PR TITLE
NoSQL: fix compilation warning

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus/build.gradle.kts
+++ b/persistence/nosql/persistence/cdi/quarkus/build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
 
   compileOnly(libs.smallrye.config.core)
 
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
 

--- a/persistence/nosql/persistence/db/mongodb/build.gradle.kts
+++ b/persistence/nosql/persistence/db/mongodb/build.gradle.kts
@@ -71,6 +71,9 @@ testing {
         dependencies {
           runtimeOnly(platform(libs.testcontainers.bom))
           runtimeOnly("org.testcontainers:testcontainers-mongodb")
+
+          compileOnly(platform(libs.jackson.bom))
+          compileOnly("com.fasterxml.jackson.core:jackson-annotations")
         }
       }
   }


### PR DESCRIPTION
Fixes this compilation warning:
```
warning: unknown enum constant Include.NON_DEFAULT
  reason: class file for com.fasterxml.jackson.annotation.JsonInclude$Include not found
```
