### PR TITLE
NoSQL: Do not interrupt running Vert.x async tasks on cancel

### DIFF
--- a/persistence/nosql/async/api/src/testFixtures/java/org/apache/polaris/nosql/async/AsyncExecTestBase.java
+++ b/persistence/nosql/async/api/src/testFixtures/java/org/apache/polaris/nosql/async/AsyncExecTestBase.java
@@ -146,6 +146,37 @@ public abstract class AsyncExecTestBase {
   }
 
   @Test
+  public void cancelRunningTaskDoesNotInterrupt() throws Exception {
+    var started = new Semaphore(0);
+    var allowFinish = new Semaphore(0);
+    var finished = new Semaphore(0);
+    var interrupted = new AtomicBoolean();
+
+    var cancelable =
+        executor.submit(
+            () -> {
+              started.release();
+              try {
+                allowFinish.acquire();
+              } catch (InterruptedException e) {
+                interrupted.set(true);
+              } finally {
+                finished.release();
+              }
+              return null;
+            });
+
+    soft.assertThat(started.tryAcquire(asyncTimeout.toMillis(), MILLISECONDS)).isTrue();
+
+    cancelable.cancel();
+    allowFinish.release();
+
+    soft.assertThat(finished.tryAcquire(asyncTimeout.toMillis(), MILLISECONDS)).isTrue();
+    soft.assertThat(interrupted.get()).isFalse();
+    cancelledAssert(assertThat(cancelable.completionStage().toCompletableFuture()));
+  }
+
+  @Test
   public void submitManyFailing() {
     int numTasks = 50;
     var sem = new Semaphore(0);

--- a/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
@@ -290,7 +290,7 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
       completable.cancel(false);
       var f = runningFuture.getAndSet(null);
       if (f != null && !f.isDone()) {
-        f.cancel(true);
+        f.cancel(false);
       }
       tasks.remove(this);
     }


### PR DESCRIPTION
Once the task is already running, cancelling the wrapper future should not try to interrupt the Vert.x worker thread.

That was turning a best-effort cancellation into a cross-thread side effect and could kill work that had already legitimately started. The added test covers the running-task case explicitly.

In other words: this change aligns the implementation to the documented and intended contract.