### PR TITLE
Fix broken CVE links in 1.4.1 downloads page

### DIFF
--- a/site/content/downloads/1.4.1/index.md
+++ b/site/content/downloads/1.4.1/index.md
@@ -49,8 +49,8 @@ Released on May 1st, 2026.
 #### Fixes
 
 This release fixes 4 security issues:
-* [CVE-2026-42809](../../community/security-advisories/CVE-2026-42809/)
-* [CVE-2026-42810](../../community/security-advisories/CVE-2026-42810/)
-* [CVE-2026-42811](../../community/security-advisories/CVE-2026-42811/)
-* [CVE-2026-42812](../../community/security-advisories/CVE-2026-42812/)
+* [CVE-2026-42809](../../community/security-advisories/cve-2026-42809/)
+* [CVE-2026-42810](../../community/security-advisories/cve-2026-42810/)
+* [CVE-2026-42811](../../community/security-advisories/cve-2026-42811/)
+* [CVE-2026-42812](../../community/security-advisories/cve-2026-42812/)
 


### PR DESCRIPTION
Currently the CVE links on the 1.4.1 downloads page point to incorrect security advisory paths due to uppercase route values.

This change updates the advisory URLs to lowercase paths so the CVE links resolve correctly.

Fixes #4429

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
