### PR TITLE
Fix Quarkus error "Failed to index: io.quarkus.test.ActivateSessionContext"

### DIFF
--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -54,8 +54,8 @@ dependencies {
     exclude(group = "com.google.protobuf", module = "protobuf-java-util")
   }
   implementation("io.quarkus:quarkus-container-image-docker")
-  
-  implementation("io.quarkus:quarkus-test-common")
+
+  "quarkusProdRuntimeClasspathConfigurationDeployment"("io.quarkus:quarkus-test-common")
 }
 
 quarkus {

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     exclude(group = "com.google.protobuf", module = "protobuf-java-util")
   }
   implementation("io.quarkus:quarkus-container-image-docker")
+  
+  implementation("io.quarkus:quarkus-test-common")
 }
 
 quarkus {


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

With recent quarkus version bumps (https://github.com/apache/polaris/pull/4336 and https://github.com/apache/polaris/pull/4364), `./gradlew run` no longer with and it will throw following error:
```
* What went wrong:
Execution failed for task ':polaris-server:quarkusRun' (registered by plugin 'io.quarkus').
> io.quarkus.builder.BuildException: Build failure: Build failed due to errors
        [error]: Build step io.quarkus.arc.deployment.BeanArchiveProcessor#build threw an exception: java.lang.IllegalStateException: Failed to index: io.quarkus.test.ActivateSessionContext
        at io.quarkus.deployment.index.IndexingUtil.indexClass(IndexingUtil.java:165)
        at io.quarkus.arc.deployment.BeanArchiveProcessor.build(BeanArchiveProcessor.java:97)
        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:898)
        at io.quarkus.builder.BuildContext.run(BuildContext.java:242)
        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
        at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
        at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
        at java.base/java.lang.Thread.run(Thread.java:1583)
        at org.jboss.threads.JBossThread.run(JBossThread.java:501)
  Caused by: java.lang.IllegalStateException: Failed to index: io.quarkus.test.ActivateSessionContext, class not present in class loader: QuarkusClassLoader:Deployment Class Loader: TEST for polaris-server-1.4.0-SNAPSHOT@1a140a8d
        at io.quarkus.deployment.index.IndexingUtil.indexClass(IndexingUtil.java:156)
        ... 11 more
```

It appears `io.quarkus:quarkus-test-common` is now needed on the newer version. With this PR, `./gradlew run` works again:
```
➜  polaris git:(main) ✗ ./gradlew run
Starting a Gradle Daemon (subsequent builds will be faster)
Configuration on demand is an incubating feature.
...
2026-05-06 19:04:28,083 INFO  [io.quarkus] [,] [,,,] (main) polaris-server 1.4.0-SNAPSHOT on JVM (powered by Quarkus 3.35.2) started in 6.834s. Listening on: http://0.0.0.0:8181. Management interface listening on http://0.0.0.0:8182.
2026-05-06 19:04:28,084 INFO  [io.quarkus] [,] [,,,] (main) Profile prod activated.
2026-05-06 19:04:28,084 INFO  [io.quarkus] [,] [,,,] (main) Installed features: [agroal, amazon-sdk-rds, cdi, hibernate-validator, jdbc-postgresql, micrometer, mongodb-client, narayana-jta, oidc, opentelemetry, reactive-routes, rest, rest-jackson, security, smallrye-context-propagation, smallrye-fault-tolerance, smallrye-health, vertx]
```

Similar error found in https://github.com/quarkusio/quarkus/issues/48950 but not fix provided.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
