### PR TITLE
NoSQL: fix race in non-prod JavaPoolAsyncExec.periodic()

### DIFF
--- a/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
@@ -47,7 +47,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.polaris.nosql.async.AsyncConfiguration;
 import org.apache.polaris.nosql.async.AsyncExec;
 import org.apache.polaris.nosql.async.Cancelable;
@@ -88,6 +87,7 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
     this(AsyncConfiguration.builder().build());
   }
 
+  @SuppressWarnings("unused")
   @Inject
   JavaPoolAsyncExec(Instance<AsyncConfiguration> asyncConfiguration) {
     this(
@@ -240,16 +240,27 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
 
   @SuppressWarnings("FutureReturnValueIgnored")
   private void delayed(CancelableFuture<?> cancelable, long delayMillis) {
-    cancelable.setScheduledFuture(
-        scheduler.schedule(() -> immediate(cancelable), delayMillis, MILLISECONDS));
+    var generation = cancelable.nextScheduledGeneration();
+    var scheduledFuture =
+        scheduler.schedule(() -> immediate(cancelable), delayMillis, MILLISECONDS);
+    delayedTaskScheduledHook(scheduledFuture);
+    cancelable.setScheduledFuture(generation, scheduledFuture);
+    delayedTaskRecordedHook(scheduledFuture);
   }
+
+  @VisibleForTesting
+  void delayedTaskScheduledHook(ScheduledFuture<?> scheduledFuture) {}
+
+  @VisibleForTesting
+  void delayedTaskRecordedHook(ScheduledFuture<?> scheduledFuture) {}
 
   private final class CancelableFuture<R> implements Cancelable<R>, Runnable {
     private final CompletableFuture<R> completable = new CompletableFuture<>();
     private final Runnable runnable;
     private final Callable<R> callable;
     private final long repeatMillis;
-    private final AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>();
+    private long scheduledGeneration;
+    private ScheduledFuture<?> scheduledFuture;
 
     CancelableFuture(Runnable runnable, long repeatMillis) {
       this.runnable = requireNonNull(runnable, "Runnable must not be null");
@@ -263,10 +274,22 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
       this.repeatMillis = -1L;
     }
 
-    void setScheduledFuture(ScheduledFuture<?> scheduledFuture) {
-      var previous = this.scheduledFuture.getAndSet(scheduledFuture);
-      if (previous != null) {
-        previous.cancel(false);
+    synchronized long nextScheduledGeneration() {
+      return ++scheduledGeneration;
+    }
+
+    void setScheduledFuture(long generation, ScheduledFuture<?> scheduledFuture) {
+      ScheduledFuture<?> toCancel;
+      synchronized (this) {
+        if (generation != scheduledGeneration || cancelledOrShutdown()) {
+          toCancel = scheduledFuture;
+        } else {
+          toCancel = this.scheduledFuture;
+          this.scheduledFuture = scheduledFuture;
+        }
+      }
+      if (toCancel != null) {
+        toCancel.cancel(false);
       }
     }
 
@@ -318,9 +341,14 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
 
     @Override
     public void cancel() {
-      var previous = this.scheduledFuture.getAndSet(null);
-      if (previous != null) {
-        previous.cancel(false);
+      ScheduledFuture<?> toCancel;
+      synchronized (this) {
+        scheduledGeneration++;
+        toCancel = scheduledFuture;
+        scheduledFuture = null;
+      }
+      if (toCancel != null) {
+        toCancel.cancel(false);
       }
       completable.cancel(false);
       tasks.remove(this);

--- a/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
@@ -18,12 +18,63 @@
  */
 package org.apache.polaris.nosql.async.java;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.polaris.nosql.async.AsyncConfiguration;
 import org.apache.polaris.nosql.async.AsyncExecTestBase;
+import org.junit.jupiter.api.Test;
 
 public class TestJavaPoolAsyncExec extends AsyncExecTestBase {
   @Override
   protected void threadAssertion() {
     var t = Thread.currentThread();
     soft.assertThat(t.getName()).startsWith(JavaPoolAsyncExec.EXECUTOR_THREAD_NAME_PREFIX);
+  }
+
+  /**
+   * The Java pool implementation could race in its timer bookkeeping. The issue was that {@code
+   * JavaPoolAsyncExec.delayed()} could install an already-fired ScheduledFuture after a newer
+   * periodic timer has been installed, then cancel the newer one.
+   */
+  @Test
+  public void periodicTaskContinuesWhenPreviousTimerIsRecordedAfterNextTimer() {
+    var scheduledHooks = new AtomicInteger();
+    var secondTimerRecorded = new CountDownLatch(1);
+    var secondTimer = new AtomicReference<ScheduledFuture<?>>();
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().build()) {
+          @Override
+          void delayedTaskScheduledHook(ScheduledFuture<?> scheduledFuture) {
+            if (scheduledHooks.incrementAndGet() == 1) {
+              try {
+                assertThat(secondTimerRecorded.await(5_000, MILLISECONDS)).isTrue();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              }
+            }
+          }
+
+          @Override
+          void delayedTaskRecordedHook(ScheduledFuture<?> scheduledFuture) {
+            if (scheduledHooks.get() >= 2 && secondTimer.compareAndSet(null, scheduledFuture)) {
+              secondTimerRecorded.countDown();
+            }
+          }
+        }) {
+      var periodic =
+          executor.schedulePeriodic(() -> {}, Duration.ofMillis(1), Duration.ofSeconds(60));
+
+      assertThat(secondTimer)
+          .hasValueSatisfying(timer -> assertThat(timer.isCancelled()).isFalse());
+      periodic.cancel();
+    }
   }
 }


### PR DESCRIPTION
Some test runs of `TestJavaPoolAsyncExec` failed in the `periodic()`/immediate test case.

The issue was this race condition:
1. delayed() schedules timer A.
2. Timer A fires before delayed() records A in CancelableFuture.scheduledFuture.
3. Timer A runs the periodic task.
4. The periodic task schedules timer B for the next run.
5. Timer B is recorded in CancelableFuture.scheduledFuture.
6. The original delayed() call resumes and records stale timer A.
7. Recording stale timer A replaces timer B and cancels timer B.
8. The next periodic run is lost, so the test waits until timeout (5 minutes).

The fix in this change is to introduce a `scheduledGeneration` that handles this race condition accordingly.

Polaris production deployments are not affected, because those use the Vert.X based implementation, which does not have this problem.