### PR TITLE
Fix banned-dependency handling wrt detached/copied configuations

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -284,9 +284,11 @@ class BannedDependencies(
   val quarkusProdBanned: List<BannedDependency>,
 ) {
   fun applyTo(configuration: Configuration) {
-    globallyBanned.forEach { it.exclude(configuration) }
-    if (configuration.name.startsWith("quarkusProd")) {
-      quarkusProdBanned.forEach { it.exclude(configuration) }
+    if (configuration.state == Configuration.State.UNRESOLVED) {
+      globallyBanned.forEach { it.exclude(configuration) }
+      if (configuration.name.startsWith("quarkusProd")) {
+        quarkusProdBanned.forEach { it.exclude(configuration) }
+      }
     }
   }
 


### PR DESCRIPTION
Gradle `Configurations` can only be updated as long as those haven't been resolved ("observed"). Detached or copied `Configuration`s, as it happens during license validation via the used plugin, can already be resolved. Updating those leads to corresponding exceptions and in turn build failures.

This change addresses this by applying the banned dependencies only to unresolved configurations, which is fine here.

This change also unblocks the current Quarkus 3.34.6 upgrade where a _copied_ (think: detached) Gradle `Configuration`, which is already resolved, is attempted to be mutated, which is illegal:
```
Caused by: org.gradle.api.InvalidUserCodeException: Cannot mutate the dependencies of configuration ':polaris-admin:quarkusProdBaseRuntimeClasspathConfigurationCopy1' after the configuration was resolved. After a configuration has been observed, it should not be modified.
```
