### PR TITLE
CLI: Ensure sub-namespace list is not error out during dry-run

### DIFF
--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -1163,7 +1163,11 @@ class SetupCommand(Command):
             parts = ns_name.split(".")
             if len(parts) > 1:
                 parent_ns = ".".join(parts[:-1])
-                if parent_ns in existing_namespaces and parent_ns not in listed_parents:
+                if (
+                    not dry_run
+                    and parent_ns in existing_namespaces
+                    and parent_ns not in listed_parents
+                ):
                     try:
                         sub_ns = catalog_api.list_namespaces(
                             prefix=catalog_name, parent=UNIT_SEPARATOR.join(parts[:-1])


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently during dry-run, the list sub-namespace would raise error such as following:
```sh
2026-05-14 20:13:02,983 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-05-14 20:13:02,984 INFO DRY-RUN: Would create namespace dev_namespace with details:
catalog: quickstart_catalog
2026-05-14 20:13:03,002 ERROR Failed to list sub-namespaces for 'dev_namespace'
Traceback (most recent call last):
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/cli/command/setup.py", line 1168, in _create_namespaces
    sub_ns = catalog_api.list_namespaces(
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        prefix=catalog_name, parent=UNIT_SEPARATOR.join(parts[:-1])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).namespaces
    ^
  File "/Users/yong/Desktop/GitHome/polaris/polaris-venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py", line 39, in wrapper_function
    return wrapper(*args, **kwargs)
  File "/Users/yong/Desktop/GitHome/polaris/polaris-venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py", line 136, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/api/iceberg_catalog_api.py", line 3409, in list_namespaces
    return self.api_client.response_deserialize(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        response_data=response_data,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        response_types_map=_response_types_map,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).data
    ^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/api_client.py", line 341, in response_deserialize
    raise ApiException.from_response(
          ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        http_resp=response_data,
        ^^^^^^^^^^^^^^^^^^^^^^^^
        body=response_text,
        ^^^^^^^^^^^^^^^^^^^
        data=return_data,
        ^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/sdk/catalog/exceptions.py", line 170, in from_response
    raise NotFoundException(http_resp=http_resp, body=body, data=data)
apache_polaris.sdk.catalog.exceptions.NotFoundException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'content-length': '108', 'Content-Type': 'application/json', 'X-Request-ID': 'd324c6dc-c0b3-4dc3-be66-e158c8f9ccc3_0000000000000000033'})
HTTP response body: error=ErrorModel(message='Namespace does not exist: dev_namespace', type='NoSuchNamespaceException', code=404, stack=None)

2026-05-14 20:13:03,006 INFO DRY-RUN: Would create namespace dev_namespace.sub_namespace with details:
```
This is due to the top level namespace is not persisted during dry-run (expected behavior). This PR fixed this to ensure we don't throw this error:
```bash
2026-05-14 20:15:38,172 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-05-14 20:15:38,173 INFO DRY-RUN: Would create namespace dev_namespace with details:
catalog: quickstart_catalog
2026-05-14 20:15:38,173 INFO DRY-RUN: Would create namespace dev_namespace.sub_namespace with details:
catalog: quickstart_catalog
```


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
