### PR TITLE
Site: separate released and developer docs navigation

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -34,3 +34,5 @@ menus:
 Welcome to the Apache Polaris documentation. Select a version below to get started.
 
 {{< docs-list >}}
+
+For main-branch developer documentation, see [Developer Docs (main branch, unreleased)](/in-dev/unreleased/).

--- a/site/content/in-dev/unreleased/_index.md
+++ b/site/content/in-dev/unreleased/_index.md
@@ -18,7 +18,7 @@
 # under the License.
 #
 title: 'Apache Polaris Documentation (Unreleased)'
-linkTitle: 'In Development'
+linkTitle: 'Developer Docs'
 type: docs
 weight: 200
 params:
@@ -27,8 +27,9 @@ params:
 menus:
   main:
     parent: doc
-    weight: -999998 # 2nd item in the menu
+    weight: 999999 # last item in the docs dropdown
     identifier: doc-in-dev
+    name: Developer Docs (main branch, unreleased)
 cascade:
   type: docs
   params:

--- a/site/content/in-dev/unreleased/_index.md
+++ b/site/content/in-dev/unreleased/_index.md
@@ -29,7 +29,7 @@ menus:
     parent: doc
     weight: 999999 # last item in the docs dropdown
     identifier: doc-in-dev
-    name: Developer Docs (main branch, unreleased)
+    name: Developer Docs (unreleased)
 cascade:
   type: docs
   params:

--- a/site/layouts/partials/sidebar-docs-tree.html
+++ b/site/layouts/partials/sidebar-docs-tree.html
@@ -51,33 +51,34 @@ under the License.
     {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
     {{ $docsPage := .Site.GetPage "/docs" -}}
     {{ $page := . }}
-    {{/* Check if current page is under /in-dev/unreleased/ or /releases/ */}}
-    {{ $activePath := or (hasPrefix $page.RelPermalink "/in-dev/unreleased") (hasPrefix $page.RelPermalink "/releases/") -}}
+    {{ $isUnreleasedPage := hasPrefix $page.RelPermalink "/in-dev/unreleased" -}}
+    {{ $isReleasedDocsPage := or (eq $page.RelPermalink "/docs/") (hasPrefix $page.RelPermalink "/releases/") -}}
+    {{ $activePath := or $isUnreleasedPage $isReleasedDocsPage -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
       {{/* Documentation root item - clickable title linking to /docs/ */}}
       <li class="td-sidebar-nav__section-title td-sidebar-nav__section with-child{{ if $activePath }} active-path{{ end }}" id="m-docs-li">
         <a href="{{ $docsPage.RelPermalink }}" class="align-left ps-0 td-sidebar-link td-sidebar-link__section tree-root" id="m-docs"><span class="">{{ $docsPage.LinkTitle }}</span></a>
         <ul class="ul-1">
           {{ with partial "releasePages.html" (dict "site" .Site) -}}
-            {{/* Render "Unreleased" first */}}
-            {{ with .unreleased -}}
-              {{ $versionPage := . -}}
-              {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
-              {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" "Unreleased") }}
-            {{ end -}}
-            {{/* Render Active Releases */}}
-            {{ range .active -}}
-              {{ $versionPage := . -}}
-              {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
-              {{ $versionLinkTitle := $versionPage.Params.release_version | default $versionPage.LinkTitle -}}
-              {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" $versionLinkTitle) }}
-            {{ end -}}
-            {{/* Render EOL Releases with (EOL) suffix */}}
-            {{ range .eol -}}
-              {{ $versionPage := . -}}
-              {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
-              {{ $versionLinkTitle := printf "%s (EOL)" ($versionPage.Params.release_version | default $versionPage.LinkTitle) -}}
-              {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" $versionLinkTitle) }}
+            {{ if $isUnreleasedPage -}}
+              {{ with .unreleased -}}
+                {{ $versionPage := . -}}
+                {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
+                {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" "Unreleased") }}
+              {{ end -}}
+            {{ else if $isReleasedDocsPage -}}
+              {{ range .active -}}
+                {{ $versionPage := . -}}
+                {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
+                {{ $versionLinkTitle := $versionPage.Params.release_version | default $versionPage.LinkTitle -}}
+                {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" $versionLinkTitle) }}
+              {{ end -}}
+              {{ range .eol -}}
+                {{ $versionPage := . -}}
+                {{ $pages := where $versionPage.Pages.ByWeight ".Params.toc_hide" "!=" true -}}
+                {{ $versionLinkTitle := printf "%s (EOL)" ($versionPage.Params.release_version | default $versionPage.LinkTitle) -}}
+                {{ template "releases-section-x-nav-section" (dict "page" $page "section" $versionPage "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" 1 "ulShow" $ulShow "pages_input" $pages "sectionLinkTitle" $versionLinkTitle) }}
+              {{ end -}}
             {{ end -}}
           {{ end -}}
         </ul>

--- a/site/layouts/shortcodes/docs-list.html
+++ b/site/layouts/shortcodes/docs-list.html
@@ -19,9 +19,6 @@ under the License.
 {{ $releasePages := partial "releasePages.html" (dict "site" .Page.Site) -}}
 
 <ul>
-
-<li>{{ partial "docs-link.html" (dict "version" "unreleased") }}</li>
-
 {{ range $releasePages.active -}}
 <li>{{ partial "docs-link.html" (dict "version" .Params.release_version) }}</li>
 {{ end -}}


### PR DESCRIPTION
The docs navigation needs a clean split between released user-facing documentation and main-branch developer documentation. On an ASF project site, that distinction should be obvious from the navigation itself and not depend on readers noticing the URL.

This keeps the unreleased developer docs available, but moves them to a clearly secondary position. The docs menu label is made explicit, the breadcrumb label is aligned, released docs no longer share a sidebar or docs chooser with /in-dev/unreleased/, and the unreleased tree gets its own isolated navigation context.
