### PR TITLE
Add the security advisories for 1.4.1 release

### DIFF
--- a/site/content/community/security-advisories/CVE-2026-42809.md
+++ b/site/content/community/security-advisories/CVE-2026-42809.md
@@ -22,7 +22,11 @@ type: docs
 weight: 500
 ---
 
-# CVE-2026-42809
+# CVE-2026-42809 - Stage-Create Credential Vending (pre-validation credential minting)
+
+## Abstract
+
+An authenticated Apache Polaris user with permission to create a table can use a staged table creation request to obtain temporary storage credentials for any storage location reachable by the catalog's configured role, regardless of whether they have permission to access that location. Polaris issues credentials before validating the requested location, allowing an attacker to target arbitrary storage paths including entire buckets.
 
 ## Severity
 

--- a/site/content/community/security-advisories/CVE-2026-42809.md
+++ b/site/content/community/security-advisories/CVE-2026-42809.md
@@ -1,0 +1,46 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+linkTitle: CVE-2026-42809
+type: docs
+weight: 500
+---
+
+# CVE-2026-42809
+
+## Severity
+
+**Important**
+
+## Affected versions
+
+- Apache Polaris before 1.4.1
+
+## Description
+
+Apache Polaris can issue broad temporary ("vended") storage credentials during staged table creation before the effective table location has been validated or durably reserved. Those temporary credentials are meant to limit the scope of
+accessible table data and metadata, but this scope limitation becomes attacker-directed because the attacker can choose a reachable target location.
+
+In the confirmed variant, if the caller supplies a custom `location` during stage create and requests credential vending, Apache Polaris uses that location to construct delegated storage credentials immediately. The stage-create path itself neither runs the normal location validation nor the overlap checks before those credentials are issued.
+
+Closely related to that, the staged-create flow also accepts `write.data.path` / `write.metadata.path` in the request properties and feeds those location overrides into the same effective table location set used for credential vending. Those fields are secondary to the main custom-`location` exploit, but they are still attacker-influenced location inputs that should be validated before any credentials are issued.
+
+## References
+
+- https://www.cve.org/CVERecord?id=CVE-2026-42809

--- a/site/content/community/security-advisories/CVE-2026-42809.md
+++ b/site/content/community/security-advisories/CVE-2026-42809.md
@@ -34,8 +34,7 @@ weight: 500
 
 ## Description
 
-Apache Polaris can issue broad temporary ("vended") storage credentials during staged table creation before the effective table location has been validated or durably reserved. Those temporary credentials are meant to limit the scope of
-accessible table data and metadata, but this scope limitation becomes attacker-directed because the attacker can choose a reachable target location.
+Apache Polaris can issue broad temporary ("vended") storage credentials during staged table creation before the effective table location has been validated or durably reserved. Those temporary credentials are meant to limit the scope of accessible table data and metadata, but this scope limitation becomes attacker-directed because the attacker can choose a reachable target location.
 
 In the confirmed variant, if the caller supplies a custom `location` during stage create and requests credential vending, Apache Polaris uses that location to construct delegated storage credentials immediately. The stage-create path itself neither runs the normal location validation nor the overlap checks before those credentials are issued.
 

--- a/site/content/community/security-advisories/CVE-2026-42810.md
+++ b/site/content/community/security-advisories/CVE-2026-42810.md
@@ -51,11 +51,10 @@ tables' S3 locations.
 
 The confirmed behavior includes:
 
-- reading another table's metadata control file ([Iceberg metadata JSON]);
-- listing another table's exact S3 table prefix ([table prefix]);
+- reading another table's metadata control file (Iceberg metadata JSON);
+- listing another table's exact S3 table prefix (table prefix);
 - and, when write delegation was returned for the crafted table, creating
-and
-deleting an object under another table's exact S3 table prefix.
+and deleting an object under another table's exact S3 table prefix.
 
 A control case using ordinary different names did not allow the same
 cross-table access.
