### PR TITLE
NoSQL: Guard maintenance runs with explicit supersede IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The ExternalCatalogFactory interface has been renamed to FederatedCatalogFactory. Its createCatalog() and createGenericCatalog() method signatures have been extended to include a `catalogProperties` parameter of type `Map<String, String>` for passing through proxy and timeout settings to federated catalog HTTP clients.
 - The `ConnectionCredentials.of()` method now throws an exception when more than one expiration timestamp property is present in the credentials map. Only a single expiration timestamp is allowed per credentials bundle.
 - Entity names (namespaces, tables, views, generic tables) submitted to the REST layer are now rejected with HTTP 400 if they are empty, contain a `/`, or have leading/trailing whitespace. Clients that were previously able to create such entities must rename them before upgrading.
+- The `MaintenanceService.performMaintenance()` signature now requires an explicit `OptionalLong overrideRunId` argument to supersede the latest unfinished maintenance run.
 
 ### New Features
 - Added `envFrom` support in Helm chart.
@@ -49,6 +50,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Removed unused `PolarisAuthorizableOperation` values: `REVOKE_PRINCIPAL_GRANT_FROM_PRINCIPAL_ROLE`, `REVOKE_PRINCIPAL_ROLE_GRANT_FROM_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_ROOT`, `ADD_PRINCIPAL_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL`, `ADD_PRINCIPAL_ROLE_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL_ROLE`, `ADD_CATALOG_ROLE_GRANT_TO_CATALOG_ROLE`, `REVOKE_CATALOG_ROLE_GRANT_FROM_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG`, `LIST_GRANTS_ON_NAMESPACE`, `LIST_GRANTS_ON_TABLE`, `LIST_GRANTS_ON_VIEW`.
 - Changed deprecated APIs in JUnit 5. This change will force downstream projects that pull in the Polaris test packages to adopt JUnit 6.
 - Added client id collision check during reset.
+- The `nosql maintenance-run` admin command now rejects a new run when the latest recorded maintenance run is still unfinished, unless the operator explicitly passes `--supersede-run=<run-id>`.
 
 ### Deprecations
 - The configuration option `polaris.event-listener.type` is deprecated and will be removed later. Please use `polaris.event-listener.types` instead.

--- a/persistence/nosql/persistence/maintenance/api/src/main/java/org/apache/polaris/persistence/nosql/maintenance/api/MaintenanceRunInProgressException.java
+++ b/persistence/nosql/persistence/maintenance/api/src/main/java/org/apache/polaris/persistence/nosql/maintenance/api/MaintenanceRunInProgressException.java
@@ -16,18 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.admintool;
+package org.apache.polaris.persistence.nosql.maintenance.api;
 
-import java.util.concurrent.Callable;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
+import static java.lang.String.format;
 
