### PR TITLE
Self-annotate DefaultPolarisAuthorizerFactory and move to service module

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultPolarisAuthorizerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultPolarisAuthorizerFactory.java
@@ -16,12 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.core.auth;
+package org.apache.polaris.service.auth;
 
+import io.smallrye.common.annotation.Identifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.polaris.core.auth.PolarisAuthorizer;
+import org.apache.polaris.core.auth.PolarisAuthorizerFactory;
+import org.apache.polaris.core.auth.PolarisAuthorizerImpl;
 import org.apache.polaris.core.config.RealmConfig;
 
 /** Factory for creating the default Polaris authorizer implementation. */
-public class DefaultPolarisAuthorizerFactory implements PolarisAuthorizerFactory {
+@ApplicationScoped
+@Identifier("internal")
+class DefaultPolarisAuthorizerFactory implements PolarisAuthorizerFactory {
 
   @Override
   public PolarisAuthorizer create(RealmConfig realmConfig) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -36,7 +36,6 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthorizationState;
-import org.apache.polaris.core.auth.DefaultPolarisAuthorizerFactory;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisAuthorizerFactory;
 import org.apache.polaris.core.config.RealmConfig;
@@ -137,13 +136,6 @@ public class ServiceProducers {
   public RealmConfig realmConfig(
       RealmContext realmContext, RealmConfigurationSource configurationSource) {
     return new RealmConfigImpl(configurationSource, realmContext);
-  }
-
-  @Produces
-  @ApplicationScoped
-  @Identifier("internal")
-  public PolarisAuthorizerFactory defaultPolarisAuthorizerFactory() {
-    return new DefaultPolarisAuthorizerFactory();
   }
 
   @Produces


### PR DESCRIPTION
Move the factory from polaris-core into runtime/service, and annotate it with @ApplicationScoped @Identifier("internal") directly on the class. CDI now discovers it uniformly, so the hand-written producer method in ServiceProducers is no longer needed.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
