### PR TITLE
Suppress Hibernate Validator HV000271 deprecation warnings

### DIFF
--- a/server-templates/pojo.mustache
+++ b/server-templates/pojo.mustache
@@ -21,8 +21,8 @@ It is updated to remove all swagger annotations and support builders and immutab
 {{#vendorExtensions.x-field-extra-annotation}}
     {{{vendorExtensions.x-field-extra-annotation}}}
 {{/vendorExtensions.x-field-extra-annotation}}
-{{#useBeanValidation}}{{>beanValidation}}{{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}  @Valid
-{{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}{{/useBeanValidation}}  private final {{{datatypeWithEnum}}} {{name}};{{/vars}}
+{{#useBeanValidation}}{{>beanValidation}}{{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}{{^isContainer}}{{^vendorExtensions.x-polaris-skip-valid-annotation}}  @Valid
+{{/vendorExtensions.x-polaris-skip-valid-annotation}}{{/isContainer}}{{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}{{/useBeanValidation}}  private final {{{datatypeWithEnum}}} {{name}};{{/vars}}
 {{#vars}}
     /**
     {{#description}}

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -858,6 +858,7 @@ components:
           description: The name of the catalog
         properties:
           type: object
+          x-polaris-skip-valid-annotation: true
           properties:
             default-base-location:
               type: string


### PR DESCRIPTION
The OpenAPI-generated model classes triggered `HV000271` warnings on startup because the `pojo.mustache` template emitted a field-level `@Valid` annotation on container types (List/Set) in addition to the type-argument-level `@Valid` (e.g. `List<@Valid T>`), which Hibernate Validator 9 deprecates.

This PR changes the template to skip the field-level `@Valid` when the field is a container.

The same warning fired for the `properties` field of `Catalog` because the generated `CatalogProperties` class extends `HashMap<String, String>`, which Hibernate also treats as a container.

This specific case was harder to solve. This PR introduces an `x-polaris-skip-valid-annotation` vendor extension to opt-out individual fields, and applies this annotation to `Catalog.properties`.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
