### PR TITLE
Releasey: make Helm index/artifacthub-repo.yml transfer idempotent

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -279,6 +279,21 @@ jobs:
           dev_helm_chart_url="${APACHE_DIST_URL}/dev/polaris/helm-chart"
           release_helm_chart_url="${APACHE_DIST_URL}/release/polaris/helm-chart"
 
+          # Remove any existing index.yaml / artifacthub-repo.yml at the release location before the move.
+          # svn mv to a URL fails with "already exists" if the destination path is present, which is the
+          # case on every release after the first one has put these files under release/polaris/helm-chart/.
+          existing_release_files=$(svn list --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive "${release_helm_chart_url}" | grep -E '^(index\.yaml|artifacthub-repo\.yml)$' || true)
+
+          if [[ -n "${existing_release_files}" ]]; then
+            files_to_remove=()
+            for f in ${existing_release_files}; do
+              files_to_remove+=("${release_helm_chart_url}/${f}")
+            done
+            exec_process svn rm --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive \
+              "${files_to_remove[@]}" \
+              -m "Remove previous Helm index and artifacthub-repo.yml (superseded by ${version_without_rc})"
+          fi
+
           # Move index.yaml and artifacthub-repo.yml from dev to release
           # The index was already properly generated in workflow 3 with relative URLs for the current
           # release and absolute URLs to archive.apache.org for previous releases, so we just transfer it as-is


### PR DESCRIPTION
The "Transfer Helm index and artifacthub-repo.yml from dev to release" step in workflow 4 uses `svn mv` to a release URL that already contains these files on every release after the first.

This is likely to fail with an "already exists" error. This change removes any pre-existing copies at the release location before the move so the step is guaranteed to succeed on subsequent releases.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
