### PR TITLE
docs: add AGENTS.md coding guidelines for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,290 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache Polaris — Coding Agent Guidelines
+
+Rules for AI coding agents contributing to Apache Polaris. Human contributors may
+also find these useful, but the primary audience is automated agents (Claude Code,
+Codex, Cursor, Copilot, and others).
+
+A human author is responsible for every change an agent produces. See
+[CONTRIBUTING.md](CONTRIBUTING.md#guidelines-for-ai-assisted-contributions) for the
+full AI-assisted contribution policy.
+
+This document has two types of rules:
+- **Hard gate** — mechanically verifiable, blocking. If it fails, do not submit.
+- **Discipline** — behavioral rule for how you work. Not mechanically verifiable,
+  but violations produce the kind of PRs that reviewers reject on sight.
+
+---
+
+## Understand Before Coding [DISCIPLINE]
+
+Read before you write. The most common agent failure mode is making wrong
+assumptions and running with them without checking.
+
+1. **Read the relevant code first.** Before changing a file, read it. Before
+   implementing an interface, find existing implementations and study them. Before
+   adding a utility, search the codebase for one that already exists.
+2. **Identify existing patterns.** Polaris has established patterns for CDI wiring,
+   request-scoped holders, persistence SPIs, and extension modules. Match them. If
+   you are unsure what pattern applies, look at two or three similar files and follow
+   what they do.
+3. **Plan multi-step tasks.** For changes that span more than one file, write a brief
+   plan before coding:
+   ```
+   1. [Step] — verify: [how you'll check it worked]
+   2. [Step] — verify: [how you'll check it worked]
+   ```
+4. **Flag contradictions.** If the task requirements conflict with existing code
+   patterns or design, say so in the PR description. Do not silently comply with
+   something that looks wrong.
+5. **State assumptions.** If you cannot verify an assumption (expected behavior,
+   intended scope, ambiguous requirements), state it explicitly in the PR description.
+   This is especially important for agents running in batch mode without interactive
+   feedback.
+6. **Investigate before editing.** When debugging, do not modify source files. Read,
+   search, and trace the code to build a diagnosis first. Speculative edits obscure
+   the original problem and risk regressions.
+
+---
+
+## Hard Gates
+
+These MUST pass before you open a pull request or declare a task complete. Treat any
+failure as a blocking error.
+
+1. **Format and compile.** [HARD GATE]
+   `./gradlew format compileAll` from the repo root. Fix every compilation error.
+   Every new source file MUST include the ASF license header — copy from
+   `codestyle/copyright-header-java.txt` for `.java` and `.kts` files,
+   `codestyle/copyright-header-hash.txt` for `.properties` and `.yml`. For other
+   types, check `codestyle/` for the matching template. Add headers manually;
+   `./gradlew check` includes the `rat` audit as a safety net.
+2. **Run module checks and tests.** [HARD GATE]
+   `./gradlew :<module>:check` for each module you touched. This runs tests,
+   Checkstyle (banned imports), and Spotless verification in one step. If you
+   changed a module that other modules depend on (e.g., `polaris-core`), run
+   `./gradlew check` (without module prefix) to catch downstream breakage.
+
+---
+
+## Build and Test
+
+**Language:** Java 21 (server modules), Java 17 (client modules).
+**Build system:** Gradle with Kotlin DSL. **Framework:** Quarkus with CDI.
+
+```bash
+# Format + compile — run before every commit
+./gradlew format compileAll
+
+# Run a specific module's checks and tests
+./gradlew :polaris-runtime-service:check
+
+# Run a specific test class
+./gradlew :polaris-runtime-service:test \
+  --tests "org.apache.polaris.service.tracing.RequestIdFilterTest"
+
+# Full check (formatting + all tests + all modules)
+./gradlew check
+```
+
+Error Prone runs during compilation. Fix every Error Prone error rather than
+suppressing checks with `@SuppressWarnings`. Do not introduce new `-Xlint` compiler
+warnings (unchecked casts, deprecation usage). [DISCIPLINE]
+
+Module names map to directory paths via `gradle/projects.main.properties`. Common
+modules:
+
+| Module | Path |
+|--------|------|
+| `polaris-core` | `polaris-core/` |
+| `polaris-runtime-service` | `runtime/service/` |
+| `polaris-server` | `runtime/server/` |
+| `polaris-relational-jdbc` | `persistence/relational-jdbc/` |
+| `polaris-tests` | `integration-tests/` |
+
+---
+
+## Code Style
+
+**Formatter:** Google Java Format via Spotless. `./gradlew format` applies it.
+Do not manually adjust the formatter's output.
+
+**Imports:** Use import statements. Never inline fully-qualified class names.
+[DISCIPLINE]
+
+```java
+import jakarta.enterprise.context.ContextNotActiveException;
+
+// correct
+} catch (ContextNotActiveException e) {
+
+// wrong
+} catch (jakarta.enterprise.context.ContextNotActiveException e) {
+```
+
+**Assertions:** Use AssertJ (`assertThat`) for test assertions. [DISCIPLINE]
+
+```java
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+```
+
+**Banned imports:** Checkstyle blocks all `*.shaded.*` imports and `*.relocated.*`
+imports (with a narrow exception) — see `codestyle/checkstyle.xml` for details.
+[HARD GATE — `./gradlew check` catches this]
+
+---
+
+## Naming
+
+### Test methods [DISCIPLINE]
+
+Match the naming style of the file you are editing. The project uses both `testXxx`
+camelCase and BDD-style `verbNounExpectation`:
+
+```java
+void testCaptureWhenScopeNotActiveReturnsNull()   // testXxx style
+void pathSegmentRejectsNullEntityType()            // BDD style
+void capture_whenScopeNotActive_returnsNull()      // wrong — no underscores
+```
+
+### Commit messages [DISCIPLINE]
+
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+```
+feat(service): async context propagation for task executor
+fix(core): null check in entity cache lookup
+refactor(persistence): extract connection pooling
+docs: update CONTRIBUTING.md with AI guidelines
+```
+
+- Scope matches the module area (`service` for `runtime/service`, `core` for
+  `polaris-core`).
+- `feat` / `fix` appear in release notes. Describe the feature or bug for users,
+  not the action.
+- No trailing period. Lowercase after the colon.
+
+### PR titles [DISCIPLINE]
+
+Same Conventional Commits format. The PR title becomes the squash-merge commit
+subject, so write it as if it will appear in release notes.
+
+---
+
+## PR Description [DISCIPLINE]
+
+Use the PR template (`.github/pull_request_template.md`). At minimum:
+
+1. Describe **why** the change is needed, not just what changed.
+2. Link the issue: `Fixes #NNN` or `Related to #NNN`.
+3. State your understanding of the current behavior and what you expect to change.
+4. Complete every checklist item.
+5. If the change affects user-facing behavior, update `CHANGELOG.md` under
+   `## [Unreleased]` in the appropriate subsection — consult existing entries
+   for the right category.
+6. If your change affects user-facing behavior or configuration, check whether
+   `site/content/in-dev/unreleased/` needs updates.
+
+---
+
+## Scope Discipline [DISCIPLINE]
+
+Change only what the task requires.
+
+- Do not reformat files you did not otherwise modify.
+- Do not refactor adjacent code that "could be better."
+- Do not add features, abstractions, or error handling beyond the task.
+- Do not add or update dependencies unless the task explicitly requires it.
+- **Clean up your own orphans.** Remove imports, variables, or methods that YOUR
+  changes made unused. Do not remove pre-existing dead code unless the task asks
+  for it.
+- **Verify scope.** Run `git diff --stat` and check that only expected files
+  appear. This requires judgment — if the task is "fix bug in RequestIdFilter" and
+  the diff shows 10 unrelated files, something went wrong.
+
+If you notice something worth improving outside the current scope, mention it in
+the PR description or file a separate issue. Do not bundle it.
+
+---
+
+## Simplicity [DISCIPLINE]
+
+Write the minimum code that solves the problem.
+
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that was not requested.
+- No error handling for scenarios that cannot happen.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+Start with the simplest correct implementation. Optimize only when the task
+requires it, and only after the simple version works and has tests.
+
+---
+
+## Verification Workflow
+
+Run this sequence before declaring work complete. Steps marked HARD GATE are
+blocking; steps marked DISCIPLINE are behavioral checks that prevent common
+rejections.
+
+```
+1. Run the Hard Gates above             — format, compile, add headers, check
+2. Re-read every changed file           — [DISCIPLINE] self-review:
+                                            - Any conceptual errors?
+                                            - Could this be simpler?
+                                            - Does it match existing patterns?
+3. git diff --stat                      — [DISCIPLINE] only expected files changed?
+4. Check orphaned code                  — [DISCIPLINE] did your changes create
+                                            unused imports/variables? Remove them.
+```
+
+If any HARD GATE step fails, fix the issue and restart from step 1.
+If a DISCIPLINE step reveals a problem, fix it and re-run the HARD GATE steps.
+
+---
+
+## Common Mistakes
+
+**Changing interface method signatures.** [DISCIPLINE]
+Polaris interfaces are implemented by downstream integrators. Changing a method
+signature breaks those implementations. Before modifying any interface, search for
+all implementations (`grep -rn 'implements YourInterface'`). When extending an
+interface, add new methods with `default` implementations rather than modifying
+existing signatures. Changes to public interfaces or extension points require prior
+discussion on the dev mailing list — see
+[CONTRIBUTING.md](CONTRIBUTING.md#code-contribution-guidelines).
+
+**Inventing new patterns.** [DISCIPLINE]
+Check the codebase for existing patterns before introducing new utility classes or
+abstractions. Follow what is already there.
+
+**Silent compliance with bad requirements.** [DISCIPLINE]
+If a task asks you to do something that contradicts existing code patterns, do not
+silently comply. Explain the contradiction in the PR description and propose an
+alternative. Reviewers would rather see a thoughtful objection than a PR that
+introduces inconsistency.
+
+**AI self-references in output.** [DISCIPLINE]
+Do not include AI tool names or model identifiers in code, comments, or commit
+messages. For PR descriptions, follow the disclosure guidance in
+[CONTRIBUTING.md](CONTRIBUTING.md#guidelines-for-ai-assisted-contributions).
+The human author owns the contribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ assumptions and running with them without checking.
 2. **Identify existing patterns.** Polaris has established patterns for CDI wiring,
    request-scoped holders, persistence SPIs, and extension modules. Match them. If
    you are unsure what pattern applies, look at two or three similar files and follow
-   what they do.
+   what they do. If in doubt, ask the user.
 3. **Plan multi-step tasks.** For changes that span more than one file, write a brief
    plan before coding:
    ```
@@ -59,9 +59,10 @@ assumptions and running with them without checking.
    intended scope, ambiguous requirements), state it explicitly in the PR description.
    This is especially important for agents running in batch mode without interactive
    feedback.
-6. **Investigate before editing.** When debugging, do not modify source files. Read,
-   search, and trace the code to build a diagnosis first. Speculative edits obscure
-   the original problem and risk regressions.
+6. **Investigate before editing.** When debugging, read, search, and trace the code
+   to build a diagnosis first. Speculative source edits obscure the original problem
+   and risk regressions. Temporary debug output (e.g., `System.out.println`) is fine
+   as long as it is removed before committing.
 
 ---
 
@@ -91,34 +92,36 @@ failure as a blocking error.
 **Build system:** Gradle with Kotlin DSL. **Framework:** Quarkus with CDI.
 
 ```bash
-# Format + compile — run before every commit
+# Full build with all checks (formatting, checkstyle, errorprone, tests)
+./gradlew check
+
+# Compile only (no tests)
+./gradlew compileAll
+
+# Format code (Google Java Format via Spotless)
+./gradlew format
+
+# Format + compile (recommended before pushing)
 ./gradlew format compileAll
 
 # Run a specific module's checks and tests
 ./gradlew :polaris-runtime-service:check
 
 # Run a specific test class
-./gradlew :polaris-runtime-service:test \
-  --tests "org.apache.polaris.service.tracing.RequestIdFilterTest"
+./gradlew :polaris-core:test \
+  --tests "org.apache.polaris.core.SomeTest"
 
-# Full check (formatting + all tests + all modules)
-./gradlew check
+# Run a specific test method
+./gradlew :polaris-core:test \
+  --tests "org.apache.polaris.core.SomeTest.testMethod"
 ```
 
 Error Prone runs during compilation. Fix every Error Prone error rather than
 suppressing checks with `@SuppressWarnings`. Do not introduce new `-Xlint` compiler
 warnings (unchecked casts, deprecation usage). [DISCIPLINE]
 
-Module names map to directory paths via `gradle/projects.main.properties`. Common
-modules:
-
-| Module | Path |
-|--------|------|
-| `polaris-core` | `polaris-core/` |
-| `polaris-runtime-service` | `runtime/service/` |
-| `polaris-server` | `runtime/server/` |
-| `polaris-relational-jdbc` | `persistence/relational-jdbc/` |
-| `polaris-tests` | `integration-tests/` |
+Module names map to directory paths via `gradle/projects.main.properties`. See
+[README.md](README.md) for a breakdown of all modules.
 
 ---
 
@@ -147,6 +150,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 ```
 
+**Tests:** Favor parameterized tests when the same behavior is tested across
+different inputs. [DISCIPLINE]
+
 **Banned imports:** Checkstyle blocks all `*.shaded.*` imports and `*.relocated.*`
 imports (with a narrow exception) — see `codestyle/checkstyle.xml` for details.
 [HARD GATE — `./gradlew check` catches this]
@@ -166,27 +172,12 @@ void pathSegmentRejectsNullEntityType()            // BDD style
 void capture_whenScopeNotActive_returnsNull()      // wrong — no underscores
 ```
 
-### Commit messages [DISCIPLINE]
+### Commit messages and PR titles [DISCIPLINE]
 
-[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
-
-```
-feat(service): async context propagation for task executor
-fix(core): null check in entity cache lookup
-refactor(persistence): extract connection pooling
-docs: update CONTRIBUTING.md with AI guidelines
-```
-
-- Scope matches the module area (`service` for `runtime/service`, `core` for
-  `polaris-core`).
-- `feat` / `fix` appear in release notes. Describe the feature or bug for users,
-  not the action.
-- No trailing period. Lowercase after the colon.
-
-### PR titles [DISCIPLINE]
-
-Same Conventional Commits format. The PR title becomes the squash-merge commit
-subject, so write it as if it will appear in release notes.
+Follow the conventions in
+[CONTRIBUTING.md](CONTRIBUTING.md#code-contribution-guidelines). The PR title
+becomes the squash-merge commit subject. Write it as if it will appear in release
+notes: describe the feature or bug for users, not the action.
 
 ---
 
@@ -265,11 +256,11 @@ If a DISCIPLINE step reveals a problem, fix it and re-run the HARD GATE steps.
 ## Common Mistakes
 
 **Changing interface method signatures.** [DISCIPLINE]
-Polaris interfaces may be implemented by downstream integrators outside this
-repository. Changing a method signature can break those implementations even if all
-in-repo usages compile. Changes to public interfaces or extension points require
-prior discussion on the dev mailing list, see
-[CONTRIBUTING.md](CONTRIBUTING.md#code-contribution-guidelines).
+Changes to public interfaces or extension points are significant design decisions
+that require prior discussion on the dev mailing list, see
+[CONTRIBUTING.md](CONTRIBUTING.md#code-contribution-guidelines). See also the
+[evolution guidelines](site/content/in-dev/unreleased/evolution.md) for the
+project's approach to API and code changes.
 
 **Inventing new patterns.** [DISCIPLINE]
 Check the codebase for existing patterns before introducing new utility classes or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,12 +265,10 @@ If a DISCIPLINE step reveals a problem, fix it and re-run the HARD GATE steps.
 ## Common Mistakes
 
 **Changing interface method signatures.** [DISCIPLINE]
-Polaris interfaces are implemented by downstream integrators. Changing a method
-signature breaks those implementations. Before modifying any interface, search for
-all implementations (`grep -rn 'implements YourInterface'`). When extending an
-interface, add new methods with `default` implementations rather than modifying
-existing signatures. Changes to public interfaces or extension points require prior
-discussion on the dev mailing list — see
+Polaris interfaces may be implemented by downstream integrators outside this
+repository. Changing a method signature can break those implementations even if all
+in-repo usages compile. Changes to public interfaces or extension points require
+prior discussion on the dev mailing list, see
 [CONTRIBUTING.md](CONTRIBUTING.md#code-contribution-guidelines).
 
 **Inventing new patterns.** [DISCIPLINE]


### PR DESCRIPTION
AI coding agents are increasingly used to contribute to Polaris. They produce a recognizable pattern of reviewer burden: missing license headers, scope creep, invented patterns, silent compliance with ambiguous requirements. This adds an `AGENTS.md` file, a cross-tool convention that agents read automatically, to catch these issues before they reach human review.

Two categories of rules:
- **Hard gates**: mechanically verifiable checks (`./gradlew format compileAll`, `./gradlew :<module>:check`) that must pass before submitting
- **Discipline rules**: behavioral guidelines (scope, simplicity, naming, PR descriptions) that prevent common rejections

Phase 1 only covers coding hygiene, no architecture context. Cross-references existing project docs (CONTRIBUTING.md, PR template, codestyle/) rather than duplicating them.

I'm thinking of having architecture context and reviewer-oriented skills (for copilot GH auto review) introduced in later phases, starting a ML discussion here: https://lists.apache.org/list?dev@polaris.apache.org:lte=1M:AGENTS.md%20for%20Polaris

## Checklist
- [x] Don't disclose security issues
- [x] Clearly explained why the changes are needed
- [x] Added/updated tests: N/A (documentation only)
- [x] Added comments for complex logic: N/A
- [ ] Updated `CHANGELOG.md`: not needed for docs-only
- [ ] Updated documentation in `site/content/in-dev/unreleased`: not needed