### PR TITLE
Exclude pom-only dependencies from Polaris server/admin license reports

### DIFF
--- a/build-logic/src/main/kotlin/licenses/QuarkusAppDependencyFilter.kt
+++ b/build-logic/src/main/kotlin/licenses/QuarkusAppDependencyFilter.kt
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package licenses
+
+import com.github.jk1.license.ConfigurationData
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.filter.DependencyFilter
+import org.gradle.api.GradleException
+
+/**
+ * Restricts the license report to the artifacts that Quarkus actually bundles in the fast-jar
+ * output. This avoids documenting pom-only convenience coordinates that appear in the resolved
+ * Gradle graph but never ship in the distribution.
+ */
+class QuarkusAppDependencyFilter : DependencyFilter {
+
+  override fun filter(data: ProjectData?): ProjectData {
+    data!!
+
+    val dependenciesFile = data.project.file("build/quarkus-app/quarkus-app-dependencies.txt")
+    if (!dependenciesFile.isFile) {
+      throw GradleException(
+        "Expected Quarkus dependency inventory at '${dependenciesFile.path}'. Run quarkusBuild before generating the license report."
+      )
+    }
+
+    val bundledDependencies =
+      dependenciesFile
+        .readLines()
+        .asSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .mapNotNull { line ->
+          val parts = line.split(':')
+          if (parts.size >= 5) "${parts[0]}:${parts[1]}" else null
+        }
+        .toSet()
+
+    val configurations =
+      data.configurations
+        .map { configuration ->
+          ConfigurationData(
+            configuration.name,
+            configuration.dependencies.filterTo(sortedSetOf()) {
+              bundledDependencies.contains("${it.group}:${it.name}")
+            },
+          )
+        }
+        .toSortedSet()
+
+    return ProjectData(data.project, configurations, data.importedModules)
+  }
+}

--- a/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
@@ -25,6 +25,7 @@ import com.github.jk1.license.render.XmlReportRenderer
 import com.github.jk1.license.task.ReportTask
 import licenses.LicenseFileValidation
 import licenses.NoticeFileLicenseFilter
+import licenses.QuarkusAppDependencyFilter
 
 plugins { id("com.github.jk1.dependency-license-report") }
 
@@ -32,6 +33,7 @@ afterEvaluate {
   licenseReport {
     filters =
       arrayOf(
+        QuarkusAppDependencyFilter(),
         LicenseBundleNormalizer(
           "${rootProject.projectDir}/gradle/license/normalizer-bundle.json",
           false,
@@ -54,10 +56,12 @@ afterEvaluate {
 
 val generateLicenseReport =
   tasks.named<ReportTask>("generateLicenseReport") {
+    dependsOn("quarkusBuild")
     inputs
       .files(
         rootProject.projectDir.resolve("gradle/license/normalizer-bundle.json"),
         rootProject.projectDir.resolve("gradle/license/allowed-licenses.json"),
+        project.layout.buildDirectory.file("quarkus-app/quarkus-app-dependencies.txt"),
       )
       .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("renderersHash", licenseReport.renderers.contentHashCode())

--- a/runtime/admin/distribution/LICENSE
+++ b/runtime/admin/distribution/LICENSE
@@ -299,7 +299,6 @@ This product bundles Quarkus.
 * Maven group:artifact IDs: io.quarkus:quarkus-development-mode-spi
 * Maven group:artifact IDs: io.quarkus:quarkus-devservices
 * Maven group:artifact IDs: io.quarkus:quarkus-fs-util
-* Maven group:artifact IDs: io.quarkus:quarkus-ide-launcher
 * Maven group:artifact IDs: io.quarkus:quarkus-jdbc-postgresql
 * Maven group:artifact IDs: io.quarkus:quarkus-jsonp
 * Maven group:artifact IDs: io.quarkus:quarkus-micrometer

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -308,7 +308,6 @@ This product bundles Quarkus.
 * Maven group:artifact IDs: io.quarkus:quarkus-fs-util
 * Maven group:artifact IDs: io.quarkus:quarkus-grpc-common
 * Maven group:artifact IDs: io.quarkus:quarkus-hibernate-validator
-* Maven group:artifact IDs: io.quarkus:quarkus-ide-launcher
 * Maven group:artifact IDs: io.quarkus:quarkus-jackson
 * Maven group:artifact IDs: io.quarkus:quarkus-jdbc-postgresql
 * Maven group:artifact IDs: io.quarkus:quarkus-jsonp
@@ -1620,7 +1619,6 @@ License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 This product bundles Parsson.
 
 * Maven group:artifact IDs: org.eclipse.parsson:parsson
-* Maven group:artifact IDs: org.eclipse.parsson:jakarta.json
 
 Project URL: https://github.com/eclipse-ee4j/parsson
 License: Eclipse Public License 2.0 - https://projects.eclipse.org/license/epl-2.0
@@ -2175,10 +2173,8 @@ License: CDDL - https://javaee.github.io/jaxb-v2/LICENSE
 
 This product bundles GraalVM libraries.
 
-* Maven group:artifact IDs: org.graalvm.js:js
 * Maven group:artifact IDs: org.graalvm.js:js-language
 * Maven group:artifact IDs: org.graalvm.js:js-scriptengine
-* Maven group:artifact IDs: org.graalvm.polyglot:js
 * Maven group:artifact IDs: org.graalvm.polyglot:polyglot
 * Maven group:artifact IDs: org.graalvm.regex:regex
 * Maven group:artifact IDs: org.graalvm.sdk:collections


### PR DESCRIPTION
The LICENSE file for Polaris server/admin includes dependency corrdinates that are pom-only artifacts. Those are not distributed and should not appear in the LICENSE file at all.
