### PR TITLE
NoSQL: Encode Snowflake time UUIDs with standard v1 timestamps

### DIFF
--- a/persistence/nosql/idgen/impl/src/main/java/org/apache/polaris/ids/impl/SnowflakeIdGeneratorImpl.java
+++ b/persistence/nosql/idgen/impl/src/main/java/org/apache/polaris/ids/impl/SnowflakeIdGeneratorImpl.java
@@ -54,6 +54,9 @@ class SnowflakeIdGeneratorImpl implements SnowflakeIdGenerator {
 
   // TODO add a specialized implementation using hard-coded values for the standardized parameters
 
+  @VisibleForTesting static final long TIME_UUID_EPOCH_OFFSET_100NS = 0x01b21dd213814000L;
+  private static final long TIME_UUID_TICKS_PER_MILLISECOND = 10_000L;
+
   private static final AtomicLongFieldUpdater<SnowflakeIdGeneratorImpl> LAST_ID_UPDATER =
       AtomicLongFieldUpdater.newUpdater(SnowflakeIdGeneratorImpl.class, "lastId");
 
@@ -289,11 +292,11 @@ class SnowflakeIdGeneratorImpl implements SnowflakeIdGenerator {
   public long timeUuidToId(@NonNull UUID uuid) {
     checkArgument(
         uuid.variant() == 2 && uuid.version() == 1, "Must be a version 1 / variant 2 UUID");
-    var ts = uuid.timestamp() - idEpoch;
+    var ts = unixMillisFromTimeUuidTimestamp(uuid.timestamp()) - idEpoch;
     var seq = uuid.clockSequence();
     var node = uuid.node();
     checkArgument(
-        ts > 0
+        ts >= 0
             && ts <= timestampMax
             && seq >= 0
             && seq <= sequenceMask
@@ -381,7 +384,7 @@ class SnowflakeIdGeneratorImpl implements SnowflakeIdGenerator {
 
   @VisibleForTesting
   private long timeUuidMsb(long timestamp) {
-    return timeUuidMsbReal(timestamp + idEpoch);
+    return timeUuidMsbReal(timeUuidTimestampFromUnixMillis(timestamp + idEpoch));
   }
 
   @VisibleForTesting
@@ -404,5 +407,20 @@ class SnowflakeIdGeneratorImpl implements SnowflakeIdGenerator {
         |
         // time_hi
         ((timestamp >>> 48) & 0x0000000000000FFFL);
+  }
+
+  @VisibleForTesting
+  static long timeUuidTimestampFromUnixMillis(long unixMillis) {
+    return unixMillis * TIME_UUID_TICKS_PER_MILLISECOND + TIME_UUID_EPOCH_OFFSET_100NS;
+  }
+
+  @VisibleForTesting
+  static long unixMillisFromTimeUuidTimestamp(long timeUuidTimestamp) {
+    var timestampSinceUnixEpoch = timeUuidTimestamp - TIME_UUID_EPOCH_OFFSET_100NS;
+    checkArgument(
+        timestampSinceUnixEpoch >= 0
+            && timestampSinceUnixEpoch % TIME_UUID_TICKS_PER_MILLISECOND == 0,
+        "TimeUUID contains values that cannot be condensed into a snowflake-ID");
+    return timestampSinceUnixEpoch / TIME_UUID_TICKS_PER_MILLISECOND;
   }
 }

--- a/persistence/nosql/idgen/impl/src/main/java/org/apache/polaris/ids/impl/SnowflakeIdGeneratorImpl.java
+++ b/persistence/nosql/idgen/impl/src/main/java/org/apache/polaris/ids/impl/SnowflakeIdGeneratorImpl.java
@@ -54,6 +54,7 @@ class SnowflakeIdGeneratorImpl implements SnowflakeIdGenerator {
 
   // TODO add a specialized implementation using hard-coded values for the standardized parameters
 
+  // Number of 100ns ticks between the UUID epoch (1582-10-15) and the Unix epoch.
   @VisibleForTesting static final long TIME_UUID_EPOCH_OFFSET_100NS = 0x01b21dd213814000L;
   private static final long TIME_UUID_TICKS_PER_MILLISECOND = 10_000L;
 

--- a/persistence/nosql/idgen/impl/src/test/java/org/apache/polaris/ids/impl/TestSnowflakeIdGeneratorImpl.java
+++ b/persistence/nosql/idgen/impl/src/test/java/org/apache/polaris/ids/impl/TestSnowflakeIdGeneratorImpl.java
@@ -28,6 +28,8 @@ import static org.apache.polaris.ids.api.SnowflakeIdGenerator.DEFAULT_TIMESTAMP_
 import static org.apache.polaris.ids.api.SnowflakeIdGenerator.ID_EPOCH_MILLIS;
 import static org.apache.polaris.ids.impl.SnowflakeIdGeneratorImpl.timeUuidLsb;
 import static org.apache.polaris.ids.impl.SnowflakeIdGeneratorImpl.timeUuidMsbReal;
+import static org.apache.polaris.ids.impl.SnowflakeIdGeneratorImpl.timeUuidTimestampFromUnixMillis;
+import static org.apache.polaris.ids.impl.SnowflakeIdGeneratorImpl.unixMillisFromTimeUuidTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -496,12 +498,15 @@ public class TestSnowflakeIdGeneratorImpl {
         var uuid = impl.idToTimeUuid(id);
 
         soft.assertThat(impl.nodeFromId(id)).isEqualTo(nodeId).isEqualTo(uuid.node());
-        soft.assertThat(impl.timestampFromId(id))
-            .isEqualTo(initialTimestamp + millis)
-            .isEqualTo(uuid.timestamp() - ID_EPOCH_MILLIS);
+        soft.assertThat(impl.timestampFromId(id)).isEqualTo(initialTimestamp + millis);
+        soft.assertThat(impl.timestampUtcFromId(id))
+            .isEqualTo(ID_EPOCH_MILLIS + initialTimestamp + millis)
+            .isEqualTo(unixMillisFromTimeUuidTimestamp(uuid.timestamp()));
         soft.assertThat(uuid).extracting(UUID::variant, UUID::version).containsExactly(2, 1);
+        soft.assertThat(uuid.timestamp())
+            .isEqualTo(
+                timeUuidTimestampFromUnixMillis(ID_EPOCH_MILLIS + initialTimestamp + millis));
         soft.assertThat(impl.timeUuidToId(uuid)).isEqualTo(id);
-        soft.assertThat(impl.timestampUtcFromId(id)).isEqualTo(uuid.timestamp());
         soft.assertThat(impl.sequenceFromId(id)).isEqualTo(j).isEqualTo(uuid.clockSequence());
         soft.assertThat(impl.idToString(id))
             .isEqualTo(
@@ -559,10 +564,28 @@ public class TestSnowflakeIdGeneratorImpl {
             () ->
                 impl.timeUuidToId(
                     new UUID(
-                        timeUuidMsbReal((1L << DEFAULT_TIMESTAMP_BITS) - 1),
+                        timeUuidMsbReal(
+                            timeUuidTimestampFromUnixMillis(
+                                ID_EPOCH_MILLIS + ((1L << DEFAULT_TIMESTAMP_BITS) - 2))),
                         timeUuidLsb(
                             (1L << DEFAULT_SEQUENCE_BITS) - 1, (1L << DEFAULT_NODE_ID_BITS) - 1))))
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void timeUuidUsesStandardTimestampEncoding() {
+    var nodeId = 42;
+    var timestamp = TimeUnit.DAYS.toMillis(365);
+    var impl =
+        new SnowflakeIdGeneratorImpl(idGeneratorSource(nodeId, () -> ID_EPOCH_MILLIS + timestamp));
+    var id = impl.constructId(timestamp, 7, nodeId);
+    var uuid = impl.idToTimeUuid(id);
+
+    soft.assertThat(uuid.timestamp())
+        .isEqualTo(timeUuidTimestampFromUnixMillis(ID_EPOCH_MILLIS + timestamp));
+    soft.assertThat(unixMillisFromTimeUuidTimestamp(uuid.timestamp()))
+        .isEqualTo(ID_EPOCH_MILLIS + timestamp);
+    soft.assertThat(impl.timeUuidToId(uuid)).isEqualTo(id);
   }
 
   @Test
@@ -587,7 +610,8 @@ public class TestSnowflakeIdGeneratorImpl {
               () -> {
                 assertThat(uuid.node()).isEqualTo(nodeId);
                 assertThat(uuid.timestamp())
-                    .isGreaterThan(ID_EPOCH_MILLIS)
+                    .isGreaterThan(timeUuidTimestampFromUnixMillis(ID_EPOCH_MILLIS));
+                assertThat(unixMillisFromTimeUuidTimestamp(uuid.timestamp()))
                     .isEqualTo(impl.timestampUtcFromId(id));
                 assertThat(uuid.clockSequence()).isGreaterThanOrEqualTo(0).isLessThan(4096);
                 assertThat(uuid.variant()).isEqualTo(2);

--- a/persistence/nosql/idgen/impl/src/test/java/org/apache/polaris/ids/impl/TestSnowflakeIdGeneratorImpl.java
+++ b/persistence/nosql/idgen/impl/src/test/java/org/apache/polaris/ids/impl/TestSnowflakeIdGeneratorImpl.java
@@ -525,6 +525,7 @@ public class TestSnowflakeIdGeneratorImpl {
     }
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void miscUuid() {
     var clockSource = new AtomicLong(ID_EPOCH_MILLIS + TimeUnit.DAYS.toMillis(365));
@@ -558,6 +559,12 @@ public class TestSnowflakeIdGeneratorImpl {
                     new UUID(
                         timeUuidMsbReal(tsUuidHighest),
                         timeUuidLsb(seqUuidHighest, nodeUuidHighest))))
+        .withMessage("TimeUUID contains values that cannot be condensed into a snowflake-ID");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                unixMillisFromTimeUuidTimestamp(
+                    timeUuidTimestampFromUnixMillis(ID_EPOCH_MILLIS) + 1))
         .withMessage("TimeUUID contains values that cannot be condensed into a snowflake-ID");
 
     soft.assertThatCode(


### PR DESCRIPTION
Use the standard UUID v1 timestamp layout when converting snowflake ids into time-based UUIDs.

The previous encoding did not line up with the normal v1 field ordering, which made these ids awkward to inspect and compare with other tooling. The tests pin the timestamp bits around the conversion.

This is a non-breaking change, as there's no production use of UUIDs from snowflake IDs.