### PR TITLE
Add MySQL as a supported database for the relational JDBC persistence backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added support for multiple event listeners. Set `polaris.event-listener.types` to a comma-separated list of event listener types to enable multiple event listeners.
 - Added support for enabling only a subset of event types and event categories per event listener. Set `polaris.event-listener.`_`<name>`_`.enabled-event-types` or `polaris.event-listener.`_`<name>`_`.enabled-event-categories` to the list of event types or categories for the specified event listener to only consume the selected subset of events.
 - Added support for **Apache Ranger** as an external authorizer (Beta).
+- Added source-level support for building a MySQL-capable Polaris server for the relational JDBC backend. Official Polaris release artifacts do not include the MySQL JDBC driver, which is GPL-licensed. Users who need this path should download the official Polaris source release and build their own derivative from that source tree (`./gradlew :polaris-server:assemble -PincludeMysqlDriver=true`); see `runtime/server/README.md` in the unpacked source release for build details.
 
 ### Changes
 - Improved Python CLI error messages and exit codes for invalid arguments and configuration errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added support for multiple event listeners. Set `polaris.event-listener.types` to a comma-separated list of event listener types to enable multiple event listeners.
 - Added support for enabling only a subset of event types and event categories per event listener. Set `polaris.event-listener.`_`<name>`_`.enabled-event-types` or `polaris.event-listener.`_`<name>`_`.enabled-event-categories` to the list of event types or categories for the specified event listener to only consume the selected subset of events.
 - Added support for **Apache Ranger** as an external authorizer (Beta).
+- Added source-level support for building a MySQL-capable Polaris server for the relational JDBC backend. Official Polaris release artifacts do not include the MySQL JDBC driver, which is GPL-licensed. Users who need this path should download the official Polaris source release and build their own derivative from that source tree (`./gradlew :polaris-server:assemble -PincludeMysqlDriver=true`); see `runtime/server/README.md` in the unpacked source release for build details.
 
 ### Changes
 

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -137,6 +137,9 @@ tasks.register<VerifyBomDependenciesTask>("verifyBomDependencies") {
       ":aggregated-license-report",
       ":polaris-config-docs-site",
       ":polaris-distribution",
+      // Integration-test-only module that pulls the GPL MySQL JDBC driver; it is not a
+      // published library, so it must not be referenced from the BOM.
+      ":polaris-relational-jdbc-mysql-tests",
     )
   )
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -143,6 +143,9 @@ tasks.register<VerifyBomDependenciesTask>("verifyBomDependencies") {
       ":aggregated-license-report",
       ":polaris-config-docs-site",
       ":polaris-distribution",
+      // Integration-test-only module that pulls the GPL MySQL JDBC driver; it is not a
+      // published library, so it must not be referenced from the BOM.
+      ":polaris-relational-jdbc-mysql-tests",
     )
   )
 }

--- a/extensions/metrics-reports/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
+++ b/extensions/metrics-reports/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
@@ -241,11 +241,8 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
     map.put(TOTAL_DURATION_MS, getTotalDurationMs());
     map.put(ATTEMPTS, getAttempts());
 
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(METADATA, toJsonbPGobject(getMetadata() != null ? getMetadata() : "{}"));
-    } else {
-      map.put(METADATA, getMetadata() != null ? getMetadata() : "{}");
-    }
+    map.put(
+        METADATA, wrapJsonForDatabase(getMetadata() != null ? getMetadata() : "{}", databaseType));
     return map;
   }
 

--- a/extensions/metrics-reports/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
+++ b/extensions/metrics-reports/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
@@ -241,11 +241,8 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
     map.put(INDEXED_DELETE_FILES, getIndexedDeleteFiles());
     map.put(TOTAL_DELETE_FILE_SIZE_BYTES, getTotalDeleteFileSizeBytes());
 
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(METADATA, toJsonbPGobject(getMetadata() != null ? getMetadata() : "{}"));
-    } else {
-      map.put(METADATA, getMetadata() != null ? getMetadata() : "{}");
-    }
+    map.put(
+        METADATA, wrapJsonForDatabase(getMetadata() != null ? getMetadata() : "{}", databaseType));
     return map;
   }
 

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -33,6 +33,7 @@ polaris-admin=runtime/admin
 polaris-runtime-common=runtime/common
 polaris-runtime-test-common=runtime/test-common
 polaris-relational-jdbc=persistence/relational-jdbc
+polaris-relational-jdbc-mysql-tests=persistence/relational-jdbc-mysql/tests
 polaris-tests=integration-tests
 aggregated-license-report=aggregated-license-report
 polaris-immutables=tools/immutables

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -34,6 +34,7 @@ polaris-admin=runtime/admin
 polaris-runtime-common=runtime/common
 polaris-runtime-test-common=runtime/test-common
 polaris-relational-jdbc=persistence/relational-jdbc