-public abstract class BaseCommand implements Callable<Integer> {
+public class MaintenanceRunInProgressException extends RuntimeException {
+  private final long runId;
+  private final MaintenanceRunInformation runInformation;
 
-  public static final int EXIT_CODE_USAGE = 2;
-  public static final int EXIT_CODE_BOOTSTRAP_ERROR = 3;
-  public static final int EXIT_CODE_PURGE_ERROR = 4;
-  public static final int EXIT_CODE_MAINTENANCE_ERROR = 5;
+  public MaintenanceRunInProgressException(long runId, MaintenanceRunInformation runInformation) {
+    super(
+        format(
+            "Maintenance run %d started at %s has not finished", runId, runInformation.started()));
+    this.runId = runId;
+    this.runInformation = runInformation;
+  }
 
-  @Spec protected CommandSpec spec;
+  public long runId() {
+    return runId;
+  }
+
+  public MaintenanceRunInformation runInformation() {
+    return runInformation;
+  }
 }

--- a/persistence/nosql/persistence/maintenance/api/src/main/java/org/apache/polaris/persistence/nosql/maintenance/api/MaintenanceService.java
+++ b/persistence/nosql/persistence/maintenance/api/src/main/java/org/apache/polaris/persistence/nosql/maintenance/api/MaintenanceService.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.persistence.nosql.maintenance.api;
 
 import java.util.List;
+import java.util.OptionalLong;
 import org.apache.polaris.persistence.nosql.realms.api.RealmDefinition.RealmStatus;
 import org.jspecify.annotations.NonNull;
 
@@ -35,10 +36,14 @@ public interface MaintenanceService {
    *
    * @param maintenanceRunSpec define the mandatory run-specification, see {@link
    *     #buildMaintenanceRunSpec()}
+   * @param overrideRunId optional run ID of the currently unfinished maintenance run that shall be
+   *     superseded
    * @return information about the maintenance run
+   * @throws MaintenanceRunInProgressException if the latest maintenance run has not finished and
+   *     {@code overrideRunId} is empty or does not match that latest unfinished run
    */
   @NonNull MaintenanceRunInformation performMaintenance(
-      @NonNull MaintenanceRunSpec maintenanceRunSpec);
+      @NonNull MaintenanceRunSpec maintenanceRunSpec, @NonNull OptionalLong overrideRunId);
 
   /**
    * Retrieve information about recent maintenance runs. The number of available elements is

--- a/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/MaintenanceServiceImpl.java
+++ b/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/MaintenanceServiceImpl.java
@@ -66,6 +66,7 @@ import org.apache.polaris.persistence.nosql.api.commit.Committer;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 import org.apache.polaris.persistence.nosql.api.obj.ObjTypes;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceConfig;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInProgressException;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInformation;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunSpec;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceService;
@@ -188,7 +189,7 @@ class MaintenanceServiceImpl implements MaintenanceService {
   @Override
   @NonNull
   public MaintenanceRunInformation performMaintenance(
-      @NonNull MaintenanceRunSpec maintenanceRunSpec) {
+      @NonNull MaintenanceRunSpec maintenanceRunSpec, @NonNull OptionalLong overrideRunId) {
     LOGGER.info(
         "Triggering maintenance run with {} realms to purge and {} realms to process",
         maintenanceRunSpec.realmsToPurge().size(),
@@ -210,12 +211,9 @@ class MaintenanceServiceImpl implements MaintenanceService {
     var config = maintenanceConfig;
     checkConfig(config);
 
-    // TODO follow-up: some safeguard that checks the run-log for an unfinished run, outside of this
-    //  function!
-
     var allRetained = constructAllRetained(config);
 
-    var runObj = initMaintenanceRunObj();
+    var runObj = initMaintenanceRunObj(overrideRunId);
     var runInfo = MaintenanceRunInformation.builder().from(runObj.runInformation());
 
     var maxCreatedAtMicros = calcMaxCreatedAtMicros(config);
@@ -569,11 +567,23 @@ class MaintenanceServiceImpl implements MaintenanceService {
     return any;
   }
 
-  private MaintenanceRunObj initMaintenanceRunObj() {
+  private MaintenanceRunObj initMaintenanceRunObj(OptionalLong overrideRunId) {
     return committer
         .commitRuntimeException(
             (state, refObjSupplier) -> {
               var refObj = refObjSupplier.get();
+              refObj
+                  .map(MaintenanceRunsObj::maintenanceRunId)
+                  .map(id -> state.persistence().fetch(id, MaintenanceRunObj.class))
+                  .filter(run -> run != null && run.runInformation().finished().isEmpty())
+                  .ifPresent(
+                      run -> {
+                        if (overrideRunId.isEmpty() || overrideRunId.getAsLong() != run.id()) {
+                          throw new MaintenanceRunInProgressException(
+                              run.id(), run.runInformation());
+                        }
+                      });
+
               var res = MaintenanceRunsObj.builder();
 
               var ro =

--- a/persistence/nosql/persistence/maintenance/impl/src/test/java/org/apache/polaris/persistence/nosql/maintenance/impl/TestMaintenance.java
+++ b/persistence/nosql/persistence/maintenance/impl/src/test/java/org/apache/polaris/persistence/nosql/maintenance/impl/TestMaintenance.java
@@ -20,9 +20,11 @@ package org.apache.polaris.persistence.nosql.maintenance.impl;
 
 import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
 import static org.apache.polaris.persistence.nosql.maintenance.impl.MutableMaintenanceConfig.GRACE_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.inject.Inject;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,8 +32,11 @@ import org.apache.polaris.ids.api.SnowflakeIdGenerator;
 import org.apache.polaris.ids.mocks.MutableMonotonicClock;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
+import org.apache.polaris.persistence.nosql.api.SystemPersistence;
 import org.apache.polaris.persistence.nosql.api.exceptions.ReferenceNotFoundException;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceConfig;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInProgressException;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInformation;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInformation.MaintenanceStats;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunSpec;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceService;
@@ -52,7 +57,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class TestMaintenance {
   @InjectSoftAssertions protected SoftAssertions soft;
 
-  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+  @SuppressWarnings("unused")
+  @WeldSetup
+  WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
 
   String realmOne;
   String realmTwo;
@@ -60,6 +67,7 @@ public class TestMaintenance {
   Persistence persTwo;
 
   @Inject MaintenanceService maintenance;
+  @Inject @SystemPersistence Persistence systemPersistence;
   @Inject RealmPersistenceFactory realmPersistenceFactory;
   @Inject MutableMonotonicClock mutableMonotonicClock;
 
@@ -92,7 +100,8 @@ public class TestMaintenance {
         MaintenanceRunSpec.builder()
             .includeSystemRealm(false)
             .realmsToPurge(Set.of(realmOne, realmTwo))
-            .build());
+            .build(),
+        latestUnfinishedMaintenanceRunId());
   }
 
   @Test
@@ -108,7 +117,7 @@ public class TestMaintenance {
     // Run maintenance, no realm given to retain or purge, must not purge anything
     var runInfo =
         maintenance.performMaintenance(
-            MaintenanceRunSpec.builder().includeSystemRealm(false).build());
+            MaintenanceRunSpec.builder().includeSystemRealm(false).build(), OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(2L).purged(0L).retained(2L).newer(0L).build());
@@ -147,7 +156,8 @@ public class TestMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmOne, realmTwo))
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(4L).purged(4L).retained(0L).newer(0L).build());
@@ -187,7 +197,8 @@ public class TestMaintenance {
         maintenance.performMaintenance(
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(true) // default
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(systemRealmCalled).hasValue(1);
 
@@ -230,7 +241,8 @@ public class TestMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmOne, realmTwo))
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(4L).purged(3L).retained(1L).newer(0L).build());
@@ -281,7 +293,8 @@ public class TestMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmOne, realmTwo))
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(4L).purged(3L).retained(1L).newer(0L).build());
@@ -341,7 +354,8 @@ public class TestMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmOne, realmTwo))
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(0L).purged(0L).retained(0L).newer(0L).build());
@@ -378,7 +392,8 @@ public class TestMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmOne, realmTwo))
-                .build());
+                .build(),
+            OptionalLong.empty());
 
     soft.assertThat(runInfo.referenceStats())
         .contains(MaintenanceStats.builder().scanned(4L).purged(0L).retained(4L).newer(0L).build());
@@ -389,5 +404,79 @@ public class TestMaintenance {
 
     soft.assertThat(persOne.fetch(objRef(rOneObj1), ObjOne.class)).isEqualTo(rOneObj1);
     soft.assertThat(persTwo.fetch(objRef(rTwoObj2), ObjTwo.class)).isEqualTo(rTwoObj2);
+  }
+
+  @Test
+  public void overrideRuns() {
+    var runId = createUnfinishedMaintenanceRun();
+
+    soft.assertThatExceptionOfType(MaintenanceRunInProgressException.class)
+        .isThrownBy(
+            () ->
+                maintenance.performMaintenance(
+                    MaintenanceRunSpec.builder().includeSystemRealm(false).build(),
+                    OptionalLong.empty()))
+        .satisfies(e -> assertThat(e.runId()).isEqualTo(runId));
+
+    soft.assertThatExceptionOfType(MaintenanceRunInProgressException.class)
+        .isThrownBy(
+            () ->
+                maintenance.performMaintenance(
+                    MaintenanceRunSpec.builder().includeSystemRealm(false).build(),
+                    OptionalLong.of(runId + 1)))
+        .satisfies(e -> assertThat(e.runId()).isEqualTo(runId));
+
+    var runInfo =
+        maintenance.performMaintenance(
+            MaintenanceRunSpec.builder().includeSystemRealm(false).build(), OptionalLong.of(runId));
+
+    soft.assertThat(runInfo.finished()).isPresent();
+    soft.assertThat(runInfo.success()).isTrue();
+    soft.assertThat(latestUnfinishedMaintenanceRunId()).isEmpty();
+  }
+
+  private long createUnfinishedMaintenanceRun() {
+    systemPersistence.createReferenceSilent(MaintenanceRunsObj.MAINTENANCE_RUNS_REF_NAME);
+
+    return systemPersistence
+        .createCommitter(
+            MaintenanceRunsObj.MAINTENANCE_RUNS_REF_NAME,
+            MaintenanceRunsObj.class,
+            MaintenanceRunObj.class)
+        .commitRuntimeException(
+            (state, refObjSupplier) -> {
+              var refObj = refObjSupplier.get();
+              var runObj =
+                  MaintenanceRunObj.builder()
+                      .id(systemPersistence.generateId())
+                      .runInformation(
+                          MaintenanceRunInformation.builder()
+                              .started(mutableMonotonicClock.currentInstant())
+                              .build())
+                      .build();
+
+              state.writeIfNew("unfinished-run", runObj, MaintenanceRunObj.class);
+
+              return state.commitResult(
+                  runObj, MaintenanceRunsObj.builder().maintenanceRunId(objRef(runObj)), refObj);
+            })
+        .orElseThrow()
+        .id();
+  }
+
+  private OptionalLong latestUnfinishedMaintenanceRunId() {
+    try {
+      return systemPersistence
+          .fetchReferenceHead(
+              MaintenanceRunsObj.MAINTENANCE_RUNS_REF_NAME, MaintenanceRunsObj.class)
+          .map(MaintenanceRunsObj::maintenanceRunId)
+          .map(id -> systemPersistence.fetch(id, MaintenanceRunObj.class))
+          .filter(run -> run.runInformation().finished().isEmpty())
+          .stream()
+          .mapToLong(MaintenanceRunObj::id)
+          .findFirst();
+    } catch (ReferenceNotFoundException e) {
+      return OptionalLong.empty();
+    }
   }
 }

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -199,7 +200,8 @@ public class TestCatalogMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmId))
-                .build());
+                .build(),
+            OptionalLong.empty());
     soft.assertThat(runInformation)
         .describedAs("%s", runInformation)
         .extracting(
@@ -233,7 +235,8 @@ public class TestCatalogMaintenance {
             MaintenanceRunSpec.builder()
                 .includeSystemRealm(false)
                 .realmsToProcess(Set.of(realmId))
-                .build());
+                .build(),
+            OptionalLong.empty());
     soft.assertThat(runInformation)
         .describedAs("%s", runInformation)
         .extracting(

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/maintenance/NoSqlMaintenanceRunCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/maintenance/NoSqlMaintenanceRunCommand.java
@@ -18,8 +18,8 @@
  */
 package org.apache.polaris.admintool.nosql.maintenance;
 
-import jakarta.inject.Inject;
-import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceService;
+import java.util.OptionalLong;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInProgressException;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -27,7 +27,12 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     description = {"Run Polaris persistence maintenance."})
 public class NoSqlMaintenanceRunCommand extends BaseNoSqlMaintenanceCommand {
-  @Inject MaintenanceService maintenanceService;
+  @CommandLine.Option(
+      names = {"--supersede-run"},
+      paramLabel = "<run-id>",
+      description =
+          "Supersede the latest unfinished maintenance run if its run ID matches <run-id>.")
+  Long supersedeRun;
 
   // TODO once there's a fully-tested tasks "client" and 'MaintenanceTaskBehavior', _running_
   //  maintenance should be directed through the tasks-API, giving users the option to run
@@ -48,10 +53,31 @@ public class NoSqlMaintenanceRunCommand extends BaseNoSqlMaintenanceCommand {
         "This can run for quite some time, messages may be not be printed immediately, stay patient...");
     out.println();
 
-    var runInformation = maintenanceService.performMaintenance(runSpec);
+    try {
+      var runInformation =
+          maintenanceService.performMaintenance(
+              runSpec, supersedeRun != null ? OptionalLong.of(supersedeRun) : OptionalLong.empty());
 
-    printRunInformation(runInformation, false);
+      printRunInformation(runInformation, false);
 
-    return 0;
+      return 0;
+    } catch (MaintenanceRunInProgressException e) {
+      var err = spec.commandLine().getErr();
+      err.println();
+      if (supersedeRun != null) {
+        err.printf(
+            "Cannot start NoSql persistence maintenance: requested supersede run ID %d does not match latest unfinished run %d.%n",
+            supersedeRun, e.runId());
+      } else {
+        err.printf(
+            "Cannot start NoSql persistence maintenance: latest run %d started at %s has not finished.%n",
+            e.runId(), e.runInformation().started());
+      }
+      err.printf(
+          "Use '--supersede-run=%d' to start a new maintenance run if that run is no longer active.%n",
+          e.runId());
+      err.println();
+      return EXIT_CODE_MAINTENANCE_ERROR;
+    }
   }
 }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/TestNoSqlMaintenanceRunCommand.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/TestNoSqlMaintenanceRunCommand.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.admintool.nosql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalLong;
