### PR TITLE
fix(rate-limiter): return Iceberg ErrorResponse JSON body on HTTP 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - Fixed `renameTable` to return HTTP 204 (No Content) instead of 200, as per the Iceberg REST Catalog spec.
+- `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 
 ### Commits
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
@@ -82,7 +82,7 @@ public class RateLimiterFilter implements ContainerRequestFilter {
               .entity(
                   ErrorResponse.builder()
                       .responseCode(Response.Status.TOO_MANY_REQUESTS.getStatusCode())
-                      .withType("RateLimitExceededException")
+                      .withType("TooManyRequestsException")
                       .withMessage("Rate exceeded")
                       .build())
               .build());

--- a/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/ratelimiter/RateLimiterFilter.java
@@ -24,9 +24,11 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.polaris.service.config.FilterPriorities;
 import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.events.EventAttributes;
@@ -74,7 +76,16 @@ public class RateLimiterFilter implements ContainerRequestFilter {
                         EventAttributes.REQUEST_URI,
                         ctx.getUriInfo().getAbsolutePath().toString())));
       }
-      ctx.abortWith(Response.status(Response.Status.TOO_MANY_REQUESTS).build());
+      ctx.abortWith(
+          Response.status(Response.Status.TOO_MANY_REQUESTS)
+              .type(MediaType.APPLICATION_JSON_TYPE)
+              .entity(
+                  ErrorResponse.builder()
+                      .responseCode(Response.Status.TOO_MANY_REQUESTS.getStatusCode())
+                      .withType("RateLimitExceededException")
+                      .withMessage("Rate exceeded")
+                      .build())
+              .build());
       LOGGER.atDebug().log("Rate limiting request");
     }
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
@@ -160,7 +160,7 @@ public class RateLimiterFilterTest {
       String body = response.readEntity(String.class);
       ErrorResponse parsed = ErrorResponseParser.fromJson(body);
       assertThat(parsed.code()).isEqualTo(Status.TOO_MANY_REQUESTS.getStatusCode());
-      assertThat(parsed.type()).isEqualTo("RateLimitExceededException");
+      assertThat(parsed.type()).isEqualTo("TooManyRequestsException");
       assertThat(parsed.message()).contains("Rate exceeded");
     }
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/ratelimiter/RateLimiterFilterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.ratelimiter;
 
+import static org.apache.polaris.service.context.TestRealmContextResolver.REALM_PROPERTY_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
@@ -28,10 +29,14 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.polaris.service.events.EventAttributes;
 import org.apache.polaris.service.events.PolarisEvent;
 import org.apache.polaris.service.events.PolarisEventType;
@@ -136,6 +141,28 @@ public class RateLimiterFilterTest {
     Consumer<Status> requestAsserter2 =
         TestUtil.constructRequestAsserter(testEnv, fixture, fixture.realm + "2");
     requestAsserter2.accept(Status.OK);
+  }
+
+  @Test
+  public void testRateLimitedResponseHasIcebergErrorBody() {
+    MockRateLimiter.allowProceed = false;
+    try (Response response =
+        fixture
+            .client
+            .target(String.format("%s/api/management/v1/principal-roles", testEnv.baseUri()))
+            .request("application/json")
+            .header("Authorization", "Bearer " + fixture.adminToken)
+            .header(REALM_PROPERTY_KEY, fixture.realm)
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(Status.TOO_MANY_REQUESTS.getStatusCode());
+      assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+
+      String body = response.readEntity(String.class);
+      ErrorResponse parsed = ErrorResponseParser.fromJson(body);
+      assertThat(parsed.code()).isEqualTo(Status.TOO_MANY_REQUESTS.getStatusCode());
+      assertThat(parsed.type()).isEqualTo("RateLimitExceededException");
+      assertThat(parsed.message()).contains("Rate exceeded");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Motivation

`RateLimiterFilter` previously returned HTTP 429 with an empty body and no `Content-Type` header:

```java
ctx.abortWith(Response.status(Response.Status.TOO_MANY_REQUESTS).build());
```

Iceberg REST clients (pyiceberg, Spark, and any third-party caller) cannot meaningfully parse this. The Iceberg Java client's `DefaultErrorHandler.parseResponse()` attempts `ErrorResponseParser.fromJson("")` on the empty body, catches the JSON parse failure, and falls back to building an `ErrorResponse` with `message = ""`. Since there is no `case 429:` in any `ErrorHandlers` switch, the result is always:

```
RESTException("Unable to process: ")
```

— an opaque error with no actionable context for the caller.

## Changes

Add an Iceberg-compatible `ErrorResponse` JSON body to the 429 response.

```java
ctx.abortWith(
    Response.status(Response.Status.TOO_MANY_REQUESTS)
        .type(MediaType.APPLICATION_JSON_TYPE)
        .entity(
            ErrorResponse.builder()
                .responseCode(Response.Status.TOO_MANY_REQUESTS.getStatusCode())
                .withType("TooManyRequestsException")
                .withMessage("Rate exceeded")
                .build())
        .build());
```

## Ecosystem Context

The Iceberg REST OpenAPI spec does not define a 429 response schema — implementations are on their own. Surveying the major catalog implementations:

| Implementation | Body on 429? | Follows Iceberg `ErrorModel`? |
|---|---|---|
| AWS Glue | Yes | No (AWS `{"__type": "ThrottlingException", ...}` format) |
| Project Nessie | Yes | No (Nessie `{"status": 429, "errorCode": "TOO_MANY_REQUESTS", ...}` format) |
| Databricks Unity Catalog | Yes | No (Databricks `{"error_code": "RESOURCE_EXHAUSTED", ...}` format) |
| Apache Polaris (this fix) | Yes | **Yes** |

All other catalogs return *some* JSON, but none follow the Iceberg `ErrorModel` schema. With this fix, Polaris becomes the most spec-consistent implementation — clients using `ErrorResponseParser` will be able to round-trip the 429 body correctly.

## Compatibility

- Existing clients that ignore the 429 body are unaffected.
- Clients that previously hit the empty-body parse failure will now receive a well-formed `ErrorResponse`.
- No change to status code or any other behavior.

## Tests

Added `testRateLimitedResponseHasIcebergErrorBody` — a full integration test that performs a live HTTP request against a rate-limited endpoint, reads the response body, and round-trips it through `ErrorResponseParser.fromJson(...)` to prove Iceberg client compatibility. Asserts `Content-Type: application/json`, `code == 429`, `type == "RateLimitExceededException"`, and `message` contains `"Rate exceeded"`.

Fixes #4402

---

> This fix was developed with AI assistance (Claude). The author has reviewed the change end-to-end and takes full responsibility for correctness and ASF licensing compliance.