### PR TITLE
NoSQL: Clarify commit log offset scan semantics

### DIFF
--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/commit/Commits.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/commit/Commits.java
@@ -29,34 +29,38 @@ public interface Commits {
    * Retrieves the commit log in the natural, chronologically reverse order - most recent commit
    * first.
    *
-   * <p>If {@code offset} is empty, iteration starts at the current head of {@code refName}.
+   * <p>If {@code offsetCommitId} is empty, iteration starts at the current head of {@code refName}.
    *
-   * <p>If {@code offset} is present, the returned iterator is inclusive of that commit ID.
-   * Resolving the offset intentionally performs a linear walk from the current head toward older
-   * commits until the offset is encountered or visible history ends. This lookup is not internally
-   * bounded; callers that require a hard limit must enforce it themselves.
+   * <p>If {@code offsetCommitId} is present, the returned iterator is inclusive of that commit ID.
+   * Resolving the offset commit ID intentionally performs a linear walk from the current head
+   * toward older commits until the commit ID is encountered or visible history ends. This lookup is
+   * not internally bounded.
    *
-   * <p>If the offset is not encountered while walking the visible history, the implementation
-   * attempts to resume directly from the commit object identified by the offset. If that commit
-   * object is not available either, iteration resumes from the oldest still-visible commit reached
-   * by the scan, if any.
+   * <p>If the offset commit ID is not encountered while walking the visible history, the
+   * implementation attempts to resume directly from the commit object identified by that ID. If
+   * that commit object is not available either, iteration resumes from the oldest still-visible
+   * commit reached by the scan, if any.
+   *
+   * @param offsetCommitId optional commit ID to resume from; not a sequential position in the
+   *     commit log
    */
   <C extends BaseCommitObj> Iterator<C> commitLog(
-      String refName, OptionalLong offset, Class<C> clazz);
+      String refName, OptionalLong offsetCommitId, Class<C> clazz);
 
   /**
-   * Retrieves the commit log in chronological order starting after the given offset.
+   * Retrieves the commit log in chronological order starting after the given offset commit ID.
    *
-   * <p>The supplied {@code offset} is exclusive. Resolving the offset intentionally performs a
-   * linear walk from the current head toward older commits until the offset is encountered or
-   * visible history ends. This lookup is not internally bounded; callers that require a hard limit
-   * must enforce it themselves.
+   * <p>The supplied {@code offsetCommitId} is exclusive. Resolving the offset commit ID
+   * intentionally performs a linear walk from the current head toward older commits until the
+   * commit ID is encountered or visible history ends. This lookup is not internally bounded.
    *
-   * <p>If the offset is not encountered in the visible history, the full visible history is
-   * returned in chronological order.
+   * <p>If the offset commit ID is not encountered in the visible history, the full visible history
+   * is returned in chronological order.
    *
    * <p>This function is useful when retrieving commits to serve events/notification use cases.
+   *
+   * @param offsetCommitId commit ID to resume after; not a sequential position in the commit log
    */
   <C extends BaseCommitObj> Iterator<C> commitLogReversed(
-      String refName, long offset, Class<C> clazz);
+      String refName, long offsetCommitId, Class<C> clazz);
 }

