### PR TITLE
Move Iceberg request.validate() to the REST adapter

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -231,8 +231,6 @@ public class CatalogHandlerUtils {
 
   public UpdateNamespacePropertiesResponse updateNamespaceProperties(
       SupportsNamespaces catalog, Namespace namespace, UpdateNamespacePropertiesRequest request) {
-    request.validate();
-
     Set<String> removals = Sets.newHashSet(request.removals());
     Map<String, String> updates = request.updates();
 
@@ -294,8 +292,6 @@ public class CatalogHandlerUtils {
 
   public LoadTableResponse registerTable(
       Catalog catalog, Namespace namespace, RegisterTableRequest request) {
-    request.validate();
-
     TableIdentifier identifier = TableIdentifier.of(namespace, request.name());
     Table table = catalog.registerTable(identifier, request.metadataLocation());
     if (table instanceof BaseTable baseTable) {
@@ -679,8 +675,6 @@ public class CatalogHandlerUtils {
 
   public LoadViewResponse createView(
       ViewCatalog catalog, Namespace namespace, CreateViewRequest request) {
-    request.validate();
-
     ViewBuilder viewBuilder =
         catalog
             .buildView(TableIdentifier.of(namespace, request.name()))

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -232,6 +232,7 @@ public class IcebergCatalogAdapter
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
+    updateNamespacePropertiesRequest.validate();
     validateIcebergProperties(realmConfig, updateNamespacePropertiesRequest.updates());
     Namespace ns =
         NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
@@ -264,6 +265,7 @@ public class IcebergCatalogAdapter
       String accessDelegationMode,
       RealmContext realmContext,
       SecurityContext securityContext) {
+    createTableRequest.validate();
     validateIcebergProperties(realmConfig, createTableRequest.properties());
     EnumSet<AccessDelegationMode> delegationModes =
         parseAccessDelegationModes(accessDelegationMode);
@@ -413,6 +415,7 @@ public class IcebergCatalogAdapter
       RegisterTableRequest registerTableRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
+    registerTableRequest.validate();
     Namespace ns =
         NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     EntityNameValidator.validateIdentifier(TableIdentifier.of(ns, registerTableRequest.name()));
@@ -486,6 +489,7 @@ public class IcebergCatalogAdapter
       CreateViewRequest createViewRequest,
       RealmContext realmContext,
       SecurityContext securityContext) {
+    createViewRequest.validate();
     validateIcebergProperties(realmConfig, createViewRequest.properties());
 
     CreateViewRequest revisedRequest =

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -465,8 +465,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     authorizeCreateTableDirect(namespace, request, !delegationModes.isEmpty());
     Optional<AccessDelegationMode> resolvedMode = resolveAccessDelegationModes(delegationModes);
 
-    request.validate();
-
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, request.name());
     if (baseCatalog.tableExists(tableIdentifier)) {
       throw alreadyExistsExceptionForTableLikeEntity(
@@ -508,8 +506,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
   }
 
   private TableMetadata stageTableCreateHelper(Namespace namespace, CreateTableRequest request) {
-    request.validate();
-
     TableIdentifier ident = TableIdentifier.of(namespace, request.name());
     if (baseCatalog.tableExists(ident)) {
       throw alreadyExistsExceptionForTableLikeEntity(ident, PolarisEntitySubType.ICEBERG_TABLE);


### PR DESCRIPTION
Why do we need this change:  
 1. Validate before authorize. Request validation (well-formedness) is cheap; authorization is expensive (entity
  resolution, role/grant checks). Doing validate first means malformed requests don't burn auth work. Also gives clearer errors: a user sending a bad payload now gets "invalid request," not "forbidden."
  2. One validation point per endpoint, regardless of branching. createTable was the clearest case: validation lived in both createTableDirect and stageTableCreateHelper because the handler branches on stageCreate. The adapter doesn't  branch yet, so validating once at the top covers both paths and removes the duplication. Same shape for the other three  endpoints. validation now lives at the boundary, not inside util methods that may be called from multiple places.
  3. Layering. Request schema validation is a REST-boundary concern; the handler should assume requests are well-formed and focus on auth + catalog logic. The new layout reflects that.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
