### PR TITLE
AWS: skip wildcard KMS policy for non-native AWS STS endpoints

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -172,6 +172,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setStsUnavailable(awsConfig.getStsUnavailable())
             .setEndpointInternal(awsConfig.getEndpointInternal())
             .setKmsUnavailable(awsConfig.getKmsUnavailable())
+            .setNoWildcardKmsPolicy(awsConfig.getNoWildcardKmsPolicy())
             .build();
       }
       if (configInfo instanceof AzureStorageConfigurationInfo azureConfig) {
@@ -325,6 +326,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
                     .stsUnavailable(awsConfigModel.getStsUnavailable())
                     .endpointInternal(awsConfigModel.getEndpointInternal())
                     .kmsUnavailable(awsConfigModel.getKmsUnavailable())
+                    .noWildcardKmsPolicy(awsConfigModel.getNoWildcardKmsPolicy())
                     .build();
             config = awsConfig;
             break;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -288,7 +288,7 @@ public class AwsCredentialsStorageIntegration
           canWrite,
           region,
           storageConfigurationInfo.getAwsAccountId(),
-          storageConfigurationInfo.getStsEndpointUri() == null);
+          !Boolean.TRUE.equals(storageConfigurationInfo.getNoWildcardKmsPolicy()));
     }
     if (!bucketListStatementBuilder.isEmpty()) {
       bucketListStatementBuilder
@@ -313,11 +313,11 @@ public class AwsCredentialsStorageIntegration
       boolean canWrite,
       String region,
       String accountId,
-      boolean isNativeAwsEndpoint) {
+      boolean allowWildcardKms) {
 
     boolean hasCurrentKey = kmsKeyArn != null;
     boolean hasAllowedKeys = hasAllowedKmsKeys(allowedKmsKeys);
-    boolean isAwsS3 = isNativeAwsEndpoint && region != null && accountId != null;
+    boolean isAwsS3 = allowWildcardKms && region != null && accountId != null;
 
     // Nothing to do if no keys are configured and not AWS S3
     if (!hasCurrentKey && !hasAllowedKeys && !isAwsS3) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -287,7 +287,8 @@ public class AwsCredentialsStorageIntegration
           policyBuilder,
           canWrite,
           region,
-          storageConfigurationInfo.getAwsAccountId());
+          storageConfigurationInfo.getAwsAccountId(),
+          storageConfigurationInfo.getStsEndpointUri() == null);
     }
     if (!bucketListStatementBuilder.isEmpty()) {
       bucketListStatementBuilder
@@ -311,11 +312,12 @@ public class AwsCredentialsStorageIntegration
       IamPolicy.Builder policyBuilder,
       boolean canWrite,
       String region,
-      String accountId) {
+      String accountId,
+      boolean isNativeAwsEndpoint) {
 
     boolean hasCurrentKey = kmsKeyArn != null;
     boolean hasAllowedKeys = hasAllowedKmsKeys(allowedKmsKeys);
-    boolean isAwsS3 = region != null && accountId != null;
+    boolean isAwsS3 = isNativeAwsEndpoint && region != null && accountId != null;
 
     // Nothing to do if no keys are configured and not AWS S3
     if (!hasCurrentKey && !hasAllowedKeys && !isAwsS3) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -118,9 +118,9 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
   public abstract @Nullable Boolean getKmsUnavailable();
 
   /**
-   * Flag indicating whether the wildcard KMS key statement should be omitted from AssumeRole
-   * inline policies. Set to {@code true} for S3-compatible STS implementations (e.g. Ceph RGW)
-   * that reject {@code kms:} actions in inline policies.
+   * Flag indicating whether the wildcard KMS key statement should be omitted from AssumeRole inline
+   * policies. Set to {@code true} for S3-compatible STS implementations (e.g. Ceph RGW) that reject
+   * {@code kms:} actions in inline policies.
    */
   public abstract @Nullable Boolean getNoWildcardKmsPolicy();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -117,6 +117,13 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
    */
   public abstract @Nullable Boolean getKmsUnavailable();
 
+  /**
+   * Flag indicating whether the wildcard KMS key statement should be omitted from AssumeRole
+   * inline policies. Set to {@code true} for S3-compatible STS implementations (e.g. Ceph RGW)
+   * that reject {@code kms:} actions in inline policies.
+   */
+  public abstract @Nullable Boolean getNoWildcardKmsPolicy();
+
   /** Endpoint URI for STS API calls */
   @Nullable
   public abstract String getStsEndpoint();

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -1675,4 +1675,90 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             Optional.empty(),
             CredentialVendingContext.empty());
   }
