### PR TITLE
Fix binary distribution download link for 1.4.0

### DIFF
--- a/1.4.0/getting-started/binary-distribution.md
+++ b/1.4.0/getting-started/binary-distribution.md
@@ -32,8 +32,8 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz | tar xz
-cd polaris-bin-1.3.0-incubating
+curl -L https://downloads.apache.org/polaris/1.4.0/polaris-bin-1.4.0.tgz | tar xz
+cd polaris-bin-1.4.0
 ```
 
 Start the Polaris server:


### PR DESCRIPTION
The link was incorrectly pointing to the 1.3.0-incubating release. Updated to the correct 1.4.0 URL (without incubating suffix since Polaris has graduated from the Apache Incubator).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
