### PR TITLE
Core: Extract shared credential rotation pre-condition check (Closes #4026)

### DIFF
--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -55,8 +55,6 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
 
   public static final String SERVICE_TYPE = "polaris";
 
-  private static final String OPERATION_NOT_ALLOWED_FOR_USER_ERROR =
-      "Principal '%s' is not authorized for op %s due to PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE";
   private static final String RANGER_AUTH_FAILED_ERROR =
       "Principal '%s' is not authorized for op '%s'";
 

--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -32,7 +32,6 @@ import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -62,15 +61,13 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
   private final String serviceName;
   private RealmContext realmContext;
   private String realmConextIdentifier;
-  private final boolean enforceCredentialRotationRequiredState;
+  private final RealmConfig realmConfig;
 
   public RangerPolarisAuthorizer(
       RangerEmbeddedAuthorizer authorizer, String serviceName, RealmConfig realmConfig) {
     this.authorizer = authorizer;
     this.serviceName = serviceName;
-    this.enforceCredentialRotationRequiredState =
-        realmConfig.getConfig(
-            FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
+    this.realmConfig = realmConfig;
   }
 
   public void setRealmContext(RealmContext aRealmContext) {
@@ -135,7 +132,7 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
 
     try {
       AuthorizationPreConditions.checkCredentialRotationRequired(
-          polarisPrincipal, authzOp, enforceCredentialRotationRequiredState);
+          polarisPrincipal, authzOp, realmConfig);
 
       if (!isAccessAuthorized(polarisPrincipal, authzOp, targets, secondaries)) {
         throw new ForbiddenException(

--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.auth.AuthorizationDecision;
+import org.apache.polaris.core.auth.AuthorizationPreConditions;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
@@ -35,7 +36,6 @@ import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.extension.auth.ranger.utils.RangerUtils;
 import org.apache.ranger.authz.api.RangerAuthzException;
@@ -136,14 +136,8 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
     }
 
     try {
-      if (enforceCredentialRotationRequiredState
-          && authzOp != PolarisAuthorizableOperation.ROTATE_CREDENTIALS
-          && polarisPrincipal
-              .getProperties()
-              .containsKey(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)) {
-        throw new ForbiddenException(
-            OPERATION_NOT_ALLOWED_FOR_USER_ERROR, polarisPrincipal.getName(), authzOp.name());
-      }
+      AuthorizationPreConditions.checkCredentialRotationRequired(
+          polarisPrincipal, authzOp, enforceCredentialRotationRequiredState);
 
       if (!isAccessAuthorized(polarisPrincipal, authzOp, targets, secondaries)) {
         throw new ForbiddenException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationPreConditions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationPreConditions.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+
+/**
+ * Common pre-condition checks shared across authorizer implementations for credential-related
+ * operations.
+ */
+public final class AuthorizationPreConditions {
+
+  private AuthorizationPreConditions() {}
+
+  /**
+   * Checks whether the principal is required to rotate credentials before performing the requested
+   * operation. If the principal has the {@code PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE}
+   * property set, only {@link PolarisAuthorizableOperation#ROTATE_CREDENTIALS} is allowed.
+   *
+   * @param polarisPrincipal the principal attempting the operation
+   * @param authzOp the operation being attempted
+   * @param enforceCredentialRotationRequiredState whether the enforcement flag is enabled
+   * @throws ForbiddenException if the principal must rotate credentials first
+   */
+  public static void checkCredentialRotationRequired(
+      PolarisPrincipal polarisPrincipal,
+      PolarisAuthorizableOperation authzOp,
+      boolean enforceCredentialRotationRequiredState) {
+    if (enforceCredentialRotationRequiredState
+        && authzOp != PolarisAuthorizableOperation.ROTATE_CREDENTIALS
+        && polarisPrincipal
+            .getProperties()
+            .containsKey(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)) {
+      throw new ForbiddenException(
+          "Principal '%s' is not authorized for op %s due to PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE",
+          polarisPrincipal.getName(), authzOp);
+    }
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationPreConditions.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationPreConditions.java
@@ -19,6 +19,8 @@
 package org.apache.polaris.core.auth;
 
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 
 /**
@@ -36,14 +38,15 @@ public final class AuthorizationPreConditions {
    *
    * @param polarisPrincipal the principal attempting the operation
    * @param authzOp the operation being attempted
-   * @param enforceCredentialRotationRequiredState whether the enforcement flag is enabled
+   * @param realmConfig the realm config, used to read the enforcement feature flag
    * @throws ForbiddenException if the principal must rotate credentials first
    */
   public static void checkCredentialRotationRequired(
       PolarisPrincipal polarisPrincipal,
       PolarisAuthorizableOperation authzOp,
-      boolean enforceCredentialRotationRequiredState) {
-    if (enforceCredentialRotationRequiredState
+      RealmConfig realmConfig) {
+    if (realmConfig.getConfig(
+            FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING)
         && authzOp != PolarisAuthorizableOperation.ROTATE_CREDENTIALS
         && polarisPrincipal
             .getProperties()

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -134,7 +134,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
@@ -881,11 +880,8 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @Nonnull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
-    boolean enforceCredentialRotationRequiredState =
-        realmConfig.getConfig(
-            FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
     AuthorizationPreConditions.checkCredentialRotationRequired(
-        polarisPrincipal, authzOp, enforceCredentialRotationRequiredState);
+        polarisPrincipal, authzOp, realmConfig);
     boolean isRoot = getRootPrincipalName().equals(polarisPrincipal.getName());
     if (authzOp == PolarisAuthorizableOperation.RESET_CREDENTIALS) {
       if (!isRoot) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -137,7 +137,6 @@ import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
@@ -885,16 +884,10 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
     boolean enforceCredentialRotationRequiredState =
         realmConfig.getConfig(
             FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING);
+    AuthorizationPreConditions.checkCredentialRotationRequired(
+        polarisPrincipal, authzOp, enforceCredentialRotationRequiredState);
     boolean isRoot = getRootPrincipalName().equals(polarisPrincipal.getName());
-    if (enforceCredentialRotationRequiredState
-        && polarisPrincipal
-            .getProperties()
-            .containsKey(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE)
-        && authzOp != PolarisAuthorizableOperation.ROTATE_CREDENTIALS) {
-      throw new ForbiddenException(
-          "Principal '%s' is not authorized for op %s due to PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE",
-          polarisPrincipal.getName(), authzOp);
-    } else if (authzOp == PolarisAuthorizableOperation.RESET_CREDENTIALS) {
+    if (authzOp == PolarisAuthorizableOperation.RESET_CREDENTIALS) {
       if (!isRoot) {
         throw new ForbiddenException("Only Root principal(service-admin) can perform %s", authzOp);
       }

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationPreConditionsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationPreConditionsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationPreConditionsTest {
+
+  private static final String ROTATION_KEY =
+      PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE;
+
+  @Test
+  public void testFlagOff_noException() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of("alice", Map.of(ROTATION_KEY, "true"), Set.of("role"));
+
+    assertThatCode(
+            () ->
+                AuthorizationPreConditions.checkCredentialRotationRequired(
+                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, false))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testFlagOn_rotateCredentialsOp_noException() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of("alice", Map.of(ROTATION_KEY, "true"), Set.of("role"));
+
+    assertThatCode(
+            () ->
+                AuthorizationPreConditions.checkCredentialRotationRequired(
+                    principal, PolarisAuthorizableOperation.ROTATE_CREDENTIALS, true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testFlagOn_nonRotationOp_propertySet_throwsForbidden() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of("alice", Map.of(ROTATION_KEY, "true"), Set.of("role"));
+
+    assertThatThrownBy(
+            () ->
+                AuthorizationPreConditions.checkCredentialRotationRequired(
+                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, true))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE");
+  }
+
+  @Test
+  public void testFlagOn_nonRotationOp_propertyNotSet_noException() {
+    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("role"));
+
+    assertThatCode(
+            () ->
+                AuthorizationPreConditions.checkCredentialRotationRequired(
+                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, true))
+        .doesNotThrowAnyException();
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationPreConditionsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationPreConditionsTest.java
@@ -20,10 +20,14 @@ package org.apache.polaris.core.auth;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +35,14 @@ public class AuthorizationPreConditionsTest {
 
   private static final String ROTATION_KEY =
       PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE;
+
+  private static RealmConfig realmConfigWithEnforcement(boolean enforce) {
+    RealmConfig realmConfig = mock(RealmConfig.class);
+    when(realmConfig.getConfig(
+            FeatureConfiguration.ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING))
+        .thenReturn(enforce);
+    return realmConfig;
+  }
 
   @Test
   public void testFlagOff_noException() {
@@ -40,7 +52,9 @@ public class AuthorizationPreConditionsTest {
     assertThatCode(
             () ->
                 AuthorizationPreConditions.checkCredentialRotationRequired(
-                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, false))
+                    principal,
+                    PolarisAuthorizableOperation.LIST_CATALOGS,
+                    realmConfigWithEnforcement(false)))
         .doesNotThrowAnyException();
   }
 
@@ -52,7 +66,9 @@ public class AuthorizationPreConditionsTest {
     assertThatCode(
             () ->
                 AuthorizationPreConditions.checkCredentialRotationRequired(
-                    principal, PolarisAuthorizableOperation.ROTATE_CREDENTIALS, true))
+                    principal,
+                    PolarisAuthorizableOperation.ROTATE_CREDENTIALS,
+                    realmConfigWithEnforcement(true)))
         .doesNotThrowAnyException();
   }
 
@@ -64,7 +80,9 @@ public class AuthorizationPreConditionsTest {
     assertThatThrownBy(
             () ->
                 AuthorizationPreConditions.checkCredentialRotationRequired(
-                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, true))
+                    principal,
+                    PolarisAuthorizableOperation.LIST_CATALOGS,
+                    realmConfigWithEnforcement(true)))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE");
   }
@@ -76,7 +94,9 @@ public class AuthorizationPreConditionsTest {
     assertThatCode(
             () ->
                 AuthorizationPreConditions.checkCredentialRotationRequired(
-                    principal, PolarisAuthorizableOperation.LIST_CATALOGS, true))
+                    principal,
+                    PolarisAuthorizableOperation.LIST_CATALOGS,
+                    realmConfigWithEnforcement(true)))
         .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
Description:                                              
  Closes #4026
              
  ## Summary
            
  Extracts the duplicated `PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE` pre-condition check from `PolarisAuthorizerImpl` and `RangerPolarisAuthorizer` into a shared `AuthorizationPreConditions` utility class.
                                                                                                                                                                                                                                                 
  Both authorizer implementations had identical logic to block non-`ROTATE_CREDENTIALS` operations when a principal is flagged for mandatory credential rotation. This duplication was flagged during the [PR #3928
  review](https://github.com/apache/polaris/pull/3928#discussion_r2921581602).                                                                                                                                                                   
                                                                              
  ### Changes                                                                                                                                                                                                                                    
  - New `AuthorizationPreConditions.checkCredentialRotationRequired()` utility method in `polaris-core`
  - `PolarisAuthorizerImpl` and `RangerPolarisAuthorizer` now delegate to the shared method            
  - Removed unused `PolarisEntityConstants` import from `RangerPolarisAuthorizer`                                                                                                                                                                
                                                                                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                                                                                   
  - [x] `polaris-core:test` — auth tests pass                                                                                                                                                                                                    
  - [x] `polaris-extensions-auth-ranger-tests:test` — Ranger tests pass                                                                                                                                                                          
  - [x] Spotless and checkstyle pass                                   
                                