### PR TITLE
NoSQL: Add explitic test coverage for `StreamUtil`

### DIFF
--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/PersistenceParams.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/PersistenceParams.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.persistence.nosql.api;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.smallrye.config.ConfigMapping;
@@ -82,6 +84,11 @@ public interface PersistenceParams {
   /** The maximum size of a serialized value in a persisted database row. */
   @WithDefault(DEFAULT_MAX_SERIALIZED_VALUE_SIZE_STRING)
   MemorySize maxSerializedValueSize();
+
+  @Value.Check
+  default void check() {
+    checkState(bucketizedBulkFetchSize() > 0, "bucketizedBulkFetchSize must be positive");
+  }
 
   @PolarisImmutable
   interface BuildablePersistenceParams extends PersistenceParams {

--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/StreamUtil.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/StreamUtil.java
@@ -19,6 +19,8 @@
 
 package org.apache.polaris.persistence.nosql.api;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Spliterator;
@@ -37,6 +39,7 @@ public final class StreamUtil {
    */
   public static <S, R> Stream<R> bucketized(
       Stream<S> source, Function<List<S>, List<R>> bucketFetcher, int bucketSize) {
+    checkArgument(bucketSize > 0, "bucketSize must be positive");
     var sourceIter = source.iterator();
 
     var split =

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/TestPersistence.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/TestPersistence.java
@@ -31,6 +31,7 @@ import org.apache.polaris.persistence.nosql.api.obj.SimpleTestObj;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
@@ -79,5 +80,23 @@ public class TestPersistence {
         .hasSize(totalSize)
         .map(SimpleTestObj::id)
         .containsExactlyElementsOf(objRefs.stream().map(ObjRef::id).toList());
+  }
+
+  @Test
+  public void bucketizedBulkFetchSizeMustBePositive() {
+    soft.assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                PersistenceParams.BuildablePersistenceParams.builder()
+                    .bucketizedBulkFetchSize(0)
+                    .build())
+        .withMessage("bucketizedBulkFetchSize must be positive");
+    soft.assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                PersistenceParams.BuildablePersistenceParams.builder()
+                    .bucketizedBulkFetchSize(-1)
+                    .build())
+        .withMessage("bucketizedBulkFetchSize must be positive");
   }
 }

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/TestStreamUtil.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/TestStreamUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.nosql.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+public class TestStreamUtil {
+
+  @Test
+  public void bucketizedFetchesBucketsInOrder() {
+    var seenBuckets = new ArrayList<List<Integer>>();
+
+    var result =
+        StreamUtil.bucketized(
+                IntStream.range(0, 7).boxed(),
+                bucket -> {
+                  seenBuckets.add(List.copyOf(bucket));
+                  return bucket.stream().map(value -> value * 10).toList();
+                },
+                3)
+            .toList();
+
+    assertThat(seenBuckets).containsExactly(List.of(0, 1, 2), List.of(3, 4, 5), List.of(6));
+    assertThat(result).containsExactly(0, 10, 20, 30, 40, 50, 60);
+  }
+
+  @Test
+  public void bucketizedRejectsNonPositiveBucketSize() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> StreamUtil.bucketized(IntStream.range(0, 1).boxed(), List::copyOf, 0))
+        .withMessage("bucketSize must be positive");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> StreamUtil.bucketized(IntStream.range(0, 1).boxed(), List::copyOf, -1))
+        .withMessage("bucketSize must be positive");
+  }
+}


### PR DESCRIPTION
This change adds explicit test coverage for the `StreamUtil` helper class.

Also fails fast on now on invalid bulk fetch size (negative and `0`).