### PR TITLE
fix: include user-defined attributes in PolarisPrincipal

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.auth;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -35,17 +36,16 @@ public interface PolarisPrincipal extends Principal {
    * roles.
    *
    * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
-   * properties will be derived from the internal properties of the entity.
+   * properties will be derived from both the user-defined and internal properties of the entity.
+   * Internal properties take precedence over user-defined ones on key conflicts.
    *
    * @param principalEntity the principal entity representing the user or service
    * @param roles the set of roles associated with the principal
    */
   static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
-    return of(
-        principalEntity.getName(),
-        principalEntity.getInternalPropertiesAsMap(),
-        roles,
-        Optional.empty());
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getPropertiesAsMap());
+    allProperties.putAll(principalEntity.getInternalPropertiesAsMap());
+    return of(principalEntity.getName(), allProperties, roles, Optional.empty());
   }
 
   /**
@@ -53,7 +53,8 @@ public interface PolarisPrincipal extends Principal {
    * roles.
    *
    * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
-   * properties will be derived from the internal properties of the entity.
+   * properties will be derived from both the user-defined and internal properties of the entity.
+   * Internal properties take precedence over user-defined ones on key conflicts.
    *
    * @param principalEntity the principal entity representing the user or service
    * @param roles the set of roles associated with the principal
@@ -61,8 +62,9 @@ public interface PolarisPrincipal extends Principal {
    */
   static PolarisPrincipal of(
       PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
-    return of(
-        principalEntity.getName(), principalEntity.getInternalPropertiesAsMap(), roles, token);
+    Map<String, String> allProperties = new HashMap<>(principalEntity.getPropertiesAsMap());
+    allProperties.putAll(principalEntity.getInternalPropertiesAsMap());
+    return of(principalEntity.getName(), allProperties, roles, token);
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.junit.jupiter.api.Test;
+
+public class PolarisPrincipalTest {
+
+  @Test
+  public void ofWithRoles_includesUserDefinedProperties() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("alice")
+            .setClientId("client-123")
+            .setProperties(Map.of("region", "northamerica", "department", "finance"))
+            .build();
+
+    PolarisPrincipal principal = PolarisPrincipal.of(entity, Set.of("analyst"));
+
+    assertThat(principal.getProperties()).containsEntry("region", "northamerica");
+    assertThat(principal.getProperties()).containsEntry("department", "finance");
+    assertThat(principal.getProperties()).containsKey("client_id");
+  }
+
+  @Test
+  public void ofWithRolesAndToken_includesUserDefinedProperties() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("bob")
+            .setClientId("client-456")
+            .setProperties(Map.of("region", "europe"))
+            .build();
+
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(entity, Set.of("viewer"), Optional.of("tok-xyz"));
+
+    assertThat(principal.getProperties()).containsEntry("region", "europe");
+    assertThat(principal.getProperties()).containsKey("client_id");
+    assertThat(principal.getToken()).contains("tok-xyz");
+  }
+
+  @Test
+  public void internalPropertiesTakePrecedenceOnConflict() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("carol")
+            .setClientId("real-client-id")
+            .setProperties(Map.of("client_id", "spoofed-id", "region", "asia"))
+            .build();
+
+    PolarisPrincipal principal = PolarisPrincipal.of(entity, Set.of());
+
+    assertThat(principal.getProperties()).containsEntry("client_id", "real-client-id");
+    assertThat(principal.getProperties()).containsEntry("region", "asia");
+  }
+}


### PR DESCRIPTION
## Summary

When creating a Polaris principal with custom user-defined attributes (e.g. `region=northamerica`), those attributes were silently dropped during API authentication. Only internal attributes like `client_id` were retained.

**Root cause:** `PolarisPrincipal.of(PrincipalEntity, ...)` called `getInternalPropertiesAsMap()` exclusively, ignoring the user-defined properties stored in `getPropertiesAsMap()`.

**Fix:** Merge both maps when constructing the principal, with internal properties taking precedence on key conflicts.

Fixes #4291

## Checklist

- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #4291
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] Added comments for complex logic
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)

> This PR was developed with the help of AI assistance (Claude). I fully understand the changes and can explain all design decisions.