### PR TITLE
Prevent client id collison during reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Changes
 - Removed unused `PolarisAuthorizableOperation` values: `REVOKE_PRINCIPAL_GRANT_FROM_PRINCIPAL_ROLE`, `REVOKE_PRINCIPAL_ROLE_GRANT_FROM_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_ROOT`, `ADD_PRINCIPAL_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL`, `ADD_PRINCIPAL_ROLE_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL_ROLE`, `ADD_CATALOG_ROLE_GRANT_TO_CATALOG_ROLE`, `REVOKE_CATALOG_ROLE_GRANT_FROM_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG`, `LIST_GRANTS_ON_NAMESPACE`, `LIST_GRANTS_ON_TABLE`, `LIST_GRANTS_ON_VIEW`.
 - Changed deprecated APIs in JUnit 5. This change will force downstream projects that pull in the Polaris test packages to adopt JUnit 6.
+- Added client id collision check during reset.
 
 ### Deprecations
 - The configuration option `polaris.event-listener.type` is deprecated and will be removed later. Please use `polaris.event-listener.types` instead.

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1087,17 +1087,17 @@ public class PolarisManagementServiceIntegrationTest {
 
   @Test
   public void testResetCredentialsClientIdCollision() {
-    PrincipalWithCredentials victimCreds =
-        managementApi.createPrincipal(client.newEntityName(("victim-principal")));
-    String victimClientId = victimCreds.getCredentials().getClientId();
-    PrincipalWithCredentials attackerCreds =
-        managementApi.createPrincipal(client.newEntityName(("attacker-principal")));
-    String attackerName = attackerCreds.getPrincipal().getName();
+    PrincipalWithCredentials principalA =
+        managementApi.createPrincipal(client.newEntityName(("principal-a")));
+    String principalAClientId = principalA.getCredentials().getClientId();
+    PrincipalWithCredentials principalB =
+        managementApi.createPrincipal(client.newEntityName(("principal-b")));
+    String principalBName = principalB.getPrincipal().getName();
     Map<String, String> collidingBody =
-        Map.of("clientId", victimClientId, "clientSecret", victimClientId);
+        Map.of("clientId", principalAClientId, "clientSecret", "new-secret");
     try (Response response =
         managementApi
-            .request("v1/principals/{p}/reset", Map.of("p", attackerName))
+            .request("v1/principals/{p}/reset", Map.of("p", principalBName))
             .post(Entity.json(collidingBody))) {
       assertThat(response).returns(Response.Status.CONFLICT.getStatusCode(), Response::getStatus);
     }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1086,6 +1086,24 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testResetCredentialsClientIdCollision() {
+    PrincipalWithCredentials victimCreds =
+        managementApi.createPrincipal(client.newEntityName(("victim-principal")));
+    String victimClientId = victimCreds.getCredentials().getClientId();
+    PrincipalWithCredentials attackerCreds =
+        managementApi.createPrincipal(client.newEntityName(("attacker-principal")));
+    String attackerName = attackerCreds.getPrincipal().getName();
+    Map<String, String> collidingBody =
+        Map.of("clientId", victimClientId, "clientSecret", victimClientId);
+    try (Response response =
+        managementApi
+            .request("v1/principals/{p}/reset", Map.of("p", attackerName))
+            .post(Entity.json(collidingBody))) {
+      assertThat(response).returns(Response.Status.CONFLICT.getStatusCode(), Response::getStatus);
+    }
+  }
+
+  @Test
   public void testCreateFederatedPrincipalRoleSucceeds() {
     // Create a federated Principal Role
     PrincipalRole federatedPrincipalRole =

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PrincipalMutations.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PrincipalMutations.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.PrincipalSecretsGenerator;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
@@ -157,7 +158,11 @@ public abstract class PrincipalMutations<RESULT> implements PrincipalsChangeComm
           .ifPresent(
               clientId -> {
                 var clientIdKey = IndexKey.key(clientId);
-                byClientId.put(clientIdKey, updatedPrincipalObjRef);
+                if (!byClientId.put(clientIdKey, updatedPrincipalObjRef)) {
+                  throw new AlreadyExistsException(
+                      String.format("Client ID already in use: %s", clientId));
+                }
+                ;
               });
 
       state.writeOrReplace("principal", updatedPrincipal);

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PrincipalMutations.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PrincipalMutations.java
@@ -162,7 +162,6 @@ public abstract class PrincipalMutations<RESULT> implements PrincipalsChangeComm
                   throw new AlreadyExistsException(
                       String.format("Client ID already in use: %s", clientId));
                 }
-                ;
               });
 
       state.writeOrReplace("principal", updatedPrincipal);

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -51,6 +51,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
@@ -918,6 +919,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
                   .toList(),
               realmId));
     } catch (SQLException e) {
+      if (datasourceOperations.isConstraintViolation(e)) {
+        throw new AlreadyExistsException(
+            String.format("Client ID already in used: %s", resolvedClientId), e);
+      }
       LOGGER.error(
           "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
           resolvedClientId,

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -920,8 +920,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               realmId));
     } catch (SQLException e) {
       if (datasourceOperations.isConstraintViolation(e)) {
-        throw new AlreadyExistsException(
-            String.format("Client ID already in used: %s", resolvedClientId), e);
+        throw new AlreadyExistsException(e.getMessage(), e);
       }
       LOGGER.error(
           "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
@@ -493,6 +494,12 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
       String customClientSecret) {
     PolarisPrincipalSecrets principalSecrets =
         new PolarisPrincipalSecrets(principalId, resolvedClientId, customClientSecret);
+
+    // check if already exists
+    PolarisPrincipalSecrets existing = this.store.getSlicePrincipalSecrets().read(resolvedClientId);
+    if (existing != null && existing.getPrincipalId() == principalId) {
+      throw new AlreadyExistsException("Client ID already in used: %s", resolvedClientId);
+    }
 
     // write back new secrets
     this.store.getSlicePrincipalSecrets().write(principalSecrets);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -497,7 +497,7 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
 
     // check if already exists
     PolarisPrincipalSecrets existing = this.store.getSlicePrincipalSecrets().read(resolvedClientId);
-    if (existing != null && existing.getPrincipalId() == principalId) {
+    if (existing != null) {
       throw new AlreadyExistsException("Client ID already in used: %s", resolvedClientId);
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TreeMapTransactionalPersistenceImpl.java
@@ -28,7 +28,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
@@ -44,6 +43,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
+import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.PrincipalSecretsGenerator;
 import org.apache.polaris.core.persistence.pagination.EntityIdToken;
@@ -498,7 +498,8 @@ public class TreeMapTransactionalPersistenceImpl extends AbstractTransactionalPe
     // check if already exists
     PolarisPrincipalSecrets existing = this.store.getSlicePrincipalSecrets().read(resolvedClientId);
     if (existing != null) {
-      throw new AlreadyExistsException("Client ID already in used: %s", resolvedClientId);
+      throw new AlreadyExistsException(
+          String.format("Client ID already in use: %s", resolvedClientId));
     }
 
     // write back new secrets

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisTreeMapAtomicOperationMetaStoreManagerTest.java
@@ -25,6 +25,8 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
@@ -41,4 +43,11 @@ public class PolarisTreeMapAtomicOperationMetaStoreManagerTest
     PolarisCallContext callCtx = new PolarisCallContext(() -> "testRealm", metaStore);
     return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
   }
+
+  @Override
+  @Test
+  @Disabled(
+      "AtomicOperationMetaStoreManager calls storePrincipalSecrets outside a transaction, which is incompatible with "
+          + "TreeMap's transactional slice reads. Collision detection is covered by JDBC and NoSQL backend tests.")
+  protected void testResetCredentialsClientIdCollision() {}
 }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -43,6 +43,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -520,5 +521,22 @@ public abstract class BasePolarisMetaStoreManagerTest {
       executorService.shutdown();
       Assertions.assertThat(executorService.awaitTermination(10, TimeUnit.MINUTES)).isTrue();
     }
+  }
+
+  @Test
+  protected void testResetCredentialsClientIdCollision() {
+    PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
+    PolarisCallContext callCtx = polarisTestMetaStoreManager.polarisCallContext;
+
+    PrincipalEntity principalA = polarisTestMetaStoreManager.createPrincipal("principalA");
+    PrincipalEntity principalB = polarisTestMetaStoreManager.createPrincipal("principalB");
+
+    String principalAClientId = principalA.getClientId();
+
+    Assertions.assertThatThrownBy(
+            () ->
+                metaStoreManager.resetPrincipalSecrets(
+                    callCtx, principalB.getId(), principalAClientId, null))
+        .isInstanceOf(AlreadyExistsException.class);
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1077,6 +1077,16 @@ public class PolarisAdminService {
       throw new ValidationException(
           "Cannot reset credentials for a federated principal: %s", principalName);
     }
+    if (customClientId != null) {
+      PolarisPrincipalSecrets collidingSecrets =
+          metaStoreManager
+              .loadPrincipalSecrets(getCurrentPolarisContext(), customClientId)
+              .getPrincipalSecrets();
+      if (collidingSecrets != null
+          && collidingSecrets.getPrincipalId() != currentPrincipalEntity.getId()) {
+        throw new AlreadyExistsException("Client ID already in used: %s", customClientId);
+      }
+    }
     PolarisPrincipalSecrets currentSecrets =
         metaStoreManager
             .loadPrincipalSecrets(getCurrentPolarisContext(), currentPrincipalEntity.getClientId())

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1077,16 +1077,6 @@ public class PolarisAdminService {
       throw new ValidationException(
           "Cannot reset credentials for a federated principal: %s", principalName);
     }
-    if (customClientId != null) {
-      PolarisPrincipalSecrets collidingSecrets =
-          metaStoreManager
-              .loadPrincipalSecrets(getCurrentPolarisContext(), customClientId)
-              .getPrincipalSecrets();
-      if (collidingSecrets != null
-          && collidingSecrets.getPrincipalId() != currentPrincipalEntity.getId()) {
-        throw new AlreadyExistsException("Client ID already in use: %s", customClientId);
-      }
-    }
     PolarisPrincipalSecrets currentSecrets =
         metaStoreManager
             .loadPrincipalSecrets(getCurrentPolarisContext(), currentPrincipalEntity.getClientId())

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1077,6 +1077,16 @@ public class PolarisAdminService {
       throw new ValidationException(
           "Cannot reset credentials for a federated principal: %s", principalName);
     }
+    if (customClientId != null) {
+      PolarisPrincipalSecrets collidingSecrets =
+          metaStoreManager
+              .loadPrincipalSecrets(getCurrentPolarisContext(), customClientId)
+              .getPrincipalSecrets();
+      if (collidingSecrets != null
+          && collidingSecrets.getPrincipalId() != currentPrincipalEntity.getId()) {
+        throw new AlreadyExistsException("Client ID already in use: %s", customClientId);
+      }
+    }
     PolarisPrincipalSecrets currentSecrets =
         metaStoreManager
             .loadPrincipalSecrets(getCurrentPolarisContext(), currentPrincipalEntity.getClientId())

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1084,7 +1084,7 @@ public class PolarisAdminService {
               .getPrincipalSecrets();
       if (collidingSecrets != null
           && collidingSecrets.getPrincipalId() != currentPrincipalEntity.getId()) {
-        throw new AlreadyExistsException("Client ID already in used: %s", customClientId);
+        throw new AlreadyExistsException("Client ID already in use: %s", customClientId);
       }
     }
     PolarisPrincipalSecrets currentSecrets =

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -29,11 +29,9 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisCallContext;
-import org.apache.polaris.core.admin.model.ResetPrincipalRequest;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
@@ -45,18 +43,14 @@ import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PolarisPrivilege;
-import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
-import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
-import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
@@ -773,42 +767,5 @@ public class PolarisAdminServiceTest {
     when(resolutionManifest.getResolvedPath(
             eq(ResolvedPathKey.of(List.of(namespace.levels()), PolarisEntityType.NAMESPACE))))
         .thenReturn(resolvedPathWrapper);
-  }
-
-  @Test
-  void testResetCredentialsClientIdCollision() {
-    String principalName = "quickstart_user";
-    String collidingClientId = "root";
-
-    PolarisResolvedPathWrapper principalWrapper = mock(PolarisResolvedPathWrapper.class);
-    ResolvedPolarisEntity principalEntity = mock(ResolvedPolarisEntity.class);
-    PrincipalEntity principal =
-        new PrincipalEntity.Builder()
-            .setName(principalName)
-            .setClientId("a35358218e1a5458")
-            .setId(2L)
-            .build();
-
-    when(principalWrapper.getResolvedLeafEntity()).thenReturn(principalEntity);
-    when(principalWrapper.getRawLeafEntity()).thenReturn(principal);
-    when(principalEntity.getEntity()).thenReturn(principal);
-
-    when(resolutionManifest.getResolvedTopLevelEntity(
-            eq(principalName), eq(PolarisEntityType.PRINCIPAL)))
-        .thenReturn(principalWrapper);
-
-    PolarisPrincipalSecrets rootPrincipalSecrets =
-        new PolarisPrincipalSecrets(1L, collidingClientId, "secret");
-    when(metaStoreManager.loadPrincipalSecrets(any(), eq(collidingClientId)))
-        .thenReturn(new PrincipalSecretsResult(rootPrincipalSecrets));
-
-    when(realmConfig.getConfig(FeatureConfiguration.ENABLE_CREDENTIAL_RESET)).thenReturn(true);
-
-    ResetPrincipalRequest resetRequest =
-        ResetPrincipalRequest.builder().setClientId(collidingClientId).build();
-
-    assertThatThrownBy(() -> adminService.resetCredentials(principalName, resetRequest))
-        .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageContaining("Client ID already in used: " + collidingClientId);
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -29,9 +29,11 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.admin.model.ResetPrincipalRequest;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
@@ -43,14 +45,18 @@ import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
+import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
@@ -767,5 +773,42 @@ public class PolarisAdminServiceTest {
     when(resolutionManifest.getResolvedPath(
             eq(ResolvedPathKey.of(List.of(namespace.levels()), PolarisEntityType.NAMESPACE))))
         .thenReturn(resolvedPathWrapper);
+  }
+
+  @Test
+  void testResetCredentialsClientIdCollision() {
+    String principalName = "quickstart_user";
+    String collidingClientId = "root";
+
+    PolarisResolvedPathWrapper principalWrapper = mock(PolarisResolvedPathWrapper.class);
+    ResolvedPolarisEntity principalEntity = mock(ResolvedPolarisEntity.class);
+    PrincipalEntity principal =
+        new PrincipalEntity.Builder()
+            .setName(principalName)
+            .setClientId("a35358218e1a5458")
+            .setId(2L)
+            .build();
+
+    when(principalWrapper.getResolvedLeafEntity()).thenReturn(principalEntity);
+    when(principalWrapper.getRawLeafEntity()).thenReturn(principal);
+    when(principalEntity.getEntity()).thenReturn(principal);
+
+    when(resolutionManifest.getResolvedTopLevelEntity(
+            eq(principalName), eq(PolarisEntityType.PRINCIPAL)))
+        .thenReturn(principalWrapper);
+
+    PolarisPrincipalSecrets rootPrincipalSecrets =
+        new PolarisPrincipalSecrets(1L, collidingClientId, "secret");
+    when(metaStoreManager.loadPrincipalSecrets(any(), eq(collidingClientId)))
+        .thenReturn(new PrincipalSecretsResult(rootPrincipalSecrets));
+
+    when(realmConfig.getConfig(FeatureConfiguration.ENABLE_CREDENTIAL_RESET)).thenReturn(true);
+
+    ResetPrincipalRequest resetRequest =
+        ResetPrincipalRequest.builder().setClientId(collidingClientId).build();
+
+    assertThatThrownBy(() -> adminService.resetCredentials(principalName, resetRequest))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Client ID already in used: " + collidingClientId);
   }
 }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently only root principal can perform principal reset (which contains both client id and client secret). The problem here is there is lack of check for client ID collision. When a client ID collision happened (used principal B's client id to reset principal A's client id), this will prevent principal B from perform auth request. This also means, if an admin who accidentally used root's client id to update a low privilege principal, we will no longer be able to obtain new token for principal root.

For example:

Assuming I accidentally reset principal `quickstart_user`'s client ID with value `root` (which is the default client ID for principal `root`), I won't be able to auth with principal `root` again (root can get itself locked out):
```sh
➜  polaris git:(main) ./polaris --profile dev principals list
{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1778384520325, "lastUpdateTimestamp": 1778384520325, "entityVersion": 1}
{"name": "quickstart_user", "clientId": "a35358218e1a5458", "properties": {}, "createTimestamp": 1778384524349, "lastUpdateTimestamp": 1778384524349, "entityVersion": 1}
➜  polaris git:(main) ./polaris --profile dev principals reset quickstart_user --new-client-id root
...
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/cli/api_client_builder.py", line 147, in _get_token
    raise Exception("Failed to get access token")
```

Here is the new behavior with this check:
```sh
➜  polaris git:(prevent_clientid_collison_during_reset) ✗  ./polaris --profile dev principals list
{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1778389833416, "lastUpdateTimestamp": 1778389833416, "entityVersion": 1}
{"name": "quickstart_user", "clientId": "8c587de26b5cc0ee", "properties": {}, "createTimestamp": 1778389837767, "lastUpdateTimestamp": 1778389837767, "entityVersion": 1}
➜  polaris git:(prevent_clientid_collison_during_reset) ✗ ./polaris --profile dev principals reset quickstart_user --new-client-id root
Exception when communicating with the Polaris server. AlreadyExistsException: Client ID already in used: root
➜  polaris git:(prevent_clientid_collison_during_reset) ✗ ./polaris --profile dev principals list
{"name": "root", "clientId": "root", "properties": {}, "createTimestamp": 1778389833416, "lastUpdateTimestamp": 1778389833416, "entityVersion": 1}
{"name": "quickstart_user", "clientId": "8c587de26b5cc0ee", "properties": {}, "createTimestamp": 1778389837767, "lastUpdateTimestamp": 1778389837767, "entityVersion": 1}
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
