### PR TITLE
Site: point onboarding links to released docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ for contribution guidelines.
 [dev-list-subscribe]: mailto:dev-subscribe@polaris.apache.org
 
 ## Polaris Overview
-Click [here](https://polaris.apache.org/in-dev/unreleased/) for a quick overview of Polaris.
+Click [here](https://polaris.apache.org/releases/latest/) for a quick overview of Polaris.
 
 ## Quickstart
-Click [here](https://polaris.apache.org/in-dev/unreleased/getting-started/) for the quickstart experience, which will help you set up a Polaris instance locally or on any supported cloud provider.
+Click [here](https://polaris.apache.org/releases/latest/getting-started/) for the quickstart experience, which will help you set up a Polaris instance locally or on any supported cloud provider.
 
 ## Project Structure
 
@@ -87,7 +87,7 @@ In addition to modules, there are:
 - [API specifications](./spec/README.md) - The OpenAPI specifications
 - [Python client](./client/python/README.md) - The Python client
 - [codestyle](./codestyle) - The code style guidelines
-- [getting-started](https://polaris.apache.org/in-dev/unreleased/getting-started/) - A collection of getting started examples
+- [getting-started](https://polaris.apache.org/releases/latest/getting-started/) - A collection of getting started examples
 - [gradle](./gradle) - The Gradle wrapper and Gradle configuration files including banned dependencies
 - [helm](./helm) - The Helm charts for Polaris.
 - [Spark Plugin](./plugins/spark/README.md) - The Polaris Spark plugin
@@ -152,7 +152,7 @@ make build-server
 - `docker run -p 8181:8181 -p 8182:8182 apache/polaris:latest` - To run the image.
 
 The Polaris codebase contains some docker compose examples to quickly get started with Polaris,
-using different configurations. See the [Quickstart](https://polaris.apache.org/in-dev/unreleased/getting-started/quick-start/)
+using different configurations. See the [Quickstart](https://polaris.apache.org/releases/latest/getting-started/quick-start/)
 for more information.
 
 #### Running in Kubernetes
@@ -162,7 +162,7 @@ for more information.
 #### Configuring Polaris
 
 Polaris Servers can be configured using a variety of ways.
-Please see the [Configuration Guide](https://polaris.apache.org/in-dev/unreleased/configuration/)
+Please see the [Configuration Guide](https://polaris.apache.org/releases/latest/configuration/)
 for more information.
 
 Default configuration values can be found in `runtime/defaults/src/main/resources/application.properties`.

--- a/site/content/_index.adoc
+++ b/site/content/_index.adoc
@@ -26,7 +26,7 @@ cascade:
 Apache Polaris is an open-source, fully-featured catalog for Apache Iceberg™. It implements Iceberg's REST API, enabling seamless multi-engine interoperability across a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™, Dremio® OSS, StarRocks, and Trino.
 
 <div class="text-center">
-<a href="/in-dev/unreleased/getting-started/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
+<a href="/releases/latest/getting-started/" class="btn btn-lg btn-dark mt-5">Get Started <i class="fas fa-arrow-alt-circle-right ms-2"></i></a>
 </div>
 
 {{< /blocks/cover >}}


### PR DESCRIPTION
The public onboarding path must lead to released documentation, not to the current state of main. On an ASF project website, published user-facing pages need a clear separation between released-version behavior and 'work in progress' on our `main` branch.

This updates the most visible entry points on the homepage and in the README to /releases/latest/.