--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/commit/Commits.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/commit/Commits.java
@@ -28,12 +28,32 @@ public interface Commits {
   /**
    * Retrieves the commit log in the natural, chronologically reverse order - most recent commit
    * first.
+   *
+   * <p>If {@code offset} is empty, iteration starts at the current head of {@code refName}.
+   *
+   * <p>If {@code offset} is present, the returned iterator is inclusive of that commit ID.
+   * Resolving the offset intentionally performs a linear walk from the current head toward older
+   * commits until the offset is encountered or visible history ends. This lookup is not internally
+   * bounded; callers that require a hard limit must enforce it themselves.
+   *
+   * <p>If the offset is not encountered while walking the visible history, the implementation
+   * attempts to resume directly from the commit object identified by the offset. If that commit
+   * object is not available either, iteration resumes from the oldest still-visible commit reached
+   * by the scan, if any.
    */
   <C extends BaseCommitObj> Iterator<C> commitLog(
       String refName, OptionalLong offset, Class<C> clazz);
 
   /**
-   * Retrieves the commit log in chronological order starting at the given offset.
+   * Retrieves the commit log in chronological order starting after the given offset.
+   *
+   * <p>The supplied {@code offset} is exclusive. Resolving the offset intentionally performs a
+   * linear walk from the current head toward older commits until the offset is encountered or
+   * visible history ends. This lookup is not internally bounded; callers that require a hard limit
+   * must enforce it themselves.
+   *
+   * <p>If the offset is not encountered in the visible history, the full visible history is
+   * returned in chronological order.
    *
    * <p>This function is useful when retrieving commits to serve events/notification use cases.
    */

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
@@ -47,7 +47,7 @@ final class CommitsImpl implements Commits {
 
   @Override
   public <C extends BaseCommitObj> Iterator<C> commitLogReversed(
-      String refName, long offset, Class<C> clazz) {
+      String refName, long offsetCommitId, Class<C> clazz) {
     var headOpt = persistence.fetchReferenceHead(refName, clazz);
     if (headOpt.isEmpty()) {
       return emptyIterator();
@@ -56,15 +56,15 @@ final class CommitsImpl implements Commits {
     var head = headOpt.get();
     var type = head.type().id();
 
-    // Resolve the exclusive offset via a linear walk from the current head. Callers that require
-    // a hard bound on this work must enforce it outside this API.
+    // Resolve the exclusive offset commit ID via a linear walk from the current head. This lookup
+    // is not internally bounded.
     //
-    // Contains the seen IDs, without the 'offset', in _natural_ order (most recent commit ID
-    // first).
+    // Contains the seen IDs, without the offset commit ID, in _natural_ order (most recent commit
+    // ID first).
     var visited = new LongArrayList();
 
-    // Only walk, if the most recent commit ID is != offset
-    if (head.id() == offset) {
+    // Only walk if the most recent commit ID is not the offset commit ID.
+    if (head.id() == offsetCommitId) {
       return emptyIterator();
     }
 
@@ -73,7 +73,7 @@ final class CommitsImpl implements Commits {
     outer:
     while (tail.length != 0) {
       for (var tailId : tail) {
-        if (tailId == offset) {
+        if (tailId == offsetCommitId) {
           break outer;
         }
         visited.add(tailId);
@@ -138,7 +138,7 @@ final class CommitsImpl implements Commits {
 
   @Override
   public <C extends BaseCommitObj> Iterator<C> commitLog(
-      String refName, OptionalLong offset, Class<C> clazz) {
+      String refName, OptionalLong offsetCommitId, Class<C> clazz) {
     var headOpt = persistence.fetchReferenceHead(refName, clazz);
     if (headOpt.isEmpty()) {
       return emptyIterator();
@@ -147,14 +147,14 @@ final class CommitsImpl implements Commits {
     var head = headOpt.get();
     var type = head.type().id();
 
-    if (offset.isPresent()) {
-      var off = offset.getAsLong();
+    if (offsetCommitId.isPresent()) {
+      var off = offsetCommitId.getAsLong();
 
-      // Resolve the inclusive offset via a linear walk from the current head. If the offset is
-      // not encountered while scanning visible history, attempt to continue directly from the
-      // commit object identified by the offset.
+      // Resolve the inclusive offset commit ID via a linear walk from the current head. If the
+      // commit ID is not encountered while scanning visible history, attempt to continue directly
+      // from the commit object identified by the offset commit ID.
 
-      // Only walk, if the most recent commit ID is != offset
+      // Only walk if the most recent commit ID is not the offset commit ID.
       if (head.id() == off) {
         return singletonList(head).iterator();
       }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitsImpl.java
@@ -56,12 +56,12 @@ final class CommitsImpl implements Commits {
     var head = headOpt.get();
     var type = head.type().id();
 
-    // find commit with Obj.id() == offset, memoize visited commits
-
-    // Contains the seen IDs, without the 'offset', in _natural_ order (most recent commit ID first)
+    // Resolve the exclusive offset via a linear walk from the current head. Callers that require
+    // a hard bound on this work must enforce it outside this API.
+    //
+    // Contains the seen IDs, without the 'offset', in _natural_ order (most recent commit ID
+    // first).
     var visited = new LongArrayList();
-
-    // TODO add safeguard to limit the work done when finding the commit with ID 'offset'
 
     // Only walk, if the most recent commit ID is != offset
     if (head.id() == offset) {
@@ -147,10 +147,12 @@ final class CommitsImpl implements Commits {
     var head = headOpt.get();
     var type = head.type().id();
 
-    // TODO add safeguard to limit the work done when finding the commit with ID 'offset'
-
     if (offset.isPresent()) {
       var off = offset.getAsLong();
+
+      // Resolve the inclusive offset via a linear walk from the current head. If the offset is
+      // not encountered while scanning visible history, attempt to continue directly from the
+      // commit object identified by the offset.
 
       // Only walk, if the most recent commit ID is != offset
       if (head.id() == off) {

--- a/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/RetainedCollectorImpl.java
+++ b/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/RetainedCollectorImpl.java
@@ -323,9 +323,10 @@ final class RetainedCollectorImpl implements Persistence, RetainedCollector {
     return new Commits() {
       @Override
       public <C extends BaseCommitObj> Iterator<C> commitLog(
-          String refName, OptionalLong offset, Class<C> clazz) {
+          String refName, OptionalLong offsetCommitId, Class<C> clazz) {
         checkArgument(
-            offset.isEmpty(), "Commit offset must be empty during retained-objects identification");
+            offsetCommitId.isEmpty(),
+            "Offset commit ID must be empty during retained-objects identification");
 
         var ref = fetchReference(refName);
 
@@ -354,7 +355,7 @@ final class RetainedCollectorImpl implements Persistence, RetainedCollector {
 
       @Override
       public <C extends BaseCommitObj> Iterator<C> commitLogReversed(
-          String refName, long offset, Class<C> clazz) {
+          String refName, long offsetCommitId, Class<C> clazz) {
         throw new UnsupportedOperationException(
             "Reversed commit scanning not supported during retained-objects identification");
       }


### PR DESCRIPTION
Document and align the offset scan semantics for commit log iteration.

The important distinction is which side of the offset boundary is included. The API wording and implementation should say the same thing.