### PR TITLE
Remove unused backingStoreMap in LocalPolarisMetaStoreManagerFactory

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -50,7 +50,6 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
 
   final Map<String, PolarisMetaStoreManager> metaStoreManagerMap = new HashMap<>();
   final Map<String, EntityCache> entityCacheMap = new HashMap<>();
-  final Map<String, StoreType> backingStoreMap = new HashMap<>();
   final Map<String, Supplier<TransactionalPersistence>> sessionSupplierMap = new HashMap<>();
 
   private static final Logger LOGGER =
@@ -134,7 +133,6 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
       BaseResult result = metaStoreManager.purge(callContext);
       results.put(realm, result);
 
-      backingStoreMap.remove(realm);
       sessionSupplierMap.remove(realm);
       metaStoreManagerMap.remove(realm);
     }


### PR DESCRIPTION
`LocalPolarisMetaStoreManagerFactory` declares a `backingStoreMap` field, but the map is never populated (no `put` operation) and is only accessed in `purgeRealms()` via `remove()`.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>


<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
