### PR TITLE
Fix client build by exclusing PKG-INFO

### DIFF
--- a/client/python/generate_clients.py
+++ b/client/python/generate_clients.py
@@ -56,6 +56,7 @@ EXCLUDE_PATHS = [
     Path("hatch_build.py"),
     Path("templates"),
     Path("spec"),
+    Path("PKG-INFO"),
     Path("LICENSE"),
     Path("NOTICE"),
 ]


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Client build is failing on my local:
```
DEBUG Calling `hatchling.build.build_wheel("/Users/yong/Desktop/GitHome/polaris/client/python/dist", {}, None)`
Preparing spec directory...
Source spec directory not found, using existing spec directory.
Fixing catalog models __init__.py...
Catalog models __init__.py fixed.
Re-applying license headers...
No header file found for PKG-INFO
Traceback (most recent call last):
  File "<string>", line 11, in <module>
    wheel_filename = backend.build_wheel("/Users/yong/Desktop/GitHome/polaris/client/python/dist", {}, None)
  File "/Users/yong/.cache/uv/builds-v0/.tmpmGffOg/lib/python3.13/site-packages/hatchling/build.py", line 58, in build_wheel
    return os.path.basename(next(builder.build(directory=wheel_directory, versions=["standard"])))
                            ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yong/.cache/uv/builds-v0/.tmpmGffOg/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py", line 149, in build
    build_hook.initialize(version, build_data)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yong/.cache/uv/sdists-v9/.tmpkXHAKP/apache_polaris-1.4.0rc2/hatch_build.py", line 26, in initialize
    subprocess.check_call([sys.executable, "generate_clients.py"])
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/Users/yong/.cache/uv/builds-v0/.tmpmGffOg/bin/python', 'generate_clients.py']' returned non-zero exit status 2.
  × Failed to build `/Users/yong/Desktop/GitHome/polaris/client/python`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_wheel` failed (exit status: 1)
      hint: This usually indicates a problem with the package or the build environment.
DEBUG Released lock at `/Users/yong/.cache/uv/.lock`
```

With some debugging, this is getting created in the uv cached directory (not sure why this happened now as this path was removed by me via https://github.com/apache/polaris/commit/0a6d7e677d4684985049e45957af3f161196551e#diff-58ca130f0fe17e5fcebbe93590459407c7bb62fea7072b07b37ad07c0ae7a418L99 a while back but this was fine around that time. You can find details output in https://github.com/apache/polaris/pull/4243 as well. So something may changed on uv side which is causing this issue...it could also be my local specific):
```
PKG-INFO
/Users/yong/.cache/uv/sdists-v9/.tmpjhFRoo/apache_polaris-1.4.0rc2
```

As the change is harmless and also to avoid others who also have this issue when building local, I think we should exclude `PKG-INFO` (this also is populated by uv and already have proper ASF header).

With this change changed, the build is moving forward:
```
➜  polaris git:(fix_client_build_exclude_pkg_info) ✗ make client-build
Installing UV and project dependencies into .venv...
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (26.1.1)
Resolved 63 packages in 17ms
Resolved 63 packages in 3ms
Audited 60 packages in 11ms
uv and dependencies installed.
--- Building client distribution ---
Building default distribution (sdist and wheel)
Building source distribution...
Preparing spec directory...
Copying spec directory from /Users/yong/Desktop/GitHome/polaris/spec to /Users/yong/Desktop/GitHome/polaris/client/python/spec
Spec directory copied to ensure it is up-to-date.
Fixing catalog models __init__.py...
Catalog models __init__.py fixed.
Re-applying license headers...
License fix complete.
Building wheel from source distribution...
Preparing spec directory...
Source spec directory not found, using existing spec directory.
Fixing catalog models __init__.py...
Catalog models __init__.py fixed.
Re-applying license headers...
License fix complete.
Successfully built dist/apache_polaris-1.4.0rc2.tar.gz
Successfully built dist/apache_polaris-1.4.0rc2-py3-none-any.whl
--- Client distribution build complete ---
```


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
