### PR TITLE
Include user-defined attributes when building PolarisPrincipal from PrincipalEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - Fixed `renameTable` to return HTTP 204 (No Content) instead of 200, as per the Iceberg REST Catalog spec.
+- Fixed `PolarisPrincipal` construction from a `PrincipalEntity` to expose the principal's user-defined properties (alongside internal properties) so external authorizers such as OPA and Ranger can use them for policy evaluation. Internal properties win on key collision so that system-managed values such as `client_id` cannot be shadowed by user input.
 
 ### Commits
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.auth;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -34,26 +35,26 @@ public interface PolarisPrincipal extends Principal {
    * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity} and
    * roles.
    *
-   * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
-   * properties will be derived from the internal properties of the entity.
+   * <p>The created principal will have the same name as the {@link PrincipalEntity}, and its
+   * properties will be the merger of the entity's user-defined properties and its internal
+   * properties. If a key appears in both maps, the internal-property value wins, so that
+   * system-managed values (for example the {@code client_id}) cannot be shadowed by user input.
    *
    * @param principalEntity the principal entity representing the user or service
    * @param roles the set of roles associated with the principal
    */
   static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
-    return of(
-        principalEntity.getName(),
-        principalEntity.getInternalPropertiesAsMap(),
-        roles,
-        Optional.empty());
+    return of(principalEntity, roles, Optional.empty());
   }
 
   /**
    * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity} and
    * roles.
    *
-   * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
-   * properties will be derived from the internal properties of the entity.
+   * <p>The created principal will have the same name as the {@link PrincipalEntity}, and its
+   * properties will be the merger of the entity's user-defined properties and its internal
+   * properties. If a key appears in both maps, the internal-property value wins, so that
+   * system-managed values (for example the {@code client_id}) cannot be shadowed by user input.
    *
    * @param principalEntity the principal entity representing the user or service
    * @param roles the set of roles associated with the principal
@@ -61,8 +62,18 @@ public interface PolarisPrincipal extends Principal {
    */
   static PolarisPrincipal of(
       PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
-    return of(
-        principalEntity.getName(), principalEntity.getInternalPropertiesAsMap(), roles, token);
+    return of(principalEntity.getName(), mergeEntityProperties(principalEntity), roles, token);
+  }
+
+  /**
+   * Merges the user-defined and internal property maps of a {@link PrincipalEntity}. On key
+   * collision the internal value wins, so that system-managed properties (for example {@code
+   * client_id}) cannot be shadowed by user-supplied properties.
+   */
+  private static Map<String, String> mergeEntityProperties(PrincipalEntity principalEntity) {
+    Map<String, String> merged = new HashMap<>(principalEntity.getPropertiesAsMap());
+    merged.putAll(principalEntity.getInternalPropertiesAsMap());
+    return merged;
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.junit.jupiter.api.Test;
+
+class PolarisPrincipalTest {
+
+  private static final String CLIENT_ID_KEY = PolarisEntityConstants.getClientIdPropertyName();
+
+  @Test
+  void ofPrincipalEntityExposesUserDefinedProperties() {
+    PrincipalEntity principalEntity =
+        new PrincipalEntity.Builder()
+            .setName("alice")
+            .setClientId("client-123")
+            .setProperties(Map.of("region", "northamerica", "department", "finance"))
+            .build();
+
+    PolarisPrincipal principal = PolarisPrincipal.of(principalEntity, Set.of("auditor"));
+
+    assertThat(principal.getName()).isEqualTo("alice");
+    assertThat(principal.getRoles()).containsExactly("auditor");
+    assertThat(principal.getProperties())
+        .containsEntry("region", "northamerica")
+        .containsEntry("department", "finance")
+        .containsEntry(CLIENT_ID_KEY, "client-123");
+  }
+
+  @Test
+  void ofPrincipalEntityWithTokenExposesUserDefinedProperties() {
+    PrincipalEntity principalEntity =
+        new PrincipalEntity.Builder()
+            .setName("bob")
+            .setClientId("client-456")
+            .setProperties(Map.of("team", "platform"))
+            .build();
+
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(principalEntity, Set.of("admin"), Optional.of("access-token"));
+
+    assertThat(principal.getName()).isEqualTo("bob");
+    assertThat(principal.getRoles()).containsExactly("admin");
+    assertThat(principal.getToken()).contains("access-token");
+    assertThat(principal.getProperties())
+        .containsEntry("team", "platform")
+        .containsEntry(CLIENT_ID_KEY, "client-456");
+  }
+
+  @Test
+  void internalPropertiesTakePrecedenceOverUserDefinedOnCollision() {
+    // Regression guard: if anyone later flips the merge order so that user-defined values win,
+    // a caller could shadow a system-managed key such as client_id by setting a property of the
+    // same name on the principal entity. This test pins the safe direction.
+    PrincipalEntity principalEntity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setClientId("legitimate-client-id")
+            .setProperties(Map.of(CLIENT_ID_KEY, "spoofed-client-id"))
+            .build();
+
+    PolarisPrincipal principal = PolarisPrincipal.of(principalEntity, Set.of());
+
+    // System-managed value wins; user-supplied value is discarded.
+    assertThat(principal.getProperties()).containsEntry(CLIENT_ID_KEY, "legitimate-client-id");
+  }
+
+  @Test
+  void ofPrincipalEntityWithoutUserPropertiesStillExposesInternalProperties() {
+    PrincipalEntity principalEntity =
+        new PrincipalEntity.Builder().setName("svc").setClientId("client-789").build();
+
+    PolarisPrincipal principal = PolarisPrincipal.of(principalEntity, Set.of());
+
+    assertThat(principal.getProperties()).containsEntry(CLIENT_ID_KEY, "client-789");
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -303,11 +303,44 @@ public class DefaultAuthenticatorTest {
     assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
   }
 
+  @Test
+  void testUserDefinedPropertiesArePreservedOnAuthenticatedPrincipal() {
+    // Given: a principal created via the management API with user-defined properties
+    String name = "principal-with-attrs";
+    PrincipalEntity created =
+        createPrincipal(name, Map.of("region", "northamerica", "department", "finance"));
+    PolarisCredential credentials =
+        PolarisCredential.of(null, name, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    // When: authenticating the principal
+    PolarisPrincipal result = authenticator.authenticate(credentials);
+
+    // Then: user-defined properties from the management API are exposed alongside
+    // system-managed internal properties (client_id) — this is what authorizers such
+    // as OPA and Ranger consume as user attributes for policy evaluation.
+    assertThat(result).isNotNull();
+    assertThat(result.getName()).isEqualTo(name);
+    assertThat(result.getProperties())
+        .containsEntry("region", "northamerica")
+        .containsEntry("department", "finance")
+        .containsKey(PolarisEntityConstants.getClientIdPropertyName());
+    // Sanity check the entity itself carried those properties.
+    assertThat(created.getPropertiesAsMap())
+        .containsEntry("region", "northamerica")
+        .containsEntry("department", "finance");
+  }
+
   private PrincipalEntity createPrincipal(String name, String... roles) {
+    return createPrincipal(name, Map.of(), roles);
+  }
+
+  private PrincipalEntity createPrincipal(
+      String name, Map<String, String> properties, String... roles) {
 
     PrincipalWithCredentialsCredentials credentials =
         adminService
-            .createPrincipal(new PrincipalEntity.Builder().setName(name).build())
+            .createPrincipal(
+                new PrincipalEntity.Builder().setName(name).setProperties(properties).build())
             .getCredentials();
 
     metaStoreManager.rotatePrincipalSecrets(


### PR DESCRIPTION
## Description

Fixes #4291

`PolarisPrincipal.of(PrincipalEntity, …)` forwards only the entity's *internal* properties (e.g. `client_id`) and silently drops the *user-defined* properties supplied at principal creation. As a result, downstream consumers that read `PolarisPrincipal.getProperties()` never see user attributes like `region=northamerica` or `department=finance`, and policies written against them never match.

Affected paths:
- `DefaultAuthenticator` - constructs the `PolarisPrincipal` during authentication.
- `AuthenticatingAugmentor` - copies the principal's properties into `QuarkusSecurityIdentity` attributes.
- External authorizers - **OPA** (`OpaPolarisAuthorizer`) and **Ranger** (`RangerUtils.getUserAttributes`) consume these as user attributes for ABAC policy evaluation. The existing OPA test suite already builds principals like `PolarisPrincipal.of("eve", Map.of("department","finance"), Set.of("auditor"))`, demonstrating the intended contract that the production path can't honor today.

## **Reproduction confirmed both ways:**

On `main` (fix reverted):
```
PolarisPrincipalTest > ofPrincipalEntityExposesUserDefinedProperties()                          FAILED
PolarisPrincipalTest > ofPrincipalEntityWithTokenExposesUserDefinedProperties()                 FAILED
DefaultAuthenticatorTest > testUserDefinedPropertiesArePreservedOnAuthenticatedPrincipal()      FAILED
```

On this branch:
```
./gradlew :polaris-core:check                                                BUILD SUCCESSFUL
./gradlew :polaris-runtime-service:test --tests "...service.auth.*"          BUILD SUCCESSFUL
./gradlew :polaris-runtime-service:spotlessCheck :checkstyleMain :checkstyleTest   BUILD SUCCESSFUL
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4291
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed) — N/A, internal behavior fix; no user-facing config or doc surface affected.
