### PR TITLE
Remove internal constant GOOGLE_USER_PROJECT_HEADER_KEY

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/iceberg/IcebergRestConnectionConfigInfoDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/iceberg/IcebergRestConnectionConfigInfoDpo.java
@@ -44,9 +44,7 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 public class IcebergRestConnectionConfigInfoDpo extends ConnectionConfigInfoDpo
     implements IcebergCatalogPropertiesProvider {
 
-  public static final String GOOGLE_USER_PROJECT_HEADER_KEY = "header.x-goog-user-project";
-
-  private static final List<String> ALLOWED_PROPERTIES = List.of(GOOGLE_USER_PROJECT_HEADER_KEY);
+  private static final List<String> ALLOWED_PROPERTIES = List.of("header.x-goog-user-project");
 
   private final String remoteCatalogName;
 

--- a/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/GcpCatalogFederationIntegrationIT.java
+++ b/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/GcpCatalogFederationIntegrationIT.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.it;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.apache.polaris.core.connection.iceberg.IcebergRestConnectionConfigInfoDpo.GOOGLE_USER_PROJECT_HEADER_KEY;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -176,7 +175,7 @@ public class GcpCatalogFederationIntegrationIT {
         IcebergRestConnectionConfigInfo.builder()
             .setRemoteCatalogName(FEDERATED_CATALOG)
             .setConnectionType(ConnectionConfigInfo.ConnectionTypeEnum.ICEBERG_REST)
-            .setProperties(Map.of(GOOGLE_USER_PROJECT_HEADER_KEY, QUOTA_PROJECT))
+            .setProperties(Map.of("header.x-goog-user-project", QUOTA_PROJECT))
             .setAuthenticationParameters(authenticationParameters)
             .setUri(BIG_LAKE_REST_URI)
             .build();


### PR DESCRIPTION
Following up on #3729

* GOOGLE_USER_PROJECT_HEADER_KEY does not appear to be meant for reuse outside of `polaris-core`

* The property is well-known from the Iceberg Java libs that are actually the final consumer for the value of this property. Therefore, tests are updated to use the property name directly.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
