### PR TITLE
docs: link Code Wiki for Apache Polaris as a navigation aid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Documentation is available at https://polaris.apache.org. The REST OpenAPI speci
 [Polaris management API doc](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/polaris-management-service.yml)
 and [Polaris Catalog API doc](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/generated/bundled-polaris-catalog-service.yaml).
 
+For a high-level, auto-generated tour of the codebase's modules and relationships, see the
+[Code Wiki for Apache Polaris](https://codewiki.google/github.com/apache/polaris).
+It is a third-party, auto-generated navigation aid, useful for orientation, but the
+source tree remains the authoritative reference.
+
 [Subscribe to the dev mailing list][dev-list-subscribe] to join discussions via email or browse [the archives](https://lists.apache.org/list.html?dev@polaris.apache.org). Check out the [CONTRIBUTING guide](CONTRIBUTING.md)
 for contribution guidelines.
 


### PR DESCRIPTION
New contributors (human and AI) spend real time building a mental map of Polaris's modules before they can make a focused change. The [Code Wiki for Apache Polaris](https://codewiki.google/github.com/apache/polaris) is a third-party, auto-generated overview of modules and their relationships that can shorten that ramp-up. This PR links it from `README.md` only.

**Scope narrowed in response to review feedback.** The initial version of this PR also added the link to `CONTRIBUTING.md` (as a new "Get oriented in the codebase" subsection) and `AGENTS.md` (as a pointer back to that subsection). Per @snazy's concern that the project should not appear to endorse content it cannot review or version, and @dimas-b's suggestion that the Code Wiki is better shared from a personal point of view, the Code Wiki reference is now only in `README.md` — outside contributor workflow docs — and framed explicitly as a third-party navigation aid, not authoritative.

Scope: docs only. No `site/` content, no extension to dependencies.

Follow-up to #4276. Motivated by [apache/polaris#1028 (comment)](https://github.com/apache/polaris/discussions/1028#discussioncomment-16819321).

Per @dimas-b's suggestion, I plan to mention this on `dev@polaris.apache.org` for visibility and broader input on the project's posture toward AI-generated external references.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: follow-up to #4276
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how): N/A (documentation only)
- [x] 💡 Added comments for complex logic: N/A
- [ ] 🧾 Updated `CHANGELOG.md` (if needed): not needed for docs-only
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): not needed