### PR TITLE
Fix spark jupyter guide

### DIFF
--- a/site/content/guides/spark/notebooks/Dockerfile
+++ b/site/content/guides/spark/notebooks/Dockerfile
@@ -39,10 +39,7 @@ COPY --chown=spark regtests/notebook_requirements.txt /tmp
 
 RUN python3 -m venv /home/spark/venv && \
     . /home/spark/venv/bin/activate && \
-    pip install -r /tmp/requirements.txt -r /tmp/notebook_requirements.txt && \
-    cd client/python && \
-    uv lock && \
-    uv sync --active --all-extras
+    pip install -r /tmp/requirements.txt -r /tmp/notebook_requirements.txt
 
 EXPOSE 8888
 CMD ["/home/spark/venv/bin/jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--NotebookApp.token=''"]

--- a/site/content/guides/spark/notebooks/Dockerfile
+++ b/site/content/guides/spark/notebooks/Dockerfile
@@ -39,7 +39,13 @@ COPY --chown=spark regtests/notebook_requirements.txt /tmp
 
 RUN python3 -m venv /home/spark/venv && \
     . /home/spark/venv/bin/activate && \
-    pip install -r /tmp/requirements.txt -r /tmp/notebook_requirements.txt
+    # Install uv
+    pip install -r /tmp/requirements.txt && \
+    # Sync polaris dependencies via uv
+    cd client/python && \
+    uv sync --active --all-extras && \
+    # Install notebook dependencies
+    pip install -r /tmp/notebook_requirements.txt
 
 EXPOSE 8888
 CMD ["/home/spark/venv/bin/jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--NotebookApp.token=''"]


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The current one is failing with following:
```
jupyter-1  | /opt/entrypoint.sh: line 128: /home/spark/venv/bin/jupyter: No such file or directory
jupyter-1 exited with code 127
```

This is due to the uv sync which anything that are not within uv.lock will get removed. We had jupyter dependency on those earlier but not anymore.

Also, uv.lock is getting auto updated now a day via renovate bot, thus, we don't need to call `uv lock` again.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
