### PR TITLE
Site: clean up non-guide public doc links

### DIFF
--- a/site/content/blog/2025/09/15/doris-polaris-integration.md
+++ b/site/content/blog/2025/09/15/doris-polaris-integration.md
@@ -237,7 +237,7 @@ With the environment ready, we'll now deploy the Polaris service and configure t
 
    This command will compile and start the Polaris service, which listens on port 8181 by default.
    
-   > You can also use binary distribution, see: https://github.com/apache/polaris/tree/main/runtime/distribution
+   > You can also use binary distribution, see: https://polaris.apache.org/releases/latest/getting-started/binary-distribution/
 
 
 #### 2.2 Create Catalog and Namespace in Polaris
@@ -424,4 +424,3 @@ If all the above operations succeed, congratulations! You have successfully esta
 For more information about managing Iceberg table with Doris, please visit:
 
 https://doris.apache.org/docs/lakehouse/catalogs/iceberg-catalog
-

--- a/site/content/blog/2026/01/06/lance-integration.md
+++ b/site/content/blog/2026/01/06/lance-integration.md
@@ -81,7 +81,7 @@ making it particularly flexible for organizing Lance tables in complex data arch
 ## What is the Generic Table API in Apache Polaris?
 
 Apache Polaris is best known as an open-source catalog for Apache Iceberg.
-In addition, Apache Polaris also offers the [**Generic Table API**]({{% ref "../../../../in-dev/unreleased/generic-table.md" %}})
+In addition, Apache Polaris also offers the [**Generic Table API**](/releases/latest/generic-table/)
 that can be used for managing non-Iceberg table formats such as Delta, Apache Hudi, Lance, and others.
 
 ### Generic Table Definition
@@ -150,7 +150,7 @@ and access them from any engine that supports Lance.
 Whether you're ingesting data with Spark, running feature engineering with Ray,
 building RAG applications with LanceDB, or analyzing with Trino,
 all these engines can work with the same Lance tables managed through Apache Polaris.
-For more information on getting started with Apache Polaris, see the [Apache Polaris Getting Started Guide](https://polaris.apache.org/in-dev/unreleased/getting-started/).
+For more information on getting started with Apache Polaris, see the [Apache Polaris Getting Started Guide](https://polaris.apache.org/releases/latest/getting-started/).
 
 Let's walk through a complete end-to-end workflow using the [BeIR/quora](https://huggingface.co/datasets/BeIR/quora)
 dataset from Hugging Face to build a question-answering system.


### PR DESCRIPTION
A few public pages outside the guides still send users to unreleased main-branch documentation. That creates the same policy problem as the homepage links: the target is valid, but it is not a stable release reference.

This cleans up those non-guide links and points them to the latest released docs instead. Guides are handled separately because they require dedicated site/it verification.
