### PR TITLE
NoSQL: Clarify Node management and lease contracts

### DIFF
--- a/persistence/nosql/nodes/api/src/main/java/org/apache/polaris/persistence/nosql/nodeids/api/NodeLease.java
+++ b/persistence/nosql/nodes/api/src/main/java/org/apache/polaris/persistence/nosql/nodeids/api/NodeLease.java
@@ -28,8 +28,11 @@ public interface NodeLease {
   @Nullable Node node();
 
   /**
-   * Permanently release the lease. Does nothing, if already released. Throws if persisting the
-   * released state fails.
+   * Permanently release the lease. Does nothing, if already released.
+   *
+   * <p>If persisting the released state fails, this lease is still considered locally released and
+   * cannot be retried or reused. The backend lease may therefore remain live until it expires
+   * naturally.
    */
   void release();
 

--- a/persistence/nosql/nodes/api/src/main/java/org/apache/polaris/persistence/nosql/nodeids/api/NodeManagement.java
+++ b/persistence/nosql/nodes/api/src/main/java/org/apache/polaris/persistence/nosql/nodeids/api/NodeManagement.java
@@ -38,9 +38,13 @@ public interface NodeManagement extends AutoCloseable {
    * Build a <em>new</em> and <em>independent</em> ID generator instance of a {@linkplain #lease()
    * leased node} using the given clock.
    *
+   * <p>Calling this method more than once for the same live lease can create multiple generators
+   * that emit overlapping Snowflake IDs. A lease must therefore back at most one long-lived ID
+   * generator instance.
+   *
    * <p>This function must only be called from {@link ApplicationScoped @ApplicationScoped} CDI
-   * producers providing the same {@link IdGenerator} for the lifetime of the given {@link Node},
-   * aka at most once for a {@link Node} instance.
+   * producers providing the same {@link IdGenerator} for the lifetime of the given {@link
+   * NodeLease}, aka at most once per lease.
    */
   IdGenerator buildIdGenerator(@NonNull NodeLease leasedNode);
 


### PR DESCRIPTION
This is a pure-javadoc contract clarification covering:

1. Document the NodeManagement side of the lease handoff more explicitly.

The existing javadoc left too much room for interpretation around who owns the lease after allocation and what callers may assume.

2. Spell out what a failed release actually means for callers.

The important bit is that failure does not imply the lease stayed live or can be safely retried blindly.