### PR TITLE
Regtests: harden MinIO client download and fail fast when setup breaks

### DIFF
--- a/regtests/Dockerfile
+++ b/regtests/Dockerfile
@@ -32,8 +32,10 @@ RUN apt-get update && \
     mkdir -p /home/spark /tmp/polaris-regtests /opt/spark/conf && \
     chown -R spark:spark /home/spark /tmp/polaris-regtests && \
     chmod -R 777 /opt/spark/conf && \
-    curl -o /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc && \
-    chmod +x /usr/local/bin/mc
+    curl -fL --retry 5 --retry-delay 2 --retry-connrefused \
+         -o /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc && \
+    chmod +x /usr/local/bin/mc && \
+    /usr/local/bin/mc --version
 
 COPY --chown=spark:spark ./regtests/setup.sh ./regtests/pyspark-setup.sh ./regtests/requirements.txt /home/spark/polaris/regtests/
 COPY --chown=spark:spark ./client/python /home/spark/polaris/client/python

--- a/regtests/run.sh
+++ b/regtests/run.sh
@@ -81,7 +81,10 @@ fi
 # Run MinIO setup if in MinIO mode
 if [ "${MINIO_TEST_ENABLED}" == "true" ]; then
   loginfo "Setting up MinIO for tests"
-  ${REGTEST_HOME}/minio-setup.sh
+  if ! ${REGTEST_HOME}/minio-setup.sh; then
+    logred "MinIO setup failed; aborting regression tests"
+    exit 1
+  fi
   loginfo "MinIO mode enabled"
 else
   loginfo "AWS mode enabled"


### PR DESCRIPTION
Fix a test failure like this, https://github.com/apache/polaris/actions/runs/24807004136/job/72603400304

The `mc` binary is fetched in the Docker build with plain `curl -o`, so a transient HTTP error or partial response produces a corrupted file that silently passes `chmod +x`. When `minio-setup.sh` later invokes it, the shell reports `line 1: a: No such file or directory` and exits; but `run.sh` does not check the setup script's exit code, so tests proceed against a bucket that was never created and fail with "The specified bucket does not exist" — masking the real cause behind a dozen pyspark regression failures.

- Dockerfile: use `curl -fL --retry 5 --retry-delay 2 --retry-connrefused` and run `mc --version` so a bad download fails the image build.
- run.sh: abort the run if `minio-setup.sh` exits non-zero.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
