### PR TITLE
Site: resolve config includes from the current release tree

### DIFF
--- a/site/layouts/shortcodes/include-config-section.html
+++ b/site/layouts/shortcodes/include-config-section.html
@@ -17,10 +17,14 @@ specific language governing permissions and limitations
 under the License.
 */}}
 {{- $sectionName := .Get 0 -}}
-{{- $pagePath := printf "/in-dev/unreleased/configuration/config-sections/%s" $sectionName -}}
+{{- $pagePath := "" -}}
+{{- with .Page.Params.release_version -}}
+  {{- $pagePath = printf "/releases/%s/configuration/config-sections/%s" . $sectionName -}}
+{{- else -}}
+  {{- $pagePath = printf "/in-dev/unreleased/configuration/config-sections/%s" $sectionName -}}
+{{- end -}}
 {{- with site.GetPage $pagePath -}}
   {{- .RawContent | $.Page.RenderString -}}
 {{- else -}}
   {{- errorf "include-config-section: page not found: %s" $pagePath -}}
 {{- end -}}
-


### PR DESCRIPTION
Released documentation needs to render released content. If a release page pulls configuration fragments from /in-dev/unreleased/, the release URL still changes with main and is no longer a reliable snapshot.

This change resolves config-section-includes from the matching release tree whenever a release version is known. Only the developer docs keep using the unreleased source tree.