### PR TITLE
Update Manual Instructions to Include Changing Link on the Binary Distribution Page

### DIFF
--- a/site/content/community/release-guides/manual-release-guide.md
+++ b/site/content/community/release-guides/manual-release-guide.md
@@ -429,6 +429,13 @@ Copy the documentation from the release tag:
 cp -r ../../content/in-dev/unreleased/* [major].[minor].[patch]/
 ```
 
+Update the binary distribution download link in `[major].[minor].[patch]/getting-started/binary-distribution.md`.
+Replace any old release URL with the correct one for this release. For a non-incubating release the URL format is:
+
+```
+https://downloads.apache.org/polaris/[major].[minor].[patch]/polaris-bin-[major].[minor].[patch].tgz
+```
+
 Edit the file `[major].[minor].[patch]/_index.md`. Compare with template
 `site/content/in-dev/release_index.md` and perform the following modifications:
 

--- a/site/content/community/release-guides/semi-automated-release-guide.md
+++ b/site/content/community/release-guides/semi-automated-release-guide.md
@@ -202,6 +202,13 @@ Copy the documentation from the release tag:
 cp -r ../../content/in-dev/unreleased/* [major].[minor].[patch]/
 ```
 
+Update the binary distribution download link in `[major].[minor].[patch]/getting-started/binary-distribution.md`.
+Replace any old release URL with the correct one for this release. For a non-incubating release the URL format is:
+
+```
+https://downloads.apache.org/polaris/[major].[minor].[patch]/polaris-bin-[major].[minor].[patch].tgz
+```
+
 Edit the file `[major].[minor].[patch]/_index.md`. Compare with template
 `site/content/in-dev/release_index.md` and perform the following modifications:
 


### PR DESCRIPTION
As stated in title. This was pointed out in the Polaris Slack as a gap: https://apache-polaris.slack.com/archives/C084QSKD6S2/p1777062935449209?thread_ts=1776983262.786339&cid=C084QSKD6S2

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
