### PR TITLE
Include user-defined attributes when constructing PolarisPrincipal from PrincipalEntity (#4291)

### DIFF
--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -212,6 +212,7 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
     RangerAccessContext context = new RangerAccessContext(SERVICE_TYPE, serviceName);
     RangerMultiAuthzRequest authzRequest =
         new RangerMultiAuthzRequest(userInfo, accessInfos, context);
+    RangerUtils.setUserAttribsInRequestContext(userInfo, context);
     RangerMultiAuthzResult authzResult = authorizer.authorize(authzRequest);
     boolean isAllowed = RangerAuthzResult.AccessDecision.ALLOW.equals(authzResult.getDecision());
 

--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
@@ -32,10 +32,13 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
+import org.apache.ranger.authz.model.RangerAccessContext;
 import org.apache.ranger.authz.model.RangerAccessInfo;
 import org.apache.ranger.authz.model.RangerResourceInfo;
 import org.apache.ranger.authz.model.RangerUserInfo;
 import org.apache.ranger.authz.util.RangerResourceNameParser;
+import org.apache.ranger.plugin.util.RangerAccessRequestUtil;
+import org.apache.ranger.plugin.util.RangerUserStore;
 
 public class RangerUtils {
 
@@ -132,5 +135,25 @@ public class RangerUtils {
     return (properties == null || properties.isEmpty())
         ? Collections.emptyMap()
         : new HashMap<>(properties);
+  }
+
+  public static void setUserAttribsInRequestContext(
+      RangerUserInfo userInfo, RangerAccessContext rangerAccessContext) {
+    if (!userInfo.getAttributes().isEmpty()) {
+      RangerUserStore store = new RangerUserStore();
+      Map<String, Map<String, String>> userAttrMapping = new HashMap<>();
+      Map<String, String> attributeMap =
+          userInfo.getAttributes().entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, e -> e.getValue() == null ? "" : e.getValue().toString()));
+      userAttrMapping.put(userInfo.getName(), attributeMap);
+      store.setUserAttrMapping(userAttrMapping);
+      if (rangerAccessContext.getAdditionalInfo() == null) {
+        rangerAccessContext.setAdditionalInfo(new HashMap<>());
+      }
+      Map<String, Object> reqContext = rangerAccessContext.getAdditionalInfo();
+      RangerAccessRequestUtil.setRequestUserStoreInContext(reqContext, store);
+    }
   }
 }

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerABACWithUserAttrIT.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerABACWithUserAttrIT.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.extension.auth.ranger.test;
+
+import static io.restassured.RestAssured.given;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RangerTestProfiles.EmbeddedPolicy.class)
+public class RangerABACWithUserAttrIT extends RangerIntegrationTestBase {
+
+  @Test
+  void getCatalogListsWithoutAuthorization() {
+    Properties userattr = new Properties();
+    userattr.put("region", "region1");
+    String regionUserToken = getUserToken("region1user", userattr);
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + regionUserToken)
+        .get("/api/management/v1/catalogs")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void getCatalogListsWithAuthorization() {
+    Properties userattr = new Properties();
+    userattr.put("region", "region2");
+    String regionUserToken = getUserToken("region2user", userattr);
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + regionUserToken)
+        .get("/api/management/v1/catalogs")
+        .then()
+        .statusCode(200);
+  }
+}

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerABACWithUserAttrIT.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerABACWithUserAttrIT.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(RangerTestProfiles.EmbeddedPolicy.class)
+@TestProfile(RangerTestProfiles.EmbeddedPolicyWithUserAttrib.class)
 public class RangerABACWithUserAttrIT extends RangerIntegrationTestBase {
 
   @Test

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 
 /**
@@ -74,20 +75,24 @@ public abstract class RangerIntegrationTestBase {
     return accessToken;
   }
 
-  protected String getUserToken(String userName) {
+  protected String getUserToken(String userName, Properties userProperties) {
     String token = user2Token.get(userName);
     if (token == null) {
-      token = createPrincipalAndGetToken(userName);
+      token = createPrincipalAndGetToken(userName, userProperties);
       user2Token.put(userName, token);
     }
     return token;
   }
 
-  protected String createPrincipalAndGetToken(String principalName) {
+  protected String getUserToken(String userName) {
+    return getUserToken(userName, new Properties());
+  }
+
+  protected String createPrincipalAndGetToken(String principalName, Properties userProperties) {
     String rootToken = getRootToken();
 
     Map<String, Object> createPrincipalBody =
-        Map.of("principal", Map.of("name", principalName, "properties", Map.of()));
+        Map.of("principal", Map.of("name", principalName, "properties", userProperties));
     String createResponse =
         given()
             .contentType("application/json")
@@ -129,6 +134,10 @@ public abstract class RangerIntegrationTestBase {
     }
 
     return accessToken;
+  }
+
+  protected String createPrincipalAndGetToken(String principalName) {
+    return createPrincipalAndGetToken(principalName, new Properties());
   }
 
   protected String extractJsonValue(String json, String key) {

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
@@ -48,4 +48,25 @@ public final class RangerTestProfiles {
       return config;
     }
   }
+
+  public static class EmbeddedPolicyWithUserAttrib implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> config = new HashMap<>();
+      config.put("polaris.authorization.type", "ranger");
+      config.put("polaris.authorization.ranger.service-name", "dev_polaris");
+      config.put(
+          "polaris.authorization.ranger.authz.default.policy.source.impl",
+          "org.apache.ranger.admin.client.EmbeddedResourcePolicySource");
+      config.put(
+          "polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher", "false");
+      config.put(
+          "polaris.authorization.ranger.authz.default.policy.source.embedded_resource.path",
+          "/authz_it_tests");
+      config.put("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
+      config.put("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
+      config.put("polaris.readiness.ignore-severe-issues", "true");
+      return config;
+    }
+  }
 }

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
@@ -737,7 +737,7 @@
             {
               "type": "_expression",
               "values": [
-                "USER.region = 'region2'"
+                "USER.region == 'region2'"
               ]
             }
           ]

--- a/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
+++ b/extensions/auth/ranger/tests/src/intTest/resources/authz_it_tests/dev_polaris.json
@@ -723,6 +723,24 @@
               ]
             }
           ]
+        },
+        {
+          "accesses": [
+            {
+              "type": "catalog-list"
+            }
+          ],
+          "users": [
+            "region1user", "region2user"
+          ],
+          "conditions": [
+            {
+              "type": "_expression",
+              "values": [
+                "USER.region = 'region2'"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.auth;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -41,11 +42,9 @@ public interface PolarisPrincipal extends Principal {
    * @param roles the set of roles associated with the principal
    */
   static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
-    return of(
-        principalEntity.getName(),
-        principalEntity.getInternalPropertiesAsMap(),
-        roles,
-        Optional.empty());
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getInternalPropertiesAsMap());
+    allProperties.putAll(principalEntity.getPropertiesAsMap());
+    return of(principalEntity.getName(), allProperties, roles, Optional.empty());
   }
 
   /**
@@ -61,8 +60,9 @@ public interface PolarisPrincipal extends Principal {
    */
   static PolarisPrincipal of(
       PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
-    return of(
-        principalEntity.getName(), principalEntity.getInternalPropertiesAsMap(), roles, token);
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getInternalPropertiesAsMap());
+    allProperties.putAll(principalEntity.getPropertiesAsMap());
+    return of(principalEntity.getName(), allProperties, roles, token);
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -42,8 +42,8 @@ public interface PolarisPrincipal extends Principal {
    * @param roles the set of roles associated with the principal
    */
   static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
-    Map<String, String> allProperties = new HashMap<>(principalEntity.getInternalPropertiesAsMap());
-    allProperties.putAll(principalEntity.getPropertiesAsMap());
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getPropertiesAsMap());
+    allProperties.putAll(principalEntity.getInternalPropertiesAsMap());
     return of(principalEntity.getName(), allProperties, roles, Optional.empty());
   }
 
