### PR TITLE
Site: update guides to latest stable docs

### DIFF
--- a/site/content/guides/keycloak/index.md
+++ b/site/content/guides/keycloak/index.md
@@ -59,7 +59,7 @@ Polaris is configured with 3 realms:
   issued by both Polaris and Keycloak.
 
 For more information about how to configure Polaris with external authentication, see the
-[Polaris documentation](../../in-dev/unreleased).
+[Polaris documentation](/releases/latest/).
 
 ## Starting the Example
 

--- a/site/content/guides/quickstart/index.md
+++ b/site/content/guides/quickstart/index.md
@@ -28,7 +28,7 @@ menus:
         weight: 2
 ---
 
-Please see the [quickstart guide](../../in-dev/unreleased/getting-started) for more information.
+Please see the [quickstart guide](/releases/latest/getting-started/) for more information.
 
 <!--
 ```shell

--- a/site/layouts/guides/baseof.html
+++ b/site/layouts/guides/baseof.html
@@ -44,12 +44,18 @@
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <h1>{{ .Title }}</h1>
             {{ $res := .Resources -}}
-            {{ $pageRelPermalink := .RelPermalink }}
             {{ if $res }}
               <div class="alert alert-primary">
                 <p class="alert-heading">
-                  ℹ️ Assets for this guide can be accessed from the <a href="https://github.com/apache/polaris/tree/main/site/content{{ $pageRelPermalink }}">Apache Polaris Git repository</a>
+                  ℹ️ Guide assets:
                 </p>
+                <ul class="mb-0">
+                  {{ range $res }}
+                    {{ if not (hasPrefix .Name ".") }}
+                      <li><a href="{{ .RelPermalink }}">{{ .Name }}</a></li>
+                    {{ end }}
+                  {{ end }}
+                </ul>
               </div>
             {{ end }}
             {{ block "main" . }}{{ end }}


### PR DESCRIPTION
The guides under site/content/guides/ are public user-facing material. They should target the latest stable release, not the unreleased 'work in progress' state of main. That distinction matters on an ASF project site, where published guidance must track released behavior.

This updates the guide links accordingly and removes the raw main-branch asset pointer from the guide layout. This guide work is isolated in its own PR because it requires the dedicated site/it verification.
