### PR TITLE
CLI: add missing parsing tests for policies, privileges and profiles

### DIFF
--- a/client/python/tests/test_policies_command.py
+++ b/client/python/tests/test_policies_command.py
@@ -151,3 +151,89 @@ class TestPoliciesCommand(CLITestBase):
                 kwargs["update_policy_request"].description, "dummy policy"
             )
             self.assertEqual(kwargs["update_policy_request"].current_policy_version, 1)
+
+    @patch("apache_polaris.cli.command.policies.PolicyAPI")
+    def test_policy_create(self, mock_policy_api_class: MagicMock) -> None:
+        mock_client = self.build_mock_client()
+        mock_policy_api = mock_policy_api_class.return_value
+
+        with patch(
+            "builtins.open",
+            unittest.mock.mock_open(
+                read_data='{"version": "2025-02-03", "enable": true}'
+            ),
+        ):
+            self.mock_execute(
+                mock_client,
+                [
+                    "policies",
+                    "create",
+                    "my-policy",
+                    "--catalog",
+                    "my-catalog",
+                    "--namespace",
+                    "ns1",
+                    "--policy-file",
+                    "dummy.json",
+                    "--policy-type",
+                    "system.data-compaction",
+                    "--policy-description",
+                    "my policy description",
+                ],
+            )
+            mock_policy_api.create_policy.assert_called_once()
+            _, kwargs = mock_policy_api.create_policy.call_args
+            self.assertEqual(kwargs["prefix"], "my-catalog")
+            self.assertEqual(kwargs["namespace"], "ns1")
+            self.assertEqual(kwargs["create_policy_request"].name, "my-policy")
+            self.assertEqual(
+                kwargs["create_policy_request"].type, "system.data-compaction"
+            )
+            self.assertEqual(
+                kwargs["create_policy_request"].description, "my policy description"
+            )
+
+    @patch("apache_polaris.cli.command.policies.PolicyAPI")
+    def test_policy_delete(self, mock_policy_api_class: MagicMock) -> None:
+        mock_client = self.build_mock_client()
+        mock_policy_api = mock_policy_api_class.return_value
+        self.mock_execute(
+            mock_client,
+            [
+                "policies",
+                "delete",
+                "my-policy",
+                "--catalog",
+                "my-catalog",
+                "--namespace",
+                "ns1",
+            ],
+        )
+        mock_policy_api.drop_policy.assert_called_once()
+        _, kwargs = mock_policy_api.drop_policy.call_args
+        self.assertEqual(kwargs["prefix"], "my-catalog")
+        self.assertEqual(kwargs["namespace"], "ns1")
+        self.assertEqual(kwargs["policy_name"], "my-policy")
+
+    @patch("apache_polaris.cli.command.policies.PolicyAPI")
+    def test_policy_get(self, mock_policy_api_class: MagicMock) -> None:
+        mock_client = self.build_mock_client()
+        mock_policy_api = mock_policy_api_class.return_value
+        mock_policy_api.load_policy.return_value.to_json.return_value = "{}"
+        self.mock_execute(
+            mock_client,
+            [
+                "policies",
+                "get",
+                "my-policy",
+                "--catalog",
+                "my-catalog",
+                "--namespace",
+                "ns1",
+            ],
+        )
+        mock_policy_api.load_policy.assert_called_once()
+        _, kwargs = mock_policy_api.load_policy.call_args
+        self.assertEqual(kwargs["prefix"], "my-catalog")
+        self.assertEqual(kwargs["namespace"], "ns1")
+        self.assertEqual(kwargs["policy_name"], "my-policy")

--- a/client/python/tests/test_privileges_command.py
+++ b/client/python/tests/test_privileges_command.py
@@ -209,3 +209,74 @@ class TestPrivilegesCommand(CLITestBase):
             ["privileges", "list", "--catalog", "foo", "--catalog-role", "bar"],
         )
         mock_client.list_grants_for_catalog_role.assert_called_with("foo", "bar")