@@ -60,8 +60,8 @@ public interface PolarisPrincipal extends Principal {
    */
   static PolarisPrincipal of(
       PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
-    Map<String, String> allProperties = new HashMap<>(principalEntity.getInternalPropertiesAsMap());
-    allProperties.putAll(principalEntity.getPropertiesAsMap());
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getPropertiesAsMap());
+    allProperties.putAll(principalEntity.getInternalPropertiesAsMap());
     return of(principalEntity.getName(), allProperties, roles, token);
   }
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This change provides a fix for issue #4291 ; It updates the construction of PolarisPrincipal from PrincipalEntity to include user-defined attributes in addition to internal attributes.

Currently, PolarisPrincipal is initialized using:  
principalEntity.getInternalPropertiesAsMap()

This results in only internal attributes (such as client_id) being available in the PolarisPrincipal, while user-defined attributes supplied during principal creation are not propagated.

This PR updates the implementation to use: 
principalEntity.getPropertiesAsMap() along with principalEntity.getInternalPropertiesAsMap()

so that both internal and user-defined attributes are available during request processing.

Fixes:  #4291 

### Problem

When a principal is created with user-defined attributes (for example, region=northamerica), those attributes are successfully stored in PrincipalEntity.

However, during authentication and request handling, the constructed PolarisPrincipal only contains internal properties, and user-defined attributes are not available.

This prevents downstream components from accessing user attributes that were explicitly configured during principal creation.

### Testing

* Verified that principals created with user-defined attributes retain those attributes during authenticated API calls.
* Confirmed that internal attributes (e.g., client_id) continue to be preserved.
* Existing authentication flows remain unaffected.
* Added test coverage to validate that user-defined attributes are available in PolarisPrincipal after authentication.
    - Added testcase with Ranger Attribute Based Access Control Policy based Integration Test (org.apache.polaris.extension.auth.ranger.test.RangerABACWithUserAttrIT) 
        - Provides access to catalog listing only for those who have region = 'region2' 

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