@@ -70,12 +69,9 @@ and use those credentials to list, read, create, and delete objects under `foo.t
 
 In Iceberg, the metadata JSON file is a control file: it tells readers which
 data files belong to the table, which snapshots exist, and which table
-version
-to read. So unauthorized access to it is already a meaningful
-confidentiality
-problem. The confirmed write-capable variant means the issue is not limited
-to
-disclosure.
+version to read. 
+So unauthorized access to it is already a meaningful confidentiality problem. 
+The confirmed write-capable variant means the issue is not limited to disclosure.
 
 ## References
 

--- a/site/content/community/security-advisories/CVE-2026-42810.md
+++ b/site/content/community/security-advisories/CVE-2026-42810.md
@@ -1,0 +1,83 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+linkTitle: CVE-2026-42810
+type: docs
+weight: 500
+---
+
+# CVE-2026-42810
+
+## Severity
+
+**Important**
+
+## Affected versions
+
+- Apache Polaris before 1.4.1
+
+## Description
+
+Apache Polaris accepts literal `*` characters in namespace and table names. When it
+later builds temporary S3 access policies for delegated table access, those
+same characters appear to be reused unescaped in S3 IAM resource patterns
+and
+`s3:prefix` conditions.
+
+In S3 IAM policy matching, `*` is treated as a wildcard rather than as
+ordinary text. That means temporary credentials issued for one crafted table
+can match the storage path of a different table.
+
+In private testing against Polaris 1.4.0 using Polaris' AWS S3 temporary-
+credential path on both MinIO and real AWS S3, credentials returned for
+crafted tables such as `f*.t1`, `f*.*`, `*.*`, and `foo.*` could reach other
+tables' S3 locations.
+
+The confirmed behavior includes:
+
+- reading another table's metadata control file ([Iceberg metadata JSON]);
+- listing another table's exact S3 table prefix ([table prefix]);
+- and, when write delegation was returned for the crafted table, creating
+and
+deleting an object under another table's exact S3 table prefix.
+
+A control case using ordinary different names did not allow the same
+cross-table access.
+
+I also confirmed a least-privilege AWS S3 variant in which the attacker
+principal had no Polaris permission on the victim table and only enough
+Polaris permission to create and use the crafted wildcard table
+(namespace-scoped `TABLE_CREATE` and `TABLE_WRITE_DATA` on `*`). In that
+setup, direct Polaris access to `foo.t1` remained forbidden, but the
+attacker
+could still create and load `*.*`, receive delegated S3 credentials, and use
+those credentials to list, read, create, and delete objects under `foo.t1`.
+
+In Iceberg, the metadata JSON file is a control file: it tells readers which
+data files belong to the table, which snapshots exist, and which table
+version
+to read. So unauthorized access to it is already a meaningful
+confidentiality
+problem. The confirmed write-capable variant means the issue is not limited
+to
+disclosure.
+
+## References
+
+- https://www.cve.org/CVERecord?id=CVE-2026-42810

--- a/site/content/community/security-advisories/CVE-2026-42810.md
+++ b/site/content/community/security-advisories/CVE-2026-42810.md
@@ -22,7 +22,11 @@ type: docs
 weight: 500
 ---
 
-# CVE-2026-42810
+# CVE-2026-42810 - AWS S3 IAM Wildcard Injection
+
+## Abstract
+
+An authenticated Apache Polaris user with permission to create a table can use wildcard characters (*) in namespace or table names to broaden the scope of vended AWS S3 credentials beyond the intended table path. Because * is treated as a wildcard in S3 IAM policy resource patterns and prefix conditions, temporary credentials issued for a crafted table can match other tables' storage paths, allowing cross-table read, write, and delete access. This issue only affects Polaris deployments using AWS S3 for credential vending.
 
 ## Severity
 
@@ -37,8 +41,7 @@ weight: 500
 Apache Polaris accepts literal `*` characters in namespace and table names. When it
 later builds temporary S3 access policies for delegated table access, those
 same characters appear to be reused unescaped in S3 IAM resource patterns
-and
-`s3:prefix` conditions.
+and `s3:prefix` conditions.
 
 In S3 IAM policy matching, `*` is treated as a wildcard rather than as
 ordinary text. That means temporary credentials issued for one crafted table

--- a/site/content/community/security-advisories/CVE-2026-42810.md
+++ b/site/content/community/security-advisories/CVE-2026-42810.md
@@ -60,14 +60,13 @@ deleting an object under another table's exact S3 table prefix.
 A control case using ordinary different names did not allow the same
 cross-table access.
 
-I also confirmed a least-privilege AWS S3 variant in which the attacker
-principal had no Polaris permission on the victim table and only enough
-Polaris permission to create and use the crafted wildcard table
-(namespace-scoped `TABLE_CREATE` and `TABLE_WRITE_DATA` on `*`). In that
-setup, direct Polaris access to `foo.t1` remained forbidden, but the
-attacker
-could still create and load `*.*`, receive delegated S3 credentials, and use
-those credentials to list, read, create, and delete objects under `foo.t1`.
+A least-privilege AWS S3 variant was also confirmed in which the attacker
+principal had no Polaris permissions on the victim table and only the 
+minimal permissions required to create and use a crafted wildcard table 
+(namespace-scoped `TABLE_CREATE` and `TABLE_WRITE_DATA` on `*`). 
+In that setup, direct Polaris access to `foo.t1` remained forbidden, but the 
+attacker could still create and load `*.*`, receive delegated S3 credentials, 
+and use those credentials to list, read, create, and delete objects under `foo.t1`.
 
 In Iceberg, the metadata JSON file is a control file: it tells readers which
 data files belong to the table, which snapshots exist, and which table

--- a/site/content/community/security-advisories/CVE-2026-42811.md
+++ b/site/content/community/security-advisories/CVE-2026-42811.md
@@ -51,7 +51,7 @@ As a result, a namespace or table identifier containing a single quote and
 other URI-safe CEL fragments can break out of the intended quoted string and
 change the meaning of the CEL condition.
 
-In private testing against Polaris 1.4.0 on real Google Cloud Storage, I
+In private testing against Polaris 1.4.0 on real Google Cloud Storage, it was
 confirmed that Polaris accepted a crafted identifier and returned delegated
 GCS
 credentials whose CEL path restriction had effectively collapsed.

--- a/site/content/community/security-advisories/CVE-2026-42811.md
+++ b/site/content/community/security-advisories/CVE-2026-42811.md
@@ -35,16 +35,14 @@ weight: 500
 ## Description
 
 In plain terms, Apache Polaris is supposed to issue short-lived GCS credentials
-that
-only work for one table's files, but a crafted namespace or table name can
+that only work for one table's files, but a crafted namespace or table name can
 cause those credentials to work across the configured bucket instead.
 Apache Polaris builds Google Cloud Storage downscoped credentials by creating a
 Credential Access Boundary (CAB) with CEL conditions that are intended to
 restrict access to the requested table's storage path.
 
 The relevant CEL string is built from the bucket name and the table path.
-That
-table path is derived from namespace and table identifiers. In current code,
+That table path is derived from namespace and table identifiers. In current code,
 that path appears to be inserted into the CEL expression without escaping.
 
 As a result, a namespace or table identifier containing a single quote and
@@ -53,8 +51,7 @@ change the meaning of the CEL condition.
 
 In private testing against Polaris 1.4.0 on real Google Cloud Storage, it was
 confirmed that Polaris accepted a crafted identifier and returned delegated
-GCS
-credentials whose CEL path restriction had effectively collapsed.
+GCS credentials whose CEL path restriction had effectively collapsed.
 
 Those delegated credentials could then:
 
@@ -62,18 +59,15 @@ Those delegated credentials could then:
 - read another table's metadata control file (Iceberg metadata JSON);
 - create and delete an object under another table's object prefix;
 - and also list, read, create, and delete objects under an unrelated
-external
-prefix in the same bucket that was not part of any table path.
+external prefix in the same bucket that was not part of any table path.
 
 That last point is important. The issue is not limited to "another table".
-In
-the confirmed setup, once Apache Polaris returned credentials for the crafted
+In the confirmed setup, once Apache Polaris returned credentials for the crafted
 table,
 the path restriction inside the configured bucket was effectively gone.
 
 The practical effect is that temporary credentials for one crafted table
-can be
-broader than the table Polaris was asked to authorize, and can become
+can be broader than the table Polaris was asked to authorize, and can become
 effectively bucket-wide within the configured bucket.
 
 The current GCS testing used a Polaris principal with broad catalog 

--- a/site/content/community/security-advisories/CVE-2026-42811.md
+++ b/site/content/community/security-advisories/CVE-2026-42811.md
@@ -22,7 +22,11 @@ type: docs
 weight: 500
 ---
 
-# CVE-2026-42811
+# CVE-2026-42811 - GCS CEL Expression Injection
+
+## Abstract
+
+An authenticated Apache Polaris user with permission to create a table can use a crafted table name containing CEL expression syntax to bypass GCS credential path restrictions, gaining Google Cloud Storage credentials scoped to the entire configured bucket rather than a single table's path. This issue only affects Polaris deployments using Google Cloud Storage for credential vending.
 
 ## Severity
 

--- a/site/content/community/security-advisories/CVE-2026-42811.md
+++ b/site/content/community/security-advisories/CVE-2026-42811.md
@@ -1,0 +1,87 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+linkTitle: CVE-2026-42811
+type: docs
+weight: 500
+---
+
+# CVE-2026-42811
+
+## Severity
+
+**Important**
+
+## Affected versions
+
+- Apache Polaris before 1.4.1
+
+## Description
+
+In plain terms, Apache Polaris is supposed to issue short-lived GCS credentials
+that
+only work for one table's files, but a crafted namespace or table name can
+cause those credentials to work across the configured bucket instead.
+Apache Polaris builds Google Cloud Storage downscoped credentials by creating a
+Credential Access Boundary (CAB) with CEL conditions that are intended to
+restrict access to the requested table's storage path.
+
+The relevant CEL string is built from the bucket name and the table path.
+That
+table path is derived from namespace and table identifiers. In current code,
+that path appears to be inserted into the CEL expression without escaping.
+
+As a result, a namespace or table identifier containing a single quote and
+other URI-safe CEL fragments can break out of the intended quoted string and
+change the meaning of the CEL condition.
+
+In private testing against Polaris 1.4.0 on real Google Cloud Storage, I
+confirmed that Polaris accepted a crafted identifier and returned delegated
+GCS
+credentials whose CEL path restriction had effectively collapsed.
+
+Those delegated credentials could then:
+
+- list another table's object prefix;
+- read another table's metadata control file (Iceberg metadata JSON);
+- create and delete an object under another table's object prefix;
+- and also list, read, create, and delete objects under an unrelated
+external
+prefix in the same bucket that was not part of any table path.
+
+That last point is important. The issue is not limited to "another table".
+In
+the confirmed setup, once Apache Polaris returned credentials for the crafted
+table,
+the path restriction inside the configured bucket was effectively gone.
+
+The practical effect is that temporary credentials for one crafted table
+can be
+broader than the table Polaris was asked to authorize, and can become
+effectively bucket-wide within the configured bucket.
+
+The current GCS repro uses a Polaris principal with broad catalog privileges
+for setup. I have not yet repeated the separate least-privilege Polaris-RBAC
+variant on GCS. However, the storage-credential broadening itself is
+confirmed
+on real GCS.
+
+## References
+
+- https://www.cve.org/CVERecord?id=CVE-2026-42811

--- a/site/content/community/security-advisories/CVE-2026-42811.md
+++ b/site/content/community/security-advisories/CVE-2026-42811.md
@@ -76,11 +76,10 @@ can be
 broader than the table Polaris was asked to authorize, and can become
 effectively bucket-wide within the configured bucket.
 
-The current GCS repro uses a Polaris principal with broad catalog privileges
-for setup. I have not yet repeated the separate least-privilege Polaris-RBAC
-variant on GCS. However, the storage-credential broadening itself is
-confirmed
-on real GCS.
+The current GCS testing used a Polaris principal with broad catalog 
+privileges for setup. A separate least-privilege Polaris RBAC variant 
+has not yet been tested on GCS. However, the storage-credential 
+broadening behavior itself has been confirmed on GCS.
 
 ## References
 

--- a/site/content/community/security-advisories/CVE-2026-42812.md
+++ b/site/content/community/security-advisories/CVE-2026-42812.md
@@ -1,0 +1,103 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+linkTitle: CVE-2026-42812
+type: docs
+weight: 500
+---
+
+# CVE-2026-42812
+
+## Severity
+
+**Important**
+
+## Affected versions
+
+- Apache Polaris before 1.4.1
+
+## Description
+
+In Apache Iceberg, the table's metadata files are control files: they tell readers
+which data files belong to the table and which table version to read.
+
+`write.metadata.path` is an optional table property that tells Polaris
+where to
+write those metadata files. For a table already registered in a
+Polaris-managed
+catalog, changing only that property through an `ALTER TABLE`-style settings
+change (not a row-level `INSERT`, `SELECT`, `UPDATE`, or `DELETE`) bypasses
+the commit-time branch that is supposed to revalidate storage locations.
+
+The full persisted / credential-vending variant requires the affected
+catalog
+to have `polaris.config.allow.unstructured.table.location=true`, with
+`allowedLocations` broad enough to include the attacker-chosen target.
+`allowedLocations` is the admin-configured allowlist of storage paths that
+the
+catalog is allowed to use. Public project materials suggest that this flag
+is a
+real supported compatibility / layout mode, not just a contrived lab-only
+prerequisite.
+
+In that configuration, a user who can change table settings can cause Apache Polaris
+itself to write new table metadata to an attacker-chosen reachable storage
+location before the intended location-validation branch runs.
+
+If the later concrete-path validation also accepts that location, Polaris
+persists the resulting metadata path into stored table state. Later
+table-load
+and credential APIs can then return temporary cloud-storage credentials for
+the
+same location without revalidating it. In plain terms, Polaris can later
+hand
+out temporary storage access for the same attacker-chosen area.
+
+That attacker-chosen area does not need to be limited to the poisoned
+table's
+own files. If it is a broader storage prefix, another table's prefix, or,
+depending on configuration or provider behavior, even a bucket/container
+root,
+the resulting disclosure or corruption scope can extend to any data and
+metadata Polaris can reach there.
+
+The practical consequences are therefore similar to the staged-create
+credential-vending issue already discussed: data and metadata reachable in
+that
+storage scope can be exposed and, if write-capable credentials are later
+issued, modified, corrupted, or removed. Even before that later credential
+step, Polaris itself performs the metadata write to the unchecked location.
+
+So the core issue is not only later credential vending. The primary defect
+is
+that Polaris skips its intended location checks before performing a
+security-
+sensitive metadata write when only `write.metadata.path` changes.
+
+When `polaris.config.allow.unstructured.table.location=false`, current code
+review suggests the later `updateTableLike(...)` validation usually rejects
+out-of-tree metadata locations before the unsafe path is persisted. That may
+reduce the persisted / credential-vending variant, but it does not prevent
+the
+underlying defect: Polaris still skips the intended pre-write location check
+when only `write.metadata.path` changes.
+
+## References
+
+- https://www.cve.org/CVERecord?id=CVE-2026-42812

--- a/site/content/community/security-advisories/CVE-2026-42812.md
+++ b/site/content/community/security-advisories/CVE-2026-42812.md
@@ -22,7 +22,11 @@ type: docs
 weight: 500
 ---
 
-# CVE-2026-42812
+# CVE-2026-42812 - write.metadata.path Location Escape
+
+## Abstract
+
+A user with permissions to alter a table can use write.metadata.path to cause Polaris to write a metadata.json file to any location within the catalog's allowed locations. If ALLOW_UNSTRUCTURED_TABLE_LOCATION is enabled, the user can then gain credentials scoped to this location.
 
 ## Severity
 

--- a/site/content/community/security-advisories/CVE-2026-42812.md
+++ b/site/content/community/security-advisories/CVE-2026-42812.md
@@ -38,22 +38,17 @@ In Apache Iceberg, the table's metadata files are control files: they tell reade
 which data files belong to the table and which table version to read.
 
 `write.metadata.path` is an optional table property that tells Polaris
-where to
-write those metadata files. For a table already registered in a
-Polaris-managed
-catalog, changing only that property through an `ALTER TABLE`-style settings
+where to write those metadata files. For a table already registered in a
+Polaris-managed catalog, changing only that property through an `ALTER TABLE`-style settings
 change (not a row-level `INSERT`, `SELECT`, `UPDATE`, or `DELETE`) bypasses
 the commit-time branch that is supposed to revalidate storage locations.
 
 The full persisted / credential-vending variant requires the affected
-catalog
-to have `polaris.config.allow.unstructured.table.location=true`, with
+catalog to have `polaris.config.allow.unstructured.table.location=true`, with
 `allowedLocations` broad enough to include the attacker-chosen target.
 `allowedLocations` is the admin-configured allowlist of storage paths that
-the
-catalog is allowed to use. Public project materials suggest that this flag
-is a
-real supported compatibility / layout mode, not just a contrived lab-only
+the catalog is allowed to use. Public project materials suggest that this flag
+is a real supported compatibility / layout mode, not just a contrived lab-only
 prerequisite.
 
 In that configuration, a user who can change table settings can cause Apache Polaris
@@ -62,40 +57,31 @@ location before the intended location-validation branch runs.
 
 If the later concrete-path validation also accepts that location, Polaris
 persists the resulting metadata path into stored table state. Later
-table-load
-and credential APIs can then return temporary cloud-storage credentials for
-the
-same location without revalidating it. In plain terms, Polaris can later
-hand
-out temporary storage access for the same attacker-chosen area.
+table-load and credential APIs can then return temporary cloud-storage credentials for
+the same location without revalidating it. In plain terms, Polaris can later
+hand out temporary storage access for the same attacker-chosen area.
 
 That attacker-chosen area does not need to be limited to the poisoned
-table's
-own files. If it is a broader storage prefix, another table's prefix, or,
+table's own files. If it is a broader storage prefix, another table's prefix, or,
 depending on configuration or provider behavior, even a bucket/container
-root,
-the resulting disclosure or corruption scope can extend to any data and
+root, the resulting disclosure or corruption scope can extend to any data and
 metadata Polaris can reach there.
 
 The practical consequences are therefore similar to the staged-create
 credential-vending issue already discussed: data and metadata reachable in
-that
-storage scope can be exposed and, if write-capable credentials are later
+that storage scope can be exposed and, if write-capable credentials are later
 issued, modified, corrupted, or removed. Even before that later credential
 step, Polaris itself performs the metadata write to the unchecked location.
 
 So the core issue is not only later credential vending. The primary defect
-is
-that Polaris skips its intended location checks before performing a
-security-
-sensitive metadata write when only `write.metadata.path` changes.
+is that Polaris skips its intended location checks before performing a
+security- sensitive metadata write when only `write.metadata.path` changes.
 
 When `polaris.config.allow.unstructured.table.location=false`, current code
 review suggests the later `updateTableLike(...)` validation usually rejects
 out-of-tree metadata locations before the unsafe path is persisted. That may
 reduce the persisted / credential-vending variant, but it does not prevent
-the
-underlying defect: Polaris still skips the intended pre-write location check
+the underlying defect: Polaris still skips the intended pre-write location check
 when only `write.metadata.path` changes.
 
 ## References

--- a/site/content/community/security-report.md
+++ b/site/content/community/security-report.md
@@ -40,4 +40,8 @@ The general process for handling security vulnerabilities as follows:
 
 # Known Security Vulnerabilities (CVEs)
 
-No CVE so far.
+* [CVE-2026-42809](../security-advisories/CVE-2026-42809/)
+* [CVE-2026-42810](../security-advisories/CVE-2026-42810/)
+* [CVE-2026-42811](../security-advisories/CVE-2026-42811/)
+* [CVE-2026-42812](../security-advisories/CVE-2026-42812/)
+

--- a/site/content/downloads/1.4.1/index.md
+++ b/site/content/downloads/1.4.1/index.md
@@ -48,9 +48,9 @@ Released on May 1st, 2026.
 
 #### Fixes
 
-- Improve storage uri handling in S3 + GCS
-- Improve locations-handling
-- Improve staged table handling
-- Improve documentation wording
-
+This release fixes 4 security issues:
+* [CVE-2026-42809](../../community/security-advisories/CVE-2026-42809/)
+* [CVE-2026-42810](../../community/security-advisories/CVE-2026-42810/)
+* [CVE-2026-42811](../../community/security-advisories/CVE-2026-42811/)
+* [CVE-2026-42812](../../community/security-advisories/CVE-2026-42812/)
 


### PR DESCRIPTION
Add the security advisories for:
- CVE-2026-42809
- CVE-2026-42810
- CVE-2026-42811
- CVE-2026-42812 
And update 1.4.1 release notes.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
