### PR TITLE
Fix gradlew run after Quarkus bump

### DIFF
--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 import io.quarkus.gradle.tasks.QuarkusBuild
-import io.quarkus.gradle.tasks.QuarkusRun
+import io.quarkus.gradle.tasks.QuarkusDev
 
 plugins {
   alias(libs.plugins.quarkus)
@@ -76,10 +76,10 @@ quarkus {
 tasks.register("run") {
   group = "application"
   description = "Runs the Apache Polaris server application"
-  dependsOn("quarkusRun")
+  dependsOn("quarkusDev")
 }
 
-tasks.named<QuarkusRun>("quarkusRun") {
+tasks.named<QuarkusDev>("quarkusDev") {
   jvmArgs =
     listOf(
       "-Dpolaris.bootstrap.credentials=POLARIS,root,s3cr3t",


### PR DESCRIPTION
## Description

With recent Quarkus version bumps introduced in #4336 and #4364, running the local developer command:

```bash
./gradlew run
```

started failing with:

```text
Failed to index: io.quarkus.test.ActivateSessionContext
```

This is caused by a Quarkus issue:

* quarkusio/quarkus#54001

As suggested by @dimas-b and agreed by @jbonofre in #4382, this change switches the `run` convenience task from `quarkusRun` to `quarkusDev`.

`./gradlew run` is intended as a local developer convenience workflow, and `quarkusDev` is the more appropriate task for this use case.

## Before

```bash
./gradlew run
```

failed with:

```text
Execution failed for task ':polaris-server:quarkusRun'

Failed to index: io.quarkus.test.ActivateSessionContext
```

## After

```bash
./gradlew run
```

starts Polaris successfully:

```text
2026-05-09 08:46:08,699 INFO  [io.quarkus] Apache Polaris Server 1.4.0-SNAPSHOT on JVM (powered by Quarkus 3.35.2) started in 3.529s. Listening on: http://localhost:8181.
2026-05-09 08:46:08,699 INFO  [io.quarkus] Profile dev activated. Live Coding activated.
```

## Docker / DevServices warning notes

When Docker is not running locally, Quarkus DevServices emits startup warnings such as:

```text
WARN  [org.testcontainers.dockerclient.DockerClientProviderStrategy]
DOCKER_HOST unix:///var/run/docker.sock is not listening

ERROR [org.testcontainers.dockerclient.DockerClientProviderStrategy]
Could not find a valid Docker environment.
```

and:

```text
WARN  [io.quarkus.datasource.deployment.devservices.DevServicesDatasourceProcessor]
Please configure the datasource URL for default datasource or ensure the Docker daemon is up and running.

WARN  [io.quarkus.mongodb.deployment.DevServicesMongoProcessor]
Please configure datasource URL for default datasource or get a working docker instance
```

These warnings are harmless for local Polaris development.

To suppress them entirely:

```bash
./gradlew run "-Dquarkus.devservices.enabled=false"
```

Startup output is then clean:

```text
2026-05-09 08:50:33,582 INFO  [io.quarkus] Apache Polaris Server 1.4.0-SNAPSHOT on JVM (powered by Quarkus 3.35.2) started in 6.732s. Listening on: http://localhost:8181.
2026-05-09 08:50:33,583 INFO  [io.quarkus] Profile dev activated. Live Coding activated.
```

## Testing

Verified locally:

```bash
./gradlew assemble
./gradlew run
./gradlew run "-Dquarkus.devservices.enabled=false"
```

Closes #4382


## Checklist

* [x] 🛡️ Don't disclose security issues! (contact [[security@apache.org](mailto:security@apache.org)](mailto:security@apache.org))
* [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4382
* [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
* [x] 💡 Added comments for complex logic
* [x] 🧾 Updated CHANGELOG.md (if needed)
* [x] 📚 Updated documentation in site/content/in-dev/unreleased (if needed)