### PR TITLE
Fix renameTable to return 204 instead of 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The configuration option `polaris.event-listener.type` is deprecated and will be removed later. Please use `polaris.event-listener.types` instead.
 
 ### Fixes
+- Fixed `renameTable` to return HTTP 204 (No Content) instead of 200, as per the Iceberg REST Catalog spec.
 
 ### Commits
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.ErrorHandler;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
@@ -149,6 +150,19 @@ public class CatalogApi extends PolarisRestApi {
             .get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class);
+    }
+  }
+
+  public void renameTable(String catalog, TableIdentifier source, TableIdentifier destination) {
+    try (Response res =
+        request("v1/{cat}/tables/rename", Map.of("cat", catalog))
+            .post(
+                Entity.json(
+                    RenameTableRequest.builder()
+                        .withSource(source)
+                        .withDestination(destination)
+                        .build()))) {
+      assertThat(res.getStatus()).isEqualTo(NO_CONTENT.getStatusCode());
     }
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -618,6 +618,19 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @Test
+  public void testRenameTableReturns204() {
+    restCatalog.createNamespace(Namespace.of("rename_ns"));
+    restCatalog
+        .buildTable(TableIdentifier.of(Namespace.of("rename_ns"), "src_table"), SCHEMA)
+        .create();
+
+    catalogApi.renameTable(
+        currentCatalogName,
+        TableIdentifier.of(Namespace.of("rename_ns"), "src_table"),
+        TableIdentifier.of(Namespace.of("rename_ns"), "dst_table"));
+  }
+
+  @Test
   public void testCreateTableWithOverriddenBaseLocation() {
     Catalog catalog = managementApi.getCatalog(currentCatalogName);
     Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -439,7 +439,7 @@ public class IcebergCatalogAdapter
         prefix,
         catalog -> {
           catalog.renameTable(renameTableRequest);
-          return Response.ok(Response.Status.NO_CONTENT).build();
+          return Response.status(Response.Status.NO_CONTENT).build();
         });
   }
 


### PR DESCRIPTION
`renameTable` returns HTTP 200 with body text `"NO_CONTENT"` instead of HTTP 204 as per the [IRC spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L1325).

### Testing

Manually verified by sending a rename table request to a local Polaris instance.

### Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)