### PR TITLE
Fix config reference for 1.4.x releases

### DIFF
--- a/site/layouts/shortcodes/include-config-section.html
+++ b/site/layouts/shortcodes/include-config-section.html
@@ -17,10 +17,14 @@ specific language governing permissions and limitations
 under the License.
 */}}
 {{- $sectionName := .Get 0 -}}
-{{- $pagePath := printf "/in-dev/unreleased/configuration/config-sections/%s" $sectionName -}}
+{{- $releaseVersion := partial "releaseVersion.html" . -}}
+{{- $docsRoot := "/in-dev/unreleased" -}}
+{{- if ne $releaseVersion "[unreleased]" -}}
+  {{- $docsRoot = printf "/releases/%s" $releaseVersion -}}
+{{- end -}}
+{{- $pagePath := printf "%s/configuration/config-sections/%s" $docsRoot $sectionName -}}
 {{- with site.GetPage $pagePath -}}
   {{- .RawContent | $.Page.RenderString -}}
 {{- else -}}
   {{- errorf "include-config-section: page not found: %s" $pagePath -}}
 {{- end -}}
-


### PR DESCRIPTION
The generated config references accidentally always served the content from in-dev/development instead of using the releases/x.y.z paths.

This change fixes this.
