### PR TITLE
feat: implement phase 1 event interceptors

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegator.java
@@ -33,6 +33,7 @@ import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.events.EventAttributes;
 import org.apache.polaris.service.events.PolarisEvent;
 import org.apache.polaris.service.events.PolarisEventDispatcher;
+import org.apache.polaris.service.events.PolarisEventInterceptorManager;
 import org.apache.polaris.service.events.PolarisEventMetadataFactory;
 import org.apache.polaris.service.events.PolarisEventType;
 import org.apache.polaris.service.types.CreateGenericTableRequest;
@@ -45,6 +46,7 @@ public class CatalogGenericTableEventServiceDelegator
 
   @Inject @Delegate GenericTableCatalogAdapter delegate;
   @Inject PolarisEventDispatcher polarisEventDispatcher;
+  @Inject PolarisEventInterceptorManager polarisEventInterceptorManager;
   @Inject PolarisEventMetadataFactory eventMetadataFactory;
   @Inject CatalogPrefixParser prefixParser;
 
@@ -98,18 +100,31 @@ public class CatalogGenericTableEventServiceDelegator
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
-    if (polarisEventDispatcher.hasListeners(PolarisEventType.BEFORE_DROP_GENERIC_TABLE)) {
-      polarisEventDispatcher.dispatch(
+    boolean hasBeforeListeners =
+        polarisEventDispatcher.hasListeners(PolarisEventType.BEFORE_DROP_GENERIC_TABLE);
+    boolean hasInterceptors = polarisEventInterceptorManager.hasInterceptors();
+    if (hasBeforeListeners || hasInterceptors) {
+      PolarisEvent beforeEvent =
           new PolarisEvent(
               PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
               eventMetadataFactory.create(),
               new EventAttributeMap()
                   .put(EventAttributes.CATALOG_NAME, catalogName)
                   .put(EventAttributes.NAMESPACE_NAME, namespace)
-                  .put(EventAttributes.GENERIC_TABLE_NAME, genericTable)));
+                  .put(EventAttributes.GENERIC_TABLE_NAME, genericTable));
+
+      if (hasInterceptors) {
+        beforeEvent = polarisEventInterceptorManager.intercept(beforeEvent);
+      }
+
+      if (hasBeforeListeners) {
+        polarisEventDispatcher.dispatch(beforeEvent);
+      }
     }
+
     Response resp =
         delegate.dropGenericTable(prefix, namespace, genericTable, realmContext, securityContext);