+import org.apache.polaris.admintool.BaseCommand;
+import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceRunCommand;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceConfig;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInProgressException;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInformation;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunSpec;
+import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceService;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+public class TestNoSqlMaintenanceRunCommand {
+  @Test
+  public void passesSupersedeRunIdToMaintenanceService() throws Exception {
+    var service = new RecordingMaintenanceService();
+    service.runInformation =
+        MaintenanceRunInformation.builder()
+            .started(Instant.parse("2026-05-11T10:15:30Z"))
+            .finished(Instant.parse("2026-05-11T10:15:31Z"))
+            .success(true)
+            .build();
+
+    var command = new NoSqlMaintenanceRunCommand();
+    inject(command, "maintenanceService", service);
+    inject(command, "maintenanceConfig", MaintenanceConfig.builder().build());
+    inject(command, "backend", backend("MongoDb"));
+
+    var stdout = new StringWriter();
+    var stderr = new StringWriter();
+    var exitCode =
+        new CommandLine(command)
+            .setOut(new PrintWriter(stdout, true))
+            .setErr(new PrintWriter(stderr, true))
+            .execute("--supersede-run=123");
+
+    assertThat(exitCode).isZero();
+    assertThat(service.overrideRunId.isPresent()).isTrue();
+    assertThat(service.overrideRunId.getAsLong()).isEqualTo(123L);
+    assertThat(stderr.toString()).isEmpty();
+  }
+
+  @Test
+  public void reportsLatestUnfinishedRunIdWhenMaintenanceIsBlocked() throws Exception {
+    var service = new RecordingMaintenanceService();
+    service.exception =
+        new MaintenanceRunInProgressException(
+            321L,
+            MaintenanceRunInformation.builder()
+                .started(Instant.parse("2026-05-11T08:00:00Z"))
+                .build());
+
+    var command = new NoSqlMaintenanceRunCommand();
+    inject(command, "maintenanceService", service);
+    inject(command, "maintenanceConfig", MaintenanceConfig.builder().build());
+    inject(command, "backend", backend("MongoDb"));
+
+    var stdout = new StringWriter();
+    var stderr = new StringWriter();
+    var exitCode =
+        new CommandLine(command)
+            .setOut(new PrintWriter(stdout, true))
+            .setErr(new PrintWriter(stderr, true))
+            .execute();
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_MAINTENANCE_ERROR);
+    assertThat(service.overrideRunId.isEmpty()).isTrue();
+    assertThat(stderr.toString())
+        .contains("latest run 321 started at 2026-05-11T08:00:00Z has not finished")
+        .contains("--supersede-run=321");
+  }
+
+  private static Backend backend(String type) {
+    return (Backend)
+        Proxy.newProxyInstance(
+            Backend.class.getClassLoader(),
+            new Class<?>[] {Backend.class},
+            (proxy, method, args) -> {
+              return switch (method.getName()) {
+                case "type" -> type;
+                case "close" -> null;
+                default -> throw new UnsupportedOperationException(method.getName());
+              };
+            });
+  }
+
+  private static void inject(Object target, String fieldName, Object value) throws Exception {
+    Class<?> type = target.getClass();
+    while (type != null) {
+      try {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException e) {
+        type = type.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+
+  static final class RecordingMaintenanceService implements MaintenanceService {
+    private final MaintenanceRunSpec runSpec = MaintenanceRunSpec.builder().build();
+    private OptionalLong overrideRunId = OptionalLong.empty();
+    private MaintenanceRunInformation runInformation;
+    private RuntimeException exception;
+
+    @Override
+    public @NonNull MaintenanceRunSpec buildMaintenanceRunSpec() {
+      return runSpec;
+    }
+
+    @Override
+    public @NonNull MaintenanceRunInformation performMaintenance(
+        @NonNull MaintenanceRunSpec maintenanceRunSpec, @NonNull OptionalLong overrideRunId) {
+      this.overrideRunId = overrideRunId;
+      if (exception != null) {
+        throw exception;
+      }
+      return runInformation;
+    }
+
+    @Override
+    public @NonNull List<MaintenanceRunInformation> maintenanceRunLog() {
+      return List.of();
+    }
+  }
+}

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -279,8 +279,13 @@ It defaults to `1.1`.
 All NoSQL maintenance configuration options are under the `polaris.persistence.nosql.maintenance` namespace.
 See the `Configuration Reference` pages for more information.
 
-Avoid running multiple instances of the `nosql maintenance-run` command at the same time to avoid an unnecessary
-database load, although this does not cause any other issues.
+The `nosql maintenance-run` command refuses to start a new run if the latest recorded maintenance run
+has not finished yet.
+If the previous run is known to be abandoned, rerun the command using the run ID reported by the
+failure message via `--supersede-run=<run-id>`.
+
+Avoid superseding a maintenance run unless you are certain that the previous run is no longer active,
+because doing so may cause overlapping maintenance work and unnecessary database load.
 
 ### Inspecting NoSQL maintenance run logs
 


### PR DESCRIPTION
Maintenance runs can be started concurrently, which is an unnecessary waste of resources.

This change effectively prevents concurrently running maintenance runs by refusing to start when the last recorded run has not been marked as "finished". That mechanism alone would make it impossible to resume a previously crashed maintenance run.

To address that issue, the admin-CLI allows specifying the ID of the maintenance run to supersede and let the maintenance-run start. Requiring the ID of the run to supersede has been chosen as that is notambiguous, contrary to some generic "force start" flag, which would also supersede a run that has been started in the meantime. In other words: this makes takeover intentional instead of accidental, and it gives the admin tool a concrete way to resume or replace a stuck run without racing a live one.