### PR TITLE
NoSQL: Harden the distributed cache invalidation endpoint

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationReceiver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationReceiver.java
@@ -111,7 +111,7 @@ class CacheInvalidationReceiver {
       String senderId,
       String token) {
     if (token == null || !validTokens.contains(token)) {
-      LOGGER.warn("Received cache invalidation with invalid token {}", token);
+      LOGGER.warn("Received cache invalidation with a missing or invalid token");
       responseInvalidToken(rc);
       return;
     }
@@ -120,7 +120,7 @@ class CacheInvalidationReceiver {
       responseNoContent(rc);
       return;
     }
-    if (!"application/json".equals(rc.request().getHeader("Content-Type"))) {
+    if (!acceptsJsonContentType(rc.request().getHeader("Content-Type"))) {
       LOGGER.warn("Received cache invalidation with invalid HTTP content type");
       responseInvalidContentType(rc);
       return;
@@ -154,6 +154,15 @@ class CacheInvalidationReceiver {
     }
 
     responseNoContent(rc);
+  }
+
+  private boolean acceptsJsonContentType(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    var separator = contentType.indexOf(';');
+    var mimeType = separator >= 0 ? contentType.substring(0, separator) : contentType;
+    return "application/json".equalsIgnoreCase(mimeType.trim());
   }
 
   private void responseServerError(RoutingContext rc) {

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationSender.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/main/java/org/apache/polaris/persistence/nosql/quarkus/distcache/CacheInvalidationSender.java
@@ -212,7 +212,7 @@ class CacheInvalidationSender implements DistributedCacheInvalidation.Sender {
       while (true) {
         lock.lock();
         try {
-          invalidations.drainTo(batch, 100);
+          invalidations.drainTo(batch, batchSize);
           if (batch.isEmpty()) {
             LOGGER.trace("Done sending invalidations");
             triggered = false;

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationReceiver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationReceiver.java
@@ -23,6 +23,7 @@ import static org.apache.polaris.persistence.nosql.api.cache.CacheInvalidations.
 import static org.apache.polaris.persistence.nosql.api.cache.CacheInvalidations.CacheInvalidationEvictReference.cacheInvalidationEvictReference;
 import static org.apache.polaris.persistence.nosql.api.cache.CacheInvalidations.cacheInvalidations;
 import static org.apache.polaris.persistence.nosql.quarkus.distcache.CacheInvalidationReceiver.CACHE_INVALIDATION_TOKEN_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
@@ -43,6 +47,7 @@ import org.apache.polaris.persistence.nosql.api.cache.CacheInvalidations;
 import org.apache.polaris.persistence.nosql.api.cache.DistributedCacheInvalidation;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class TestCacheInvalidationReceiver {
   private static final ObjRef SOME_OBJ_REF = ObjRef.objRef("foo", 1234);
@@ -65,6 +70,40 @@ public class TestCacheInvalidationReceiver {
             r -> {
               when(r.getParam("sender")).thenReturn(senderId.instanceId());
               when(r.getHeader(CACHE_INVALIDATION_TOKEN_HEADER)).thenReturn(token);
+            });
+    var reqBody = mock(RequestBody.class);
+    when(reqBody.asString()).thenReturn(new ObjectMapper().writeValueAsString(invalidations));
+    when(rc.body()).thenReturn(reqBody);
+
+    receiver.cacheInvalidations(rc);
+
+    verify(rc.response()).setStatusCode(204);
+    verify(rc.response()).setStatusMessage("No content");
+
+    verify(distributedCacheInvalidation).evictObj("repo", SOME_OBJ_REF);
+    verify(distributedCacheInvalidation).evictReference("repo", "refs/foo/bar");
+    verifyNoMoreInteractions(distributedCacheInvalidation);
+  }
+
+  @Test
+  public void senderReceiverAcceptsJsonContentTypeWithParameters() throws Exception {
+    var distributedCacheInvalidation = mock(DistributedCacheInvalidation.Receiver.class);
+
+    var token = "cafe";
+    var tokens = singletonList(token);
+    var receiverId = ServerInstanceId.of("receiverId");
+    var senderId = ServerInstanceId.of("senderId");
+
+    var receiver = buildReceiver(tokens, receiverId, distributedCacheInvalidation);
+
+    var invalidations = cacheInvalidations(allInvalidationTypes());
+
+    var rc =
+        expectResponse(
+            r -> {
+              when(r.getParam("sender")).thenReturn(senderId.instanceId());
+              when(r.getHeader(CACHE_INVALIDATION_TOKEN_HEADER)).thenReturn(token);
+              when(r.getHeader("Content-Type")).thenReturn("application/json; charset=utf-8");
             });
     var reqBody = mock(RequestBody.class);
     when(reqBody.asString()).thenReturn(new ObjectMapper().writeValueAsString(invalidations));
@@ -134,15 +173,28 @@ public class TestCacheInvalidationReceiver {
     CacheInvalidationReceiver receiver =
         buildReceiver(tokens, receiverId, distributedCacheInvalidation);
 
-    RoutingContext rc = expectResponse();
-    receiver.cacheInvalidations(
-        rc,
-        () -> cacheInvalidations(allInvalidationTypes()),
-        senderId.instanceId(),
-        differentToken);
+    var rc = expectResponse();
+    var logger = (Logger) LoggerFactory.getLogger(CacheInvalidationReceiver.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      receiver.cacheInvalidations(
+          rc,
+          () -> cacheInvalidations(allInvalidationTypes()),
+          senderId.instanceId(),
+          differentToken);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
 
     verify(rc.response()).setStatusCode(400);
     verify(rc.response()).setStatusMessage("Invalid token");
+    assertThat(appender.list)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .contains("Received cache invalidation with a missing or invalid token")
+        .allSatisfy(message -> assertThat(message).doesNotContain(differentToken));
 
     verifyNoMoreInteractions(distributedCacheInvalidation);
   }

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationSender.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationSender.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -383,6 +384,55 @@ public class TestCacheInvalidationSender {
     soft.assertThat(received).containsExactlyInAnyOrderElementsOf(expected);
   }
 
+  @Test
+  public void sendInvalidationsUsesConfiguredBatchSize() throws Exception {
+    var senderId = ServerInstanceId.of("senderId");
+    var config =
+        buildConfig(
+            singletonList("token"),
+            Optional.of(singletonList("service-name")),
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(10),
+            2);
+    var resolvedServiceNames = singletonList("service-name-resolved");
+
+    var sem = new Semaphore(0);
+    var batchSizes = new CopyOnWriteArrayList<Integer>();
+
+    var sender =
+        new CacheInvalidationSender(vertx, config, senderId) {
+          private volatile int managementPort;
+
+          @Override
+          Future<List<String>> resolveServiceNames(List<String> serviceNames) {
+            return succeededFuture(resolvedServiceNames);
+          }
+
+          @Override
+          List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
+              List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
+            batchSizes.add(batch.size());
+            sem.release(batch.size());
+            return null;
+          }
+
+          @Override
+          int quarkusManagementPort() {
+            return managementPort;
+          }
+        };
+
+    for (var i = 0; i < 5; i++) {
+      sender.evictObj("repo", ObjRef.objRef("foo", i));
+    }
+
+    sender.managementPort = 42;
+    sender.evictObj("repo", ObjRef.objRef("foo", 5));
+
+    assertThat(sem.tryAcquire(6, 30, TimeUnit.SECONDS)).isTrue();
+    soft.assertThat(batchSizes).containsExactly(2, 2, 2);
+  }
+
   @ParameterizedTest
   @MethodSource("invalidations")
   public void sendSingleInvalidation(
@@ -570,11 +620,20 @@ public class TestCacheInvalidationSender {
       Optional<List<String>> serviceName,
       Duration interval,
       Duration requestTimeout) {
+    return buildConfig(tokens, serviceName, interval, requestTimeout, 10);
+  }
+
+  private static QuarkusDistributedCacheInvalidationsConfig buildConfig(
+      List<String> tokens,
+      Optional<List<String>> serviceName,
+      Duration interval,
+      Duration requestTimeout,
+      int batchSize) {
     var config = mock(QuarkusDistributedCacheInvalidationsConfig.class);
     when(config.cacheInvalidationValidTokens()).thenReturn(Optional.of(tokens));
     when(config.cacheInvalidationServiceNames()).thenReturn(serviceName);
     when(config.cacheInvalidationServiceNameLookupInterval()).thenReturn(interval);
-    when(config.cacheInvalidationBatchSize()).thenReturn(10);
+    when(config.cacheInvalidationBatchSize()).thenReturn(batchSize);
     when(config.cacheInvalidationUri()).thenReturn("/foo/bar/");
     when(config.cacheInvalidationRequestTimeout()).thenReturn(Optional.of(requestTimeout));
     when(config.dnsQueryTimeout()).thenReturn(Duration.ofSeconds(5));


### PR DESCRIPTION
This tightens up the distributed cache invalidation endpoint in three small but related ways.

* The sender side now actually honors the configured invalidation batch size instead of using a hard coded value.
* The receiver now accepts normal parameterized JSON content types such as `application/json; charset=UTF-8` instead of only the exact bare media type. This is more a nice-to-have, but could be useful.
* The invalidation token is no longer written to logs. The token is just transport/auth material for the invalidation call, and logging it adds noise at best and leaks unnecessary sensitive data at worst.
