### PR TITLE
Site: show unreleased banner on all developer docs pages

### DIFF
--- a/site/content/in-dev/unreleased/_index.md
+++ b/site/content/in-dev/unreleased/_index.md
@@ -37,12 +37,6 @@ cascade:
 # This file will NOT be copied into a new release's versioned docs folder.
 ---
 
-> [!DANGER] Caution!
-> 
-> These pages refer to the current state of the main branch, which is still under active development.
-> 
-> Functionalities can be changed, removed or added without prior notice.
-
 Apache Polaris is a catalog implementation for Apache Iceberg&trade; tables and is built on the open source Apache Iceberg&trade; REST protocol.
 
 With Polaris, you can provide centralized, secure read and write access to your Iceberg tables across different REST-compatible query engines.

--- a/site/layouts/partials/version-banner.html
+++ b/site/layouts/partials/version-banner.html
@@ -1,0 +1,41 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+{{ if .Site.Params.archived_version }}
+  {{ $color := "primary" }}
+  {{ $latestVersion := .Site.Params.url_latest_version }}
+  {{ $currentVersion := .Site.Params.version }}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    {{ with $currentVersion }}<p>Version {{ . | markdownify }} of the
+      documentation is no longer actively maintained. The site that you are
+      currently viewing is an archived snapshot.
+      {{ with $latestVersion }}For up-to-date documentation, see the
+        <a href="{{ $latestVersion | safeURL }}" target="_blank">latest version</a>.</p>
+      {{ end }}
+    {{ end }}
+  </div>
+{{ else if hasPrefix .RelPermalink "/in-dev/unreleased" }}
+  <div class="pageinfo pageinfo-warning">
+    <p>
+      <strong>IMPORTANT:</strong> Developer documentation for the current <code>main</code> branch.
+      This content is unreleased and may change before the next Polaris release.
+      For stable user documentation, see the
+      <a href="/releases/latest/">latest release docs</a>.
+    </p>
+  </div>
+{{ end }}


### PR DESCRIPTION
The unreleased warning only appeared on the /in-dev/unreleased/ landing page.
Deep links into the same tree lost that context, although those are exactly the pages where readers most easily miss that they are on main-branch documentation.
    
This moves the notice into the shared docs banner so it appears on every page under /in-dev/unreleased/.
The banner is clearly marked as IMPORTANT and points normal users back to the latest release docs.