+polaris-relational-jdbc-mysql-tests=persistence/relational-jdbc-mysql/tests
 polaris-tests=integration-tests
 aggregated-license-report=aggregated-license-report
 polaris-immutables=tools/immutables

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -326,6 +326,55 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCatalogsDifferingOnlyByCaseCoexist() {
+    // Cross-backend regression check that identifier uniqueness is case-sensitive on the
+    // `entities` table. Notably this catches MySQL collation regressions: a default
+    // case-insensitive collation would collapse `foo` and `Foo` into a single row via the
+    // (realm_id, catalog_id, parent_id, type_code, name) unique constraint, diverging from
+    // PostgreSQL's case-sensitive TEXT semantics.
+    AwsStorageConfigInfo awsConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::000000000000:role/polaris-it")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of("s3://test-bucket/"))
+            .build();
+    String lowerName = client.newEntityName("foo");
+    String upperName = lowerName.replaceFirst("foo", "Foo");
+    Catalog lowerCatalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(lowerName)
+            .setProperties(new CatalogProperties("s3://test-bucket/" + lowerName))
+            .setStorageConfigInfo(awsConfigModel)
+            .build();
+    Catalog upperCatalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(upperName)
+            .setProperties(new CatalogProperties("s3://test-bucket/" + upperName))
+            .setStorageConfigInfo(awsConfigModel)
+            .build();
+    managementApi.createCatalog(lowerCatalog);
+    try {
+      managementApi.createCatalog(upperCatalog);
+      try {
+        try (Response r = managementApi.request("v1/catalogs/" + lowerName).get()) {
+          assertThat(r).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+          assertThat(r.readEntity(Catalog.class).getName()).isEqualTo(lowerName);
+        }
+        try (Response r = managementApi.request("v1/catalogs/" + upperName).get()) {
+          assertThat(r).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+          assertThat(r.readEntity(Catalog.class).getName()).isEqualTo(upperName);
+        }
+      } finally {
+        managementApi.deleteCatalog(upperName);
+      }
+    } finally {
+      managementApi.deleteCatalog(lowerName);
+    }
+  }
+
+  @Test
   public void testCreateCatalogWithNullBaseLocation() {
     AwsStorageConfigInfo awsConfigModel =
         AwsStorageConfigInfo.builder()

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -475,6 +475,47 @@ public class PolarisPolicyServiceIntegrationTest {
   }
 
   @Test
+  public void testAttachAndDetachPolicyWithNonTrivialJsonParameters() {
+    // Regression coverage for `JdbcBasePersistenceImpl.deleteFromPolicyMappingRecords`:
+    // the DELETE WHERE clause passes the `parameters` JSON column value verbatim and
+    // must match the stored row. On MySQL this requires `CAST(? AS JSON)` placeholder
+    // selection (via `ModelRegistry.isJsonColumn` + `DatabaseType.asJsonConditionPlaceholder`);
+    // on PostgreSQL the `parameters` column is jsonb and matches with a plain `?`
+    // placeholder bound to a `PGobject(jsonb)` value. Either way, attaching with
+    // non-trivial JSON parameters and then detaching must succeed.
+    restCatalog.createNamespace(NS1);
+    policyApi.createPolicy(
+        currentCatalogName,
+        NS1_P1,
+        PredefinedPolicyTypes.DATA_COMPACTION,
+        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+        "test policy");
+
+    PolicyAttachmentTarget catalogTarget =
+        PolicyAttachmentTarget.builder().setType(PolicyAttachmentTarget.TypeEnum.CATALOG).build();
+    Map<String, String> nonTrivialParameters =
+        Map.of("retention", "30days", "scope", "namespace-and-tables", "owner", "polaris-it");
+    policyApi.attachPolicy(currentCatalogName, NS1_P1, catalogTarget, nonTrivialParameters);
+
+    // Detach exercises `deleteFromPolicyMappingRecords` which uses the `parameters`
+    // JSON column in the DELETE WHERE clause. A regression that drops the JSON
+    // placeholder selection (or that re-introduces `Converter.MysqlJsonValue`-based
+    // dispatch in the wrong way) would silently fail to delete the row on MySQL.
+    policyApi.detachPolicy(currentCatalogName, NS1_P1, catalogTarget);
+
+    // Re-attaching the same target with different non-trivial parameters must succeed
+    // (the previous row must have actually been deleted, not just orphaned).
+    policyApi.attachPolicy(
+        currentCatalogName,
+        NS1_P1,
+        catalogTarget,
+        Map.of("retention", "7days", "scope", "namespace-only"));
+    policyApi.detachPolicy(currentCatalogName, NS1_P1, catalogTarget);
+
+    policyApi.dropPolicy(currentCatalogName, NS1_P1);
+  }
+
+  @Test
   public void testDropNonExistingPolicy() {
     restCatalog.createNamespace(NS1);
     try (Response res =

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -475,6 +475,40 @@ public class PolarisPolicyServiceIntegrationTest {
   }
 
   @Test
+  public void testAttachAndDetachPolicyWithNonTrivialJsonParameters() {
+    // Round-trip coverage for non-trivial JSON policy parameters: the re-attach below only
+    // succeeds if the first detach actually removed the row. This does not reach a JSON column
+    // in a WHERE clause — `deleteFromPolicyMappingRecords` keys on the identity columns — so
+    // MySQL's `CAST(? AS JSON)` handling is covered by `MysqlJsonColumnPredicateIT` instead.
+    restCatalog.createNamespace(NS1);
+    policyApi.createPolicy(
+        currentCatalogName,
+        NS1_P1,
+        PredefinedPolicyTypes.DATA_COMPACTION,
+        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+        "test policy");
+
+    PolicyAttachmentTarget catalogTarget =
+        PolicyAttachmentTarget.builder().setType(PolicyAttachmentTarget.TypeEnum.CATALOG).build();
+    Map<String, String> nonTrivialParameters =
+        Map.of("retention", "30days", "scope", "namespace-and-tables", "owner", "polaris-it");
+    policyApi.attachPolicy(currentCatalogName, NS1_P1, catalogTarget, nonTrivialParameters);
+
+    policyApi.detachPolicy(currentCatalogName, NS1_P1, catalogTarget);
+
+    // Re-attaching the same target with different non-trivial parameters must succeed
+    // (the previous row must have actually been deleted, not just orphaned).
+    policyApi.attachPolicy(
+        currentCatalogName,
+        NS1_P1,
+        catalogTarget,
+        Map.of("retention", "7days", "scope", "namespace-only"));
+    policyApi.detachPolicy(currentCatalogName, NS1_P1, catalogTarget);
+
+    policyApi.dropPolicy(currentCatalogName, NS1_P1);
+  }
+
+  @Test
   public void testDropNonExistingPolicy() {
     restCatalog.createNamespace(NS1);
     try (Response res =

--- a/persistence/relational-jdbc-mysql/tests/build.gradle.kts
+++ b/persistence/relational-jdbc-mysql/tests/build.gradle.kts
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  alias(libs.plugins.quarkus)
+  id("org.kordamp.gradle.jandex")
+  id("polaris-runtime")
+}
+
+// Mirror `runtime/test-common`'s antlr/Scala exclusions and additionally drop
+// jackson-module-scala: Jackson's ServiceLoader otherwise tries to instantiate
+// DefaultScalaModule during RESTEasy provider init and fails.
+configurations.all {
+  if (name != "checkstyle") {
+    exclude(group = "org.antlr", module = "antlr4-runtime")
+    exclude(group = "org.scala-lang", module = "scala-library")
+    exclude(group = "org.scala-lang", module = "scala-reflect")
+    exclude(group = "com.fasterxml.jackson.module", module = "jackson-module-scala_2.12")
+    exclude(group = "com.fasterxml.jackson.module", module = "jackson-module-scala_2.13")
+  }
+}
+
+dependencies {
+  implementation(platform(libs.quarkus.bom))
+  implementation("io.quarkus:quarkus-rest-jackson")
+  // The MySQL JDBC driver lives only in this test module so it stays off the
+  // production-facing `runtime/service` classpath.
+  implementation("io.quarkus:quarkus-jdbc-mysql")
+  implementation(project(":polaris-relational-jdbc"))
+  implementation(project(":polaris-runtime-service"))
+
+  testImplementation(project(":polaris-runtime-test-common"))
+
+  intTestImplementation("io.quarkus:quarkus-junit")
+  intTestImplementation("io.rest-assured:rest-assured")
+  intTestImplementation(project(":polaris-api-management-model"))
+  intTestImplementation(project(":polaris-tests"))
+  // Reuse the existing `ServerManager` (the PolarisServerManager SPI impl) from
+  // runtime-service test fixtures instead of duplicating it in this module.
+  intTestImplementation(testFixtures(project(":polaris-runtime-service")))
+  intTestImplementation(platform(libs.iceberg.bom))
+  intTestImplementation("org.apache.iceberg:iceberg-api")
+  intTestImplementation("org.apache.iceberg:iceberg-core")
+  // CatalogTests / ViewCatalogTests test fixtures used by Mysql*IT base classes.
+  intTestImplementation("org.apache.iceberg:iceberg-api:${libs.versions.iceberg.get()}:tests")
+  intTestImplementation("org.apache.iceberg:iceberg-core:${libs.versions.iceberg.get()}:tests")
+
+  intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation("org.testcontainers:testcontainers-junit-jupiter")
+  intTestImplementation("org.testcontainers:testcontainers-mysql")
+  intTestImplementation(project(":polaris-container-spec-helper"))
+
+  // RESTEasy Classic (via keycloak-admin-client) provides the jakarta.ws.rs.client.ClientBuilder
+  // SPI used by `PolarisClient`. Must remain `intTestRuntimeOnly` so it does not participate
+  // in Quarkus augmentation (which uses RESTEasy Reactive).
+  intTestRuntimeOnly(libs.keycloak.admin.client)
+}
+
+// `runtime/defaults` keeps the MySQL named datasource off by default; flip it on at Quarkus
+// build time for this test module only. The matching `active=true` runtime override is set
+// by `MysqlRelationalJdbcLifeCycleManagement`.
+quarkus { quarkusBuildProperties.put("quarkus.datasource.mysql.jdbc", "true") }
+
+tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.withType<Test> {
+  if (System.getenv("AWS_REGION") == null) {
+    environment("AWS_REGION", "us-west-2")
+  }
+  environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,test-admin,test-secret")
+  val apiVersion = System.getenv("DOCKER_API_VERSION") ?: "1.44"
+  systemProperty("api.version", apiVersion)
+  jvmArgs("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
+  systemProperty("java.security.manager", "allow")
+  maxParallelForks = 1
+
+  val logsDir = project.layout.buildDirectory.get().asFile.resolve("logs")
+  jvmArgumentProviders.add(
+    CommandLineArgumentProvider {
+      listOf("-Dquarkus.log.file.path=${logsDir.resolve("polaris.log").absolutePath}")
+    }
+  )
+  doFirst {
+    logsDir.deleteRecursively()
+    project.layout.buildDirectory.get().asFile.resolve("quarkus.log").delete()
+  }
+}

--- a/persistence/relational-jdbc-mysql/tests/build.gradle.kts
+++ b/persistence/relational-jdbc-mysql/tests/build.gradle.kts
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+  alias(libs.plugins.quarkus)
+  id("org.kordamp.gradle.jandex")
+  id("polaris-runtime")
+}
+
+// Mirror `runtime/test-common`'s antlr/Scala exclusions and additionally drop
+// jackson-module-scala: Jackson's ServiceLoader otherwise tries to instantiate
+// DefaultScalaModule during RESTEasy provider init and fails.
+configurations.all {
+  if (name != "checkstyle") {
+    exclude(group = "org.antlr", module = "antlr4-runtime")
+    exclude(group = "org.scala-lang", module = "scala-library")
+    exclude(group = "org.scala-lang", module = "scala-reflect")
+    exclude(group = "com.fasterxml.jackson.module", module = "jackson-module-scala_2.12")
+    exclude(group = "com.fasterxml.jackson.module", module = "jackson-module-scala_2.13")
+  }
+}
+
+dependencies {
+  implementation(platform(libs.quarkus.bom))
+  implementation("io.quarkus:quarkus-rest-jackson")
+  // The MySQL JDBC driver lives only in this test module so it stays off the
+  // production-facing `runtime/service` classpath.
+  implementation("io.quarkus:quarkus-jdbc-mysql")
+  implementation(project(":polaris-relational-jdbc"))
+  implementation(project(":polaris-runtime-service"))
+
+  testImplementation(project(":polaris-runtime-test-common"))
+
+  intTestImplementation("io.quarkus:quarkus-junit")
+  intTestImplementation("io.rest-assured:rest-assured")
+  intTestImplementation(project(":polaris-api-management-model"))
+  intTestImplementation(project(":polaris-tests"))
+  // Reuse the existing `ServerManager` (the PolarisServerManager SPI impl) from
+  // runtime-service test fixtures instead of duplicating it in this module.
+  intTestImplementation(testFixtures(project(":polaris-runtime-service")))
+  intTestImplementation(platform(libs.iceberg.bom))
+  intTestImplementation("org.apache.iceberg:iceberg-api")
+  intTestImplementation("org.apache.iceberg:iceberg-core")
+  // CatalogTests / ViewCatalogTests test fixtures used by Mysql*IT base classes.
+  intTestImplementation("org.apache.iceberg:iceberg-api:${libs.versions.iceberg.get()}:tests")
+  intTestImplementation("org.apache.iceberg:iceberg-core:${libs.versions.iceberg.get()}:tests")
+
+  intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation("org.testcontainers:testcontainers-junit-jupiter")
+  intTestImplementation("org.testcontainers:testcontainers-mysql")
+  intTestImplementation(project(":polaris-container-spec-helper"))
+
+  // Standalone JAX-RS client runtime supplying the jakarta.ws.rs.client.ClientBuilder SPI used by
+  // `PolarisClient`. RESTEasy Classic, matching the repo convention (see extensions/openlineage).
+  // Must remain `intTestRuntimeOnly` so it does not participate in Quarkus augmentation (which
+  // uses RESTEasy Reactive). The JSON provider arrives transitively via `polaris-tests`.
+  intTestRuntimeOnly(platform(libs.quarkus.bom))
+  intTestRuntimeOnly("org.jboss.resteasy:resteasy-client")
+  intTestRuntimeOnly("org.jboss.resteasy:resteasy-core")
+}
+
+// `runtime/defaults` keeps the MySQL named datasource off by default; flip it on at Quarkus
+// build time for this test module only. The matching `active=true` runtime override is set
+// by `MysqlRelationalJdbcLifeCycleManagement`.
+quarkus { quarkusBuildProperties.put("quarkus.datasource.mysql.jdbc", "true") }
+
+tasks.named("javadoc") { dependsOn("jandex") }
+
+tasks.withType<Test> {
+  if (System.getenv("AWS_REGION") == null) {
+    environment("AWS_REGION", "us-west-2")
+  }
+  environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,test-admin,test-secret")
+  val apiVersion = System.getenv("DOCKER_API_VERSION") ?: "1.44"
+  systemProperty("api.version", apiVersion)
+  jvmArgs("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
+  systemProperty("java.security.manager", "allow")
+  maxParallelForks = 1
+
+  val logsDir = project.layout.buildDirectory.get().asFile.resolve("logs")
+  jvmArgumentProviders.add(
+    CommandLineArgumentProvider {
+      listOf("-Dquarkus.log.file.path=${logsDir.resolve("polaris.log").absolutePath}")
+    }
+  )
+  doFirst {
+    logsDir.deleteRecursively()
+    project.layout.buildDirectory.get().asFile.resolve("quarkus.log").delete()
+  }
+}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlApplicationIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlApplicationIT.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
-
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
-}
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlApplicationIT extends PolarisApplicationIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlApplicationIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlApplicationIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest;
+
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlApplicationIT extends PolarisApplicationIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlJsonColumnPredicateIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlJsonColumnPredicateIT.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpecHelper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.apache.polaris.persistence.relational.jdbc.DatasourceOperations;
+import org.apache.polaris.persistence.relational.jdbc.QueryGenerator;
+import org.apache.polaris.persistence.relational.jdbc.RelationalJdbcConfiguration;
+import org.apache.polaris.persistence.relational.jdbc.models.ModelPolicyMappingRecord;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end coverage for the JSON placeholder selection described on {@code ModelRegistry}: fails
+ * with 0 rows deleted if {@link DatabaseType#asJsonConditionPlaceholder()} stops emitting {@code
+ * CAST(? AS JSON)}, which no unit test can catch because they only inspect generated SQL.
+ */
+@Testcontainers
+public class MysqlJsonColumnPredicateIT {
+
+  private static final String REALM_ID = "POLARIS";
+
+  record TestConfiguration(
+      Optional<Integer> maxRetries,
+      Optional<Long> maxDurationInMs,
+      Optional<Long> initialDelayInMs,
+      Optional<String> databaseType)
+      implements RelationalJdbcConfiguration {}
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final MySQLContainer<?> MYSQL =
+      new MySQLContainer<>(
+              containerSpecHelper("mysql", MysqlJsonColumnPredicateIT.class)
+                  .dockerImageName(null)
+                  .asCompatibleSubstituteFor("mysql"))
+          .withDatabaseName("POLARIS_SCHEMA");
+
+  private static DatasourceOperations datasourceOperations;
+
+  @BeforeAll
+  static void createSchema() throws SQLException {
+    MysqlDataSource dataSource = new MysqlDataSource();
+    dataSource.setUrl(MYSQL.getJdbcUrl());
+    dataSource.setUser(MYSQL.getUsername());
+    dataSource.setPassword(MYSQL.getPassword());
+
+    datasourceOperations =
+        new DatasourceOperations(
+            dataSource,
+            new TestConfiguration(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(DatabaseType.MYSQL.getDisplayName())));
+    datasourceOperations.executeScript(
+        DatabaseType.MYSQL.openInitScriptResource(DatabaseType.MYSQL.getLatestSchemaVersion()));
+  }
+
+  @Test
+  void deleteKeyedOnTheWholeRowMatchesTheStoredJson() throws SQLException {
+    ModelPolicyMappingRecord record =
+        ModelPolicyMappingRecord.builder()
+            .targetCatalogId(1L)
+            .targetId(2L)
+            .policyTypeCode(3)
+            .policyCatalogId(4L)
+            .policyId(5L)
+            .parameters("{\"retention\":\"30days\",\"scope\":\"ns\"}")
+            .build();
+
+    // `values()` order follows ALL_COLUMNS, which is what generateInsertQuery expects.
+    Map<String, Object> row = record.toMap(DatabaseType.MYSQL);
+    datasourceOperations.executeUpdate(
+        QueryGenerator.generateInsertQuery(
+            ModelPolicyMappingRecord.ALL_COLUMNS,
+            ModelPolicyMappingRecord.TABLE_NAME,
+            List.copyOf(row.values()),
+            REALM_ID));
+
+    // The whole row as the WHERE clause, as QueryGeneratorTest#testGenerateDeleteQuery_byObject
+    // pins it and JdbcBasePersistenceImpl#deleteFromGrantRecords still uses it.
+    row.put("realm_id", REALM_ID);
+    int deleted =
+        datasourceOperations.executeUpdate(
+            new QueryGenerator(DatabaseType.MYSQL)
+                .generateDeleteQuery(
+                    ModelPolicyMappingRecord.ALL_COLUMNS,
+                    ModelPolicyMappingRecord.TABLE_NAME,
+                    row));
+
+    assertEquals(1, deleted, "JSON column in the WHERE clause must match the stored row");
+  }
+}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlManagementServiceIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlManagementServiceIT.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
-
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
-}
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlManagementServiceIT extends PolarisManagementServiceIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlManagementServiceIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlManagementServiceIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
+
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlManagementServiceIT extends PolarisManagementServiceIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlPolicyServiceIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlPolicyServiceIT.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisPolicyServiceIntegrationTest;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
-
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
-}
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlPolicyServiceIT extends PolarisPolicyServiceIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlPolicyServiceIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlPolicyServiceIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisPolicyServiceIntegrationTest;
+
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlPolicyServiceIT extends PolarisPolicyServiceIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcLifeCycleManagement.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcLifeCycleManagement.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpecHelper;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Map;
+import org.testcontainers.containers.MySQLContainer;
+
+public class MysqlRelationalJdbcLifeCycleManagement
+    implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+  public static final String INIT_SCRIPT = "init-script";
+
+  private MySQLContainer<?> mysql;
+  private String initScript;
+  private DevServicesContext context;
+
+  @Override
+  public void init(Map<String, String> initArgs) {
+    initScript = initArgs.get(INIT_SCRIPT);
+  }
+
+  @Override
+  @SuppressWarnings("resource")
+  public Map<String, String> start() {
+    mysql =
+        new MySQLContainer<>(
+                containerSpecHelper("mysql", MysqlRelationalJdbcLifeCycleManagement.class)
+                    .dockerImageName(null)
+                    .asCompatibleSubstituteFor("mysql"))
+            .withDatabaseName("POLARIS_SCHEMA");
+
+    if (initScript != null) {
+      mysql.withInitScript(initScript);
+    }
+
+    context.containerNetworkId().ifPresent(mysql::withNetworkMode);
+    mysql.start();
+
+    return Map.of(
+        "polaris.persistence.type",
+        "relational-jdbc",
+        "polaris.persistence.relational.jdbc.database-type",
+        "mysql",
+        "polaris.persistence.relational.jdbc.max-retries",
+        "2",
+        // The named MySQL datasource is declared as inactive in the bundled defaults; tests
+        // (and production users) opt in by setting `active=true` on the named datasource.
+        "quarkus.datasource.mysql.active",
+        "true",
+        "quarkus.datasource.mysql.jdbc.url",
+        mysql.getJdbcUrl(),
+        "quarkus.datasource.mysql.username",
+        mysql.getUsername(),
+        "quarkus.datasource.mysql.password",
+        mysql.getPassword(),
+        "quarkus.datasource.mysql.jdbc.initial-size",
+        "10");
+  }
+
+  @Override
+  public void stop() {
+    if (mysql != null) {
+      try {
+        mysql.stop();
+      } finally {
+        mysql = null;
+      }
+    }
+  }
+
+  @Override
+  public void setIntegrationTestContext(DevServicesContext context) {
+    this.context = context;
+  }
+}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcProfile.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcProfile.java
@@ -16,23 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.List;
+import java.util.Map;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
+public class MysqlRelationalJdbcProfile implements QuarkusTestProfile {
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(
+        "polaris.persistence.auto-bootstrap-types",
+        "relational-jdbc",
+        "polaris.persistence.relational.jdbc.database-type",
+        "mysql");
+  }
 
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
+  @Override
+  public List<TestResourceEntry> testResources() {
+    return List.of(
+        new QuarkusTestProfile.TestResourceEntry(
+            MysqlRelationalJdbcLifeCycleManagement.class, Map.of()));
+  }
 }

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcProfile.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRelationalJdbcProfile.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.List;
+import java.util.Map;
+
+public class MysqlRelationalJdbcProfile implements QuarkusTestProfile {
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(
+        "polaris.persistence.auto-bootstrap-types",
+        "relational-jdbc",
+        "polaris.persistence.relational.jdbc.database-type",
+        "mysql");
+  }
+
+  @Override
+  public List<TestResourceEntry> testResources() {
+    return List.of(
+        new QuarkusTestProfile.TestResourceEntry(
+            MysqlRelationalJdbcLifeCycleManagement.class, Map.of()));
+  }
+}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRestCatalogIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRestCatalogIT.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisRestCatalogFileIntegrationTest;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
-
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
-}
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlRestCatalogIT extends PolarisRestCatalogFileIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRestCatalogIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlRestCatalogIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisRestCatalogFileIntegrationTest;
+
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlRestCatalogIT extends PolarisRestCatalogFileIntegrationTest {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlViewFileIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlViewFileIT.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.relational.jdbc;
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
 
-import java.util.Optional;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
 
-public interface RelationalJdbcConfiguration {
-  // max retries before giving up
-  Optional<Integer> maxRetries();
-
-  // max retry duration
-  Optional<Long> maxDurationInMs();
-
-  // initial delay
-  Optional<Long> initialDelayInMs();
-
-  /**
-   * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
-   */
-  Optional<String> databaseType();
-}
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlViewFileIT.java
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/java/org/apache/polaris/persistence/relational/jdbc/mysql/tests/MysqlViewFileIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.mysql.tests;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
+
+@TestProfile(MysqlRelationalJdbcProfile.class)
+@QuarkusIntegrationTest
+public class MysqlViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {}

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/resources/META-INF/services/org.apache.polaris.service.it.ext.PolarisServerManager
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/resources/META-INF/services/org.apache.polaris.service.it.ext.PolarisServerManager
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.apache.polaris.service.it.ServerManager

--- a/persistence/relational-jdbc-mysql/tests/src/intTest/resources/org/apache/polaris/persistence/relational/jdbc/mysql/tests/Dockerfile-mysql-version
+++ b/persistence/relational-jdbc-mysql/tests/src/intTest/resources/org/apache/polaris/persistence/relational/jdbc/mysql/tests/Dockerfile-mysql-version
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM mysql:8.0

--- a/persistence/relational-jdbc/MYSQL.md
+++ b/persistence/relational-jdbc/MYSQL.md
@@ -1,0 +1,84 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# MySQL support for the Relational JDBC backend (custom downstream build)
+
+The Relational JDBC persistence backend can run on MySQL 8.0+, alongside the officially supported PostgreSQL, CockroachDB and H2 options.
+
+> **The MySQL JDBC driver is GPL-licensed (ASF Category X) and is intentionally not bundled in the official Apache Polaris release artifacts** (see [issue #2491](https://github.com/apache/polaris/issues/2491)). The Java code that supports MySQL ships in the official source release, but enabling it requires building your own runner from source with the opt-in flag described below. The resulting runner is a *custom downstream derivative*, not an official Apache Polaris artifact, and the builder is responsible for satisfying the driver's GPL v2 + FOSS Exception obligations.
+
+## Building a MySQL-capable server
+
+Add the MySQL JDBC driver to the runner with the `-PincludeMysqlDriver=true` Gradle property:
+
+```shell
+./gradlew :polaris-server:assemble -PincludeMysqlDriver=true
+```
+
+The Docker image can be built the same way with `-Dquarkus.container-image.build=true`. To avoid overwriting the GPL-free image, pass a distinct image name:
+
+```shell
+./gradlew \
+  :polaris-server:assemble \
+  :polaris-server:quarkusAppPartsBuild --rerun \
+  -PincludeMysqlDriver=true \
+  -Dquarkus.container-image.build=true \
+  -Dquarkus.container-image.name=polaris-mysql
+```
+
+### Verification contract under `-PincludeMysqlDriver=true`
+
+Supported tasks: `:polaris-server:assemble` and the Quarkus image build (`quarkusAppPartsBuild` with `-Dquarkus.container-image.build=true`).
+
+`check`, `build`, `publishToMavenLocal`, and the `generateLicenseReport` / `checkLicense` / `licenseReportZip` tasks will fail by design because the GPL MySQL JDBC driver is intentionally absent from `LICENSE`. No license tasks are disabled — the default (GPL-free) build continues to run and pass all license checks unchanged. Downstream builders distributing the resulting (non-official) artifact are responsible for satisfying the driver's GPL v2 + FOSS Exception obligations.
+
+## Runtime configuration
+
+MySQL is exposed as a Quarkus *named* datasource (`mysql`) that is declared inactive by default. To use the MySQL backend at runtime, set the following properties (or the equivalent environment variables, e.g. `QUARKUS_DATASOURCE_MYSQL_JDBC_URL`):
+
+```properties
+polaris.persistence.type=relational-jdbc
+polaris.persistence.relational.jdbc.database-type=mysql
+
+quarkus.datasource.mysql.active=true
+quarkus.datasource.mysql.jdbc.url=jdbc:mysql://<host>:3306/POLARIS_SCHEMA
+quarkus.datasource.mysql.username=<your-username>
+quarkus.datasource.mysql.password=<your-password>
+```
+
+PostgreSQL, CockroachDB and H2 continue to use the default (unnamed) datasource and require no changes to existing configuration.
+
+If `database-type=mysql` is configured but the `mysql` named datasource is not available (for example, the runner was built without `-PincludeMysqlDriver=true`, or `quarkus.datasource.mysql.active` is left at its default of `false`), the server fails fast at startup with a message pointing back to the build flag and the `active` / connection properties above, rather than silently falling back to the default datasource.
+
+## Bootstrapping the MySQL backend
+
+The Polaris admin tool does not currently bundle the MySQL JDBC driver, so the standard admin-tool `bootstrap` flow does not apply. Instead, configure the Polaris server to bootstrap itself on first startup:
+
+```properties
+polaris.persistence.auto-bootstrap-types=in-memory,relational-jdbc
+polaris.realm-context.realms=<your-realm>
+```
+
+```shell
+POLARIS_BOOTSTRAP_CREDENTIALS=<realm>,<client-id>,<client-secret>
+```
+
+The server will execute `mysql/schema-v4.sql` and create the root principal automatically. Run a single replica for the initial bootstrap to avoid races; the bootstrap log line confirms completion.
+
+**Auto-bootstrap on persistent backends is not yet idempotent** ([apache/polaris#2324](https://github.com/apache/polaris/issues/2324)): re-running the server with these settings against an already-bootstrapped database fails on startup with `metastore manager has already been bootstrapped`. Treat the auto-bootstrap startup as a one-time operation until #2324 is resolved.

--- a/persistence/relational-jdbc/MYSQL.md
+++ b/persistence/relational-jdbc/MYSQL.md
@@ -1,0 +1,90 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# MySQL support for the Relational JDBC backend (custom downstream build)
+
+The Relational JDBC persistence backend can run on MySQL 8.0+, alongside the officially supported PostgreSQL, CockroachDB and H2 options.
+
+> **The MySQL JDBC driver is GPL-licensed (ASF Category X) and is intentionally not bundled in the official Apache Polaris release artifacts** (see [issue #2491](https://github.com/apache/polaris/issues/2491)). The Java code that supports MySQL ships in the official source release, but enabling it requires building your own runner from source with the opt-in flag described below. The resulting runner is a *custom downstream derivative*, not an official Apache Polaris artifact, and the builder is responsible for satisfying the driver's GPL v2 + FOSS Exception obligations.
+
+## Building a MySQL-capable server
+
+Add the MySQL JDBC driver to the runner with the `-PincludeMysqlDriver=true` Gradle property:
+
+```shell
+./gradlew :polaris-server:assemble -PincludeMysqlDriver=true
+```
+
+The Docker image can be built the same way with `-Dquarkus.container-image.build=true`. To avoid overwriting the GPL-free image, pass a distinct image name:
+
+```shell
+./gradlew \
+  :polaris-server:assemble \
+  :polaris-server:quarkusAppPartsBuild --rerun \
+  -PincludeMysqlDriver=true \
+  -Dquarkus.container-image.build=true \
+  -Dquarkus.container-image.name=polaris-mysql
+```
+
+### Verification contract under `-PincludeMysqlDriver=true`
+
+Supported tasks: `:polaris-server:assemble` and the Quarkus image build (`quarkusAppPartsBuild` with `-Dquarkus.container-image.build=true`).
+
+`check`, `build`, `publishToMavenLocal`, and the `generateLicenseReport` / `checkLicense` / `licenseReportZip` tasks will fail by design because the GPL MySQL JDBC driver is intentionally absent from `LICENSE`. No license tasks are disabled — the default (GPL-free) build continues to run and pass all license checks unchanged. Downstream builders distributing the resulting (non-official) artifact are responsible for satisfying the driver's GPL v2 + FOSS Exception obligations.
+
+## Runtime configuration
+
+MySQL is exposed as a Quarkus *named* datasource (`mysql`) that is declared inactive by default. To use the MySQL backend at runtime, set the following properties (or the equivalent environment variables, e.g. `QUARKUS_DATASOURCE_MYSQL_JDBC_URL`):
+
+```properties
+polaris.persistence.type=relational-jdbc
+polaris.persistence.relational.jdbc.database-type=mysql
+
+quarkus.datasource.mysql.active=true
+quarkus.datasource.mysql.jdbc.url=jdbc:mysql://<host>:3306/POLARIS_SCHEMA
+quarkus.datasource.mysql.username=<your-username>
+quarkus.datasource.mysql.password=<your-password>
+```
+
+PostgreSQL, CockroachDB and H2 continue to use the default (unnamed) datasource and require no changes to existing configuration.
+
+### Selecting the schema
+
+The generated SQL uses unqualified table names, so the schema is whatever the connection already selects. In MySQL, schema is synonymous with database, and the database is the path component of the JDBC URL — `POLARIS_SCHEMA` in the example above. Use a different name there to run several Polaris deployments in one MySQL server. The database must exist before Polaris connects, and the configured user needs privileges on it; Polaris does not issue `CREATE DATABASE`.
+
+The `quarkus.datasource.jdbc.additional-jdbc-properties.currentSchema` default that Polaris ships is a PostgreSQL driver property and applies to the default datasource, so it plays no part here: MySQL uses the named `mysql` datasource, and MySQL Connector/J has no `currentSchema` property. Do not set `currentSchema` on `quarkus.datasource.mysql.*`.
+
+If `database-type=mysql` is configured but the `mysql` named datasource is not available (for example, the runner was built without `-PincludeMysqlDriver=true`, or `quarkus.datasource.mysql.active` is left at its default of `false`), the server fails fast at startup with a message pointing back to the build flag and the `active` / connection properties above, rather than silently falling back to the default datasource.
+
+## Bootstrapping the MySQL backend
+
+The Polaris admin tool does not currently bundle the MySQL JDBC driver, so the standard admin-tool `bootstrap` flow does not apply. Instead, configure the Polaris server to bootstrap itself on first startup:
+
+```properties
+polaris.persistence.auto-bootstrap-types=in-memory,relational-jdbc
+polaris.realm-context.realms=<your-realm>
+```
+
+```shell
+POLARIS_BOOTSTRAP_CREDENTIALS=<realm>,<client-id>,<client-secret>
+```
+
+The server will execute `mysql/schema-v6.sql` and create the root principal automatically. Run a single replica for the initial bootstrap to avoid races; the bootstrap log line confirms completion.
+
+**Auto-bootstrap on persistent backends is not yet idempotent** ([apache/polaris#2324](https://github.com/apache/polaris/issues/2324)): re-running the server with these settings against an already-bootstrapped database fails on startup with `metastore manager has already been bootstrapped`. Treat the auto-bootstrap startup as a one-time operation until #2324 is resolved.

--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-api")
 
   implementation(libs.smallrye.common.annotation) // @Identifier
+  compileOnly(platform(libs.quarkus.bom))
+  compileOnly("io.quarkus:quarkus-agroal") // DataSourceLiteral for named DataSource lookup
   implementation(libs.postgresql)
 
   compileOnly(project(":polaris-immutables"))

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -34,7 +34,8 @@ import java.util.Locale;
 public enum DatabaseType {
   POSTGRES("postgres"),
   COCKROACHDB("cockroachdb"),
-  H2("h2");
+  H2("h2"),
+  MYSQL("mysql");
 
   private final String displayName; // Store the user-friendly name
 
@@ -48,6 +49,22 @@ public enum DatabaseType {
   }
 
   /**
+   * Returns the SQL placeholder text to use for equality comparisons against a JSON-typed column.
+   *
+   * <p>MySQL JSON columns require {@code CAST(? AS JSON)} so the right-hand side is parsed into a
+   * JSON value and compared structurally; comparing a JSON column to a plain string parameter is
+   * formatting-sensitive (e.g. {@code '{"a":1}'} vs {@code '{"a": 1}'}) and may not match.
+   *
+   * <p>All other supported databases use the default {@code ?} placeholder.
+   */
+  public String asJsonConditionPlaceholder() {
+    return switch (this) {
+      case MYSQL -> "CAST(? AS JSON)";
+      case POSTGRES, COCKROACHDB, H2 -> "?";
+    };
+  }
+
+  /**
    * Returns the latest schema version available for this database type. This is used as the default
    * schema version for new installations.
    */
@@ -56,6 +73,7 @@ public enum DatabaseType {
       case POSTGRES -> 4; // PostgreSQL has schemas v1, v2, v3, v4
       case COCKROACHDB -> 4; // CockroachDB schema version kept in sync with PostgreSQL
       case H2 -> 4; // H2 uses same schemas as PostgreSQL
+      case MYSQL -> 4; // MySQL has schema v4 only
     };
   }
 
@@ -64,6 +82,7 @@ public enum DatabaseType {
       case "h2" -> DatabaseType.H2;
       case "postgresql" -> DatabaseType.POSTGRES;
       case "cockroachdb" -> DatabaseType.COCKROACHDB;
+      case "mysql" -> DatabaseType.MYSQL;
       default -> throw new IllegalStateException("Unsupported DatabaseType: '" + displayName + "'");
     };
   }
@@ -100,6 +119,8 @@ public enum DatabaseType {
         inferredType = DatabaseType.POSTGRES;
       } else if (productName.contains("h2")) {
         inferredType = DatabaseType.H2;
+      } else if (productName.contains("mysql")) {
+        inferredType = DatabaseType.MYSQL;
       }
 
       // If a type was explicitly configured, use it and validate

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatabaseType.java
@@ -34,7 +34,8 @@ import java.util.Locale;
 public enum DatabaseType {
   POSTGRES("postgres"),
   COCKROACHDB("cockroachdb"),
-  H2("h2");
+  H2("h2"),
+  MYSQL("mysql");
 
   private final String displayName; // Store the user-friendly name
 
@@ -48,6 +49,17 @@ public enum DatabaseType {
   }
 
   /**
+   * Returns the SQL placeholder for an equality comparison against a JSON column. See {@code
+   * ModelRegistry} for why MySQL needs {@code CAST(? AS JSON)} and the others do not.
+   */
+  public String asJsonConditionPlaceholder() {
+    return switch (this) {
+      case MYSQL -> "CAST(? AS JSON)";
+      case POSTGRES, COCKROACHDB, H2 -> "?";
+    };
+  }
+
+  /**
    * Returns the latest schema version available for this database type. This is used as the default
    * schema version for new installations.
    */
@@ -56,6 +68,20 @@ public enum DatabaseType {
       case POSTGRES -> 6; // PostgreSQL has schemas v1, v2, v3, v4, v5, v6
       case COCKROACHDB -> 6; // CockroachDB schema version kept in sync with PostgreSQL
       case H2 -> 6; // H2 uses same schemas as PostgreSQL
+      case MYSQL -> 6; // MySQL ships schema v6 only
+    };
+  }
+
+  /**
+   * Returns the earliest schema version available for this database type. Schema resources exist
+   * for {@link #getFirstSchemaVersion()} through {@link #getLatestSchemaVersion()} only: MySQL
+   * support was added when v6 was already current, so it ships that one version and has no earlier
+   * scripts to upgrade from.
+   */
+  public int getFirstSchemaVersion() {
+    return switch (this) {
+      case POSTGRES, COCKROACHDB, H2 -> 1;
+      case MYSQL -> 6; // MySQL ships schema-v6.sql only
     };
   }
 
@@ -64,6 +90,7 @@ public enum DatabaseType {
       case "h2" -> DatabaseType.H2;
       case "postgresql" -> DatabaseType.POSTGRES;
       case "cockroachdb" -> DatabaseType.COCKROACHDB;
+      case "mysql" -> DatabaseType.MYSQL;
       default -> throw new IllegalStateException("Unsupported DatabaseType: '" + displayName + "'");
     };
   }
@@ -100,6 +127,8 @@ public enum DatabaseType {
         inferredType = DatabaseType.POSTGRES;
       } else if (productName.contains("h2")) {
         inferredType = DatabaseType.H2;
+      } else if (productName.contains("mysql")) {
+        inferredType = DatabaseType.MYSQL;
       }
 
       // If a type was explicitly configured, use it and validate
@@ -149,13 +178,16 @@ public enum DatabaseType {
    * caller.
    */
   public InputStream openInitScriptResource(int schemaVersion) {
-    // Validate schema version is within acceptable range for this database type
+    // Validate schema version is within acceptable range for this database type. The lower bound is
+    // per-database: a type that ships only recent scripts must not accept a version it has no
+    // resource for, which would fail later with a less actionable "resource not found".
+    int firstVersion = getFirstSchemaVersion();
     int latestVersion = getLatestSchemaVersion();
-    if (schemaVersion <= 0 || schemaVersion > latestVersion) {
+    if (schemaVersion < firstVersion || schemaVersion > latestVersion) {
       throw new IllegalArgumentException(
           String.format(
-              "Invalid schema version %d for database type %s. Valid range: 1-%d",
-              schemaVersion, this, latestVersion));
+              "Invalid schema version %d for database type %s. Valid range: %d-%d",
+              schemaVersion, this, firstVersion, latestVersion));
     }
 
     final String resourceName =

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -64,6 +64,14 @@ public class DatasourceOperations {
   private static final String H2_SCHEMA_DOES_NOT_EXIST = "90079";
   private static final String H2_TABLE_DOES_NOT_EXIST = "42S02";
 
+  // MYSQL STATUS CODES
+  // SQLSTATE 23000 = integrity constraint violation (duplicate key / FK / NOT NULL / CHECK).
+  // Pair with vendor error 1062 (duplicate entry) to narrow down to duplicate-key only.
+  private static final String MYSQL_CONSTRAINT_VIOLATION = "23000";
+  private static final int MYSQL_DUPLICATE_ENTRY_CODE = 1062;
+  // SQLSTATE 42S02 = base table or view not found (shared with H2).
+  private static final String MYSQL_TABLE_DOES_NOT_EXIST = "42S02";
+
   // POSTGRES RETRYABLE EXCEPTIONS
   private static final String SERIALIZATION_FAILURE_SQL_CODE = "40001";
 
@@ -94,7 +102,7 @@ public class DatasourceOperations {
     }
   }
 
-  DatabaseType getDatabaseType() {
+  public DatabaseType getDatabaseType() {
     return databaseType;
   }
 
@@ -450,7 +458,17 @@ public class DatasourceOperations {
   }
 
   public boolean isUniquenessConstraintViolation(SQLException e) {
-    return UNIQUENESS_CONSTRAINT_VIOLATION_SQL_CODE.equals(e.getSQLState());
+    // PostgreSQL / CockroachDB: SQLSTATE 23505 is specifically unique_violation.
+    if (UNIQUENESS_CONSTRAINT_VIOLATION_SQL_CODE.equals(e.getSQLState())) {
+      return true;
+    }
+    // MySQL: combine SQLSTATE 23000 with vendor error 1062 to match PG's 23505 precision.
+    if (databaseType == DatabaseType.MYSQL
+        && MYSQL_CONSTRAINT_VIOLATION.equals(e.getSQLState())
+        && e.getErrorCode() == MYSQL_DUPLICATE_ENTRY_CODE) {
+      return true;
+    }
+    return false;
   }
 
   public boolean isRelationDoesNotExist(SQLException e) {
@@ -458,7 +476,9 @@ public class DatasourceOperations {
             && (databaseType == DatabaseType.POSTGRES || databaseType == DatabaseType.COCKROACHDB))
         || ((H2_SCHEMA_DOES_NOT_EXIST.equals(e.getSQLState())
                 || H2_TABLE_DOES_NOT_EXIST.equals(e.getSQLState()))
-            && databaseType == DatabaseType.H2);
+            && databaseType == DatabaseType.H2)
+        || (MYSQL_TABLE_DOES_NOT_EXIST.equals(e.getSQLState())
+            && databaseType == DatabaseType.MYSQL);
   }
 
   private Connection borrowConnection() throws SQLException {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -68,6 +68,14 @@ public class DatasourceOperations {
   private static final String H2_TABLE_DOES_NOT_EXIST = "42S02";
   private static final String H2_TABLE_NOT_FOUND_DATABASE_EMPTY = "42S04";
 
+  // MYSQL STATUS CODES
+  // SQLSTATE 23000 = integrity constraint violation (duplicate key / FK / NOT NULL / CHECK).
+  // Pair with vendor error 1062 (duplicate entry) to narrow down to duplicate-key only.
+  private static final String MYSQL_CONSTRAINT_VIOLATION = "23000";
+  private static final int MYSQL_DUPLICATE_ENTRY_CODE = 1062;
+  // SQLSTATE 42S02 = base table or view not found (shared with H2).
+  private static final String MYSQL_TABLE_DOES_NOT_EXIST = "42S02";
+
   // POSTGRES RETRYABLE EXCEPTIONS
   private static final String SERIALIZATION_FAILURE_SQL_CODE = "40001";
 
@@ -457,7 +465,17 @@ public class DatasourceOperations {
   }
 
   public boolean isUniquenessConstraintViolation(SQLException e) {
-    return UNIQUENESS_CONSTRAINT_VIOLATION_SQL_CODE.equals(e.getSQLState());
+    // PostgreSQL / CockroachDB: SQLSTATE 23505 is specifically unique_violation.
+    if (UNIQUENESS_CONSTRAINT_VIOLATION_SQL_CODE.equals(e.getSQLState())) {
+      return true;
+    }
+    // MySQL: combine SQLSTATE 23000 with vendor error 1062 to match PG's 23505 precision.
+    if (databaseType == DatabaseType.MYSQL
+        && MYSQL_CONSTRAINT_VIOLATION.equals(e.getSQLState())
+        && e.getErrorCode() == MYSQL_DUPLICATE_ENTRY_CODE) {
+      return true;
+    }
+    return false;
   }
 
   public boolean isRelationDoesNotExist(SQLException e) {
@@ -466,7 +484,9 @@ public class DatasourceOperations {
         || ((H2_SCHEMA_DOES_NOT_EXIST.equals(e.getSQLState())
                 || H2_TABLE_DOES_NOT_EXIST.equals(e.getSQLState())
                 || H2_TABLE_NOT_FOUND_DATABASE_EMPTY.equals(e.getSQLState()))
-            && databaseType == DatabaseType.H2);
+            && databaseType == DatabaseType.H2)
+        || (MYSQL_TABLE_DOES_NOT_EXIST.equals(e.getSQLState())
+            && databaseType == DatabaseType.MYSQL);
   }
 
   private Connection borrowConnection() throws SQLException {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -90,6 +90,9 @@ public class JdbcBasePersistenceImpl
 
   private final PolarisDiagnostics diagnostics;
   private final DatasourceOperations datasourceOperations;
+  // Bound to the active DatabaseType at construction time so call sites do not need to thread
+  // the database type through every QueryGenerator.generate*Query(...) invocation.
+  private final QueryGenerator queryGenerator;
   private final PrincipalSecretsGenerator secretsGenerator;
   private final String realmId;
   private final int schemaVersion;
@@ -105,6 +108,7 @@ public class JdbcBasePersistenceImpl
       int schemaVersion) {
     this.diagnostics = diagnostics;
     this.datasourceOperations = databaseOperations;
+    this.queryGenerator = new QueryGenerator(databaseOperations.getDatabaseType());
     this.secretsGenerator = secretsGenerator;
     this.realmId = realmId;
     this.schemaVersion = schemaVersion;
@@ -232,7 +236,7 @@ public class JdbcBasePersistenceImpl
         int rowsUpdated =
             queryAction.apply(
                 connection,
-                QueryGenerator.generateUpdateQuery(
+                queryGenerator.generateUpdateQuery(
                     ModelEntity.getAllColumnNames(schemaVersion),
                     ModelEntity.TABLE_NAME,
                     values,
@@ -342,7 +346,7 @@ public class JdbcBasePersistenceImpl
             realmId);
     try {
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
     } catch (SQLException e) {
       throw new RuntimeException(
@@ -359,7 +363,7 @@ public class JdbcBasePersistenceImpl
           modelGrantRecord.toMap(datasourceOperations.getDatabaseType());
       whereClause.put("realm_id", realmId);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, whereClause));
     } catch (SQLException e) {
       throw new RuntimeException(
@@ -390,21 +394,21 @@ public class JdbcBasePersistenceImpl
           connection -> {
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelPrincipalAuthenticationData.ALL_COLUMNS,
                     ModelPrincipalAuthenticationData.TABLE_NAME,
                     params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelPolicyMappingRecord.ALL_COLUMNS,
                     ModelPolicyMappingRecord.TABLE_NAME,
                     params));
@@ -422,7 +426,7 @@ public class JdbcBasePersistenceImpl
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "type_code", typeCode, "realm_id", realmId);
     return getPolarisBaseEntity(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
   }
 
@@ -446,7 +450,7 @@ public class JdbcBasePersistenceImpl
             "realm_id",
             realmId);
     return getPolarisBaseEntity(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
   }
 
@@ -552,7 +556,7 @@ public class JdbcBasePersistenceImpl
       whereGreater = Map.of();
     }
 
-    return QueryGenerator.generateSelectQuery(
+    return queryGenerator.generateSelectQuery(
         queryProjections, ModelEntity.TABLE_NAME, whereEquals, whereGreater, orderByColumnName);
   }
 
@@ -632,7 +636,7 @@ public class JdbcBasePersistenceImpl
         Map.of("catalog_id", catalogId, "id", entityId, "realm_id", realmId);
     PolarisBaseEntity b =
         getPolarisBaseEntity(
-            QueryGenerator.generateSelectQuery(
+            queryGenerator.generateSelectQuery(
                 ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
     return b == null ? 0 : b.getGrantRecordsVersion();
   }
@@ -662,7 +666,7 @@ public class JdbcBasePersistenceImpl
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       if (results.size() > 1) {
@@ -694,7 +698,7 @@ public class JdbcBasePersistenceImpl
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       return results == null ? Collections.emptyList() : results;
@@ -717,7 +721,7 @@ public class JdbcBasePersistenceImpl
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       return results == null ? Collections.emptyList() : results;
@@ -746,7 +750,7 @@ public class JdbcBasePersistenceImpl
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params),
               new ModelEntity(schemaVersion));
       return results != null && !results.isEmpty();
@@ -851,7 +855,7 @@ public class JdbcBasePersistenceImpl
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelPrincipalAuthenticationData.ALL_COLUMNS,
                   ModelPrincipalAuthenticationData.TABLE_NAME,
                   params),
@@ -991,7 +995,7 @@ public class JdbcBasePersistenceImpl
       ModelPrincipalAuthenticationData modelPrincipalAuthenticationData =
           ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateUpdateQuery(
+          queryGenerator.generateUpdateQuery(
               ModelPrincipalAuthenticationData.ALL_COLUMNS,
               ModelPrincipalAuthenticationData.TABLE_NAME,
               modelPrincipalAuthenticationData
@@ -1021,7 +1025,7 @@ public class JdbcBasePersistenceImpl
         Map.of("principal_client_id", clientId, "principal_id", principalId, "realm_id", realmId);
     try {
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPrincipalAuthenticationData.ALL_COLUMNS,
               ModelPrincipalAuthenticationData.TABLE_NAME,
               params));
@@ -1113,7 +1117,7 @@ public class JdbcBasePersistenceImpl
       ModelPolicyMappingRecord modelPolicyMappingRecord =
           ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
       PreparedQuery updateQuery =
-          QueryGenerator.generateUpdateQuery(
+          queryGenerator.generateUpdateQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS,
               ModelPolicyMappingRecord.TABLE_NAME,
               modelPolicyMappingRecord
@@ -1139,7 +1143,7 @@ public class JdbcBasePersistenceImpl
           modelPolicyMappingRecord.toMap(datasourceOperations.getDatabaseType());
       objectMap.put("realm_id", realmId);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS,
               ModelPolicyMappingRecord.TABLE_NAME,
               objectMap));
@@ -1168,7 +1172,7 @@ public class JdbcBasePersistenceImpl
       }
       queryParams.put("realm_id", realmId);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS,
               ModelPolicyMappingRecord.TABLE_NAME,
               queryParams));
@@ -1203,7 +1207,7 @@ public class JdbcBasePersistenceImpl
             realmId);
     List<PolarisPolicyMappingRecord> results =
         fetchPolicyMappingRecords(
-            QueryGenerator.generateSelectQuery(
+            queryGenerator.generateSelectQuery(
                 ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
     Preconditions.checkState(results.size() <= 1, "More than one policy mapping records found");
     return results.size() == 1 ? results.getFirst() : null;
@@ -1227,7 +1231,7 @@ public class JdbcBasePersistenceImpl
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
@@ -1264,7 +1268,7 @@ public class JdbcBasePersistenceImpl
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params),
         connection);
   }
@@ -1276,7 +1280,7 @@ public class JdbcBasePersistenceImpl
     Map<String, Object> params =
         Map.of("target_catalog_id", targetCatalogId, "target_id", targetId, "realm_id", realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
@@ -1298,7 +1302,7 @@ public class JdbcBasePersistenceImpl
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -88,6 +88,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   private final PolarisDiagnostics diagnostics;
   private final DatasourceOperations datasourceOperations;
+  // Bound to the active DatabaseType at construction time so call sites do not need to thread
+  // the database type through every QueryGenerator.generate*Query(...) invocation.
+  private final QueryGenerator queryGenerator;
   private final PrincipalSecretsGenerator secretsGenerator;
   private final String realmId;
   private final int schemaVersion;
@@ -118,6 +121,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       int schemaVersion) {
     this.diagnostics = diagnostics;
     this.datasourceOperations = databaseOperations;
+    this.queryGenerator = new QueryGenerator(databaseOperations.getDatabaseType());
     this.secretsGenerator = secretsGenerator;
     this.realmId = realmId;
     this.schemaVersion = schemaVersion;
@@ -186,7 +190,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     AtomicBoolean exists = new AtomicBoolean(false);
     datasourceOperations.executeSelectOverStream(
         connection,
-        QueryGenerator.generateExistsQuery(
+        queryGenerator.generateExistsQuery(
             ModelEntity.getAllColumnNames(schemaVersion),
             ModelEntity.TABLE_NAME,
             entityKeyParams(entityId)),
@@ -260,7 +264,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         int rowsUpdated =
             queryAction.apply(
                 connection,
-                QueryGenerator.generateUpdateQuery(
+                queryGenerator.generateUpdateQuery(
                     ModelEntity.getAllColumnNames(schemaVersion),
                     ModelEntity.TABLE_NAME,
                     values,
@@ -370,7 +374,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             realmId);
     try {
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
     } catch (SQLException e) {
       throw new RuntimeException(
@@ -387,7 +391,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
           modelGrantRecord.toMap(datasourceOperations.getDatabaseType());
       whereClause.put("realm_id", realmId);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, whereClause));
     } catch (SQLException e) {
       throw new RuntimeException(
@@ -418,21 +422,21 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
           connection -> {
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelPrincipalAuthenticationData.ALL_COLUMNS,
                     ModelPrincipalAuthenticationData.TABLE_NAME,
                     params));
             datasourceOperations.execute(
                 connection,
-                QueryGenerator.generateDeleteQuery(
+                queryGenerator.generateDeleteQuery(
                     ModelPolicyMappingRecord.ALL_COLUMNS,
                     ModelPolicyMappingRecord.TABLE_NAME,
                     params));
@@ -450,7 +454,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "type_code", typeCode, "realm_id", realmId);
     return getPolarisBaseEntity(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
   }
 
@@ -478,7 +482,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             "realm_id",
             realmId);
     return getPolarisBaseEntity(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
   }
 
@@ -591,7 +595,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       whereGreater = Map.of();
     }
 
-    return QueryGenerator.generateSelectQuery(
+    return queryGenerator.generateSelectQuery(
         queryProjections,
         ModelEntity.TABLE_NAME,
         whereEquals,
@@ -706,7 +710,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       if (results.size() > 1) {
@@ -738,7 +742,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       return results == null ? Collections.emptyList() : results;
@@ -761,7 +765,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelGrantRecord.ALL_COLUMNS, ModelGrantRecord.TABLE_NAME, params),
               new ModelGrantRecord());
       return results == null ? Collections.emptyList() : results;
@@ -790,7 +794,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateExistsQuery(
+              queryGenerator.generateExistsQuery(
                   ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params),
               ROW_EXISTS_CONVERTER);
       return results != null && !results.isEmpty();
@@ -895,7 +899,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     try {
       var results =
           datasourceOperations.executeSelect(
-              QueryGenerator.generateSelectQuery(
+              queryGenerator.generateSelectQuery(
                   ModelPrincipalAuthenticationData.ALL_COLUMNS,
                   ModelPrincipalAuthenticationData.TABLE_NAME,
                   params),
@@ -1035,7 +1039,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       ModelPrincipalAuthenticationData modelPrincipalAuthenticationData =
           ModelPrincipalAuthenticationData.fromPrincipalAuthenticationData(principalSecrets);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateUpdateQuery(
+          queryGenerator.generateUpdateQuery(
               ModelPrincipalAuthenticationData.ALL_COLUMNS,
               ModelPrincipalAuthenticationData.TABLE_NAME,
               modelPrincipalAuthenticationData
@@ -1065,7 +1069,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         Map.of("principal_client_id", clientId, "principal_id", principalId, "realm_id", realmId);
     try {
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPrincipalAuthenticationData.ALL_COLUMNS,
               ModelPrincipalAuthenticationData.TABLE_NAME,
               params));
@@ -1144,7 +1148,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       ModelPolicyMappingRecord modelPolicyMappingRecord =
           ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
       PreparedQuery updateQuery =
-          QueryGenerator.generateUpdateQuery(
+          queryGenerator.generateUpdateQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS,
               ModelPolicyMappingRecord.TABLE_NAME,
               modelPolicyMappingRecord
@@ -1204,7 +1208,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       // cannot turn this delete into a no-op.
       Map<String, Object> params = policyMappingIdentity(record);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
     } catch (SQLException e) {
       throw new RuntimeException(
@@ -1231,7 +1235,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       }
       queryParams.put("realm_id", realmId);
       datasourceOperations.executeUpdate(
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelPolicyMappingRecord.ALL_COLUMNS,
               ModelPolicyMappingRecord.TABLE_NAME,
               queryParams));
@@ -1254,7 +1258,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         policyMappingIdentity(targetCatalogId, targetId, policyTypeCode, policyCatalogId, policyId);
     List<PolarisPolicyMappingRecord> results =
         fetchPolicyMappingRecords(
-            QueryGenerator.generateSelectQuery(
+            queryGenerator.generateSelectQuery(
                 ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
     Preconditions.checkState(results.size() <= 1, "More than one policy mapping records found");
     return results.size() == 1 ? results.getFirst() : null;
@@ -1278,7 +1282,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
@@ -1315,7 +1319,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params),
         connection);
   }
@@ -1327,7 +1331,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     Map<String, Object> params =
         Map.of("target_catalog_id", targetCatalogId, "target_id", targetId, "realm_id", realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
@@ -1349,7 +1353,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             "realm_id",
             realmId);
     return fetchPolicyMappingRecords(
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -20,8 +20,10 @@ package org.apache.polaris.persistence.relational.jdbc;
 
 import static org.apache.polaris.core.auth.AuthBootstrapUtil.createPolarisPrincipalForRealm;
 
+import io.quarkus.agroal.DataSource.DataSourceLiteral;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
@@ -94,8 +96,38 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Produces
   @ApplicationScoped
   static DatasourceOperations produceDatasourceOperations(
-      Instance<DataSource> dataSource, RelationalJdbcConfiguration relationalJdbcConfiguration) {
-    return new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
+      Instance<DataSource> defaultDataSource,
+      @Any Instance<DataSource> dataSources,
+      RelationalJdbcConfiguration relationalJdbcConfiguration) {
+    Optional<String> configuredType = relationalJdbcConfiguration.databaseType();
+    String mysql = DatabaseType.MYSQL.getDisplayName();
+
+    // Use a named DataSource if one is declared for the configured database-type; otherwise fall
+    // back to the default (unnamed) DataSource shared by PostgreSQL, CockroachDB and H2.
+    //
+    // MySQL is the only backend that requires its own named DataSource (it needs the GPL MySQL
+    // driver, which is opt-in at build time and inactive by default). If MySQL is configured but
+    // its named DataSource is not resolvable, fail fast at the fallback point with actionable
+    // guidance instead of silently using the default (PostgreSQL-driver) DataSource — that would
+    // otherwise surface much later as a confusing database-type mismatch.
+    DataSource ds =
+        configuredType
+            .map(type -> dataSources.select(new DataSourceLiteral(type)))
+            .filter(Instance::isResolvable)
+            .map(Instance::get)
+            .orElseGet(
+                () -> {
+                  if (configuredType.map(type -> type.equals(mysql)).orElse(false)) {
+                    throw new IllegalStateException(
+                        "Database type 'mysql' is configured but the 'mysql' named datasource is"
+                            + " not available. Build the server with -PincludeMysqlDriver=true and"
+                            + " enable the datasource at runtime: quarkus.datasource.mysql.active="
+                            + "true together with quarkus.datasource.mysql.jdbc.url, .username and"
+                            + " .password.");
+                  }
+                  return defaultDataSource.get();
+                });
+    return new DatasourceOperations(ds, relationalJdbcConfiguration);
   }
 
   protected PrincipalSecretsGenerator secretsGenerator(

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -20,14 +20,17 @@ package org.apache.polaris.persistence.relational.jdbc;
 
 import static org.apache.polaris.core.auth.AuthBootstrapUtil.createPolarisPrincipalForRealm;
 
+import io.quarkus.agroal.DataSource.DataSourceLiteral;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -93,8 +96,46 @@ public class JdbcMetaStoreManagerFactory implements MetaStoreManagerFactory {
   @Produces
   @ApplicationScoped
   static DatasourceOperations produceDatasourceOperations(
-      Instance<DataSource> dataSource, RelationalJdbcConfiguration relationalJdbcConfiguration) {
-    return new DatasourceOperations(dataSource.get(), relationalJdbcConfiguration);
+      Instance<DataSource> defaultDataSource,
+      @Any Instance<DataSource> dataSources,
+      RelationalJdbcConfiguration relationalJdbcConfiguration) {
+    Optional<String> configuredType = relationalJdbcConfiguration.databaseType();
+    String mysql = DatabaseType.MYSQL.getDisplayName();
+
+    // Use a named DataSource if one is declared for the configured database-type; otherwise fall
+    // back to the default (unnamed) DataSource shared by PostgreSQL, CockroachDB and H2.
+    //
+    // MySQL is the only backend that requires its own named DataSource (it needs the GPL MySQL
+    // driver, which is opt-in at build time and inactive by default). If MySQL is configured but
+    // its named DataSource is not resolvable, fail fast at the fallback point with actionable
+    // guidance instead of silently using the default (PostgreSQL-driver) DataSource — that would
+    // otherwise surface much later as a confusing database-type mismatch.
+    //
+    // `DatabaseType.fromDisplayName` matches case-insensitively, so `database-type=MySQL` is a
+    // valid configuration. Canonicalize it before it is used as a DataSource name or compared,
+    // otherwise that spelling resolves no named DataSource *and* skips the guard below, which is
+    // exactly the silent fallback this code exists to prevent. Only the MySQL spelling is
+    // canonicalized; other backends keep using the configured value verbatim.
+    boolean mysqlConfigured =
+        configuredType.map(type -> type.toLowerCase(Locale.ROOT).equals(mysql)).orElse(false);
+    DataSource ds =
+        configuredType
+            .map(type -> dataSources.select(new DataSourceLiteral(mysqlConfigured ? mysql : type)))
+            .filter(Instance::isResolvable)
+            .map(Instance::get)
+            .orElseGet(
+                () -> {
+                  if (mysqlConfigured) {
+                    throw new IllegalStateException(
+                        "Database type 'mysql' is configured but the 'mysql' named datasource is"
+                            + " not available. Build the server with -PincludeMysqlDriver=true and"
+                            + " enable the datasource at runtime: quarkus.datasource.mysql.active="
+                            + "true together with quarkus.datasource.mysql.jdbc.url, .username and"
+                            + " .password.");
+                  }
+                  return defaultDataSource.get();
+                });
+    return new DatasourceOperations(ds, relationalJdbcConfiguration);
   }
 
   protected PrincipalSecretsGenerator secretsGenerator(

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -32,12 +32,22 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelGrantRecord;
+import org.apache.polaris.persistence.relational.jdbc.models.ModelRegistry;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Utility class to generate parameterized SQL queries (SELECT, INSERT, UPDATE, DELETE). Ensures
- * consistent SQL generation and protects against injection by managing parameters separately.
+ * Generates parameterized SQL queries (SELECT, INSERT, UPDATE, DELETE). Ensures consistent SQL
+ * generation and protects against injection by managing parameters separately.
+ *
+ * <p>An instance is bound to a {@link DatabaseType} at construction time; the active database is
+ * not passed through every public method, so callers do not need to thread it through the call
+ * site. This keeps database-type knowledge contained at the persistence-layer boundary (typically a
+ * single field per {@code JdbcBasePersistenceImpl}).
+ *
+ * <p>Methods that produce SQL whose shape does not depend on the database type (INSERT, the
+ * hard-coded grant-record DELETE, the schema-version SELECT, etc.) are kept as {@code static}
+ * because callers can reuse them without a {@code QueryGenerator} instance.
  */
 public class QueryGenerator {
 
@@ -50,6 +60,17 @@ public class QueryGenerator {
   /** A container for the query fragment SQL string and the ordered parameter values. */
   record QueryFragment(String sql, List<Object> parameters) {}
 
+  private final DatabaseType databaseType;
+
+  public QueryGenerator(@NonNull DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
+
+  /** Returns the {@link DatabaseType} bound to this generator. */
+  public DatabaseType databaseType() {
+    return databaseType;
+  }
+
   /**
    * Generates a SELECT query with projection and filtering.
    *
@@ -59,7 +80,7 @@ public class QueryGenerator {
    * @return A parameterized SELECT query.
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
@@ -75,20 +96,24 @@ public class QueryGenerator {
    * @return A parameterized SELECT query.
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater,
       @Nullable String orderByColumn) {
     QueryFragment where =
-        generateWhereClause(new HashSet<>(projections), whereEquals, whereGreater);
-    PreparedQuery query = generateSelectQuery(projections, tableName, where.sql(), orderByColumn);
+        generateWhereClause(tableName, new HashSet<>(projections), whereEquals, whereGreater);
+    PreparedQuery query =
+        generateSelectQueryStatic(projections, tableName, where.sql(), orderByColumn);
     return new PreparedQuery(query.sql(), where.parameters());
   }
 
   /**
    * Builds a DELETE query to remove grant records for a given entity.
+   *
+   * <p>The WHERE clause is hard-coded and does not reference JSON columns, so this method does not
+   * need a {@link DatabaseType} and stays static.
    *
    * @param entity The target entity (either grantee or securable).
    * @param realmId The associated realm.
@@ -112,6 +137,9 @@ public class QueryGenerator {
   /**
    * Builds a SELECT query using a list of entity ID pairs (catalog_id, id).
    *
+   * <p>The WHERE clause is constructed manually and does not reference JSON columns, so this method
+   * stays static.
+   *
    * @param realmId Realm to filter by.
    * @param schemaVersion The schema version of entities table to query
    * @param entityIds List of PolarisEntityId pairs.
@@ -132,7 +160,7 @@ public class QueryGenerator {
     params.add(realmId);
     String where = " WHERE (catalog_id, id) IN (" + placeholders + ") AND realm_id = ?";
     return new PreparedQuery(
-        generateSelectQuery(
+        generateSelectQueryStatic(
                 ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, where, null)
             .sql(),
         params);
@@ -140,6 +168,9 @@ public class QueryGenerator {
 
   /**
    * Generates an INSERT query for a given table.
+   *
+   * <p>INSERT does not have a WHERE clause and the per-column placeholder is always {@code ?}, so
+   * this method stays static.
    *
    * @param allColumns Columns to insert values into.
    * @param tableName Target table name.
@@ -178,13 +209,14 @@ public class QueryGenerator {
    * @param whereClause Conditions for filtering rows to update.
    * @return UPDATE query with parameter values.
    */
-  public static PreparedQuery generateUpdateQuery(
+  public PreparedQuery generateUpdateQuery(
       @NonNull List<String> allColumns,
       @NonNull String tableName,
       @NonNull List<Object> values,
       @NonNull Map<String, Object> whereClause) {
     List<Object> bindingParams = new ArrayList<>(values);
-    QueryFragment where = generateWhereClause(new HashSet<>(allColumns), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(allColumns), whereClause, Map.of());
     String setClause = allColumns.stream().map(c -> c + " = ?").collect(Collectors.joining(", "));
     String sql =
         "UPDATE " + getFullyQualifiedTableName(tableName) + " SET " + setClause + where.sql();
@@ -209,7 +241,7 @@ public class QueryGenerator {
    * @param whereIsNotNull Columns that must be NOT NULL.
    * @return UPDATE query with parameter bindings.
    */
-  public static PreparedQuery generateUpdateQuery(
+  public PreparedQuery generateUpdateQuery(
       @NonNull List<String> tableColumns,
       @NonNull String tableName,
       @NonNull Map<String, Object> setClause,
@@ -227,7 +259,7 @@ public class QueryGenerator {
 
     QueryFragment where =
         generateWhereClauseExtended(
-            columns, whereEquals, whereGreater, whereLess, whereIsNull, whereIsNotNull);
+            tableName, columns, whereEquals, whereGreater, whereLess, whereIsNull, whereIsNotNull);
 
     List<String> setParts = new ArrayList<>();
     List<Object> params = new ArrayList<>();
@@ -254,11 +286,12 @@ public class QueryGenerator {
    * @param whereClause Column-value filters.
    * @return DELETE query with parameter bindings.
    */
-  public static PreparedQuery generateDeleteQuery(
+  public PreparedQuery generateDeleteQuery(
       @NonNull List<String> tableColumns,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
-    QueryFragment where = generateWhereClause(new HashSet<>(tableColumns), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(tableColumns), whereClause, Map.of());
     return new PreparedQuery(
         "DELETE FROM " + getFullyQualifiedTableName(tableName) + where.sql(), where.parameters());
   }
@@ -267,7 +300,7 @@ public class QueryGenerator {
    * Builds a DELETE query that supports richer WHERE predicates (equality, greater-than, less-than,
    * IS NULL, IS NOT NULL).
    */
-  public static PreparedQuery generateDeleteQuery(
+  public PreparedQuery generateDeleteQuery(
       @NonNull List<String> tableColumns,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereEquals,
@@ -278,12 +311,12 @@ public class QueryGenerator {
     Set<String> columns = new HashSet<>(tableColumns);
     QueryFragment where =
         generateWhereClauseExtended(
-            columns, whereEquals, whereGreater, whereLess, whereIsNull, whereIsNotNull);
+            tableName, columns, whereEquals, whereGreater, whereLess, whereIsNull, whereIsNotNull);
     return new PreparedQuery(
         "DELETE FROM " + getFullyQualifiedTableName(tableName) + where.sql(), where.parameters());
   }
 
-  private static PreparedQuery generateSelectQuery(
+  private static PreparedQuery generateSelectQueryStatic(
       @NonNull List<String> columnNames,
       @NonNull String tableName,
       @NonNull String filter,
@@ -301,12 +334,13 @@ public class QueryGenerator {
   }
 
   @VisibleForTesting
-  static QueryFragment generateWhereClause(
+  QueryFragment generateWhereClause(
+      @NonNull String tableName,
       @NonNull Set<String> tableColumns,
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater) {
     return generateWhereClauseExtended(
-        tableColumns, whereEquals, whereGreater, Map.of(), Set.of(), Set.of());
+        tableName, tableColumns, whereEquals, whereGreater, Map.of(), Set.of(), Set.of());
   }
 
   private static void validateColumns(
@@ -319,7 +353,8 @@ public class QueryGenerator {
   }
 
   @VisibleForTesting
-  static QueryFragment generateWhereClauseExtended(
+  QueryFragment generateWhereClauseExtended(
+      @NonNull String tableName,
       @NonNull Set<String> tableColumns,
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater,
@@ -335,7 +370,12 @@ public class QueryGenerator {
     List<String> conditions = new ArrayList<>();
     List<Object> parameters = new ArrayList<>();
     for (Map.Entry<String, Object> entry : whereEquals.entrySet()) {
-      conditions.add(entry.getKey() + " = ?");
+      String column = entry.getKey();
+      if (ModelRegistry.isJsonColumn(tableName, column)) {
+        conditions.add(column + " = " + databaseType.asJsonConditionPlaceholder());
+      } else {
+        conditions.add(column + " = ?");
+      }
       parameters.add(entry.getValue());
     }
     for (Map.Entry<String, Object> entry : whereGreater.entrySet()) {
@@ -414,7 +454,7 @@ public class QueryGenerator {
 
     QueryFragment where = new QueryFragment(clause, finalParams);
     PreparedQuery query =
-        generateSelectQuery(
+        generateSelectQueryStatic(
             ModelEntity.getAllColumnNames(schemaVersion),
             ModelEntity.TABLE_NAME,
             where.sql(),

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -33,16 +33,26 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelGrantRecord;
+import org.apache.polaris.persistence.relational.jdbc.models.ModelRegistry;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Utility class to generate parameterized SQL queries (SELECT, INSERT, UPDATE, DELETE). Ensures
- * consistent SQL generation and protects against injection by managing parameters separately.
+ * Generates parameterized SQL queries (SELECT, INSERT, UPDATE, DELETE). Ensures consistent SQL
+ * generation and protects against injection by managing parameters separately.
  *
  * <p>Generated queries reference tables by their unqualified names; the schema holding the Polaris
  * tables is selected through the datasource configuration (for example the PostgreSQL driver's
  * {@code currentSchema} connection property), so the persistence code is agnostic of it.
+ *
+ * <p>An instance is bound to a {@link DatabaseType} at construction time; the active database is
+ * not passed through every public method, so callers do not need to thread it through the call
+ * site. This keeps database-type knowledge contained at the persistence-layer boundary (typically a
+ * single field per {@code JdbcBasePersistenceImpl}).
+ *
+ * <p>Methods that produce SQL whose shape does not depend on the database type (INSERT, the
+ * hard-coded grant-record DELETE, the schema-version SELECT, etc.) are kept as {@code static}
+ * because callers can reuse them without a {@code QueryGenerator} instance.
  */
 public class QueryGenerator {
 
@@ -55,6 +65,12 @@ public class QueryGenerator {
   /** A container for the query fragment SQL string and the ordered parameter values. */
   record QueryFragment(String sql, List<Object> parameters) {}
 
+  private final DatabaseType databaseType;
+
+  public QueryGenerator(@NonNull DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
+
   /**
    * Generates a SELECT query with projection and filtering.
    *
@@ -65,7 +81,7 @@ public class QueryGenerator {
    * @throws IllegalArgumentException if any whereClause column isn't in projections or if limit is
    *     not positive.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
@@ -83,12 +99,13 @@ public class QueryGenerator {
    * @return A parameterized SELECT query with a LIMIT clause.
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause,
       int limit) {
-    QueryFragment where = generateWhereClause(new HashSet<>(projections), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(projections), whereClause, Map.of());
     PreparedQuery query = generateSelectQuery(projections, tableName, where.sql(), null, limit);
     return new PreparedQuery(query.sql(), where.parameters());
   }
@@ -102,7 +119,7 @@ public class QueryGenerator {
    * @return A parameterized SELECT query.
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereEquals,
@@ -125,7 +142,7 @@ public class QueryGenerator {
    * @throws IllegalArgumentException if any whereClause column isn't in projections or if limit is
    *     not positive.
    */
-  public static PreparedQuery generateSelectQuery(
+  public PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereEquals,
@@ -133,7 +150,7 @@ public class QueryGenerator {
       @Nullable String orderByColumn,
       @Nullable Integer limit) {
     QueryFragment where =
-        generateWhereClause(new HashSet<>(projections), whereEquals, whereGreater);
+        generateWhereClause(tableName, new HashSet<>(projections), whereEquals, whereGreater);
     PreparedQuery query =
         generateSelectQuery(projections, tableName, where.sql(), orderByColumn, limit);
     return new PreparedQuery(query.sql(), where.parameters());
@@ -201,7 +218,7 @@ public class QueryGenerator {
     params.add(realmId);
     String where = " WHERE (catalog_id, id) IN (" + placeholders + ") AND realm_id = ?";
     return new PreparedQuery(
-        generateSelectQuery(columns, ModelEntity.TABLE_NAME, where, null).sql(), params);
+        generateSelectQueryStatic(columns, ModelEntity.TABLE_NAME, where, null).sql(), params);
   }
 
   /**
@@ -237,13 +254,14 @@ public class QueryGenerator {
    * @param whereClause Conditions for filtering rows to update.
    * @return UPDATE query with parameter values.
    */
-  public static PreparedQuery generateUpdateQuery(
+  public PreparedQuery generateUpdateQuery(
       @NonNull List<String> allColumns,
       @NonNull String tableName,
       @NonNull List<Object> values,
       @NonNull Map<String, Object> whereClause) {
     List<Object> bindingParams = new ArrayList<>(values);
-    QueryFragment where = generateWhereClause(new HashSet<>(allColumns), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(allColumns), whereClause, Map.of());
     String setClause = allColumns.stream().map(c -> c + " = ?").collect(Collectors.joining(", "));
     String sql = "UPDATE " + tableName + " SET " + setClause + where.sql();
     bindingParams.addAll(where.parameters());
@@ -258,15 +276,16 @@ public class QueryGenerator {
    * @param whereClause Column-value filters.
    * @return DELETE query with parameter bindings.
    */
-  public static PreparedQuery generateDeleteQuery(
+  public PreparedQuery generateDeleteQuery(
       @NonNull List<String> tableColumns,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
-    QueryFragment where = generateWhereClause(new HashSet<>(tableColumns), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(tableColumns), whereClause, Map.of());
     return new PreparedQuery("DELETE FROM " + tableName + where.sql(), where.parameters());
   }
 
-  private static PreparedQuery generateSelectQuery(
+  private static PreparedQuery generateSelectQueryStatic(
       @NonNull List<String> columnNames,
       @NonNull String tableName,
       @NonNull String filter,
@@ -294,12 +313,13 @@ public class QueryGenerator {
   }
 
   @VisibleForTesting
-  static QueryFragment generateWhereClause(
+  QueryFragment generateWhereClause(
+      @NonNull String tableName,
       @NonNull Set<String> tableColumns,
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater) {
     return generateWhereClauseExtended(
-        tableColumns, whereEquals, whereGreater, Map.of(), Set.of(), Set.of());
+        tableName, tableColumns, whereEquals, whereGreater, Map.of(), Set.of(), Set.of());
   }
 
   private static void validateColumns(
@@ -312,7 +332,8 @@ public class QueryGenerator {
   }
 
   @VisibleForTesting
-  static QueryFragment generateWhereClauseExtended(
+  QueryFragment generateWhereClauseExtended(
+      @NonNull String tableName,
       @NonNull Set<String> tableColumns,
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater,
@@ -328,7 +349,12 @@ public class QueryGenerator {
     List<String> conditions = new ArrayList<>();
     List<Object> parameters = new ArrayList<>();
     for (Map.Entry<String, Object> entry : whereEquals.entrySet()) {
-      conditions.add(entry.getKey() + " = ?");
+      String column = entry.getKey();
+      if (ModelRegistry.isJsonColumn(tableName, column)) {
+        conditions.add(column + " = " + databaseType.asJsonConditionPlaceholder());
+      } else {
+        conditions.add(column + " = ?");
+      }
       parameters.add(entry.getValue());
     }
     for (Map.Entry<String, Object> entry : whereGreater.entrySet()) {
@@ -358,11 +384,12 @@ public class QueryGenerator {
    * Generates a {@code SELECT 1 ... WHERE ... LIMIT 1} query to test row existence without fetching
    * any column data. All filter conditions must be supplied in {@code whereClause}.
    */
-  public static PreparedQuery generateExistsQuery(
+  public PreparedQuery generateExistsQuery(
       @NonNull List<String> tableColumns,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
-    QueryFragment where = generateWhereClause(new HashSet<>(tableColumns), whereClause, Map.of());
+    QueryFragment where =
+        generateWhereClause(tableName, new HashSet<>(tableColumns), whereClause, Map.of());
     String sql = "SELECT 1 FROM " + tableName + where.sql() + " LIMIT 1";
     return new PreparedQuery(sql, where.parameters());
   }
@@ -439,7 +466,7 @@ public class QueryGenerator {
 
     QueryFragment where = new QueryFragment(clause, finalParams);
     PreparedQuery query =
-        generateSelectQuery(
+        generateSelectQueryStatic(
             ModelEntity.getAllColumnNames(schemaVersion),
             ModelEntity.TABLE_NAME,
             where.sql(),

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcConfiguration.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcConfiguration.java
@@ -32,7 +32,7 @@ public interface RelationalJdbcConfiguration {
 
   /**
    * Explicitly configured database type. If not specified, the database type will be inferred from
-   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2"
+   * the JDBC connection metadata. Supported values: "postgresql", "cockroachdb", "h2", "mysql"
    */
   Optional<String> databaseType();
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
@@ -40,11 +40,13 @@ import org.jspecify.annotations.NonNull;
 public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
 
   private final DatasourceOperations datasourceOperations;
+  private final QueryGenerator queryGenerator;
 
   public RelationalJdbcIdempotencyStore(
       @NonNull DataSource dataSource, @NonNull RelationalJdbcConfiguration cfg)
       throws SQLException {
     this.datasourceOperations = new DatasourceOperations(dataSource, cfg);
+    this.queryGenerator = new QueryGenerator(datasourceOperations.getDatabaseType());
   }
 
   @Override
@@ -94,7 +96,7 @@ public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
   public Optional<IdempotencyRecord> load(String realmId, String idempotencyKey) {
     try {
       QueryGenerator.PreparedQuery query =
-          QueryGenerator.generateSelectQuery(
+          queryGenerator.generateSelectQuery(
               ModelIdempotencyRecord.ALL_COLUMNS,
               ModelIdempotencyRecord.TABLE_NAME,
               Map.of(
@@ -150,7 +152,7 @@ public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
     }
 
     QueryGenerator.PreparedQuery update =
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator.generateUpdateQuery(
             ModelIdempotencyRecord.ALL_COLUMNS,
             ModelIdempotencyRecord.TABLE_NAME,
             Map.of(
@@ -213,7 +215,7 @@ public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
     whereEquals.put(ModelIdempotencyRecord.IDEMPOTENCY_KEY, idempotencyKey);
 
     QueryGenerator.PreparedQuery update =
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator.generateUpdateQuery(
             ModelIdempotencyRecord.ALL_COLUMNS,
             ModelIdempotencyRecord.TABLE_NAME,
             setClause,
@@ -234,7 +236,7 @@ public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
   public int purgeExpired(String realmId, Instant before) {
     try {
       QueryGenerator.PreparedQuery delete =
-          QueryGenerator.generateDeleteQuery(
+          queryGenerator.generateDeleteQuery(
               ModelIdempotencyRecord.ALL_COLUMNS,
               ModelIdempotencyRecord.TABLE_NAME,
               Map.of(ModelIdempotencyRecord.REALM_ID, realmId),

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/Converter.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/Converter.java
@@ -50,4 +50,11 @@ public interface Converter<T> {
       throw new RuntimeException(e);
     }
   }
+
+  default Object wrapJsonForDatabase(String json, DatabaseType databaseType) {
+    return switch (databaseType) {
+      case POSTGRES -> toJsonbPGobject(json);
+      case MYSQL, H2, COCKROACHDB -> json;
+    };
+  }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.persistence.metrics.CommitMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
@@ -103,6 +104,8 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
           TOTAL_DURATION_MS,
           ATTEMPTS,
           METADATA);
+
+  Set<String> JSON_COLUMNS = Set.of(METADATA);
 
   // Getters
   String getReportId();
@@ -241,11 +244,8 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
     map.put(TOTAL_DURATION_MS, getTotalDurationMs());
     map.put(ATTEMPTS, getAttempts());
 
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(METADATA, toJsonbPGobject(getMetadata() != null ? getMetadata() : "{}"));
-    } else {
-      map.put(METADATA, getMetadata() != null ? getMetadata() : "{}");
-    }
+    map.put(
+        METADATA, wrapJsonForDatabase(getMetadata() != null ? getMetadata() : "{}", databaseType));
     return map;
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -32,6 +33,8 @@ import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 
 public class ModelEntity implements Converter<PolarisBaseEntity> {
   public static final String TABLE_NAME = "ENTITIES";
+
+  public static final Set<String> JSON_COLUMNS = Set.of("properties", "internal_properties");
 
   public static final String ID_COLUMN = "id";
 
@@ -256,13 +259,8 @@ public class ModelEntity implements Converter<PolarisBaseEntity> {
     map.put("purge_timestamp", this.getPurgeTimestamp());
     map.put("to_purge_timestamp", this.getToPurgeTimestamp());
     map.put("last_update_timestamp", this.getLastUpdateTimestamp());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("properties", toJsonbPGobject(this.getProperties()));
-      map.put("internal_properties", toJsonbPGobject(this.getInternalProperties()));
-    } else {
-      map.put("properties", this.getProperties());
-      map.put("internal_properties", this.getInternalProperties());
-    }
+    map.put("properties", wrapJsonForDatabase(this.getProperties(), databaseType));
+    map.put("internal_properties", wrapJsonForDatabase(this.getInternalProperties(), databaseType));
     map.put("grant_records_version", this.getGrantRecordsVersion());
     if (this.getSchemaVersion() >= 2) {
       map.put("location_without_scheme", this.getLocationWithoutScheme());

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEntity.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -32,6 +33,8 @@ import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 
 public class ModelEntity implements Converter<PolarisBaseEntity> {
   public static final String TABLE_NAME = "ENTITIES";
+
+  public static final Set<String> JSON_COLUMNS = Set.of("properties", "internal_properties");
 
   public static final String ID_COLUMN = "id";
 
@@ -260,13 +263,8 @@ public class ModelEntity implements Converter<PolarisBaseEntity> {
     map.put("purge_timestamp", this.getPurgeTimestamp());
     map.put("to_purge_timestamp", this.getToPurgeTimestamp());
     map.put("last_update_timestamp", this.getLastUpdateTimestamp());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("properties", toJsonbPGobject(this.getProperties()));
-      map.put("internal_properties", toJsonbPGobject(this.getInternalProperties()));
-    } else {
-      map.put("properties", this.getProperties());
-      map.put("internal_properties", this.getInternalProperties());
-    }
+    map.put("properties", wrapJsonForDatabase(this.getProperties(), databaseType));
+    map.put("internal_properties", wrapJsonForDatabase(this.getInternalProperties(), databaseType));
     map.put("grant_records_version", this.getGrantRecordsVersion());
     if (this.getSchemaVersion() >= 2) {
       map.put("location_without_scheme", this.getLocationWithoutScheme());

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
@@ -54,6 +55,8 @@ public interface ModelEvent extends Converter<EventEntity> {
           RESOURCE_TYPE,
           RESOURCE_IDENTIFIER,
           ADDITIONAL_PROPERTIES);
+
+  Set<String> JSON_COLUMNS = Set.of(ADDITIONAL_PROPERTIES);
 
   /**
    * Dummy instance to be used as a Converter when calling #fromResultSet().
@@ -128,11 +131,7 @@ public interface ModelEvent extends Converter<EventEntity> {
     map.put(PRINCIPAL_NAME, getPrincipalName());
     map.put(RESOURCE_TYPE, getResourceType().toString());
     map.put(RESOURCE_IDENTIFIER, getResourceIdentifier());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(ADDITIONAL_PROPERTIES, toJsonbPGobject(getAdditionalProperties()));
-    } else {
-      map.put(ADDITIONAL_PROPERTIES, getAdditionalProperties());
-    }
+    map.put(ADDITIONAL_PROPERTIES, wrapJsonForDatabase(getAdditionalProperties(), databaseType));
     return map;
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
@@ -66,6 +67,8 @@ public interface ModelEvent extends Converter<EventEntity> {
           RESOURCE_TYPE,
           RESOURCE_IDENTIFIER,
           ADDITIONAL_PROPERTIES);
+
+  Set<String> JSON_COLUMNS = Set.of(ADDITIONAL_PROPERTIES);
 
   /**
    * Dummy instance to be used as a Converter when calling #fromResultSet().
@@ -140,11 +143,7 @@ public interface ModelEvent extends Converter<EventEntity> {
     map.put(PRINCIPAL_NAME, getPrincipalName());
     map.put(RESOURCE_TYPE, getResourceType().toString());
     map.put(RESOURCE_IDENTIFIER, getResourceIdentifier());
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(ADDITIONAL_PROPERTIES, toJsonbPGobject(getAdditionalProperties()));
-    } else {
-      map.put(ADDITIONAL_PROPERTIES, getAdditionalProperties());
-    }
+    map.put(ADDITIONAL_PROPERTIES, wrapJsonForDatabase(getAdditionalProperties(), databaseType));
     return map;
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelPolicyMappingRecord.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 
@@ -37,6 +38,8 @@ public class ModelPolicyMappingRecord implements Converter<PolarisPolicyMappingR
           "policy_catalog_id",
           "policy_id",
           "parameters");
+
+  public static final Set<String> JSON_COLUMNS = Set.of("parameters");
 
   // id of the catalog where target entity resides
   private long targetCatalogId;
@@ -175,11 +178,7 @@ public class ModelPolicyMappingRecord implements Converter<PolarisPolicyMappingR
     map.put("policy_type_code", policyTypeCode);
     map.put("policy_catalog_id", policyCatalogId);
     map.put("policy_id", policyId);
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put("parameters", toJsonbPGobject(this.getParameters()));
-    } else {
-      map.put("parameters", this.getParameters());
-    }
+    map.put("parameters", wrapJsonForDatabase(this.getParameters(), databaseType));
     return map;
   }
 }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistry.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.models;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Aggregates schema-level metadata across the {@code Model*} classes.
+ *
+ * <p>Currently the registry exposes the set of JSON-typed columns per table. JSON columns require
+ * database-specific WHERE-clause placeholder handling (MySQL needs {@code CAST(? AS JSON)} for
+ * structural equality), and {@code QueryGenerator} consults this registry instead of inspecting
+ * parameter values at runtime.
+ */
+public final class ModelRegistry {
+
+  private static final Map<String, Set<String>> JSON_COLUMNS_BY_TABLE =
+      Map.of(
+          ModelEntity.TABLE_NAME, ModelEntity.JSON_COLUMNS,
+          ModelEvent.TABLE_NAME, ModelEvent.JSON_COLUMNS,
+          ModelPolicyMappingRecord.TABLE_NAME, ModelPolicyMappingRecord.JSON_COLUMNS,
+          ModelCommitMetricsReport.TABLE_NAME, ModelCommitMetricsReport.JSON_COLUMNS,
+          ModelScanMetricsReport.TABLE_NAME, ModelScanMetricsReport.JSON_COLUMNS);
+
+  private ModelRegistry() {}
+
+  /**
+   * Returns {@code true} when {@code columnName} is declared as a JSON column on the table named
+   * {@code tableName}. Tables that have no JSON columns (or are not registered) return {@code
+   * false}.
+   */
+  public static boolean isJsonColumn(String tableName, String columnName) {
+    Set<String> jsonColumns = JSON_COLUMNS_BY_TABLE.get(tableName);
+    return jsonColumns != null && jsonColumns.contains(columnName);
+  }
+}

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistry.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.models;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Records which columns are JSON-typed, per table. JSON columns need database-specific WHERE-clause
+ * placeholder handling, and {@code QueryGenerator} consults this registry rather than inspecting
+ * parameter values at runtime.
+ *
+ * <p>MySQL normalizes a value on its way into a {@code JSON} column — object keys are reordered and
+ * a space is inserted after each colon — so the stored text never equals the text that was written.
+ * Bound as a plain {@code ?} the comparison is textual, matches nothing, and raises no error;
+ * {@code CAST(? AS JSON)} parses the parameter into a JSON value and compares structurally.
+ * PostgreSQL needs no such handling because jsonb already compares structurally.
+ *
+ * <p>Only tables owned by this module are listed: the metrics-report tables live in an extension
+ * that depends on this module and only ever issues INSERTs, so they never reach WHERE-clause
+ * generation.
+ */
+public final class ModelRegistry {
+
+  private static final Map<String, Set<String>> JSON_COLUMNS_BY_TABLE =
+      Map.of(
+          ModelEntity.TABLE_NAME, ModelEntity.JSON_COLUMNS,
+          ModelEvent.TABLE_NAME, ModelEvent.JSON_COLUMNS,
+          ModelPolicyMappingRecord.TABLE_NAME, ModelPolicyMappingRecord.JSON_COLUMNS);
+
+  private ModelRegistry() {}
+
+  /**
+   * Returns {@code true} when {@code columnName} is declared as a JSON column on the table named
+   * {@code tableName}. Tables that have no JSON columns (or are not registered) return {@code
+   * false}.
+   */
+  public static boolean isJsonColumn(String tableName, String columnName) {
+    Set<String> jsonColumns = JSON_COLUMNS_BY_TABLE.get(tableName);
+    return jsonColumns != null && jsonColumns.contains(columnName);
+  }
+}

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.polaris.core.persistence.metrics.ScanMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
@@ -103,6 +104,8 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
           INDEXED_DELETE_FILES,
           TOTAL_DELETE_FILE_SIZE_BYTES,
           METADATA);
+
+  Set<String> JSON_COLUMNS = Set.of(METADATA);
 
   // Getters
   String getReportId();
@@ -241,11 +244,8 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
     map.put(INDEXED_DELETE_FILES, getIndexedDeleteFiles());
     map.put(TOTAL_DELETE_FILE_SIZE_BYTES, getTotalDeleteFileSizeBytes());
 
-    if (databaseType.equals(DatabaseType.POSTGRES)) {
-      map.put(METADATA, toJsonbPGobject(getMetadata() != null ? getMetadata() : "{}"));
-    } else {
-      map.put(METADATA, getMetadata() != null ? getMetadata() : "{}");
-    }
+    map.put(
+        METADATA, wrapJsonForDatabase(getMetadata() != null ? getMetadata() : "{}", databaseType));
     return map;
   }
 

--- a/persistence/relational-jdbc/src/main/resources/mysql/schema-v4.sql
+++ b/persistence/relational-jdbc/src/main/resources/mysql/schema-v4.sql
@@ -1,0 +1,254 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MySQL schema v4 (matching PostgreSQL schema v4)
+-- Design notes:
+--  * The POLARIS_SCHEMA database must be pre-created and the user must have privileges on it.
+--  * In MySQL, schema is synonymous with database.
+--  * Indexes are declared inside CREATE TABLE because MySQL does not support
+--    "CREATE INDEX IF NOT EXISTS" — the bootstrap runs this script once per realm
+--    and "CREATE TABLE IF NOT EXISTS" handles the idempotency.
+--  * Uses VARCHAR(255) for PRIMARY KEY / UNIQUE KEY columns where PostgreSQL uses TEXT
+--    (MySQL forbids TEXT columns in keys without a prefix length).
+--  * Uses JSON type instead of JSONB.
+--  * Uses ON DUPLICATE KEY UPDATE instead of ON CONFLICT ... DO UPDATE.
+--  * Table identifiers use the same case as the Java `Model*.TABLE_NAME` constants
+--    (UPPERCASE for everything except `idempotency_records`, which is lowercase to
+--    match `ModelIdempotencyRecord.TABLE_NAME`). This keeps the schema working on
+--    default Linux MySQL (`lower_case_table_names=0`, case-sensitive identifiers)
+--    without any server-level flag.
+--  * Every table sets `DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin` so string
+--    comparisons are case-sensitive/binary, matching the PostgreSQL `TEXT` semantics
+--    expected by Polaris (e.g. `entities.name` must treat `foo` and `Foo` as distinct).
+
+USE POLARIS_SCHEMA;
+
+CREATE TABLE IF NOT EXISTS VERSION (
+    version_key VARCHAR(255) PRIMARY KEY COMMENT 'version key',
+    version_value INTEGER NOT NULL COMMENT 'version value'
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'the version of the JDBC schema in use';
+
+INSERT INTO VERSION (version_key, version_value)
+VALUES ('version', 4)
+ON DUPLICATE KEY UPDATE version_value = VALUES(version_value);
+
+CREATE TABLE IF NOT EXISTS ENTITIES (
+    realm_id VARCHAR(255) NOT NULL COMMENT 'realm_id used for multi-tenancy',
+    catalog_id BIGINT NOT NULL COMMENT 'catalog id',
+    id BIGINT NOT NULL COMMENT 'entity id',
+    parent_id BIGINT NOT NULL COMMENT 'entity id of parent',
+    -- Matches Polaris's MAX_IDENTIFIER_LENGTH = 256. Keeps the UNIQUE
+    -- (realm_id, ..., name) index well within the InnoDB 3072-byte key-length
+    -- limit: 255*4 + 8+8+4 + 256*4 = 2064 bytes (utf8mb4).
+    name VARCHAR(256) NOT NULL COMMENT 'entity name',
+    entity_version INT NOT NULL COMMENT 'version of the entity',
+    type_code INT NOT NULL COMMENT 'type code',
+    sub_type_code INT NOT NULL COMMENT 'sub type of entity',
+    create_timestamp BIGINT NOT NULL COMMENT 'creation time of entity',
+    drop_timestamp BIGINT NOT NULL COMMENT 'time of drop of entity',
+    purge_timestamp BIGINT NOT NULL COMMENT 'time to start purging entity',
+    to_purge_timestamp BIGINT NOT NULL,
+    last_update_timestamp BIGINT NOT NULL COMMENT 'last time the entity is touched',
+    properties JSON NOT NULL DEFAULT ('{}') COMMENT 'entities properties json',
+    internal_properties JSON NOT NULL DEFAULT ('{}') COMMENT 'entities internal properties json',
+    grant_records_version INT NOT NULL COMMENT 'the version of grant records change on the entity',
+    location_without_scheme TEXT,
+    PRIMARY KEY (realm_id, id),
+    CONSTRAINT constraint_name UNIQUE (realm_id, catalog_id, parent_id, type_code, name),
+    INDEX idx_entities (realm_id, catalog_id, id),
+    INDEX idx_entities_catalog_id_id (catalog_id, id),
+    -- location_without_scheme is TEXT, use prefix length 400 to stay under
+    -- the InnoDB 3072-byte key length limit (utf8mb4 = 4 bytes/char).
+    INDEX idx_locations (realm_id, parent_id, location_without_scheme(400))
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'all the entities';
+
+CREATE TABLE IF NOT EXISTS GRANT_RECORDS (
+    realm_id VARCHAR(255) NOT NULL,
+    securable_catalog_id BIGINT NOT NULL COMMENT 'catalog id of the securable',
+    securable_id BIGINT NOT NULL COMMENT 'entity id of the securable',
+    grantee_catalog_id BIGINT NOT NULL COMMENT 'catalog id of the grantee',
+    grantee_id BIGINT NOT NULL COMMENT 'id of the grantee',
+    privilege_code INTEGER COMMENT 'privilege code',
+    PRIMARY KEY (realm_id, securable_catalog_id, securable_id, grantee_catalog_id, grantee_id, privilege_code),
+    INDEX idx_grants_realm_grantee (realm_id, grantee_id),
+    INDEX idx_grants_realm_securable (realm_id, securable_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'grant records for entities';
+
+CREATE TABLE IF NOT EXISTS PRINCIPAL_AUTHENTICATION_DATA (
+    realm_id VARCHAR(255) NOT NULL,
+    principal_id BIGINT NOT NULL,
+    principal_client_id VARCHAR(255) NOT NULL,
+    main_secret_hash VARCHAR(255) NOT NULL,
+    secondary_secret_hash VARCHAR(255) NOT NULL,
+    secret_salt VARCHAR(255) NOT NULL,
+    PRIMARY KEY (realm_id, principal_client_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'authentication data for client';
+
+CREATE TABLE IF NOT EXISTS POLICY_MAPPING_RECORD (
+    realm_id VARCHAR(255) NOT NULL,
+    target_catalog_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    policy_type_code INTEGER NOT NULL,
+    policy_catalog_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    parameters JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (realm_id, target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id),
+    INDEX idx_policy_mapping_record (realm_id, policy_type_code, policy_catalog_id, policy_id, target_catalog_id, target_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS EVENTS (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id VARCHAR(255) NOT NULL,
+    event_id VARCHAR(255) NOT NULL,
+    request_id VARCHAR(255),
+    event_type VARCHAR(255) NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    resource_type VARCHAR(255) NOT NULL,
+    resource_identifier VARCHAR(1024) NOT NULL,
+    additional_properties JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (event_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- Idempotency records (key-only idempotency; durable replay).
+-- This is the one table whose Java constant (`ModelIdempotencyRecord.TABLE_NAME`) is
+-- lowercase; matching the Java case is what lets the MySQL backend run on default
+-- Linux MySQL without `lower_case_table_names=1`.
+CREATE TABLE IF NOT EXISTS idempotency_records (
+    realm_id VARCHAR(255) NOT NULL,
+    idempotency_key VARCHAR(255) NOT NULL,
+    operation_type VARCHAR(255) NOT NULL,
+    resource_id VARCHAR(1024) NOT NULL,
+
+    http_status INTEGER,
+    error_subtype VARCHAR(255),
+    response_summary TEXT,
+    response_headers TEXT,
+    finalized_at TIMESTAMP NULL,
+
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    heartbeat_at TIMESTAMP NULL,
+    executor_id VARCHAR(255),
+    expires_at TIMESTAMP NULL,
+
+    PRIMARY KEY (realm_id, idempotency_key),
+    INDEX idx_idemp_realm_expires (realm_id, expires_at)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- ============================================================================
+-- SCAN METRICS REPORT TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS SCAN_METRICS_REPORT (
+    report_id VARCHAR(255) NOT NULL,
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    request_id VARCHAR(255),
+
+    otel_trace_id VARCHAR(255),
+    otel_span_id VARCHAR(255),
+    report_trace_id VARCHAR(255),
+
+    snapshot_id BIGINT,
+    schema_id INTEGER,
+    filter_expression TEXT,
+    projected_field_ids TEXT,
+    projected_field_names TEXT,
+
+    result_data_files BIGINT DEFAULT 0,
+    result_delete_files BIGINT DEFAULT 0,
+    total_file_size_bytes BIGINT DEFAULT 0,
+    total_data_manifests BIGINT DEFAULT 0,
+    total_delete_manifests BIGINT DEFAULT 0,
+    scanned_data_manifests BIGINT DEFAULT 0,
+    scanned_delete_manifests BIGINT DEFAULT 0,
+    skipped_data_manifests BIGINT DEFAULT 0,
+    skipped_delete_manifests BIGINT DEFAULT 0,
+    skipped_data_files BIGINT DEFAULT 0,
+    skipped_delete_files BIGINT DEFAULT 0,
+    total_planning_duration_ms BIGINT DEFAULT 0,
+
+    equality_delete_files BIGINT DEFAULT 0,
+    positional_delete_files BIGINT DEFAULT 0,
+    indexed_delete_files BIGINT DEFAULT 0,
+    total_delete_file_size_bytes BIGINT DEFAULT 0,
+
+    metadata JSON DEFAULT ('{}'),
+
+    PRIMARY KEY (realm_id, report_id),
+    INDEX idx_scan_report_timestamp (realm_id, timestamp_ms),
+    INDEX idx_scan_report_lookup (realm_id, catalog_id, table_id, timestamp_ms)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'Scan metrics reports as first-class entities';
+
+-- ============================================================================
+-- COMMIT METRICS REPORT TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS COMMIT_METRICS_REPORT (
+    report_id VARCHAR(255) NOT NULL,
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    request_id VARCHAR(255),
+
+    otel_trace_id VARCHAR(255),
+    otel_span_id VARCHAR(255),
+    report_trace_id VARCHAR(255),
+
+    snapshot_id BIGINT NOT NULL,
+    sequence_number BIGINT,
+    operation VARCHAR(255) NOT NULL,
+
+    added_data_files BIGINT DEFAULT 0,
+    removed_data_files BIGINT DEFAULT 0,
+    total_data_files BIGINT DEFAULT 0,
+    added_delete_files BIGINT DEFAULT 0,
+    removed_delete_files BIGINT DEFAULT 0,
+    total_delete_files BIGINT DEFAULT 0,
+
+    added_equality_delete_files BIGINT DEFAULT 0,
+    removed_equality_delete_files BIGINT DEFAULT 0,
+
+    added_positional_delete_files BIGINT DEFAULT 0,
+    removed_positional_delete_files BIGINT DEFAULT 0,
+
+    added_records BIGINT DEFAULT 0,
+    removed_records BIGINT DEFAULT 0,
+    total_records BIGINT DEFAULT 0,
+
+    added_file_size_bytes BIGINT DEFAULT 0,
+    removed_file_size_bytes BIGINT DEFAULT 0,
+    total_file_size_bytes BIGINT DEFAULT 0,
+
+    total_duration_ms BIGINT DEFAULT 0,
+    attempts INTEGER DEFAULT 1,
+
+    metadata JSON DEFAULT ('{}'),
+
+    PRIMARY KEY (realm_id, report_id),
+    INDEX idx_commit_report_timestamp (realm_id, timestamp_ms),
+    INDEX idx_commit_report_lookup (realm_id, catalog_id, table_id, timestamp_ms)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'Commit metrics reports as first-class entities';

--- a/persistence/relational-jdbc/src/main/resources/mysql/schema-v6.sql
+++ b/persistence/relational-jdbc/src/main/resources/mysql/schema-v6.sql
@@ -1,0 +1,229 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MySQL schema v6 (matching PostgreSQL schema v6)
+-- Design notes:
+--  * In MySQL, schema is synonymous with database. This script is schema-agnostic: it
+--    creates unqualified tables in whatever database the connection already selects,
+--    which for MySQL is the database named in the JDBC URL path. The database must be
+--    pre-created and the user must have privileges on it.
+--  * Indexes are declared inside CREATE TABLE because MySQL does not support
+--    "CREATE INDEX IF NOT EXISTS" — the bootstrap runs this script once per realm
+--    and "CREATE TABLE IF NOT EXISTS" handles the idempotency.
+--  * Uses VARCHAR(255) for PRIMARY KEY / UNIQUE KEY columns where PostgreSQL uses TEXT
+--    (MySQL forbids TEXT columns in keys without a prefix length).
+--  * Uses JSON type instead of JSONB.
+--  * Uses ON DUPLICATE KEY UPDATE instead of ON CONFLICT ... DO UPDATE.
+--  * Table identifiers use the same case as the Java `Model*.TABLE_NAME` constants
+--    (UPPERCASE). This keeps the schema working on default Linux MySQL
+--    (`lower_case_table_names=0`, case-sensitive identifiers) without any
+--    server-level flag.
+--  * Every table sets `DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin` so string
+--    comparisons are case-sensitive/binary, matching the PostgreSQL `TEXT` semantics
+--    expected by Polaris (e.g. `entities.name` must treat `foo` and `Foo` as distinct).
+
+CREATE TABLE IF NOT EXISTS VERSION (
+    version_key VARCHAR(255) PRIMARY KEY COMMENT 'version key',
+    version_value INTEGER NOT NULL COMMENT 'version value'
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'the version of the JDBC schema in use';
+
+INSERT INTO VERSION (version_key, version_value)
+VALUES ('version', 6)
+ON DUPLICATE KEY UPDATE version_value = VALUES(version_value);
+
+CREATE TABLE IF NOT EXISTS ENTITIES (
+    realm_id VARCHAR(255) NOT NULL COMMENT 'realm_id used for multi-tenancy',
+    catalog_id BIGINT NOT NULL COMMENT 'catalog id',
+    id BIGINT NOT NULL COMMENT 'entity id',
+    parent_id BIGINT NOT NULL COMMENT 'entity id of parent',
+    -- Matches Polaris's MAX_IDENTIFIER_LENGTH = 256. Keeps the UNIQUE
+    -- (realm_id, ..., name) index well within the InnoDB 3072-byte key-length
+    -- limit: 255*4 + 8+8+4 + 256*4 = 2064 bytes (utf8mb4).
+    name VARCHAR(256) NOT NULL COMMENT 'entity name',
+    entity_version INT NOT NULL COMMENT 'version of the entity',
+    type_code INT NOT NULL COMMENT 'type code',
+    sub_type_code INT NOT NULL COMMENT 'sub type of entity',
+    create_timestamp BIGINT NOT NULL COMMENT 'creation time of entity',
+    drop_timestamp BIGINT NOT NULL COMMENT 'time of drop of entity',
+    purge_timestamp BIGINT NOT NULL COMMENT 'time to start purging entity',
+    to_purge_timestamp BIGINT NOT NULL,
+    last_update_timestamp BIGINT NOT NULL COMMENT 'last time the entity is touched',
+    properties JSON NOT NULL DEFAULT ('{}') COMMENT 'entities properties json',
+    internal_properties JSON NOT NULL DEFAULT ('{}') COMMENT 'entities internal properties json',
+    grant_records_version INT NOT NULL COMMENT 'the version of grant records change on the entity',
+    location_without_scheme TEXT,
+    PRIMARY KEY (realm_id, id),
+    CONSTRAINT constraint_name UNIQUE (realm_id, catalog_id, parent_id, type_code, name),
+    INDEX idx_entities (realm_id, catalog_id, id),
+    INDEX idx_entities_catalog_id_id (catalog_id, id),
+    -- idx_locations leads with catalog_id (not parent_id) to match the predicate in
+    -- QueryGenerator.generateOverlapQuery (WHERE realm_id = ? AND catalog_id = ?).
+    -- location_without_scheme is TEXT, use prefix length 400 to stay under
+    -- the InnoDB 3072-byte key length limit (utf8mb4 = 4 bytes/char).
+    INDEX idx_locations (realm_id, catalog_id, location_without_scheme(400))
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'all the entities';
+
+CREATE TABLE IF NOT EXISTS GRANT_RECORDS (
+    realm_id VARCHAR(255) NOT NULL,
+    securable_catalog_id BIGINT NOT NULL COMMENT 'catalog id of the securable',
+    securable_id BIGINT NOT NULL COMMENT 'entity id of the securable',
+    grantee_catalog_id BIGINT NOT NULL COMMENT 'catalog id of the grantee',
+    grantee_id BIGINT NOT NULL COMMENT 'id of the grantee',
+    privilege_code INTEGER COMMENT 'privilege code',
+    PRIMARY KEY (realm_id, securable_catalog_id, securable_id, grantee_catalog_id, grantee_id, privilege_code),
+    INDEX idx_grants_realm_grantee (realm_id, grantee_id),
+    INDEX idx_grants_realm_securable (realm_id, securable_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'grant records for entities';
+
+CREATE TABLE IF NOT EXISTS PRINCIPAL_AUTHENTICATION_DATA (
+    realm_id VARCHAR(255) NOT NULL,
+    principal_id BIGINT NOT NULL,
+    principal_client_id VARCHAR(255) NOT NULL,
+    main_secret_hash VARCHAR(255) NOT NULL,
+    secondary_secret_hash VARCHAR(255) NOT NULL,
+    secret_salt VARCHAR(255) NOT NULL,
+    PRIMARY KEY (realm_id, principal_client_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'authentication data for client';
+
+CREATE TABLE IF NOT EXISTS POLICY_MAPPING_RECORD (
+    realm_id VARCHAR(255) NOT NULL,
+    target_catalog_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    policy_type_code INTEGER NOT NULL,
+    policy_catalog_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    parameters JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (realm_id, target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id),
+    INDEX idx_policy_mapping_record (realm_id, policy_type_code, policy_catalog_id, policy_id, target_catalog_id, target_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS EVENTS (
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id TEXT,
+    event_id VARCHAR(255) NOT NULL,
+    request_id VARCHAR(255),
+    event_type VARCHAR(255) NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    principal_name TEXT,
+    resource_type VARCHAR(255) NOT NULL,
+    resource_identifier TEXT NOT NULL,
+    additional_properties JSON NOT NULL DEFAULT ('{}'),
+    PRIMARY KEY (event_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- ============================================================================
+-- SCAN METRICS REPORT TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS SCAN_METRICS_REPORT (
+    report_id VARCHAR(255) NOT NULL,
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    request_id VARCHAR(255),
+
+    otel_trace_id VARCHAR(255),
+    otel_span_id VARCHAR(255),
+    report_trace_id VARCHAR(255),
+
+    snapshot_id BIGINT,
+    schema_id INTEGER,
+    filter_expression TEXT,
+    projected_field_ids TEXT,
+    projected_field_names TEXT,
+
+    result_data_files BIGINT DEFAULT 0,
+    result_delete_files BIGINT DEFAULT 0,
+    total_file_size_bytes BIGINT DEFAULT 0,
+    total_data_manifests BIGINT DEFAULT 0,
+    total_delete_manifests BIGINT DEFAULT 0,
+    scanned_data_manifests BIGINT DEFAULT 0,
+    scanned_delete_manifests BIGINT DEFAULT 0,
+    skipped_data_manifests BIGINT DEFAULT 0,
+    skipped_delete_manifests BIGINT DEFAULT 0,
+    skipped_data_files BIGINT DEFAULT 0,
+    skipped_delete_files BIGINT DEFAULT 0,
+    total_planning_duration_ms BIGINT DEFAULT 0,
+
+    equality_delete_files BIGINT DEFAULT 0,
+    positional_delete_files BIGINT DEFAULT 0,
+    indexed_delete_files BIGINT DEFAULT 0,
+    total_delete_file_size_bytes BIGINT DEFAULT 0,
+
+    metadata JSON DEFAULT ('{}'),
+
+    PRIMARY KEY (realm_id, report_id),
+    INDEX idx_scan_report_timestamp (realm_id, timestamp_ms),
+    INDEX idx_scan_report_lookup (realm_id, catalog_id, table_id, timestamp_ms)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'Scan metrics reports as first-class entities';
+
+-- ============================================================================
+-- COMMIT METRICS REPORT TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS COMMIT_METRICS_REPORT (
+    report_id VARCHAR(255) NOT NULL,
+    realm_id VARCHAR(255) NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+
+    timestamp_ms BIGINT NOT NULL,
+    principal_name VARCHAR(255),
+    request_id VARCHAR(255),
+
+    otel_trace_id VARCHAR(255),
+    otel_span_id VARCHAR(255),
+    report_trace_id VARCHAR(255),
+
+    snapshot_id BIGINT NOT NULL,
+    sequence_number BIGINT,
+    operation VARCHAR(255) NOT NULL,
+
+    added_data_files BIGINT DEFAULT 0,
+    removed_data_files BIGINT DEFAULT 0,
+    total_data_files BIGINT DEFAULT 0,
+    added_delete_files BIGINT DEFAULT 0,
+    removed_delete_files BIGINT DEFAULT 0,
+    total_delete_files BIGINT DEFAULT 0,
+
+    added_equality_delete_files BIGINT DEFAULT 0,
+    removed_equality_delete_files BIGINT DEFAULT 0,
+
+    added_positional_delete_files BIGINT DEFAULT 0,
+    removed_positional_delete_files BIGINT DEFAULT 0,
+
+    added_records BIGINT DEFAULT 0,
+    removed_records BIGINT DEFAULT 0,
+    total_records BIGINT DEFAULT 0,
+
+    added_file_size_bytes BIGINT DEFAULT 0,
+    removed_file_size_bytes BIGINT DEFAULT 0,
+    total_file_size_bytes BIGINT DEFAULT 0,
+
+    total_duration_ms BIGINT DEFAULT 0,
+    attempts INTEGER DEFAULT 1,
+
+    metadata JSON DEFAULT ('{}'),
+
+    PRIMARY KEY (realm_id, report_id),
+    INDEX idx_commit_report_timestamp (realm_id, timestamp_ms),
+    INDEX idx_commit_report_lookup (realm_id, catalog_id, table_id, timestamp_ms)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin COMMENT = 'Commit metrics reports as first-class entities';

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
@@ -41,6 +41,10 @@ public class QueryGeneratorTest {
 
   private static final String REALM_ID = "testRealm";
 
+  // Bound to H2 for the bulk of the assertions; tests that need a different DatabaseType
+  // construct their own instance.
+  private final QueryGenerator queryGenerator = new QueryGenerator(DatabaseType.H2);
+
   @Test
   void testGenerateSelectQuery_withMaQueryGeneratorpWhereClause() {
     Map<String, Object> whereClause = new HashMap<>();
@@ -50,7 +54,8 @@ public class QueryGeneratorTest {
         "SELECT id, catalog_id, parent_id, type_code, name, entity_version, sub_type_code, create_timestamp, drop_timestamp, purge_timestamp, to_purge_timestamp, last_update_timestamp, properties, internal_properties, grant_records_version, location_without_scheme FROM POLARIS_SCHEMA.ENTITIES WHERE entity_version = ? AND name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateSelectQuery(
+        queryGenerator
+            .generateSelectQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause)
             .sql());
   }
@@ -123,7 +128,8 @@ public class QueryGeneratorTest {
         "UPDATE POLARIS_SCHEMA.ENTITIES SET id = ?, catalog_id = ?, parent_id = ?, type_code = ?, name = ?, entity_version = ?, sub_type_code = ?, create_timestamp = ?, drop_timestamp = ?, purge_timestamp = ?, to_purge_timestamp = ?, last_update_timestamp = ?, properties = ?, internal_properties = ?, grant_records_version = ?, location_without_scheme = ? WHERE id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator
+            .generateUpdateQuery(
                 ModelEntity.getAllColumnNames(2),
                 ModelEntity.TABLE_NAME,
                 entity.toMap(DatabaseType.H2).values().stream().toList(),
@@ -140,7 +146,8 @@ public class QueryGeneratorTest {
         "UPDATE POLARIS_SCHEMA.ENTITIES SET id = ?, catalog_id = ?, parent_id = ?, type_code = ?, name = ?, entity_version = ?, sub_type_code = ?, create_timestamp = ?, drop_timestamp = ?, purge_timestamp = ?, to_purge_timestamp = ?, last_update_timestamp = ?, properties = ?, internal_properties = ?, grant_records_version = ?, location_without_scheme = ? WHERE id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator
+            .generateUpdateQuery(
                 ModelEntity.getAllColumnNames(2),
                 ModelEntity.TABLE_NAME,
                 entity.toMap(DatabaseType.H2).values().stream().toList(),
@@ -155,7 +162,8 @@ public class QueryGeneratorTest {
     String expectedQuery = "DELETE FROM POLARIS_SCHEMA.ENTITIES WHERE name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator
+            .generateDeleteQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause)
             .sql());
   }
@@ -165,7 +173,8 @@ public class QueryGeneratorTest {
     String expectedQuery = "DELETE FROM POLARIS_SCHEMA.ENTITIES WHERE name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator
+            .generateDeleteQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, Map.of("name", "oldName"))
             .sql());
   }
@@ -180,8 +189,8 @@ public class QueryGeneratorTest {
         "DELETE FROM POLARIS_SCHEMA.ENTITIES WHERE id = ? AND catalog_id = ? AND parent_id = ? AND type_code = ? AND name = ? AND entity_version = ? AND sub_type_code = ? AND create_timestamp = ? AND drop_timestamp = ? AND purge_timestamp = ? AND to_purge_timestamp = ? AND last_update_timestamp = ? AND properties = ? AND internal_properties = ? AND grant_records_version = ? AND location_without_scheme = ? AND realm_id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
-                ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, objMap)
+        queryGenerator
+            .generateDeleteQuery(ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, objMap)
             .sql());
   }
 
@@ -191,7 +200,9 @@ public class QueryGeneratorTest {
     whereClause.put("name", "test");
     assertEquals(
         " WHERE name = ?",
-        QueryGenerator.generateWhereClause(Set.of("name"), whereClause, Map.of()).sql());
+        queryGenerator
+            .generateWhereClause(ModelEntity.TABLE_NAME, Set.of("name"), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -201,7 +212,10 @@ public class QueryGeneratorTest {
     whereClause.put("version", 1);
     assertEquals(
         " WHERE name = ? AND version = ?",
-        QueryGenerator.generateWhereClause(Set.of("name", "version"), whereClause, Map.of()).sql());
+        queryGenerator
+            .generateWhereClause(
+                ModelEntity.TABLE_NAME, Set.of("name", "version"), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -211,15 +225,23 @@ public class QueryGeneratorTest {
     whereClause.put("version", 1);
     assertEquals(
         " WHERE name = ? AND version = ? AND id > ?",
-        QueryGenerator.generateWhereClause(
-                Set.of("name", "version", "id"), whereClause, Map.of("id", 123))
+        queryGenerator
+            .generateWhereClause(
+                ModelEntity.TABLE_NAME,
+                Set.of("name", "version", "id"),
+                whereClause,
+                Map.of("id", 123))
             .sql());
   }
 
   @Test
   void testGenerateWhereClause_emptyMap() {
     Map<String, Object> whereClause = Collections.emptyMap();
-    assertEquals("", QueryGenerator.generateWhereClause(Set.of(), whereClause, Map.of()).sql());
+    assertEquals(
+        "",
+        queryGenerator
+            .generateWhereClause(ModelEntity.TABLE_NAME, Set.of(), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -235,7 +257,8 @@ public class QueryGeneratorTest {
     Set<String> whereIsNotNull = new LinkedHashSet<>(List.of("e"));
 
     QueryGenerator.QueryFragment where =
-        QueryGenerator.generateWhereClauseExtended(
+        queryGenerator.generateWhereClauseExtended(
+            "test_table",
             Set.of("a", "b", "c", "d", "e"),
             whereEquals,
             whereGreater,
@@ -245,6 +268,26 @@ public class QueryGeneratorTest {
 
     assertEquals(" WHERE a = ? AND b > ? AND c < ? AND d IS NULL AND e IS NOT NULL", where.sql());
     Assertions.assertThat(where.parameters()).containsExactly("A", 2, 3);
+  }
+
+  @Test
+  void testGenerateWhereClause_mysqlJsonColumn_emitsCastPlaceholder() {
+    // POLICY_MAPPING_RECORD.parameters is declared as JSON in ModelRegistry; MySQL needs
+    // CAST(? AS JSON) for structural equality, other backends keep the plain ? placeholder.
+    Map<String, Object> whereEquals = new LinkedHashMap<>();
+    whereEquals.put("parameters", "{\"a\":1}");
+
+    QueryGenerator mysqlGenerator = new QueryGenerator(DatabaseType.MYSQL);
+    QueryGenerator.QueryFragment mysqlFragment =
+        mysqlGenerator.generateWhereClause(
+            "POLICY_MAPPING_RECORD", Set.of("parameters"), whereEquals, Map.of());
+    assertEquals(" WHERE parameters = CAST(? AS JSON)", mysqlFragment.sql());
+
+    QueryGenerator postgresGenerator = new QueryGenerator(DatabaseType.POSTGRES);
+    QueryGenerator.QueryFragment postgresFragment =
+        postgresGenerator.generateWhereClause(
+            "POLICY_MAPPING_RECORD", Set.of("parameters"), whereEquals, Map.of());
+    assertEquals(" WHERE parameters = ?", postgresFragment.sql());
   }
 
   @Test
@@ -261,7 +304,7 @@ public class QueryGeneratorTest {
     whereLess.put("http_status", 500);
 
     QueryGenerator.PreparedQuery q =
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator.generateUpdateQuery(
             List.of("error_subtype", "http_status", "realm_id", "idempotency_key", "executor_id"),
             "idempotency_records",
             setClause,
@@ -283,7 +326,7 @@ public class QueryGeneratorTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            QueryGenerator.generateUpdateQuery(
+            queryGenerator.generateUpdateQuery(
                 List.of("a"),
                 "t",
                 Map.of(),
@@ -297,7 +340,7 @@ public class QueryGeneratorTest {
   @Test
   void testGenerateDeleteQueryExtended_includesNullPredicatesAndLessThan() {
     QueryGenerator.PreparedQuery q =
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator.generateDeleteQuery(
             List.of("realm_id", "expires_at", "finalized_at"),
             "idempotency_records",
             Map.of("realm_id", "r1"),
@@ -315,7 +358,7 @@ public class QueryGeneratorTest {
   @Test
   void testGenerateDeleteQueryExtended_allowsRealmIdEvenIfNotInTableColumns() {
     QueryGenerator.PreparedQuery q =
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator.generateDeleteQuery(
             List.of("id"),
             "some_table",
             Map.of("realm_id", "r1"),
@@ -336,7 +379,7 @@ public class QueryGeneratorTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            QueryGenerator.generateUpdateQuery(
+            queryGenerator.generateUpdateQuery(
                 List.of("a"),
                 "t",
                 setClause,

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
@@ -45,6 +45,10 @@ public class QueryGeneratorTest {
 
   private static final String REALM_ID = "testRealm";
 
+  // Bound to H2 for the bulk of the assertions; tests that need a different DatabaseType
+  // construct their own instance.
+  private final QueryGenerator queryGenerator = new QueryGenerator(DatabaseType.H2);
+
   @Test
   void testGenerateSelectQuery_withMaQueryGeneratorpWhereClause() {
     Map<String, Object> whereClause = new HashMap<>();
@@ -54,7 +58,8 @@ public class QueryGeneratorTest {
         "SELECT id, catalog_id, parent_id, type_code, name, entity_version, sub_type_code, create_timestamp, drop_timestamp, purge_timestamp, to_purge_timestamp, last_update_timestamp, properties, internal_properties, grant_records_version, location_without_scheme FROM ENTITIES WHERE entity_version = ? AND name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateSelectQuery(
+        queryGenerator
+            .generateSelectQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause)
             .sql());
   }
@@ -67,7 +72,7 @@ public class QueryGeneratorTest {
     String expectedQuery =
         "SELECT id, catalog_id, parent_id, type_code, name, entity_version, sub_type_code, create_timestamp, drop_timestamp, purge_timestamp, to_purge_timestamp, last_update_timestamp, properties, internal_properties, grant_records_version, location_without_scheme FROM ENTITIES WHERE catalog_id = ? AND parent_id = ? LIMIT 1";
     QueryGenerator.PreparedQuery query =
-        QueryGenerator.generateSelectQuery(
+        queryGenerator.generateSelectQuery(
             ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause, 1);
     assertEquals(expectedQuery, query.sql());
     Assertions.assertThat(query.parameters()).containsExactly(123L, 1L);
@@ -80,7 +85,7 @@ public class QueryGeneratorTest {
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                QueryGenerator.generateSelectQuery(
+                queryGenerator.generateSelectQuery(
                     ModelEntity.getAllColumnNames(2),
                     ModelEntity.TABLE_NAME,
                     Map.of("catalog_id", 123L),
@@ -191,7 +196,8 @@ public class QueryGeneratorTest {
         "UPDATE ENTITIES SET id = ?, catalog_id = ?, parent_id = ?, type_code = ?, name = ?, entity_version = ?, sub_type_code = ?, create_timestamp = ?, drop_timestamp = ?, purge_timestamp = ?, to_purge_timestamp = ?, last_update_timestamp = ?, properties = ?, internal_properties = ?, grant_records_version = ?, location_without_scheme = ? WHERE id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator
+            .generateUpdateQuery(
                 ModelEntity.getAllColumnNames(2),
                 ModelEntity.TABLE_NAME,
                 entity.toMap(DatabaseType.H2).values().stream().toList(),
@@ -208,7 +214,8 @@ public class QueryGeneratorTest {
         "UPDATE ENTITIES SET id = ?, catalog_id = ?, parent_id = ?, type_code = ?, name = ?, entity_version = ?, sub_type_code = ?, create_timestamp = ?, drop_timestamp = ?, purge_timestamp = ?, to_purge_timestamp = ?, last_update_timestamp = ?, properties = ?, internal_properties = ?, grant_records_version = ?, location_without_scheme = ? WHERE id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateUpdateQuery(
+        queryGenerator
+            .generateUpdateQuery(
                 ModelEntity.getAllColumnNames(2),
                 ModelEntity.TABLE_NAME,
                 entity.toMap(DatabaseType.H2).values().stream().toList(),
@@ -223,7 +230,8 @@ public class QueryGeneratorTest {
     String expectedQuery = "DELETE FROM ENTITIES WHERE name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator
+            .generateDeleteQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause)
             .sql());
   }
@@ -233,7 +241,8 @@ public class QueryGeneratorTest {
     String expectedQuery = "DELETE FROM ENTITIES WHERE name = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
+        queryGenerator
+            .generateDeleteQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, Map.of("name", "oldName"))
             .sql());
   }
@@ -248,8 +257,8 @@ public class QueryGeneratorTest {
         "DELETE FROM ENTITIES WHERE id = ? AND catalog_id = ? AND parent_id = ? AND type_code = ? AND name = ? AND entity_version = ? AND sub_type_code = ? AND create_timestamp = ? AND drop_timestamp = ? AND purge_timestamp = ? AND to_purge_timestamp = ? AND last_update_timestamp = ? AND properties = ? AND internal_properties = ? AND grant_records_version = ? AND location_without_scheme = ? AND realm_id = ?";
     assertEquals(
         expectedQuery,
-        QueryGenerator.generateDeleteQuery(
-                ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, objMap)
+        queryGenerator
+            .generateDeleteQuery(ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, objMap)
             .sql());
   }
 
@@ -259,7 +268,9 @@ public class QueryGeneratorTest {
     whereClause.put("name", "test");
     assertEquals(
         " WHERE name = ?",
-        QueryGenerator.generateWhereClause(Set.of("name"), whereClause, Map.of()).sql());
+        queryGenerator
+            .generateWhereClause(ModelEntity.TABLE_NAME, Set.of("name"), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -269,7 +280,10 @@ public class QueryGeneratorTest {
     whereClause.put("version", 1);
     assertEquals(
         " WHERE name = ? AND version = ?",
-        QueryGenerator.generateWhereClause(Set.of("name", "version"), whereClause, Map.of()).sql());
+        queryGenerator
+            .generateWhereClause(
+                ModelEntity.TABLE_NAME, Set.of("name", "version"), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -279,15 +293,23 @@ public class QueryGeneratorTest {
     whereClause.put("version", 1);
     assertEquals(
         " WHERE name = ? AND version = ? AND id > ?",
-        QueryGenerator.generateWhereClause(
-                Set.of("name", "version", "id"), whereClause, Map.of("id", 123))
+        queryGenerator
+            .generateWhereClause(
+                ModelEntity.TABLE_NAME,
+                Set.of("name", "version", "id"),
+                whereClause,
+                Map.of("id", 123))
             .sql());
   }
 
   @Test
   void testGenerateWhereClause_emptyMap() {
     Map<String, Object> whereClause = Collections.emptyMap();
-    assertEquals("", QueryGenerator.generateWhereClause(Set.of(), whereClause, Map.of()).sql());
+    assertEquals(
+        "",
+        queryGenerator
+            .generateWhereClause(ModelEntity.TABLE_NAME, Set.of(), whereClause, Map.of())
+            .sql());
   }
 
   @Test
@@ -303,7 +325,8 @@ public class QueryGeneratorTest {
     Set<String> whereIsNotNull = new LinkedHashSet<>(List.of("e"));
 
     QueryGenerator.QueryFragment where =
-        QueryGenerator.generateWhereClauseExtended(
+        queryGenerator.generateWhereClauseExtended(
+            "test_table",
             Set.of("a", "b", "c", "d", "e"),
             whereEquals,
             whereGreater,
@@ -313,6 +336,26 @@ public class QueryGeneratorTest {
 
     assertEquals(" WHERE a = ? AND b > ? AND c < ? AND d IS NULL AND e IS NOT NULL", where.sql());
     Assertions.assertThat(where.parameters()).containsExactly("A", 2, 3);
+  }
+
+  @Test
+  void testGenerateWhereClause_mysqlJsonColumn_emitsCastPlaceholder() {
+    // POLICY_MAPPING_RECORD.parameters is declared as JSON in ModelRegistry; MySQL needs
+    // CAST(? AS JSON) for structural equality, other backends keep the plain ? placeholder.
+    Map<String, Object> whereEquals = new LinkedHashMap<>();
+    whereEquals.put("parameters", "{\"a\":1}");
+
+    QueryGenerator mysqlGenerator = new QueryGenerator(DatabaseType.MYSQL);
+    QueryGenerator.QueryFragment mysqlFragment =
+        mysqlGenerator.generateWhereClause(
+            "POLICY_MAPPING_RECORD", Set.of("parameters"), whereEquals, Map.of());
+    assertEquals(" WHERE parameters = CAST(? AS JSON)", mysqlFragment.sql());
+
+    QueryGenerator postgresGenerator = new QueryGenerator(DatabaseType.POSTGRES);
+    QueryGenerator.QueryFragment postgresFragment =
+        postgresGenerator.generateWhereClause(
+            "POLICY_MAPPING_RECORD", Set.of("parameters"), whereEquals, Map.of());
+    assertEquals(" WHERE parameters = ?", postgresFragment.sql());
   }
 
   @Test
@@ -413,8 +456,8 @@ public class QueryGeneratorTest {
     params.put("catalog_id", 1L);
     params.put("parent_id", 2L);
     String sql =
-        QueryGenerator.generateExistsQuery(
-                ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, params)
+        queryGenerator
+            .generateExistsQuery(ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, params)
             .sql();
     assertTrue(sql.startsWith("SELECT 1 "), sql);
     assertTrue(sql.endsWith("LIMIT 1"), sql);
@@ -429,7 +472,7 @@ public class QueryGeneratorTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            QueryGenerator.generateExistsQuery(
+            queryGenerator.generateExistsQuery(
                 ModelEntity.getAllColumnNames(2),
                 ModelEntity.TABLE_NAME,
                 Map.of("not_a_column", 1)));

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SchemaVersions.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SchemaVersions.java
@@ -77,6 +77,7 @@ final class SchemaVersions {
     return switch (databaseType) {
       case H2 -> 0;
       case POSTGRES, COCKROACHDB -> 1;
+      case MYSQL -> 4; // MySQL ships schema-v4.sql only
     };
   }
 }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SchemaVersions.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SchemaVersions.java
@@ -74,9 +74,8 @@ final class SchemaVersions {
   }
 
   private static int firstSchemaVersion(DatabaseType databaseType) {
-    return switch (databaseType) {
-      case H2 -> 0;
-      case POSTGRES, COCKROACHDB -> 1;
-    };
+    // Which versions ship is a property of the database type itself; the only test-side difference
+    // is H2's schema-v0.sql, which lives in test resources to cover legacy bootstrap behavior.
+    return databaseType == DatabaseType.H2 ? 0 : databaseType.getFirstSchemaVersion();
   }
 }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SimpleRelationalJdbcConfiguration.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/SimpleRelationalJdbcConfiguration.java
@@ -34,6 +34,7 @@ final class SimpleRelationalJdbcConfiguration implements RelationalJdbcConfigura
       case H2 -> new SimpleRelationalJdbcConfiguration("h2");
       case POSTGRES -> new SimpleRelationalJdbcConfiguration("postgresql");
       case COCKROACHDB -> new SimpleRelationalJdbcConfiguration("cockroachdb");
+      case MYSQL -> new SimpleRelationalJdbcConfiguration("mysql");
     };
   }
 

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistryTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ModelRegistryTest {
+
+  @Test
+  void entityJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "properties")).isTrue();
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "internal_properties")).isTrue();
+  }
+
+  @Test
+  void eventJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEvent.TABLE_NAME, "additional_properties")).isTrue();
+  }
+
+  @Test
+  void policyMappingRecordJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelPolicyMappingRecord.TABLE_NAME, "parameters"))
+        .isTrue();
+  }
+
+  @Test
+  void metricsReportJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelCommitMetricsReport.TABLE_NAME, "metadata"))
+        .isTrue();
+    assertThat(ModelRegistry.isJsonColumn(ModelScanMetricsReport.TABLE_NAME, "metadata")).isTrue();
+  }
+
+  @Test
+  void nonJsonColumnsReturnFalse() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "id")).isFalse();
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "name")).isFalse();
+    assertThat(ModelRegistry.isJsonColumn(ModelPolicyMappingRecord.TABLE_NAME, "policy_id"))
+        .isFalse();
+  }
+
+  @Test
+  void unregisteredTableReturnsFalse() {
+    assertThat(ModelRegistry.isJsonColumn("UNKNOWN_TABLE", "any_column")).isFalse();
+  }
+}

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistryTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelRegistryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ModelRegistryTest {
+
+  @Test
+  void entityJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "properties")).isTrue();
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "internal_properties")).isTrue();
+  }
+
+  @Test
+  void eventJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEvent.TABLE_NAME, "additional_properties")).isTrue();
+  }
+
+  @Test
+  void policyMappingRecordJsonColumnsAreRegistered() {
+    assertThat(ModelRegistry.isJsonColumn(ModelPolicyMappingRecord.TABLE_NAME, "parameters"))
+        .isTrue();
+  }
+
+  @Test
+  void nonJsonColumnsReturnFalse() {
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "id")).isFalse();
+    assertThat(ModelRegistry.isJsonColumn(ModelEntity.TABLE_NAME, "name")).isFalse();
+    assertThat(ModelRegistry.isJsonColumn(ModelPolicyMappingRecord.TABLE_NAME, "policy_id"))
+        .isFalse();
+  }
+
+  @Test
+  void unregisteredTableReturnsFalse() {
+    assertThat(ModelRegistry.isJsonColumn("UNKNOWN_TABLE", "any_column")).isFalse();
+  }
+}

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -51,6 +51,16 @@ quarkus.otel.enabled=true
 #quarkus.mongodb.connection-string=mongodb://localhost:27017
 quarkus.datasource.db-kind=postgresql
 
+# Named datasource for MySQL (the one relational backend that does not share the PostgreSQL
+# JDBC driver). `jdbc=false` skips driver-extension validation when the GPL-licensed MySQL
+# driver is absent from the build; `-PincludeMysqlDriver=true` flips it back to `true`.
+# `active=false` keeps the bean inactive by default; users opt in by setting
+# `polaris.persistence.relational.jdbc.database-type=mysql` together with
+# `quarkus.datasource.mysql.active=true` and the connection properties.
+quarkus.datasource.mysql.db-kind=mysql
+quarkus.datasource.mysql.jdbc=false
+quarkus.datasource.mysql.active=false
+
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.
 

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -57,6 +57,16 @@ quarkus.datasource.db-kind=postgresql
 # connects; creating it is a DBA task requiring elevated privileges.
 quarkus.datasource.jdbc.additional-jdbc-properties.currentSchema=POLARIS_SCHEMA
 
+# Named datasource for MySQL (the one relational backend that does not share the PostgreSQL
+# JDBC driver). `jdbc=false` skips driver-extension validation when the GPL-licensed MySQL
+# driver is absent from the build; `-PincludeMysqlDriver=true` flips it back to `true`.
+# `active=false` keeps the bean inactive by default; users opt in by setting
+# `polaris.persistence.relational.jdbc.database-type=mysql` together with
+# `quarkus.datasource.mysql.active=true` and the connection properties.
+quarkus.datasource.mysql.db-kind=mysql
+quarkus.datasource.mysql.jdbc=false
+quarkus.datasource.mysql.active=false
+
 # ---- Runtime Configuration ----
 # Below are default values for properties that can be changed in runtime.
 

--- a/runtime/server/README.md
+++ b/runtime/server/README.md
@@ -64,3 +64,7 @@ following command:
   -Dquarkus.container-image.group=apache \
   -Dquarkus.container-image.name=polaris-local
 ```
+
+## MySQL support
+
+MySQL is available for the Relational JDBC backend via an opt-in, build-from-source path: the GPL-licensed MySQL JDBC driver (ASF Category X) is not bundled in the official Polaris artifacts. Because this is a custom downstream build rather than part of the standard server, the build, configuration and bootstrap details live in separate JDBC/MySQL documentation: see [`persistence/relational-jdbc/MYSQL.md`](../../persistence/relational-jdbc/MYSQL.md).

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -59,6 +59,26 @@ dependencies {
   implementation("io.quarkus:quarkus-container-image-docker")
 }
 
+// MySQL is opt-in: the GPL JDBC driver (ASF Category X) is not bundled in the default
+// build. `runtime/service` does not bring the driver transitively, so the default
+// release build stays GPL-free without any classpath exclusions. The driver is added
+// directly here only when `-PincludeMysqlDriver=true` is provided.
+//
+// Verification contract for the opt-in `-PincludeMysqlDriver=true` build:
+// - Supported: `:polaris-server:assemble`, Quarkus image build tasks.
+// - NOT supported (will fail by design because the GPL MySQL JDBC driver is
+//   intentionally absent from `LICENSE`):
+//   `:polaris-server:build`, `:polaris-server:check`,
+//   `:polaris-server:publishToMavenLocal`, `:polaris-server:generateLicenseReport`,
+//   `:polaris-server:checkLicense`, `:polaris-server:licenseReportZip`.
+// See `runtime/server/README.md` for the downstream/custom-build framing.
+if (project.hasProperty("includeMysqlDriver")) {
+  dependencies { runtimeOnly("io.quarkus:quarkus-jdbc-mysql") }
+  // Override the `jdbc=false` default in `application.properties` so Quarkus wires up
+  // the MySQL named datasource at build time.
+  quarkus { quarkusBuildProperties.put("quarkus.datasource.mysql.jdbc", "true") }
+}
+
 quarkus {
   quarkusBuildProperties.put("quarkus.package.jar.type", "fast-jar")
   // Pull manifest attributes from the "main" `jar` task to get the

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -63,6 +63,28 @@ dependencies {
   implementation("io.quarkus:quarkus-container-image-docker")
 }
 
+// MySQL is opt-in: the GPL JDBC driver (ASF Category X) is not bundled in the default
+// build. `runtime/service` does not bring the driver transitively, so the default
+// release build stays GPL-free without any classpath exclusions. The driver is added
+// directly here only when `-PincludeMysqlDriver=true` is provided. The value is compared,
+// not merely the presence of the property: `-PincludeMysqlDriver=false` must not produce a
+// GPL-carrying artifact, which is the whole point of making this opt-in.
+//
+// Verification contract for the opt-in `-PincludeMysqlDriver=true` build:
+// - Supported: `:polaris-server:assemble`, Quarkus image build tasks.
+// - NOT supported (will fail by design because the GPL MySQL JDBC driver is
+//   intentionally absent from `LICENSE`):
+//   `:polaris-server:build`, `:polaris-server:check`,
+//   `:polaris-server:publishToMavenLocal`, `:polaris-server:generateLicenseReport`,
+//   `:polaris-server:checkLicense`, `:polaris-server:licenseReportZip`.
+// See `runtime/server/README.md` for the downstream/custom-build framing.
+if (project.findProperty("includeMysqlDriver") == "true") {
+  dependencies { runtimeOnly("io.quarkus:quarkus-jdbc-mysql") }
+  // Override the `jdbc=false` default in `application.properties` so Quarkus wires up
+  // the MySQL named datasource at build time.
+  quarkus { quarkusBuildProperties.put("quarkus.datasource.mysql.jdbc", "true") }
+}
+
 quarkus {
   quarkusBuildProperties.put("quarkus.package.jar.type", "fast-jar")
   // Pull manifest attributes from the "main" `jar` task to get the

--- a/site/content/in-dev/unreleased/metastores/relational-jdbc.md
+++ b/site/content/in-dev/unreleased/metastores/relational-jdbc.md
@@ -68,7 +68,13 @@ quarkus.rds.credentials-provider.aws.port=6160
 
 This is the basic configuration. For more details, please refer to the [Quarkus plugin documentation](https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-rds.html#_configuration_reference).
 
-The Relational JDBC metastore currently relies on a Quarkus-managed datasource and supports only PostgresSQL and H2 databases. At this time, official documentation is provided exclusively for usage with PostgreSQL.
+## 3. MySQL (custom source build)
+
+The relational JDBC backend can be built with MySQL 8.0+ support, but the MySQL JDBC driver is GPL-licensed and is not bundled in the official Polaris release artifacts (see [issue #2491](https://github.com/apache/polaris/issues/2491)). To use this path, download the official Polaris source release and build your own derivative from that source tree; see `persistence/relational-jdbc/MYSQL.md` in the unpacked source release for build and configuration details. The runner you build is a custom downstream derivative, not an official Polaris artifact.
+
+---
+
+The Relational JDBC metastore currently relies on a Quarkus-managed datasource. Official Polaris release artifacts support PostgreSQL and H2; MySQL is available only via a custom source build as described above. At this time, the most detailed documentation is provided for PostgreSQL.
 Please refer to the documentation here:
 [Configure data sources in Quarkus](https://quarkus.io/guides/datasource).
 

--- a/site/content/in-dev/unreleased/metastores/relational-jdbc.md
+++ b/site/content/in-dev/unreleased/metastores/relational-jdbc.md
@@ -68,7 +68,13 @@ quarkus.rds.credentials-provider.aws.port=6160
 
 This is the basic configuration. For more details, please refer to the [Quarkus plugin documentation](https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-rds.html#_configuration_reference).
 
-The Relational JDBC metastore currently relies on a Quarkus-managed datasource and supports only PostgreSQL and H2 databases. At this time, official documentation is provided exclusively for usage with PostgreSQL.
+## 3. MySQL (custom source build)
+
+The relational JDBC backend can be built with MySQL 8.0+ support, but the MySQL JDBC driver is GPL-licensed and is not bundled in the official Polaris release artifacts (see [issue #2491](https://github.com/apache/polaris/issues/2491)). To use this path, download the official Polaris source release and build your own derivative from that source tree; see `persistence/relational-jdbc/MYSQL.md` in the unpacked source release for build and configuration details. The runner you build is a custom downstream derivative, not an official Polaris artifact.
+
+---
+
+The Relational JDBC metastore currently relies on a Quarkus-managed datasource. Official Polaris release artifacts support PostgreSQL and H2. At this time, the most detailed documentation is provided for PostgreSQL.
 Please refer to the documentation here:
 [Configure data sources in Quarkus](https://quarkus.io/guides/datasource).
 
@@ -77,6 +83,8 @@ Additionally, the retries can be configured via `polaris.persistence.relational.
 By default, Polaris stores its tables in a schema named `POLARIS_SCHEMA`. The schema is selected entirely through the datasource configuration — Polaris ships the default as the JDBC driver's `currentSchema` connection property (`quarkus.datasource.jdbc.additional-jdbc-properties.currentSchema=POLARIS_SCHEMA`), and the persistence code itself is agnostic of the schema name. To use a different schema (for example, to run multiple Polaris deployments in the same database or to comply with a schema-naming policy), override that property or set `currentSchema` directly in the JDBC URL (the URL takes precedence). The name is passed to the driver unquoted, so the database applies its usual identifier case folding (for example, PostgreSQL folds it to lowercase).
 
 The schema must exist before Polaris connects: Polaris does not issue `CREATE SCHEMA`, since that is a privileged operation best performed by a database administrator. Setting up a fresh deployment is therefore a two-step procedure: a DBA first creates the schema (for example `CREATE SCHEMA polaris_schema;`), then the [Admin Tool]({{% ref "../admin-tool" %}}) bootstraps the realm using a datasource configured with the same schema. The database user Polaris runs with needs `USAGE` (and, for bootstrap, `CREATE`) privileges on that schema only.
+
+The `currentSchema` mechanism above is specific to the PostgreSQL driver (also used for CockroachDB) on the default datasource. On the MySQL custom source build, schema is synonymous with database and is selected by the path component of the JDBC URL on the named `mysql` datasource; `currentSchema` is not a MySQL Connector/J property and has no effect there. The rule that the schema must pre-exist still applies. See `persistence/relational-jdbc/MYSQL.md` for details.
 
 {{< alert important >}}
 **Upgrading an existing deployment:** if your JDBC URL already sets `currentSchema`, check it


### PR DESCRIPTION
This PR continues the work @Jayden-Chiu started in #2704 and owes its overall shape to that earlier effort — the `DatabaseType` enum extension, the MySQL `toMap` branching pattern, the testcontainer-based MySQL lifecycle management, and the per-subclass integration-test layout are all derived from @Jayden-Chiu's original proposal. Where this PR differs, it is to incorporate the review feedback (from @adutra, @dimas-b, @eric-maynard, @jbonofre, @flyrain) that landed on #2704 and #2491 after that PR went stale. Concretely:

* The MySQL JDBC driver is GPL-licensed and cannot be bundled with Apache Polaris under ASF Category X policy. This PR ships the Java code changes without the driver and adds an opt-in `-PincludeMysqlDriver=true` flag for downstream builds. (@adutra, @dimas-b, @jbonofre, @flyrain on #2491 and #2704.)
* MySQL gets a single schema file aligned with the latest Polaris schema version (v4) rather than retroactively backfilling v1/v2/v3. (@eric-maynard, @dimas-b on #2704.)

## Changes

### Persistence layer

- Added `MYSQL` to the `DatabaseType` enum, with product-name detection in `inferFromConnection` and display-name support for `"mysql"`. (Follows the enum-addition pattern from #2704.)
- Added MySQL SQLSTATE handling to `DatasourceOperations`:
  - `23000` (integrity constraint violation) combined with MySQL vendor error `1062` (duplicate entry) to match PostgreSQL's `23505` precision. MySQL does not have a dedicated SQLSTATE for unique-key violation.
  - `42S02` (table not found) — same code as H2.
- Added `mysql/schema-v4.sql` (the structure follows the tables Jayden-Chiu drafted in #2704, upgraded to the current v4 layout). Notable MySQL-specific adjustments:
  - `JSONB` → `JSON`; `ON CONFLICT` → `ON DUPLICATE KEY UPDATE`; `JSON` columns use `DEFAULT ('{}')` to match PostgreSQL's default.
  - `USE POLARIS_SCHEMA;` in place of `CREATE SCHEMA ... SET search_path` (in MySQL, a schema is a database; the database is provisioned via the JDBC URL / testcontainer).
  - Indexes declared inside `CREATE TABLE` because MySQL lacks `CREATE INDEX IF NOT EXISTS`. The bootstrap re-runs this script per realm, and idempotency is covered by `CREATE TABLE IF NOT EXISTS`.
  - `entities.name` sized to `VARCHAR(256)` to match Polaris' `MAX_IDENTIFIER_LENGTH` while staying within the InnoDB 3072-byte key length for the `(realm_id, ..., name)` unique key.
  - `location_without_scheme` indexed with a 400-char prefix for the same key-length reason.
- **JSON-column handling for MySQL.** MySQL's JDBC driver (Connector/J) maps `JSON` columns to `java.lang.String` and has no `Types.JSON`, so a bound `VARCHAR` compared against a `JSON` column in a `WHERE` clause is always type-different / never-equal under MySQL's JSON comparison rules — which was the root cause of `MysqlPolicyServiceIT` failing on the policy-mapping detach path. (Not caught in #2704; surfaced here because the integration test suite exercises detach/drop end-to-end.) This PR addresses it with a static schema lookup rather than any value-level marker:
  - A new `ModelRegistry` records which `(table, column)` pairs are JSON columns; each `Model*` class declares a `JSON_COLUMNS` set.
  - `QueryGenerator` consults `ModelRegistry.isJsonColumn(table, column)` when building `WHERE` equality conditions and, for JSON columns, emits the placeholder returned by `DatabaseType.asJsonConditionPlaceholder()` — `CAST(? AS JSON)` for MySQL and the plain `?` for PostgreSQL / CockroachDB / H2.
  - On the write side, the previously copy-pasted `if (POSTGRES) toJsonbPGobject(...) else raw-string` branches in `ModelEntity`, `ModelEvent`, `ModelPolicyMappingRecord`, `ModelCommitMetricsReport` and `ModelScanMetricsReport` are consolidated into a single shared helper `Converter#wrapJsonForDatabase(json, databaseType)` (PostgreSQL wraps to a `PGobject`; MySQL/H2/CockroachDB pass the raw JSON string, which MySQL implicitly parses into the `JSON` column on INSERT/UPDATE).
  - `ModelRegistryTest` and updates to `QueryGeneratorTest` cover the new path.
- `JdbcMetaStoreManagerFactory.produceDatasourceOperations` selects between the default (unnamed) datasource and a named MySQL datasource based on the configured `database-type`, failing fast with actionable guidance if `mysql` is configured but its named datasource is unavailable.

### Runtime module

- The standard `runtime/server` is the runner used for every relational backend; the MySQL JDBC driver is added to it (as `runtimeOnly`) only when `-PincludeMysqlDriver=true` is passed to Gradle, which also sets `quarkus.datasource.mysql.jdbc=true` at Quarkus build time so the named MySQL datasource is wired up.
- Because the GPL driver is intentionally absent from `LICENSE`, the license-report / verification / publish tasks are **not supported** under `-PincludeMysqlDriver=true` and will fail by design — `:polaris-server:build`, `:check`, `:publishToMavenLocal`, `:generateLicenseReport`, `:checkLicense`, `:licenseReportZip`. Only `:assemble` and the Docker image build are supported with the flag (the unsupported tasks are listed in `runtime/server/build.gradle.kts`).
- The default release build remains GPL-free:

  ./gradlew :polaris-server:assemble                              # ASF compliant (no MySQL driver)
  ./gradlew :polaris-server:assemble -PincludeMysqlDriver=true    # opt-in custom downstream build

- The Quarkus runtime distinguishes between the default (unnamed) datasource — used by PostgreSQL, CockroachDB and H2 — and the named MySQL datasource. The named MySQL datasource is declared inactive (`quarkus.datasource.mysql.active=false`, `quarkus.datasource.mysql.jdbc=false`) in `runtime/defaults/.../application.properties`; users opt in at runtime by setting `quarkus.datasource.mysql.active=true` and the connection properties on `quarkus.datasource.mysql.*`.

### Test infrastructure

- A new, dedicated Gradle module **`persistence/relational-jdbc-mysql/tests`** (project `:polaris-relational-jdbc-mysql-tests`) holds the MySQL integration tests. It is an integration-test-only module that pulls the GPL MySQL JDBC driver (`io.quarkus:quarkus-jdbc-mysql`), so it is **not a published library** and is explicitly excluded from the BOM (`bom/build.gradle.kts`) and registered in `gradle/projects.main.properties`. Keeping the driver in this module keeps it off the production-facing `runtime/service` classpath.
- The module's `intTest` source set contains `MysqlRelationalJdbcLifeCycleManagement`, `MysqlRelationalJdbcProfile`, and the `MysqlApplicationIT` / `MysqlManagementServiceIT` / `MysqlPolicyServiceIT` / `MysqlRestCatalogIT` / `MysqlViewFileIT` tests. The `*IT` classes extend the shared Polaris integration-test base classes from `org.apache.polaris.service.it.test` (the `:polaris-tests` / integration-tests module) and **reuse the existing `ServerManager` (the `PolarisServerManager` SPI impl) from `runtime/service` test fixtures** rather than duplicating it; the SPI is registered via a `META-INF/services/org.apache.polaris.service.it.ext.PolarisServerManager` resource in this module.
- `MysqlRelationalJdbcLifeCycleManagement` starts a `MySQLContainer` (image pinned via `Dockerfile-mysql-version`, currently `mysql:8.0`, Renovate-managed), provisions the `POLARIS_SCHEMA` database, and injects the runtime config the tests need: `polaris.persistence.relational.jdbc.database-type=mysql`, `quarkus.datasource.mysql.active=true`, and the container's JDBC URL / credentials. `quarkus.datasource.mysql.jdbc=true` is set for this module at Quarkus build time.
- Two cross-backend regression tests were added to the **shared** integration-test classes and therefore run against all backends (PostgreSQL, CockroachDB, H2, MySQL): a case-sensitivity coexistence test in `PolarisManagementServiceIntegrationTest` and a non-trivial-JSON attach/detach test in `PolarisPolicyServiceIntegrationTest` (the latter exercises the JSON-column `WHERE`-clause path described above).

### Documentation

- `persistence/relational-jdbc/MYSQL.md`: a new doc describing the MySQL backend, the GPL-driver opt-in build, and runtime configuration.
- `runtime/server/README.md`: a "Building a MySQL-capable server (custom downstream build)" note: GPL-driver disclaimer, `-PincludeMysqlDriver=true` build commands (including the Docker image build), and runtime configuration for the named MySQL datasource.
- `site/content/in-dev/unreleased/metastores/relational-jdbc.md`: a paragraph noting that the MySQL path requires a custom downstream build from the official source release and pointing to the source-tree README; the closing paragraph clarifies that official Polaris release artifacts support PostgreSQL and H2, with MySQL available only via a custom source build.
- `CHANGELOG.md`: entry framed as "source-level support", with an explicit statement that official Polaris release artifacts do not include the MySQL JDBC driver.

## Impact on existing backends

None. PostgreSQL, CockroachDB and H2 users do not need to change any configuration: they continue to use the default (unnamed) datasource via `quarkus.datasource.*`. The only MySQL-aware code on the shared persistence path is the `DatabaseType` switch in `QueryGenerator` (`asJsonConditionPlaceholder()` returns `CAST(? AS JSON)` for MySQL and `?` for every other backend) and the MySQL branches in `DatasourceOperations.isUniquenessConstraintViolation` / `isRelationDoesNotExist`, all gated on `DatabaseType.MYSQL`. Non-MySQL backends take the existing code paths unchanged, and the `Converter#wrapJsonForDatabase` refactor preserves the prior PostgreSQL `PGobject` / raw-string behavior.

## How it was tested

- `./gradlew :polaris-relational-jdbc-mysql-tests:intTest -PincludeMysqlDriver=true` — the full MySQL integration-test suite passes against a testcontainer-managed `mysql:8.0`: **482 tests, 0 failures** (`MysqlApplicationIT` 18, `MysqlManagementServiceIT` 52, `MysqlPolicyServiceIT` 47, `MysqlRestCatalogIT` 313, `MysqlViewFileIT` 52). These exercise bootstrap, the Polaris management API, policy attach/detach with non-trivial JSON parameters, and the Iceberg REST catalog/view CRUD flows end-to-end.
- `./gradlew :polaris-runtime-service:intTest --tests "*JdbcApplicationIT" --tests "*CockroachApplicationIT"` — the existing PostgreSQL and CockroachDB `*ApplicationIT` suites continue to pass, confirming no regression from the shared-path changes.
- `./gradlew :polaris-server:assemble` (no opt-in flag) succeeds and `:polaris-server:quarkusBuild` produces a GPL-free runner; the license-report tasks pass.
- `./gradlew :polaris-server:assemble -PincludeMysqlDriver=true` produces a runner with the MySQL JDBC driver bundled.
- `./gradlew :polaris-relational-jdbc:test` — unit tests (including `ModelRegistryTest` and the updated `QueryGeneratorTest`) pass.

## Acknowledgments

Thanks to @Jayden-Chiu for the original work in #2704 — its `DatabaseType` extension, schema-file layout, and test-infrastructure patterns are the foundation of this PR. Thanks also to @adutra, @dimas-b, @eric-maynard, @jbonofre, @flyrain, @singhpk234, and @snazy for the review feedback on #2704, #2491 and this PR that shaped the design.

## AI-assisted contribution

Parts of this change were drafted with AI assistance (Claude). The author (@Y-Wakuta) reviewed, tested, and takes full responsibility for the final code.

Fixes #2491
Continues #2704

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #2491
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)