### PR TITLE
Group the CVEs by Polaris release

### DIFF
--- a/site/content/community/security-report.md
+++ b/site/content/community/security-report.md
@@ -40,8 +40,9 @@ The general process for handling security vulnerabilities as follows:
 
 # Known Security Vulnerabilities (CVEs)
 
-* [CVE-2026-42809](../security-advisories/cve-2026-42809/)
-* [CVE-2026-42810](../security-advisories/cve-2026-42810/)
-* [CVE-2026-42811](../security-advisories/cve-2026-42811/)
-* [CVE-2026-42812](../security-advisories/cve-2026-42812/)
+* Fixed in Apache Polaris 1.4.1
+  * [CVE-2026-42809](../security-advisories/cve-2026-42809/)
+  * [CVE-2026-42810](../security-advisories/cve-2026-42810/)
+  * [CVE-2026-42811](../security-advisories/cve-2026-42811/)
+  * [CVE-2026-42812](../security-advisories/cve-2026-42812/)
 


### PR DESCRIPTION
I propose to group the CVEs per release where they are fixed, for clarity for our users.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