+
+  @Test
+  public void testNoKmsWildcardForCustomStsEndpoint() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
+    String externalId = "externalId";
+    String bucket = "bucket";
+    String warehouseKeyPrefix = "path/to/warehouse";
+    String region = "us-east-1";
+
+    Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              AssumeRoleRequest request = invocation.getArgument(0);
+              IamPolicy policy = IamPolicy.fromJson(request.policy());
+              assertThat(policy.statements())
+                  .noneMatch(
+                      stmt ->
+                          stmt.actions().stream()
+                              .anyMatch(action -> action.value().startsWith("kms:")));
+              return ASSUME_ROLE_RESPONSE;
+            });
+
+    // Custom stsEndpoint (e.g. Ceph RGW) with region + accountId set: wildcard KMS must be
+    // suppressed because non-AWS STS endpoints reject kms: actions in inline policies.
+    new AwsCredentialsStorageIntegration(
+            AwsStorageConfigurationInfo.builder()
+                .addAllowedLocation(s3Path(bucket, warehouseKeyPrefix))
+                .roleARN(roleARN)
+                .externalId(externalId)
+                .region(region)
+                .stsEndpoint("http://ceph-rgw:8080")
+                .build(),
+            stsClient)
+        .getSubscopedCreds(
+            EMPTY_REALM_CONFIG,
+            true,
+            Set.of(s3Path(bucket, warehouseKeyPrefix + "/table")),
+            Set.of(),
+            POLARIS_PRINCIPAL,
+            Optional.empty(),
+            CredentialVendingContext.empty());
+  }
+
+  @Test
+  public void testNoKmsWildcardForS3CompatibleEndpoint() {
+    StsClient stsClient = Mockito.mock(StsClient.class);
+    String roleARN = "arn:aws:iam::012345678901:role/jdoe";
+    String externalId = "externalId";
+    String bucket = "bucket";
+    String warehouseKeyPrefix = "path/to/warehouse";
+    String region = "us-east-1";
+
+    Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              AssumeRoleRequest request = invocation.getArgument(0);
+              IamPolicy policy = IamPolicy.fromJson(request.policy());
+              assertThat(policy.statements())
+                  .noneMatch(
+                      stmt ->
+                          stmt.actions().stream()
+                              .anyMatch(action -> action.value().startsWith("kms:")));
+              return ASSUME_ROLE_RESPONSE;
+            });
+
+    // S3-compatible endpoint set (no explicit stsEndpoint): STS endpoint URI is derived from the
+    // S3 endpoint, so it is also non-AWS and must not receive a wildcard KMS policy.
+    new AwsCredentialsStorageIntegration(
+            AwsStorageConfigurationInfo.builder()
+                .addAllowedLocation(s3Path(bucket, warehouseKeyPrefix))
+                .roleARN(roleARN)
+                .externalId(externalId)
+                .region(region)
+                .endpoint("http://minio:9000")
+                .build(),
+            stsClient)
+        .getSubscopedCreds(
+            EMPTY_REALM_CONFIG,
+            true,
+            Set.of(s3Path(bucket, warehouseKeyPrefix + "/table")),
+            Set.of(),
+            POLARIS_PRINCIPAL,
+            Optional.empty(),
+            CredentialVendingContext.empty());
+  }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -1677,7 +1677,7 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   }
 
   @Test
