### PR TITLE
CLI: Improve setup dry-run output readability

### DIFF
--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -599,19 +599,23 @@ class SetupCommand(Command):
             f"Name   : {entity_name}\n"
         )
         if details:
-            details_copy = {k: v for k, v in details.copy().items() if v}
+            details_copy = {
+                k: v for k, v in details.items()
+                if v is not None and v != ""
+            }
 
-            message += (
-                "----------------------------------------\n"
-                "Details\n"
-                "----------------------------------------\n"
-            )
+            if details_copy:
+                message += (
+                    "----------------------------------------\n"
+                    "Details\n"
+                    "----------------------------------------\n"
+                )
 
-            for key, value in details_copy.items():
-                message += f"{key:<15}: {value}\n"
+                for key, value in details_copy.items():
+                    message += f"{key:<15}: {value}\n"
 
-        message += "========================================"
-            
+        message += "\n========================================"
+
         logger.info(message)
 
     def _create_principals(

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -600,8 +600,7 @@ class SetupCommand(Command):
         )
         if details:
             details_copy = {
-                k: v for k, v in details.items()
-                if v is not None and v != ""
+                k: v for k, v in details.items() if v is not None and v != ""
             }
 
             if details_copy:

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -599,14 +599,19 @@ class SetupCommand(Command):
             f"Name   : {entity_name}\n"
         )
         if details:
-            details_copy = details.copy()
-            # Clean up empty fields for cleaner output
-            for key in [k for k, v in details_copy.items() if not v and v is not False]:
-                if key in details_copy:
-                    del details_copy[key]
-            if details_copy:
-                details_str = yaml.dump(details_copy, indent=2, sort_keys=False).strip()
-                message += f" with details:\n{details_str}"
+            details_copy = {k: v for k, v in details.copy().items() if v}
+
+            message += (
+                "----------------------------------------\n"
+                "Details\n"
+                "----------------------------------------\n"
+            )
+
+            for key, value in details_copy.items():
+                message += f"{key:<15}: {value}\n"
+
+        message += "========================================"
+            
         logger.info(message)
 
     def _create_principals(

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -589,7 +589,15 @@ class SetupCommand(Command):
         details: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Helper for logging dry-run actions."""
-        message = f"DRY-RUN: Would {action} {entity_type} {entity_name}"
+        message = (
+            "\n"
+            "========================================\n"
+            "DRY-RUN\n"
+            "========================================\n"
+            f"Action : {action}\n"
+            f"Type   : {entity_type}\n"
+            f"Name   : {entity_name}\n"
+        )
         if details:
             details_copy = details.copy()
             # Clean up empty fields for cleaner output


### PR DESCRIPTION
What is changed

Improves readability of setup --dry-run CLI output by restructuring the logged output into a clearer multi-line format.

Why

The current dry-run output can be difficult to scan when processing larger setup configurations. This change makes the output easier to read while preserving the existing behavior and compatibility.

This is an incremental improvement related to #4090.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Related to #4090
- [x] 🧪 Manually verified the updated dry-run output formatting locally.
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
