### PR TITLE
Fix deprecation warning in RelationalJdbcIdempotencyStorePostgresIT

### DIFF
--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStorePostgresIT.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStorePostgresIT.java
@@ -34,16 +34,16 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.postgresql.ds.PGSimpleDataSource;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 @Testcontainers
 public class RelationalJdbcIdempotencyStorePostgresIT {
 
   @Container
-  private static final PostgreSQLContainer<?> POSTGRES =
-      new PostgreSQLContainer<>(
+  private static final PostgreSQLContainer POSTGRES =
+      new PostgreSQLContainer(
           containerSpecHelper("postgres", PostgresRelationalJdbcLifeCycleManagement.class)
               .dockerImageName(null)
               .asCompatibleSubstituteFor("postgres"));


### PR DESCRIPTION
Replace deprecated `PostgreSQLContainer` type.