-  public void testNoKmsWildcardForCustomStsEndpoint() {
+  public void testNoWildcardKmsPolicyFlag() {
     StsClient stsClient = Mockito.mock(StsClient.class);
     String roleARN = "arn:aws:iam::012345678901:role/jdoe";
     String externalId = "externalId";
@@ -1698,15 +1698,13 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
               return ASSUME_ROLE_RESPONSE;
             });
 
-    // Custom stsEndpoint (e.g. Ceph RGW) with region + accountId set: wildcard KMS must be
-    // suppressed because non-AWS STS endpoints reject kms: actions in inline policies.
     new AwsCredentialsStorageIntegration(
             AwsStorageConfigurationInfo.builder()
                 .addAllowedLocation(s3Path(bucket, warehouseKeyPrefix))
                 .roleARN(roleARN)
                 .externalId(externalId)
                 .region(region)
-                .stsEndpoint("http://ceph-rgw:8080")
+                .noWildcardKmsPolicy(true)
                 .build(),
             stsClient)
         .getSubscopedCreds(
@@ -1720,36 +1718,41 @@ class AwsCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   }
 
   @Test
-  public void testNoKmsWildcardForS3CompatibleEndpoint() {
+  public void testWildcardKmsPresentWithExplicitAwsRegionalStsEndpoint() {
     StsClient stsClient = Mockito.mock(StsClient.class);
     String roleARN = "arn:aws:iam::012345678901:role/jdoe";
     String externalId = "externalId";
     String bucket = "bucket";
     String warehouseKeyPrefix = "path/to/warehouse";
     String region = "us-east-1";
+    String accountId = "012345678901";
 
+    // An explicit regional AWS STS endpoint without noWildcardKmsPolicy must still receive the
+    // wildcard KMS statement. This would have been incorrectly suppressed by the old
+    // getStsEndpointUri() == null heuristic.
     Mockito.when(stsClient.assumeRole(Mockito.isA(AssumeRoleRequest.class)))
         .thenAnswer(
             invocation -> {
               AssumeRoleRequest request = invocation.getArgument(0);
               IamPolicy policy = IamPolicy.fromJson(request.policy());
               assertThat(policy.statements())
-                  .noneMatch(
+                  .anySatisfy(
                       stmt ->
-                          stmt.actions().stream()
-                              .anyMatch(action -> action.value().startsWith("kms:")));
+                          assertThat(stmt.resources())
+                              .contains(
+                                  IamResource.create(
+                                      String.format(
+                                          "arn:aws:kms:%s:%s:key/*", region, accountId))));
               return ASSUME_ROLE_RESPONSE;
             });
 
-    // S3-compatible endpoint set (no explicit stsEndpoint): STS endpoint URI is derived from the
-    // S3 endpoint, so it is also non-AWS and must not receive a wildcard KMS policy.
     new AwsCredentialsStorageIntegration(
             AwsStorageConfigurationInfo.builder()
                 .addAllowedLocation(s3Path(bucket, warehouseKeyPrefix))
                 .roleARN(roleARN)
                 .externalId(externalId)
                 .region(region)
-                .endpoint("http://minio:9000")
+                .stsEndpoint("https://sts.us-east-1.amazonaws.com")
                 .build(),
             stsClient)
         .getSubscopedCreds(

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -329,7 +329,7 @@ public class RestCatalogMinIOSpecialIT {
   }
 
   @Test
-  public void testCreateTableVendedCredentialsWithFullAwsShapeAndKmsEnabledFails()
+  public void testCreateTableVendedCredentialsWithFullAwsShapeAndNonNativeEndpointPasses()
       throws IOException {
     try (RESTCatalog restCatalog =
         createCatalog(
@@ -344,7 +344,7 @@ public class RestCatalogMinIOSpecialIT {
             Optional.of(false))) {
       TableIdentifier id = createTableAndVerifyMetadata(restCatalog);
       try {
-        assertLoadTableWithVendedCredentialsFailsWithKmsError(id);
+        assertLoadTableWithVendedCredentialsSucceeds(id);
       } finally {
         catalogApi.dropTable(catalogName, id);
       }
@@ -372,19 +372,6 @@ public class RestCatalogMinIOSpecialIT {
         catalogApi.dropTable(catalogName, id);
       }
     }
-  }
-
-  private void assertLoadTableWithVendedCredentialsFailsWithKmsError(TableIdentifier id) {
-    assertThatThrownBy(
-            () ->
-                catalogApi.loadTable(
-                    catalogName,
-                    id,
-                    "ALL",
-                    Map.of("X-Iceberg-Access-Delegation", VENDED_CREDENTIALS.protocolValue())))
-        .hasMessageContaining("Failed to get subscoped credentials")
-        .hasMessageContaining("invalid resource")
-        .hasMessageContaining("arn:aws:kms:us-west-2:000000000000:key/*");
   }
 
   private void assertLoadTableWithVendedCredentialsSucceeds(TableIdentifier id) {

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -214,6 +214,30 @@ public class RestCatalogMinIOSpecialIT {
       Optional<String> region,
       Optional<String> roleArn,
       Optional<Boolean> kmsUnavailable) {
+    return createCatalog(
+        endpoint,
+        stsEndpoint,
+        pathStyleAccess,
+        endpointInternal,
+        delegationMode,
+        stsEnabled,
+        region,
+        roleArn,
+        kmsUnavailable,
+        Optional.empty());
+  }
+
+  private RESTCatalog createCatalog(
+      Optional<String> endpoint,
+      Optional<String> stsEndpoint,
+      boolean pathStyleAccess,
+      Optional<String> endpointInternal,
+      Optional<AccessDelegationMode> delegationMode,
+      boolean stsEnabled,
+      Optional<String> region,
+      Optional<String> roleArn,
+      Optional<Boolean> kmsUnavailable,
+      Optional<Boolean> noWildcardKmsPolicy) {
     AwsStorageConfigInfo.Builder storageConfig =
         AwsStorageConfigInfo.builder()
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
@@ -227,6 +251,7 @@ public class RestCatalogMinIOSpecialIT {
     region.ifPresent(storageConfig::setRegion);
     roleArn.ifPresent(storageConfig::setRoleArn);
     kmsUnavailable.ifPresent(storageConfig::setKmsUnavailable);
+    noWildcardKmsPolicy.ifPresent(storageConfig::setNoWildcardKmsPolicy);
 
     CatalogProperties.Builder catalogProps =
         CatalogProperties.builder(storageBase.toASCIIString() + "/" + catalogName);
@@ -341,7 +366,8 @@ public class RestCatalogMinIOSpecialIT {
             true,
             Optional.of(TEST_REGION),
             Optional.of(TEST_ROLE_ARN),
-            Optional.of(false))) {
+            Optional.of(false),
+            Optional.of(true))) {
       TableIdentifier id = createTableAndVerifyMetadata(restCatalog);
       try {
         assertLoadTableWithVendedCredentialsSucceeds(id);

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
@@ -330,7 +330,7 @@ public class RestCatalogRustFSSpecialIT {
   }
 
   @Test
-  public void testCreateTableVendedCredentialsWithFullAwsShapeAndKmsEnabledFails()
+  public void testCreateTableVendedCredentialsWithFullAwsShapeAndNonNativeEndpointPasses()
       throws IOException {
     try (RESTCatalog restCatalog =
         createCatalog(
@@ -345,7 +345,7 @@ public class RestCatalogRustFSSpecialIT {
             Optional.of(false))) {
       TableIdentifier id = createTableAndVerifyMetadata(restCatalog);
       try {
-        assertLoadTableWithVendedCredentialsFailsWithKmsError(id);
+        assertLoadTableWithVendedCredentialsSucceeds(id);
       } finally {
         catalogApi.dropTable(catalogName, id);
       }
@@ -373,18 +373,6 @@ public class RestCatalogRustFSSpecialIT {
         catalogApi.dropTable(catalogName, id);
       }
     }
-  }
-
-  private void assertLoadTableWithVendedCredentialsFailsWithKmsError(TableIdentifier id) {
-    assertThatThrownBy(
-            () ->
-                catalogApi.loadTable(
-                    catalogName,
-                    id,
-                    "ALL",
-                    Map.of("X-Iceberg-Access-Delegation", VENDED_CREDENTIALS.protocolValue())))
-        .hasMessageContaining("Failed to get subscoped credentials")
-        .hasMessageContaining("Status Code: 400");
   }
 
   private void assertLoadTableWithVendedCredentialsSucceeds(TableIdentifier id) {

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
@@ -215,6 +215,30 @@ public class RestCatalogRustFSSpecialIT {
       Optional<String> region,
       Optional<String> roleArn,
       Optional<Boolean> kmsUnavailable) {
+    return createCatalog(
+        endpoint,
+        stsEndpoint,
+        pathStyleAccess,
+        endpointInternal,
+        delegationMode,
+        stsEnabled,
+        region,
+        roleArn,
+        kmsUnavailable,
+        Optional.empty());
+  }
+
+  private RESTCatalog createCatalog(
+      Optional<String> endpoint,
+      Optional<String> stsEndpoint,
+      boolean pathStyleAccess,
+      Optional<String> endpointInternal,
+      Optional<AccessDelegationMode> delegationMode,
+      boolean stsEnabled,
+      Optional<String> region,
+      Optional<String> roleArn,
+      Optional<Boolean> kmsUnavailable,
+      Optional<Boolean> noWildcardKmsPolicy) {
     AwsStorageConfigInfo.Builder storageConfig =
         AwsStorageConfigInfo.builder()
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
@@ -228,6 +252,7 @@ public class RestCatalogRustFSSpecialIT {
     region.ifPresent(storageConfig::setRegion);
     roleArn.ifPresent(storageConfig::setRoleArn);
     kmsUnavailable.ifPresent(storageConfig::setKmsUnavailable);
+    noWildcardKmsPolicy.ifPresent(storageConfig::setNoWildcardKmsPolicy);
 
     CatalogProperties.Builder catalogProps =
         CatalogProperties.builder(storageBase.toASCIIString() + "/" + catalogName);
@@ -342,7 +367,8 @@ public class RestCatalogRustFSSpecialIT {
             true,
             Optional.of(TEST_REGION),
             Optional.of(TEST_ROLE_ARN),
-            Optional.of(false))) {
+            Optional.of(false),
+            Optional.of(true))) {
       TableIdentifier id = createTableAndVerifyMetadata(restCatalog);
       try {
         assertLoadTableWithVendedCredentialsSucceeds(id);

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1173,6 +1173,15 @@ components:
               type: boolean
               description: >-
                 if set to `true`, instructs Polaris Servers to avoid adding KMS key policies.
+            noWildcardKmsPolicy:
+              type: boolean
+              description: >-
+                if set to `true`, instructs Polaris Servers to omit the wildcard KMS key
+                statement from the inline policy passed to AssumeRole. Set this when using
+                an S3-compatible STS implementation (e.g. Ceph RGW) that does not support
+                `kms:` actions in AssumeRole inline policies. Unlike `kmsUnavailable`, this
+                only suppresses the wildcard statement; explicitly configured KMS keys
+                (via `currentKmsKey` or `allowedKmsKeys`) are still included.
 
     AzureStorageConfigInfo:
       type: object


### PR DESCRIPTION
When a custom STS endpoint is configured (e.g. Ceph RGW, MinIO), the inline policy passed to AssumeRole must not contain kms: actions because non-AWS STS implementations reject them with a 400 error.

`addKmsKeyPolicy` now receives an `isNativeAwsEndpoint` flag derived from `getStsEndpointUri() == null`; the wildcard KMS statement is only added when that flag is true AND region + accountId are both present (i.e. genuine AWS S3). Explicitly configured KMS keys (`currentKmsKey` / `allowedKmsKeys`) are unaffected and still require `kmsUnavailable=true` to suppress.

This is related to discussion #4306.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
