### PR TITLE
Narrow SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION scope

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -68,14 +68,12 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION")
           .description(
-              "If set to true, skip credential-subscoping indirection entirely whenever trying\n"
-                  + "   to obtain storage credentials for instantiating a FileIO. If 'true', no attempt is made\n"
-                  + "   to use StorageConfigs to generate table-specific storage credentials, but instead the default\n"
-                  + "   fallthrough of table-level credential properties or else provider-specific APPLICATION_DEFAULT\n"
-                  + "   credential-loading will be used for the FileIO.\n"
-                  + "   Typically this setting is used in single-tenant server deployments that don't rely on\n"
-                  + "   \"credential-vending\" and can use server-default environment variables or credential config\n"
-                  + "   files for all storage access, or in test/dev scenarios.")
+              "Test/dev-only. If true, bypass credential subscoping entirely: FileIO falls back to\n"
+                  + "   the server's ambient credentials (pod IAM role, env vars, credential files).\n"
+                  + "   Intended for tests with fake storage paths (no real STS). NOT for production:\n"
+                  + "   those credentials are handed to every client, breaking defense-in-depth. For\n"
+                  + "   S3-compatible storage without STS, set stsUnavailable: true on the storage config\n"
+                  + "   instead.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -299,8 +299,8 @@ public class ProductionReadinessChecks {
     var message =
         "SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION is enabled. This flag is test/dev-only and returns "
             + "the Polaris server's ambient credentials to every client, breaking defense-in-depth. "
-            + "For S3-compatible storage without STS, set stsUnavailable: true on the catalog's "
-            + "storage config instead.";
+            + "For S3-compatible storage without STS, set stsUnavailable: true on the storage "
+            + "config instead.";
     var errors = new ArrayList<Error>();
     if (Boolean.parseBoolean(featureConfiguration.defaults().get(flag.key()))) {
       errors.add(Error.of(message, format("polaris.features.\"%s\"", flag.key())));

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -293,6 +293,37 @@ public class ProductionReadinessChecks {
   }
 
   @Produces
+  public ProductionReadinessCheck checkSkipCredentialSubscopingIndirection(
+      FeaturesConfiguration featureConfiguration) {
+    var flag = FeatureConfiguration.SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION;
+    var message =
+        "SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION is enabled. This flag is test/dev-only and returns "
+            + "the Polaris server's ambient credentials to every client, breaking defense-in-depth. "
+            + "For S3-compatible storage without STS, set stsUnavailable: true on the catalog's "
+            + "storage config instead.";
+    var errors = new ArrayList<Error>();
+    if (Boolean.parseBoolean(featureConfiguration.defaults().get(flag.key()))) {
+      errors.add(Error.of(message, format("polaris.features.\"%s\"", flag.key())));
+    }
+    featureConfiguration
+        .realmOverrides()
+        .forEach(
+            (realmId, overrides) -> {
+              if (Boolean.parseBoolean(overrides.overrides().get(flag.key()))) {
+                errors.add(
+                    Error.of(
+                        message,
+                        format(
+                            "polaris.features.realm-overrides.\"%s\".overrides.\"%s\"",
+                            realmId, flag.key())));
+              }
+            });
+    return errors.isEmpty()
+        ? ProductionReadinessCheck.OK
+        : ProductionReadinessCheck.of(errors.toArray(new Error[0]));
+  }
+
+  @Produces
   public ProductionReadinessCheck checkOverlappingSiblingCheckSettings(
       FeaturesConfiguration featureConfiguration) {
     var optimizedSiblingCheck = FeatureConfiguration.OPTIMIZED_SIBLING_CHECK;

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -431,7 +431,7 @@ A comma-separated list of fields to include as session tags in AWS STS AssumeRol
 
 ##### `polaris.features."SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION"`
 
-If set to true, skip credential-subscoping indirection entirely whenever trying to obtain storage credentials for instantiating a FileIO. If 'true', no attempt is made to use StorageConfigs to generate table-specific storage credentials, but instead the default fallthrough of table-level credential properties or else provider-specific APPLICATION_DEFAULT credential-loading will be used for the FileIO. Typically this setting is used in single-tenant server deployments that don't rely on "credential-vending" and can use server-default environment variables or credential config files for all storage access, or in test/dev scenarios.
+Test/dev-only. If true, bypass credential subscoping entirely: FileIO falls back to the server's ambient credentials (pod IAM role, env vars, credential files). Intended for tests with fake storage paths (no real STS). NOT for production: those credentials are handed to every client, breaking defense-in-depth. For S3-compatible storage without STS, set stsUnavailable: true on the storage config instead.
 
 - **Type:** `Boolean`
 - **Default:** `false`


### PR DESCRIPTION
Rewrite the flag description to state it's test/dev-only, spell out the defense-in-depth risk of handing the server's ambient credentials to every client, and steer S3-compatible deployments without STS to stsUnavailable: true on the storage config.

Add a non-severe ProductionReadinessCheck that emits a WARN on startup when the flag is enabled in defaults or any realm override, so operators see the security caveat without breaking existing deployments.

Runtime behavior is unchanged.

Related dev discussion, https://lists.apache.org/thread/1trcnbm04zzqztpxkzrzs1pvrlyd49bg

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
