### PR TITLE
Cleanup Python dist area before publishing

### DIFF
--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -616,6 +616,7 @@ jobs:
 
       - name: Build Python client RC for Test PyPI
         run: |
+          rm -rf client/python/dist/
           make client-rc-testpypi-build RC_VERSION="${version_without_rc}" RC_NUMBER="${rc_number}"
 
       - name: Publish Python client RC to Test PyPI


### PR DESCRIPTION
This fix twine error when publishing Python CLI during release process (step 3).

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