+
+    def test_privilege_catalog_grant(self) -> None:
+        mock_client = self.build_mock_client()
+        self.mock_execute(
+            mock_client,
+            [
+                "privileges",
+                "catalog",
+                "grant",
+                "--catalog",
+                "foo",
+                "--catalog-role",
+                "bar",
+                "TABLE_READ_DATA",
+            ],
+        )
+        call_args = mock_client.add_grant_to_catalog_role.call_args[0]
+        self.assertEqual(call_args[0], "foo")
+        self.assertEqual(call_args[1], "bar")
+        self.assertEqual(call_args[2].grant.privilege.value, "TABLE_READ_DATA")
+
+    def test_privilege_namespace_revoke(self) -> None:
+        mock_client = self.build_mock_client()
+        self.mock_execute(
+            mock_client,
+            [
+                "privileges",
+                "namespace",
+                "revoke",
+                "--namespace",
+                "a.b.c",
+                "--catalog",
+                "foo",
+                "--catalog-role",
+                "bar",
+                "TABLE_READ_DATA",
+            ],
+        )
+        call_args = mock_client.revoke_grant_from_catalog_role.call_args[0]
+        self.assertEqual(call_args[0], "foo")
+        self.assertEqual(call_args[1], "bar")
+        self.assertEqual(call_args[2], False)
+        self.assertEqual(call_args[3].grant.privilege.value, "TABLE_READ_DATA")
+        self.assertEqual(call_args[3].grant.namespace, ["a", "b", "c"])
+
+    def test_privilege_view_revoke(self) -> None:
+        mock_client = self.build_mock_client()
+        self.mock_execute(
+            mock_client,
+            [
+                "privileges",
+                "view",
+                "revoke",
+                "--namespace",
+                "a.b.c",
+                "--catalog",
+                "foo",
+                "--catalog-role",
+                "bar",
+                "--view",
+                "v",
+                "VIEW_FULL_METADATA",
+            ],
+        )
+        call_args = mock_client.revoke_grant_from_catalog_role.call_args[0]
+        self.assertEqual(call_args[0], "foo")
+        self.assertEqual(call_args[1], "bar")
+        self.assertEqual(call_args[2], False)
+        self.assertEqual(call_args[3].grant.privilege.value, "VIEW_FULL_METADATA")
+        self.assertEqual(call_args[3].grant.namespace, ["a", "b", "c"])
+        self.assertEqual(call_args[3].grant.view_name, "v")

--- a/client/python/tests/test_profiles_command.py
+++ b/client/python/tests/test_profiles_command.py
@@ -97,6 +97,7 @@ class TestProfilesCommand(CLITestBase):
         with patch("sys.stdout", new_callable=io.StringIO):
             self.mock_execute(mock_client, ["profiles", "create", "dev"])
         mock_exit.assert_called_once_with(1)
+
     @patch("apache_polaris.cli.command.profiles.os.path.exists")
     @patch(
         "apache_polaris.cli.command.profiles.open",

--- a/client/python/tests/test_profiles_command.py
+++ b/client/python/tests/test_profiles_command.py
@@ -97,3 +97,50 @@ class TestProfilesCommand(CLITestBase):
         with patch("sys.stdout", new_callable=io.StringIO):
             self.mock_execute(mock_client, ["profiles", "create", "dev"])
         mock_exit.assert_called_once_with(1)
+    @patch("apache_polaris.cli.command.profiles.os.path.exists")
+    @patch(
+        "apache_polaris.cli.command.profiles.open",
+        new_callable=mock_open,
+        read_data='{"dev": {"client_id": "root", "client_secret": "s3cr3t", "host": "localhost", "port": 8181, "realm": "", "header": "Polaris-Realm"}}',
+    )
+    def test_profile_delete(
+        self, mock_file: MagicMock, mock_exists: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_exists.return_value = True
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.mock_execute(mock_client, ["profiles", "delete", "dev"])
+            output = mock_stdout.getvalue()
+            self.assertIn("Polaris profile dev deleted successfully.", output)
+        mock_file.assert_called_with(ANY, "w")
+
+    @patch("apache_polaris.cli.command.profiles.os.path.exists")
+    @patch(
+        "apache_polaris.cli.command.profiles.open",
+        new_callable=mock_open,
+        read_data='{"dev": {"client_id": "root", "client_secret": "s3cr3t", "host": "localhost", "port": 8181, "realm": "", "header": "Polaris-Realm"}}',
+    )
+    @patch("builtins.input")
+    @patch("apache_polaris.cli.command.profiles.os.makedirs")
+    def test_profile_update(
+        self,
+        mock_makedirs: MagicMock,
+        mock_input: MagicMock,
+        mock_file: MagicMock,
+        mock_exists: MagicMock,
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_exists.return_value = True
+        mock_input.side_effect = [
+            "new-id",
+            "new-secret",
+            "newhost",
+            9090,
+            "myrealm",
+            "Polaris-Realm",
+        ]
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.mock_execute(mock_client, ["profiles", "update", "dev"])
+            output = mock_stdout.getvalue()
+            self.assertIn("Polaris profile dev updated successfully.", output)
+        mock_file.assert_called_with(ANY, "w")


### PR DESCRIPTION
#4169 refactored CLI unit tests and covered some of the missing cases 
reported in #4017. This PR adds the remaining missing test coverage 
identified by auditing all subcommands against `polaris --help` output.

Added tests:
- `test_policy_create`, `test_policy_delete`, `test_policy_get` in `test_policies_command.py`
- `test_profile_delete`, `test_profile_update` in `test_profiles_command.py`
- `test_privilege_catalog_grant`, `test_privilege_namespace_revoke`, `test_privilege_view_revoke` in `test_privileges_command.py`

Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Closes #4017
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated CHANGELOG.md (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)