### PR TITLE
Added Integration Tests to validate auto-upgrade of Graalvm version by Renovate-bot (#4275)

### DIFF
--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
@@ -27,6 +27,7 @@ import io.restassured.http.ContentType;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +40,8 @@ public abstract class RangerIntegrationTestBase {
 
   private static final JsonMapper mapper = JsonMapper.builder().build();
   private final List<String> catalogsToCleanup = new ArrayList<>();
+
+  protected Map<String, String> user2Token = new HashMap<>();
 
   protected String toJson(Object value) {
     try {
@@ -69,6 +72,15 @@ public abstract class RangerIntegrationTestBase {
       fail("Failed to parse access_token from admin OAuth response: " + response);
     }
     return accessToken;
+  }
+
+  protected String getUserToken(String userName) {
+    String token = user2Token.get(userName);
+    if (token == null) {
+      token = createPrincipalAndGetToken(userName);
+      user2Token.put(userName, token);
+    }
+    return token;
   }
 
   protected String createPrincipalAndGetToken(String principalName) {

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerPolicyConditionIT.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerPolicyConditionIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class RangerPolicyConditionIT extends RangerIntegrationTestBase {
 
   @Test
-  void getPrincipalListsWithoutAuthorization() {
+  void getCatalogListsWithoutAuthorization() {
     String polcondu1Token = getUserToken("polcondu1");
     given()
         .contentType(ContentType.JSON)
@@ -41,7 +41,7 @@ public class RangerPolicyConditionIT extends RangerIntegrationTestBase {
   }
 
   @Test
-  void getPrincipalListsWithAuthorization() {
+  void getCatalogListsWithAuthorization() {
     String polcondu2Token = getUserToken("polcondu2");
     given()
         .contentType(ContentType.JSON)

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerPolicyConditionIT.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerPolicyConditionIT.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.extension.auth.ranger.test;
+
+import static io.restassured.RestAssured.given;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RangerTestProfiles.EmbeddedPolicy.class)
+public class RangerPolicyConditionIT extends RangerIntegrationTestBase {
+
+  @Test
+  void getPrincipalListsWithoutAuthorization() {
+    String polcondu1Token = getUserToken("polcondu1");
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + polcondu1Token)
+        .get("/api/management/v1/catalogs")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void getPrincipalListsWithAuthorization() {
+    String polcondu2Token = getUserToken("polcondu2");
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + polcondu2Token)
+        .get("/api/management/v1/catalogs")
+        .then()
+        .statusCode(200);
+  }
+}

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
@@ -37,7 +37,8 @@ public final class RangerTestProfiles {
       config.put(
           "polaris.authorization.ranger.authz.default.policy.source.impl",
           "org.apache.ranger.admin.client.EmbeddedResourcePolicySource");
-      config.put("polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher", "true");
+      config.put(
+          "polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher", "true");
       config.put(
           "polaris.authorization.ranger.authz.default.policy.source.embedded_resource.path",
           "/authz_it_tests");

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
@@ -37,6 +37,7 @@ public final class RangerTestProfiles {
       config.put(
           "polaris.authorization.ranger.authz.default.policy.source.impl",
           "org.apache.ranger.admin.client.EmbeddedResourcePolicySource");
+      config.put("polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher", "true");
       config.put(
           "polaris.authorization.ranger.authz.default.policy.source.embedded_resource.path",
           "/authz_it_tests");

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
@@ -713,31 +713,13 @@
             }
           ],
           "users": [
-            "polcondu1"
+            "polcondu1", "polcondu2"
           ],
           "conditions": [
             {
               "type": "_expression",
               "values": [
-                "new java.util.Date().getHours() >= 10 && new java.util.Date().getHours() <= 9"
-              ]
-            }
-          ]
-        },
-        {
-          "accesses": [
-            {
-              "type": "catalog-list"
-            }
-          ],
-          "users": [
-            "polcondu2"
-          ],
-          "conditions": [
-            {
-              "type": "_expression",
-              "values": [
-                "new java.util.Date().getHours() >= 0 && new java.util.Date().getHours() <= 24"
+                "USER.allowedSensitiveLevel > 5"
               ]
             }
           ]

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
@@ -701,7 +701,7 @@
       ]
     },
     {
-      "id": 12, "name": "policy:POLARIS/catalog-list",
+      "id": 12, "name": "Realm:POLARIS",
       "resources": {
         "root":      { "values": [ "POLARIS" ] }
       },

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
@@ -439,6 +439,16 @@
       { "itemId": 67, "name": "policy-attach",        "label": "Policy Attach",        "category": "MANAGE" },
       { "itemId": 68, "name": "policy-detach",        "label": "Policy Detach",        "category": "MANAGE" },
       { "itemId": 69, "name": "policy-metadata-full", "label": "Policy Metadata Full", "category": "MANAGE", "impliedGrants": [ "policy-create", "policy-drop", "policy-list", "policy-read", "policy-write" ] }
+    ],
+    "policyConditions": [
+      {
+        "itemId":1,
+        "name":"_expression",
+        "evaluator": "org.apache.ranger.plugin.conditionevaluator.RangerScriptConditionEvaluator",
+        "evaluatorOptions" : {"engineName":"JavaScript"},
+        "label":"Enter boolean expression",
+        "description": "Boolean expression"
+      }
     ]
   },
   "policies": [
@@ -688,6 +698,50 @@
             { "type": "policy-detach" }
           ],
           "users": [ "root" ] }
+      ]
+    },
+    {
+      "id": 12, "name": "policy:POLARIS/catalog-list",
+      "resources": {
+        "root":      { "values": [ "POLARIS" ] }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "catalog-list"
+            }
+          ],
+          "users": [
+            "polcondu1"
+          ],
+          "conditions": [
+            {
+              "type": "_expression",
+              "values": [
+                "new java.util.Date().getHours() >= 10 && new java.util.Date().getHours() <= 9"
+              ]
+            }
+          ]
+        },
+        {
+          "accesses": [
+            {
+              "type": "catalog-list"
+            }
+          ],
+          "users": [
+            "polcondu2"
+          ],
+          "conditions": [
+            {
+              "type": "_expression",
+              "values": [
+                "new java.util.Date().getHours() >= 0 && new java.util.Date().getHours() <= 24"
+              ]
+            }
+          ]
+        }
       ]
     }
   ]

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris_userstore.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris_userstore.json
@@ -1,0 +1,7 @@
+{
+  "userAttrMapping": {
+    "polcondu1": { "dept": "finance",   "allowedSensitiveLevel": "1" },
+    "polcondu2": { "dept": "audit",     "allowedSensitiveLevel": "10" }
+  },
+  "userStoreVersion": 1
+}


### PR DESCRIPTION

Added two Integration Tests that would evaluate policies based on Java Script conditions specified in the policy. This will ensure that the policy engine works well with the specific version of Graalvm script engine.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