+
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_DROP_GENERIC_TABLE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import java.util.Objects;
+
+/** Synchronous interceptor that can allow, deny, or modify an in-flight Polaris event. */
+public interface PolarisEventInterceptor {
+
+  Result intercept(PolarisEvent event);
+
+  record Result(Action action, String reason, PolarisEvent modifiedEvent) {
+
+    public enum Action {
+      ALLOW,
+      DENY,
+      MODIFY
+    }
+
+    public Result {
+      Objects.requireNonNull(action, "action");
+      if (action == Action.DENY) {
+        Objects.requireNonNull(reason, "reason");
+      }
+      if (action == Action.MODIFY) {
+        Objects.requireNonNull(modifiedEvent, "modifiedEvent");
+      }
+    }
+
+    public static Result allow() {
+      return new Result(Action.ALLOW, null, null);
+    }
+
+    public static Result deny(String reason) {
+      return new Result(Action.DENY, reason, null);
+    }
+
+    public static Result modify(PolarisEvent modifiedEvent) {
+      return new Result(Action.MODIFY, null, modifiedEvent);
+    }
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptorConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptorConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
+import java.util.List;
+import java.util.Optional;
+
+@StaticInitSafe
+@ConfigMapping(prefix = "polaris.event-interceptor")
+public interface PolarisEventInterceptorConfiguration {
+  /** Ordered interceptor type identifiers. */
+  Optional<List<String>> types();
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptorManager.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventInterceptorManager.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Evaluates configured event interceptors in order for in-flight Polaris events. */
+@ApplicationScoped
+public class PolarisEventInterceptorManager {
+  private final List<PolarisEventInterceptor> interceptors;
+
+  @Inject
+  public PolarisEventInterceptorManager(
+      PolarisEventInterceptorConfiguration configuration,
+      @Any Instance<PolarisEventInterceptor> interceptorBeans) {
+    this(resolveInterceptors(configuration, interceptorBeans));
+  }
+
+  public PolarisEventInterceptorManager(List<PolarisEventInterceptor> interceptors) {
+    this.interceptors = List.copyOf(interceptors);
+  }
+
+  private static List<PolarisEventInterceptor> resolveInterceptors(
+      PolarisEventInterceptorConfiguration configuration,
+      Instance<PolarisEventInterceptor> interceptorBeans) {
+    List<PolarisEventInterceptor> resolvedInterceptors = new ArrayList<>();
+    for (String interceptorType : configuration.types().orElse(List.of())) {
+      resolvedInterceptors.add(
+          interceptorBeans.select(Identifier.Literal.of(interceptorType)).get());
+    }
+    return resolvedInterceptors;
+  }
+
+  public boolean hasInterceptors() {
+    return !interceptors.isEmpty();
+  }
+
+  public PolarisEvent intercept(PolarisEvent event) {
+    Objects.requireNonNull(event, "event");
+
+    PolarisEvent effectiveEvent = event;
+    for (PolarisEventInterceptor interceptor : interceptors) {
+      PolarisEventInterceptor.Result result = interceptor.intercept(effectiveEvent);
+      if (result == null) {
+        throw new IllegalStateException(
+            "Interceptor " + interceptor.getClass().getName() + " returned null result");
+      }
+
+      switch (result.action()) {
+        case ALLOW -> {
+          // no-op
+        }
+        case DENY -> throw new ForbiddenException(result.reason());
+        case MODIFY -> effectiveEvent = result.modifiedEvent();
+      }
+    }
+
+    return effectiveEvent;
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events.interceptors;
+
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Locale;
+import org.apache.polaris.service.events.EventAttributes;
+import org.apache.polaris.service.events.PolarisEvent;
+import org.apache.polaris.service.events.PolarisEventInterceptor;
+import org.apache.polaris.service.events.PolarisEventType;
+
+/** Denies dropping tables with a configured protection tag encoded in table names. */
+@ApplicationScoped
+@Identifier("protected-table-drop")
+public class ProtectedTableDropInterceptor implements PolarisEventInterceptor {
+  private final ProtectedTableDropInterceptorConfiguration configuration;
+
+  @Inject
+  public ProtectedTableDropInterceptor(ProtectedTableDropInterceptorConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  @Override
+  public Result intercept(PolarisEvent event) {
+    if (!isDropTableEvent(event.type())) {
+      return Result.allow();
+    }
+
+    String tableName =
+        event
+            .attributes()
+            .get(EventAttributes.GENERIC_TABLE_NAME)
+            .or(() -> event.attributes().get(EventAttributes.TABLE_NAME))
+            .orElse(null);
+
+    if (tableName == null) {
+      return Result.allow();
+    }
+
+    if (containsProtectedTag(tableName, configuration.tagToken(), configuration.separator())) {
+      return Result.deny("Drop denied for protected table '" + tableName + "'");
+    }
+
+    return Result.allow();
+  }
+
+  static boolean isDropTableEvent(PolarisEventType eventType) {
+    return eventType == PolarisEventType.BEFORE_DROP_GENERIC_TABLE
+        || eventType == PolarisEventType.BEFORE_DROP_TABLE;
+  }
+
+  static boolean containsProtectedTag(String tableName, String tagToken, String separator) {
+    if (tableName == null || tableName.isBlank() || tagToken == null || tagToken.isBlank()) {
+      return false;
+    }
+
+    String normalizedName = tableName.toLowerCase(Locale.ROOT);
+    String normalizedToken = tagToken.toLowerCase(Locale.ROOT);
+
+    if (separator == null || separator.isBlank()) {
+      return normalizedName.contains(normalizedToken);
+    }
+
+    return normalizedName.equals(normalizedToken)
+        || normalizedName.startsWith(normalizedToken + separator)
+        || normalizedName.endsWith(separator + normalizedToken)
+        || normalizedName.contains(separator + normalizedToken + separator);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptorConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptorConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events.interceptors;
+
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+@StaticInitSafe
+@ConfigMapping(prefix = "polaris.event-interceptor.protected-table-drop")
+public interface ProtectedTableDropInterceptorConfiguration {
+
+  @WithName("tag-token")
+  @WithDefault("protected")
+  String tagToken();
+
+  @WithDefault("__")
+  String separator();
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegatorInterceptorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/CatalogGenericTableEventServiceDelegatorInterceptorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.catalog.generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.Response;
+import org.apache.polaris.service.catalog.CatalogPrefixParser;
+import org.apache.polaris.service.events.PolarisEvent;
+import org.apache.polaris.service.events.PolarisEventDispatcher;
+import org.apache.polaris.service.events.PolarisEventInterceptor;
+import org.apache.polaris.service.events.PolarisEventInterceptorManager;
+import org.apache.polaris.service.events.PolarisEventMetadataFactory;
+import org.apache.polaris.service.events.PolarisEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class CatalogGenericTableEventServiceDelegatorInterceptorTest {
+
+  private CatalogGenericTableEventServiceDelegator delegator;
+  private GenericTableCatalogAdapter delegate;
+  private PolarisEventDispatcher eventDispatcher;
+
+  @BeforeEach
+  void setUp() {
+    delegator = new CatalogGenericTableEventServiceDelegator();
+
+    delegate = mock(GenericTableCatalogAdapter.class);
+    eventDispatcher = mock(PolarisEventDispatcher.class);
+    PolarisEventMetadataFactory metadataFactory = mock(PolarisEventMetadataFactory.class);
+    CatalogPrefixParser prefixParser = mock(CatalogPrefixParser.class);
+
+    when(prefixParser.prefixToCatalogName("cat")).thenReturn("cat");
+    when(metadataFactory.create()).thenReturn(null);
+
+    delegator.delegate = delegate;
+    delegator.polarisEventDispatcher = eventDispatcher;
+    delegator.polarisEventInterceptorManager =
+        new PolarisEventInterceptorManager(java.util.List.of());
+    delegator.eventMetadataFactory = metadataFactory;
+    delegator.prefixParser = prefixParser;
+  }
+
+  @Test
+  void denyAbortsOperationBeforeDelegateInvocation() {
+    PolarisEventInterceptor denyInterceptor =
+        event -> PolarisEventInterceptor.Result.deny("drop blocked by policy");
+    delegator.polarisEventInterceptorManager =
+        new PolarisEventInterceptorManager(java.util.List.of(denyInterceptor));
+
+    assertThatThrownBy(() -> delegator.dropGenericTable("cat", "ns", "orders", null, null))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("drop blocked by policy");
+
+    verify(delegate, never()).dropGenericTable(any(), any(), any(), any(), any());
+    verify(eventDispatcher, never()).dispatch(any());
+  }
+
+  @Test
+  void allowDispatchesEventsAndCallsDelegate() {
+    PolarisEventInterceptor allowInterceptor = event -> PolarisEventInterceptor.Result.allow();
+    delegator.polarisEventInterceptorManager =
+        new PolarisEventInterceptorManager(java.util.List.of(allowInterceptor));
+    when(eventDispatcher.hasListeners(PolarisEventType.BEFORE_DROP_GENERIC_TABLE)).thenReturn(true);
+    when(eventDispatcher.hasListeners(PolarisEventType.AFTER_DROP_GENERIC_TABLE)).thenReturn(true);
+
+    when(delegate.dropGenericTable(any(), any(), any(), any(), any()))
+        .thenReturn(Response.noContent().build());
+
+    Response response = delegator.dropGenericTable("cat", "ns", "orders", null, null);
+
+    assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+    verify(delegate, times(1)).dropGenericTable(eq("cat"), eq("ns"), eq("orders"), any(), any());
+
+    ArgumentCaptor<PolarisEvent> eventCaptor = ArgumentCaptor.forClass(PolarisEvent.class);
+    verify(eventDispatcher, times(2)).dispatch(eventCaptor.capture());
+    assertThat(eventCaptor.getAllValues().get(0).type())
+        .isEqualTo(PolarisEventType.BEFORE_DROP_GENERIC_TABLE);
+    assertThat(eventCaptor.getAllValues().get(1).type())
+        .isEqualTo(PolarisEventType.AFTER_DROP_GENERIC_TABLE);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventInterceptorManagerConfigurationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventInterceptorManagerConfigurationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(PolarisEventInterceptorManagerConfigurationTest.Profile.class)
+public class PolarisEventInterceptorManagerConfigurationTest {
+
+  @ApplicationScoped
+  @Identifier("test-modify")
+  public static class TestModifyInterceptor implements PolarisEventInterceptor {
+    @Override
+    public Result intercept(PolarisEvent event) {
+      if (event.type() != PolarisEventType.BEFORE_DROP_GENERIC_TABLE) {
+        return Result.allow();
+      }
+
+      return Result.modify(
+          new PolarisEvent(
+              event.type(),
+              event.metadata(),
+              new EventAttributeMap(event.attributes())
+                  .put(EventAttributes.GENERIC_TABLE_NAME, "orders__protected")));
+    }
+  }
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("polaris.event-interceptor.types", "test-modify")
+          .build();
+    }
+  }
+
+  @Inject PolarisEventInterceptorManager manager;
+
+  @Test
+  void usesConfiguredInterceptorTypesInOrder() {
+    PolarisEvent event =
+        new PolarisEvent(
+            PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+            null,
+            new EventAttributeMap().put(EventAttributes.GENERIC_TABLE_NAME, "orders"));
+
+    PolarisEvent intercepted = manager.intercept(event);
+
+    assertThat(intercepted.attributes().getRequired(EventAttributes.GENERIC_TABLE_NAME))
+        .isEqualTo("orders__protected");
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventInterceptorManagerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventInterceptorManagerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.ws.rs.ForbiddenException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class PolarisEventInterceptorManagerTest {
+
+  @Test
+  void returnsOriginalEventWhenNoInterceptorsConfigured() {
+    PolarisEventInterceptorManager manager = new PolarisEventInterceptorManager(List.of());
+
+    PolarisEvent originalEvent = dropGenericTableEvent("orders");
+    PolarisEvent interceptedEvent = manager.intercept(originalEvent);
+
+    assertThat(interceptedEvent).isSameAs(originalEvent);
+  }
+
+  @Test
+  void appliesModifyAndUsesModifiedEventForFollowingInterceptors() {
+    PolarisEventInterceptor modifyInterceptor =
+        event ->
+            PolarisEventInterceptor.Result.modify(
+                new PolarisEvent(
+                    event.type(),
+                    event.metadata(),
+                    new EventAttributeMap(event.attributes())
+                        .put(EventAttributes.GENERIC_TABLE_NAME, "orders__protected")));
+
+    String[] seenBySecondInterceptor = new String[1];
+    PolarisEventInterceptor observingInterceptor =
+        event -> {
+          seenBySecondInterceptor[0] =
+              event.attributes().getRequired(EventAttributes.GENERIC_TABLE_NAME);
+          return PolarisEventInterceptor.Result.allow();
+        };
+
+    PolarisEventInterceptorManager manager =
+        new PolarisEventInterceptorManager(List.of(modifyInterceptor, observingInterceptor));
+
+    PolarisEvent interceptedEvent = manager.intercept(dropGenericTableEvent("orders"));
+
+    assertThat(interceptedEvent.attributes().getRequired(EventAttributes.GENERIC_TABLE_NAME))
+        .isEqualTo("orders__protected");
+    assertThat(seenBySecondInterceptor[0]).isEqualTo("orders__protected");
+  }
+
+  @Test
+  void throwsForbiddenAndShortCircuitsOnDeny() {
+    AtomicBoolean secondInterceptorCalled = new AtomicBoolean(false);
+
+    PolarisEventInterceptor denyInterceptor =
+        event -> PolarisEventInterceptor.Result.deny("drop blocked by policy");
+    PolarisEventInterceptor secondInterceptor =
+        event -> {
+          secondInterceptorCalled.set(true);
+          return PolarisEventInterceptor.Result.allow();
+        };
+
+    PolarisEventInterceptorManager manager =
+        new PolarisEventInterceptorManager(List.of(denyInterceptor, secondInterceptor));
+
+    assertThatThrownBy(() -> manager.intercept(dropGenericTableEvent("orders__protected")))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("drop blocked by policy");
+    assertThat(secondInterceptorCalled).isFalse();
+  }
+
+  @Test
+  void throwsWhenInterceptorReturnsNullResult() {
+    PolarisEventInterceptor invalidInterceptor = event -> null;
+
+    PolarisEventInterceptorManager manager =
+        new PolarisEventInterceptorManager(List.of(invalidInterceptor));
+
+    assertThatThrownBy(() -> manager.intercept(dropGenericTableEvent("orders")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("returned null result");
+  }
+
+  @Test
+  void propagatesUnexpectedInterceptorExceptions() {
+    PolarisEventInterceptor failingInterceptor =
+        event -> {
+          throw new IllegalStateException("interceptor failure");
+        };
+
+    PolarisEventInterceptorManager manager =
+        new PolarisEventInterceptorManager(List.of(failingInterceptor));
+
+    assertThatThrownBy(() -> manager.intercept(dropGenericTableEvent("orders")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("interceptor failure");
+  }
+
+  private static PolarisEvent dropGenericTableEvent(String tableName) {
+    return new PolarisEvent(
+        PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+        null,
+        new EventAttributeMap().put(EventAttributes.GENERIC_TABLE_NAME, tableName));
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/interceptors/ProtectedTableDropInterceptorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events.interceptors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.polaris.service.events.EventAttributeMap;
+import org.apache.polaris.service.events.EventAttributes;
+import org.apache.polaris.service.events.PolarisEvent;
+import org.apache.polaris.service.events.PolarisEventInterceptor;
+import org.apache.polaris.service.events.PolarisEventType;
+import org.junit.jupiter.api.Test;
+
+public class ProtectedTableDropInterceptorTest {
+
+  @Test
+  void deniesGenericTableDropWhenProtectedTagExists() {
+    ProtectedTableDropInterceptor interceptor =
+        new ProtectedTableDropInterceptor(configuration("protected", "__"));
+
+    PolarisEvent event =
+        new PolarisEvent(
+            PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+            null,
+            new EventAttributeMap().put(EventAttributes.GENERIC_TABLE_NAME, "orders__protected"));
+
+    PolarisEventInterceptor.Result result = interceptor.intercept(event);
+
+    assertThat(result.action()).isEqualTo(PolarisEventInterceptor.Result.Action.DENY);
+    assertThat(result.reason()).contains("orders__protected");
+  }
+
+  @Test
+  void deniesIcebergTableDropWhenProtectedTagExists() {
+    ProtectedTableDropInterceptor interceptor =
+        new ProtectedTableDropInterceptor(configuration("protected", "__"));
+
+    PolarisEvent event =
+        new PolarisEvent(
+            PolarisEventType.BEFORE_DROP_TABLE,
+            null,
+            new EventAttributeMap().put(EventAttributes.TABLE_NAME, "orders__protected"));
+
+    PolarisEventInterceptor.Result result = interceptor.intercept(event);
+
+    assertThat(result.action()).isEqualTo(PolarisEventInterceptor.Result.Action.DENY);
+    assertThat(result.reason()).contains("orders__protected");
+  }
+
+  @Test
+  void allowsDropWhenProtectedTagDoesNotExist() {
+    ProtectedTableDropInterceptor interceptor =
+        new ProtectedTableDropInterceptor(configuration("protected", "__"));
+
+    PolarisEvent event =
+        new PolarisEvent(
+            PolarisEventType.BEFORE_DROP_GENERIC_TABLE,
+            null,
+            new EventAttributeMap().put(EventAttributes.GENERIC_TABLE_NAME, "orders"));
+
+    PolarisEventInterceptor.Result result = interceptor.intercept(event);
+
+    assertThat(result.action()).isEqualTo(PolarisEventInterceptor.Result.Action.ALLOW);
+  }
+
+  @Test
+  void ignoresNonDropEvents() {
+    ProtectedTableDropInterceptor interceptor =
+        new ProtectedTableDropInterceptor(configuration("protected", "__"));
+
+    PolarisEvent event =
+        new PolarisEvent(
+            PolarisEventType.BEFORE_LOAD_GENERIC_TABLE,
+            null,
+            new EventAttributeMap().put(EventAttributes.GENERIC_TABLE_NAME, "orders__protected"));
+
+    PolarisEventInterceptor.Result result = interceptor.intercept(event);
+
+    assertThat(result.action()).isEqualTo(PolarisEventInterceptor.Result.Action.ALLOW);
+  }
+
+  private static ProtectedTableDropInterceptorConfiguration configuration(
+      String tagToken, String separator) {
+    return new ProtectedTableDropInterceptorConfiguration() {
+      @Override
+      public String tagToken() {
+        return tagToken;
+      }
+
+      @Override
+      public String separator() {
+        return separator;
+      }
+    };
+  }
+}


### PR DESCRIPTION
# Phase 1 Event Interceptors

## Summary

This PR implements Phase 1 of synchronous Event Interceptors for Polaris request-path policy enforcement. It restores the interceptor implementation after rebase recovery and aligns delegator wiring with the current upstream event-dispatch optimization (`hasListeners`).

## Why

Polaris before/after events are currently observational. This change introduces a synchronous control-path mechanism that can:

- allow an operation,
- deny an operation with a clear reason, or
- modify the in-flight event passed through the chain.

This enables deterministic pre-commit policy enforcement such as blocking protected table drops.

## What Changed

1. Added interceptor API:
- `PolarisEventInterceptor`
- `Result.allow()`, `Result.deny(reason)`, `Result.modify(modifiedEvent)`

2. Added interceptor chain config:
- `PolarisEventInterceptorConfiguration` (`polaris.event-interceptor.types`)

3. Added interceptor manager:
- `PolarisEventInterceptorManager`
- CDI `@Identifier` resolution from configured chain
- Ordered synchronous evaluation
- DENY -> `ForbiddenException` short-circuit
- MODIFY propagation to downstream interceptors

4. Added built-in example interceptor:
- `ProtectedTableDropInterceptor` (`@Identifier("protected-table-drop")`)
- `ProtectedTableDropInterceptorConfiguration`
- Supports `BEFORE_DROP_GENERIC_TABLE` and `BEFORE_DROP_TABLE`

5. Wired Phase 1 into one delegator path:
- `CatalogGenericTableEventServiceDelegator.dropGenericTable(...)`
- Interception executes before delegate invocation
- Existing before/after dispatch remains `hasListeners`-gated

6. Added/updated tests:
- `PolarisEventInterceptorManagerTest`
- `ProtectedTableDropInterceptorTest`
- `CatalogGenericTableEventServiceDelegatorInterceptorTest`
- `PolarisEventInterceptorManagerConfigurationTest`

## Scope and Non-Goals

- Phase 1 is intentionally scoped to one delegator path for safe rollout.
- No asynchronous interception, plugin loader, or rule DSL in this PR.
- Broader delegator coverage is planned for follow-on phases.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
