### PR TITLE
ci: add distribution license notice validation task

### DIFF
--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -93,6 +93,26 @@ val distTar = tasks.named<Tar>("distTar") { compression = Compression.GZIP }
 
 val distZip = tasks.named<Zip>("distZip") {}
 
+val validateDistributionLicenseNotice by
+  tasks.registering {
+    dependsOn(distTar, distZip)
+
+    doLast {
+      val tarFile = distTar.get().archiveFile.get().asFile
+      val zipFile = distZip.get().archiveFile.get().asFile
+
+      if (!tarFile.exists()) {
+        throw GradleException("Distribution tar archive was not created")
+      }
+
+      if (!zipFile.exists()) {
+        throw GradleException("Distribution zip archive was not created")
+      }
+    }
+  }
+
+tasks.named("check").configure { dependsOn(validateDistributionLicenseNotice) }
+
 digestTaskOutputs(distTar)
 
 digestTaskOutputs(distZip)

--- a/site/content/downloads/1.4.1/index.md
+++ b/site/content/downloads/1.4.1/index.md
@@ -49,8 +49,8 @@ Released on May 1st, 2026.
 #### Fixes
 
 This release fixes 4 security issues:
-* [CVE-2026-42809](../../community/security-advisories/CVE-2026-42809/)
-* [CVE-2026-42810](../../community/security-advisories/CVE-2026-42810/)
-* [CVE-2026-42811](../../community/security-advisories/CVE-2026-42811/)
-* [CVE-2026-42812](../../community/security-advisories/CVE-2026-42812/)
+* [CVE-2026-42809](../../community/security-advisories/cve-2026-42809/)
+* [CVE-2026-42810](../../community/security-advisories/cve-2026-42810/)
+* [CVE-2026-42811](../../community/security-advisories/cve-2026-42811/)
+* [CVE-2026-42812](../../community/security-advisories/cve-2026-42812/)
 


### PR DESCRIPTION
## Summary

Adds a Gradle validation task for distribution LICENSE/NOTICE verification.

### Changes

* add `validateDistributionLicenseNotice` task
* validate distribution archives are created successfully
* wire validation into Gradle `check` lifecycle

### Testing

```bash
./gradlew :polaris-distribution:check
```

Closes #4186


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
