### PR TITLE
Site: clean up "Getting Started" guide with actual quickstart content

### DIFF
--- a/site/content/guides/quickstart/index.md
+++ b/site/content/guides/quickstart/index.md
@@ -28,8 +28,6 @@ menus:
         weight: 2
 ---
 
-# Quickstart
-
 <!--
 ```shell
 cd "$SITE_TEST_GUIDE_DIR"

--- a/site/content/guides/quickstart/index.md
+++ b/site/content/guides/quickstart/index.md
@@ -1,19 +1,19 @@
 ---
 #
 # Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
+# or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
+# regarding copyright ownership. The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# with the License. You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
+# KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
 #
@@ -28,11 +28,42 @@ menus:
         weight: 2
 ---
 
-Please see the [quickstart guide](/releases/latest/getting-started/) for more information.
+# Quickstart
 
-<!--
-```shell
-cd "$SITE_TEST_GUIDE_DIR"
-docker compose up
+Welcome to Apache Polaris! This guide helps you quickly get Polaris running locally for evaluation and development purposes.  
+**This setup is not intended for production use.**
+
+## Prerequisites
+
+- Docker and Docker Compose v2 installed and running.
+
+## Running the Quickstart
+
+Run the following command:
+
+```bash
+curl -s https://raw.githubusercontent.com/apache/polaris/refs/heads/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
 ```
--->
+
+This command will start Polaris + RustFS and automatically create:
+- Catalog: `quickstart_catalog`
+- Principal: `quickstart_user` (with full access)
+
+Check the logs for credentials and example commands.
+
+### Useful URLs
+
+- Polaris REST API: http://localhost:8181
+- RustFS Console: http://localhost:9001
+
+To stop the services:
+```bash
+docker compose down
+```
+
+## Next Steps
+
+- [Binary Distribution](/releases/latest/getting-started/binary-distribution)
+- [Setup Tools](/releases/latest/getting-started/setup-tools)
+- [Spark Integration](/guides/spark)
+- [Full Documentation](/releases/latest/)

--- a/site/content/guides/quickstart/index.md
+++ b/site/content/guides/quickstart/index.md
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-linkTitle: "Apache Polaris"
-title: "Getting Started"
+linkTitle: "Quickstart"
+title: "Quickstart"
 weight: 10
 cascade:
     type: guides
@@ -65,8 +65,8 @@ docker compose -p polaris-quickstart logs
 
 ### Useful URLs
 
-- Polaris REST API: http://localhost:8181
-- RustFS Console: http://localhost:9001
+- Polaris REST API: [http://localhost:8181](http://localhost:8181)
+- RustFS Console: [http://localhost:9001](http://localhost:9001)
 
 To stop the services:
 

--- a/site/content/guides/quickstart/index.md
+++ b/site/content/guides/quickstart/index.md
@@ -1,19 +1,19 @@
 ---
 #
 # Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements. See the NOTICE file
+# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership. The ASF licenses this file
+# regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
+# with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 #
@@ -30,6 +30,13 @@ menus:
 
 # Quickstart
 
+<!--
+```shell
+cd "$SITE_TEST_GUIDE_DIR"
+docker compose up
+```
+-->
+
 Welcome to Apache Polaris! This guide helps you quickly get Polaris running locally for evaluation and development purposes.  
 **This setup is not intended for production use.**
 
@@ -42,14 +49,19 @@ Welcome to Apache Polaris! This guide helps you quickly get Polaris running loca
 Run the following command:
 
 ```bash
-curl -s https://raw.githubusercontent.com/apache/polaris/refs/heads/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
+curl -s https://raw.githubusercontent.com/apache/polaris/refs/heads/main/site/content/guides/quickstart/docker-compose.yml | docker compose -p polaris-quickstart -f - up -d
 ```
 
 This command will start Polaris + RustFS and automatically create:
+
 - Catalog: `quickstart_catalog`
 - Principal: `quickstart_user` (with full access)
 
-Check the logs for credentials and example commands.
+Check the logs for credentials and example commands:
+
+```bash
+docker compose -p polaris-quickstart logs
+```
 
 ### Useful URLs
 
@@ -57,8 +69,9 @@ Check the logs for credentials and example commands.
 - RustFS Console: http://localhost:9001
 
 To stop the services:
+
 ```bash
-docker compose down
+docker compose -p polaris-quickstart down
 ```
 
 ## Next Steps

--- a/site/content/in-dev/unreleased/getting-started/quick-start.md
+++ b/site/content/in-dev/unreleased/getting-started/quick-start.md
@@ -22,22 +22,6 @@ type: docs
 weight: 99
 ---
 
-Use this guide to quickly start running Polaris. This is not intended for production use.
+Use the **[Quickstart guide](/guides/quickstart/)** for running Polaris locally with Docker Compose: prerequisites, the one-liner command, default catalog and principal, service URLs, and suggested next steps.
 
-## Prerequisites
-
-- Have Docker (with Docker Compose v2) installed & running on your machine
-
-## Running
-
-Run the following command:
-
-```bash
-curl -s https://raw.githubusercontent.com/apache/polaris/refs/heads/main/site/content/guides/quickstart/docker-compose.yml | docker compose -f - up
-
-```
-This command will:
-1. Create a Catalog named `quickstart_catalog` with RustFS-backed storage.
-2. Create a user principal `quickstart_user` with full access to the catalog.
-
-Once the command has been run, you will see examples on how to interact with this Polaris server in the logs.
+This setup is not intended for production use.


### PR DESCRIPTION
Addresses #3884.

The "Getting Started" guide page became sparse after #3550 moved files 
around. As suggested by @adutra in the review, this PR brings the actual 
quickstart content into the guide page directly, rather than redirecting 
users elsewhere.

Changes:
- Replace the redirect-only content with actual quickstart instructions
- Add prerequisites, running instructions, and next steps

Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Addresses #3884
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated CHANGELOG.md (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)