### PR TITLE
Remove the replace-new-location-prefix-with-catalog-default catalog property

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -70,7 +70,6 @@ import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
-import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.service.it.env.ClientPrincipal;
 import org.apache.polaris.service.it.env.IntegrationTestsHelper;
@@ -208,10 +207,7 @@ public class PolarisApplicationIntegrationTest {
       StorageConfigInfo storageConfig,
       String defaultBaseLocation,
       Map<String, String> additionalProperties) {
-    CatalogProperties.Builder propsBuilder =
-        CatalogProperties.builder(defaultBaseLocation)
-            .addProperty(
-                CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:/");
+    CatalogProperties.Builder propsBuilder = CatalogProperties.builder(defaultBaseLocation);
     for (var entry : additionalProperties.entrySet()) {
       propsBuilder.addProperty(entry.getKey(), entry.getValue());
     }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -59,7 +59,6 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.admin.model.TableGrant;
 import org.apache.polaris.core.admin.model.TablePrivilege;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
-import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
 import org.apache.polaris.service.it.env.CatalogConfig;
@@ -182,11 +181,6 @@ public class PolarisPolicyServiceIntegrationTest {
         IntegrationTestsHelper.mergeFromAnnotatedElements(
             testInfo, CatalogConfig.class, CatalogConfig::properties);
     catalogPropsBuilder.putAll(catalogProperties);
-
-    if (!s3BucketBase.getScheme().equals("file")) {
-      catalogPropsBuilder.addProperty(
-          CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:");
-    }
 
     Catalog.TypeEnum catalogType =
         IntegrationTestsHelper.extractFromAnnotatedElements(

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -95,7 +95,6 @@ import org.apache.polaris.core.admin.model.TablePrivilege;
 import org.apache.polaris.core.admin.model.ViewGrant;
 import org.apache.polaris.core.admin.model.ViewPrivilege;
 import org.apache.polaris.core.config.FeatureConfiguration;
-import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.service.it.env.CatalogApi;
 import org.apache.polaris.service.it.env.CatalogConfig;
@@ -285,11 +284,6 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
 
     catalogPropsBuilder.addProperty(
         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true");
-
-    if (!testRuntimeURI.getScheme().equals("file")) {
-      catalogPropsBuilder.addProperty(
-          CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:");
-    }
 
     Catalog.TypeEnum catalogType =
         IntegrationTestsHelper.extractFromAnnotatedElements(

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
@@ -19,14 +19,12 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on Azure. */
 public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
@@ -70,8 +68,4 @@ public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
   @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
   @Override
   public void updateViewLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
@@ -18,29 +18,31 @@
  */
 package org.apache.polaris.service.it.test;
 
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.List;
+import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on the local filesystem. */
 public abstract class PolarisRestCatalogViewFileIntegrationTestBase
     extends PolarisRestCatalogViewIntegrationBase {
-  static String baseLocation;
-
-  @BeforeAll
-  public static void setUp(@TempDir Path tempDir) {
-    String baseUri = tempDir.toAbsolutePath().toUri().toString();
-    if (baseUri.endsWith("/")) {
-      baseUri = baseUri.substring(0, baseUri.length() - 1);
-    }
-    baseLocation = baseUri;
-  }
 
   @Override
   protected StorageConfigInfo getStorageConfigInfo() {
+    Path tempDir;
+    try {
+      Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
+      field.setAccessible(true);
+      tempDir = (Path) field.get(this);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    String baseLocation = tempDir.toAbsolutePath().toUri().toString();
+    if (baseLocation.endsWith("/")) {
+      baseLocation = baseLocation.substring(0, baseLocation.length() - 1);
+    }
     return FileStorageConfigInfo.builder()
         .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
         .setAllowedLocations(List.of(baseLocation))

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
@@ -19,13 +19,11 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on GCP. */
 public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
@@ -68,8 +66,4 @@ public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
   @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
   @Override
   public void updateViewLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -21,11 +21,9 @@ package org.apache.polaris.service.it.test;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
 
 import java.lang.reflect.Method;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.View;
@@ -36,7 +34,6 @@ import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.FeatureConfiguration;
-import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.IcebergHelper;
@@ -54,7 +51,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
@@ -88,6 +84,7 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
 
   private RESTCatalog restCatalog;
   private StorageConfigInfo storageConfig;
+  private String defaultBaseLocation;
 
   @BeforeAll
   static void setup(PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
@@ -115,7 +112,7 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
     String catalogName = client.newEntityName(method.getName());
 
     storageConfig = getStorageConfigInfo();
-    String defaultBaseLocation =
+    defaultBaseLocation =
         storageConfig.getAllowedLocations().getFirst()
             + "/"
             + System.getenv("USER")
@@ -123,8 +120,6 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
 
     CatalogProperties props =
         CatalogProperties.builder(defaultBaseLocation)
-            .addProperty(
-                CatalogEntity.REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, "file:")
             .addProperty(FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
             .addProperty(
                 FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
@@ -195,19 +190,11 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
     return true;
   }
 
-  @Override
   @Test
-  public void createViewWithCustomMetadataLocation() {
-    Assertions.assertThatThrownBy(super::createViewWithCustomMetadataLocation)
-        .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining("Forbidden: Invalid locations");
-  }
-
-  @Test
-  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {
+  public void createViewWithCustomMetadataLocationUsingPolaris() {
     TableIdentifier identifier = TableIdentifier.of("ns", "view");
 
-    String location = Paths.get(tempDir.toUri().toString()).toString();
+    String location = defaultBaseLocation + "/custom-view-location";
     String customLocation =
         Paths.get(storageConfig.getAllowedLocations().getFirst(), "/custom-location1").toString();
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
@@ -19,14 +19,12 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.io.TempDir;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on AWS. */
 public abstract class PolarisRestCatalogViewS3IntegrationTestBase
@@ -70,8 +68,4 @@ public abstract class PolarisRestCatalogViewS3IntegrationTestBase
   @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
   @Override
   public void updateViewLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocationUsingPolaris(@TempDir Path tempDir) {}
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -63,21 +63,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
   // catalog, stored in the "properties" map.
   public static final String DEFAULT_BASE_LOCATION_KEY = "default-base-location";
 
-  /**
-   * Test-only property that specifies a prefix that will be replaced with the catalog's
-   * default-base-location whenever it matches a specified new table or view location.
-   *
-   * <p>For example, if the catalog base location is "s3://my-bucket/base/location" and the prefix
-   * specified here is "file:/tmp" then any new table attempting to specify a base location of
-   * "file:/tmp/ns1/ns2/table1" will be translated into
-   * "s3://my-bucket/base/location/ns1/ns2/table1".
-   *
-   * <p><strong>WARNING:</strong> This property is intended for testing purposes only and should not
-   * be used in production environments.
-   */
-  public static final String REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY =
-      "replace-new-location-prefix-with-catalog-default";
-
   public CatalogEntity(PolarisBaseEntity sourceEntity) {
     super(sourceEntity);
     Preconditions.checkState(
@@ -220,10 +205,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     return getPropertiesAsMap().get(DEFAULT_BASE_LOCATION_KEY);
   }
 
-  public String getReplaceNewLocationPrefixWithCatalogDefault() {
-    return getPropertiesAsMap().get(REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY);
-  }
-
   public @Nullable PolarisStorageConfigurationInfo getStorageConfigurationInfo() {
     String configStr =
         getInternalPropertiesAsMap().get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
@@ -282,12 +263,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     public Builder setDefaultBaseLocation(String defaultBaseLocation) {
       // Note that this member lives in the main 'properties' map rather than internalProperties.
       properties.put(DEFAULT_BASE_LOCATION_KEY, defaultBaseLocation);
-      return this;
-    }
-
-    public Builder setReplaceNewLocationPrefixWithCatalogDefault(String value) {
-      // Note that this member lives in the main 'properties' map rather than internalProperties.
-      properties.put(REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY, value);
       return this;
     }
 

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogViewFileIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogViewFileIT.java
@@ -19,21 +19,7 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
-import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusIntegrationTest
-public class RestCatalogViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {
-
-  @BeforeEach
-  public void setUpTempDir(@TempDir Path tempDir) throws Exception {
-    // see https://github.com/quarkusio/quarkus/issues/13261
-    Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
-    field.setAccessible(true);
-    field.set(this, tempDir);
-  }
-}
+public class RestCatalogViewFileIT extends PolarisRestCatalogViewFileIntegrationTestBase {}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -990,35 +990,12 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   /**
-   * Applies the rule controlled by REPLACE_NEW_LOCATION_PREFIX_WITH_CATALOG_DEFAULT_KEY to a
-   * tablelike location
-   */
-  private String applyReplaceNewLocationWithCatalogDefault(String specifiedTableLikeLocation) {
-    String replaceNewLocationPrefix = catalogEntity.getReplaceNewLocationPrefixWithCatalogDefault();
-    if (specifiedTableLikeLocation != null
-        && replaceNewLocationPrefix != null
-        && specifiedTableLikeLocation.startsWith(replaceNewLocationPrefix)) {
-      String modifiedLocation =
-          defaultBaseLocation
-              + specifiedTableLikeLocation.substring(replaceNewLocationPrefix.length());
-      LOGGER
-          .atDebug()
-          .addKeyValue("specifiedTableLikeLocation", specifiedTableLikeLocation)
-          .addKeyValue("modifiedLocation", modifiedLocation)
-          .log("Translating specifiedTableLikeLocation based on config");
-      return modifiedLocation;
-    }
-    return specifiedTableLikeLocation;
-  }
-
-  /**
    * Based on configuration settings, for callsites that need to handle potentially setting a new
    * base location for a TableLike entity, produces the transformed location if applicable, or else
    * the unaltered specified location.
    */
   public String transformTableLikeLocation(TableIdentifier tableIdentifier, String location) {
-    return applyDefaultLocationObjectStoragePrefix(
-        tableIdentifier, applyReplaceNewLocationWithCatalogDefault(location));
+    return applyDefaultLocationObjectStoragePrefix(tableIdentifier, location);
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -183,7 +183,6 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
                 new CatalogEntity.Builder()
                     .setName(CATALOG_NAME)
                     .setDefaultBaseLocation(storageLocation)
-                    .setReplaceNewLocationPrefixWithCatalogDefault("file:")
                     .addProperty(
                         FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                     .addProperty(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -213,6 +213,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
   private static final String VIEW_QUERY = "select * from ns1.layer1_table";
 
   public static final String CATALOG_NAME = "polaris-catalog";
+  public static final String STORAGE_LOCATION = "s3://my-bucket/path/to/data";
   public static final String TEST_ACCESS_KEY = "test_access_key";
   public static final String SECRET_ACCESS_KEY = "secret_access_key";
   public static final String SESSION_TOKEN = "session_token";
@@ -286,22 +287,20 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
     realmContextHolder.set(() -> realmName);
     polarisContext = callContext.getPolarisCallContext();
 
-    String storageLocation = "s3://my-bucket/path/to/data";
     AwsStorageConfigInfo storageConfigModel =
         AwsStorageConfigInfo.builder()
             .setRoleArn("arn:aws:iam::012345678901:role/jdoe")
             .setExternalId("externalId")
             .setUserArn("aws::a:user:arn")
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
-            .setAllowedLocations(List.of(storageLocation, "s3://externally-owned-bucket"))
+            .setAllowedLocations(List.of(STORAGE_LOCATION, "s3://externally-owned-bucket"))
             .build();
     catalogEntity =
         adminService.createCatalog(
             new CreateCatalogRequest(
                 new CatalogEntity.Builder()
                     .setName(CATALOG_NAME)
-                    .setDefaultBaseLocation(storageLocation)
-                    .setReplaceNewLocationPrefixWithCatalogDefault("file:")
+                    .setDefaultBaseLocation(STORAGE_LOCATION)
                     .addProperty(
                         FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                     .addProperty(
@@ -309,7 +308,7 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
                         "true")
                     .addProperty(
                         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true")
-                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, storageLocation)
+                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, STORAGE_LOCATION)
                     .build()
                     .asCatalog(serviceIdentityProvider)));
 
@@ -384,6 +383,17 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
   @Override
   protected boolean overridesRequestedLocation() {
     return true;
+  }
+
+  @Override
+  protected String baseTableLocation(TableIdentifier identifier) {
+    // Override the file:/tmp default used by CatalogTests so inherited tests pass locations that
+    // fall inside this catalog's allowed S3 locations.
+    return STORAGE_LOCATION
+        + "/baseTableLocation/"
+        + String.join("/", identifier.namespace().levels())
+        + "/"
+        + identifier.name();
   }
 
   protected boolean supportsNotifications() {
@@ -1898,7 +1908,6 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             new CatalogEntity.Builder()
                 .setName(noPurgeCatalogName)
                 .setDefaultBaseLocation(storageLocation)
-                .setReplaceNewLocationPrefixWithCatalogDefault("file:")
                 .addProperty(
                     FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                 .addProperty(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -204,7 +204,6 @@ public abstract class AbstractPolicyCatalogTest {
                 new CatalogEntity.Builder()
                     .setName(CATALOG_NAME)
                     .setDefaultBaseLocation(storageLocation)
-                    .setReplaceNewLocationPrefixWithCatalogDefault("file:")
                     .addProperty(
                         FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
                     .addProperty(

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogViewFileIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogViewFileIntegrationTest.java
@@ -21,13 +21,8 @@ package org.apache.polaris.service.it;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
 import java.util.Map;
-import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 
 @QuarkusTest
 @TestProfile(RestCatalogViewFileIntegrationTest.Profile.class)
@@ -46,13 +41,5 @@ public class RestCatalogViewFileIntegrationTest
           "polaris.readiness.ignore-severe-issues",
           "true");
     }
-  }
-
-  @BeforeEach
-  public void setUpTempDir(@TempDir Path tempDir) throws Exception {
-    // see https://github.com/quarkusio/quarkus/issues/13261
-    Field field = ViewCatalogTests.class.getDeclaredField("tempDir");
-    field.setAccessible(true);
-    field.set(this, tempDir);
   }
 }


### PR DESCRIPTION
This catalog property was documented as test-only but was honored unconditionally by `IcebergCatalog#transformTableLikeLocation` in production.

The property is no longer needed by the tests that relied on it: the unit-test abstract bases now produce paths matching the storage provider directly, and the integration-test bases either had a `baseTableLocation` override that already produced scheme-appropriate paths, or only relied on the rewrite for tests that are disabled on cloud backends.

This change removes the property declaration, getter, and builder setter from `CatalogEntity`, and the
`applyReplaceNewLocationWithCatalogDefault` method from `IcebergCatalog`, then adjusts the tests accordingly.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
