### PR TITLE
docs: add production configuration pages for AWS S3 and Azure Blob storage (#1325)

### DIFF
--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -17,16 +17,20 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-title: Configuring AWS S3 Cloud Storage
-linkTitle: Configuring AWS S3 Cloud Storage
+title: Configuring S3 Storage
+linkTitle: Configuring S3 Storage
 type: docs
 weight: 610
 ---
 
-This page covers configuring AWS S3 as the storage backend for a Polaris catalog. All read and write
-operations against S3 are performed using credential vending, in which Polaris assumes an IAM role
-on behalf of the client and returns scoped, short-lived credentials. The IAM role, its trust policy,
+This page covers configuring AWS S3, and S3-compatible object stores (MinIO, Apache Ozone S3
+gateway, Ceph RGW, and similar), as the storage backend for a Polaris catalog. On AWS S3, all read
+and write operations are performed using credential vending: Polaris assumes a customer IAM role
+via STS and returns scoped, short-lived credentials to the client. The IAM role, its trust policy,
 and the bucket itself must be set up before the catalog is created.
+
+This page is limited to native Polaris authentication. External identity providers are also
+supported but are not yet covered here; the configuration patterns below remain otherwise the same.
 
 ## IAM role and trust policy
 
@@ -37,10 +41,11 @@ must:
    (`s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` and, if encryption is in use,
    the relevant `kms:*` actions).
 2. Trust the Polaris service principal — typically the IAM role that the Polaris server runs as.
-   Polaris fills the `sts:AssumeRole` request with the configured `userArn` and, when supplied, an
-   `externalId`. The trust policy must accept both.
+   Polaris fills the `sts:AssumeRole` request with an `externalId` when one is configured. The
+   trust policy must accept the same external ID.
 
-A minimal trust policy looks like:
+Using `externalId` is recommended for cross-account or hosted Polaris deployments to mitigate the
+confused-deputy problem. A minimal trust policy looks like:
 
 ```json
 {
@@ -58,29 +63,29 @@ A minimal trust policy looks like:
 }
 ```
 
-If you do not require an external ID, omit the `Condition` block and the matching `externalId`
-field in the storage config.
-
 ## Catalog storage configuration
 
-Provide the role ARN and region when creating the catalog. `userArn` is the identity Polaris
-itself uses (typically the role ARN of the server); `externalId` matches the trust policy above.
+Provide the role ARN, region, and `externalId` when creating the catalog. The token in the
+`Authorization` header below is the Polaris admin bearer token obtained from
+`/api/catalog/v1/oauth/tokens` (see [Configuring Polaris for Production]({{% relref "." %}}) for
+how to bootstrap and issue admin tokens).
 
 ```bash
 curl -X POST https://<polaris-host>/management/v1/catalogs \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-        "type": "INTERNAL",
-        "name": "warehouse_s3",
-        "storageConfigInfo": {
-          "storageType": "S3",
-          "roleArn": "arn:aws:iam::123456789012:role/polaris-warehouse-access",
-          "userArn": "arn:aws:iam::123456789012:role/polaris-server",
-          "externalId": "polaris-prod",
-          "region": "us-east-1"
-        },
-        "properties": { "default-base-location": "s3://warehouse-bucket/prod/" }
+        "catalog": {
+          "type": "INTERNAL",
+          "name": "warehouse_s3",
+          "properties": { "default-base-location": "s3://warehouse-bucket/prod/" },
+          "storageConfigInfo": {
+            "storageType": "S3",
+            "roleArn": "arn:aws:iam::123456789012:role/polaris-warehouse-access",
+            "externalId": "polaris-prod",
+            "region": "us-east-1"
+          }
+        }
       }'
 ```
 
@@ -89,8 +94,10 @@ ill-formed ARN is rejected at catalog creation time.
 
 ## Server-side encryption with KMS
 
-When the bucket uses SSE-KMS, supply the key Polaris should use for writes and the full set of
-keys it is allowed to read from:
+When the bucket uses SSE-KMS, supply both `currentKmsKey` (the key Polaris should use for writes)
+and `allowedKmsKeys` (every key the catalog is allowed to read from). The two fields are processed
+independently in `AwsCredentialsStorageIntegration`, so the write key must be included in
+`allowedKmsKeys` as well if you want it readable through vended credentials:
 
 ```json
 "storageConfigInfo": {
@@ -105,8 +112,9 @@ keys it is allowed to read from:
 }
 ```
 
-The IAM role's policy must include `kms:GenerateDataKey` and `kms:Decrypt` on every key listed in
-`allowedKmsKeys`, and the key policy must grant the same to the role principal.
+The IAM role's policy must include `kms:GenerateDataKey` and `kms:Decrypt` on `currentKmsKey` and
+`kms:Decrypt` on every key listed in `allowedKmsKeys`, and each key policy must grant the same to
+the role principal.
 
 If the deployment does not use KMS, set `kmsUnavailable` to `true` so Polaris will not request
 KMS-related session permissions:
@@ -127,14 +135,9 @@ The available fields are:
 - `stsEndpoint` — STS endpoint; defaults to `endpointInternal` then `endpoint` when not set.
 - `stsUnavailable` — set to `true` when the backend does not implement STS.
 
-How clients receive credentials depends on whether the backend implements STS.
-
-### Backends with STS support (e.g. AWS S3, MinIO)
-
-Leave `stsUnavailable` unset (or `false`). Polaris will assume the role and vend short-lived,
-subscoped credentials to the client at table-load time when the client sends
-`X-Iceberg-Access-Delegation: vended-credentials`. This is the recommended deployment for AWS S3
-and any compatible backend that exposes the STS API.
+The credential-vending guarantee at the top of this page assumes that the backend implements STS.
+For AWS S3 and S3-compatible backends that expose the STS API (such as MinIO), leave
+`stsUnavailable` unset (or `false`) and the vended-credentials flow described above works as is.
 
 ```json
 "storageConfigInfo": {
@@ -145,13 +148,11 @@ and any compatible backend that exposes the STS API.
 }
 ```
 
-### Backends without STS support (e.g. Apache Ozone S3 gateway, Ceph RGW without STS enabled)
-
-Set `stsUnavailable: true`. Polaris will then skip subscoped credential vending, and clients must
-authenticate to the object store directly with long-lived credentials. Because the vended-credential
-path is disabled, the client must omit the `X-Iceberg-Access-Delegation` header and supply its own
-access key / secret to the underlying FileIO. The Polaris guides for [Apache Ozone][ozone-guide]
-and [Ceph][ceph-guide] show this pattern.
+For S3-compatible backends without STS (Apache Ozone S3 gateway, or Ceph RGW without STS enabled),
+set `stsUnavailable: true`. Polaris will then skip subscoped credential vending entirely, and the
+client must omit `X-Iceberg-Access-Delegation: vended-credentials` and authenticate to the object
+store directly. The Polaris guides for [Apache Ozone][ozone-guide] and [Ceph][ceph-guide] show
+this pattern end-to-end.
 
 ```json
 "storageConfigInfo": {
@@ -192,9 +193,11 @@ The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls
 hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback
 is slated for removal in a future Iceberg release.
 
-For Trino, use the Iceberg connector with the REST catalog. Two groups of properties are
-required: the REST/OAuth2 settings for talking to Polaris, and the native S3 filesystem settings
-that Trino uses to read the vended credentials.
+For Trino, use the Iceberg connector with the REST catalog. The REST/OAuth2 properties talk to
+Polaris; the native S3 filesystem properties consume the vended credentials. Polaris itself
+returns `endpoint`, `path-style-access`, and `region` in the catalog config response, so the
+client-side `s3.*` block below is only needed where Trino requires it to be explicit (for
+example, on S3-compatible endpoints where the default AWS endpoint resolver does not apply).
 
 ```properties
 connector.name=iceberg
@@ -210,7 +213,7 @@ fs.native-s3.enabled=true
 s3.region=us-east-1
 ```
 
-When pointing at an S3-compatible endpoint, also set:
+For S3-compatible endpoints, set the endpoint and path-style flag explicitly on the Trino side:
 
 ```properties
 s3.endpoint=https://s3.internal.example.com

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -1,0 +1,188 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: Configuring AWS S3 Cloud Storage
+linkTitle: Configuring AWS S3 Cloud Storage
+type: docs
+weight: 610
+---
+
+This page covers configuring AWS S3 as the storage backend for a Polaris catalog. All read and write
+operations against S3 are performed using credential vending, in which Polaris assumes an IAM role
+on behalf of the client and returns scoped, short-lived credentials. The IAM role, its trust policy,
+and the bucket itself must be set up before the catalog is created.
+
+## IAM role and trust policy
+
+Polaris assumes a customer-managed IAM role via STS when a client requests credentials. The role
+must:
+
+1. Grant the actions required for object access on the bucket and prefix that backs the catalog
+   (`s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` and, if encryption is in use,
+   the relevant `kms:*` actions).
+2. Trust the Polaris service principal — typically the IAM role that the Polaris server runs as.
+   Polaris fills the `sts:AssumeRole` request with the configured `userArn` and, when supplied, an
+   `externalId`. The trust policy must accept both.
+
+A minimal trust policy looks like:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::123456789012:role/polaris-server" },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": { "sts:ExternalId": "polaris-prod" }
+      }
+    }
+  ]
+}
+```
+
+If you do not require an external ID, omit the `Condition` block and the matching `externalId`
+field in the storage config.
+
+## Catalog storage configuration
+
+Provide the role ARN and region when creating the catalog. `userArn` is the identity Polaris
+itself uses (typically the role ARN of the server); `externalId` matches the trust policy above.
+
+```bash
+curl -X POST https://<polaris-host>/management/v1/catalogs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "type": "INTERNAL",
+        "name": "warehouse_s3",
+        "storageConfigInfo": {
+          "storageType": "S3",
+          "roleArn": "arn:aws:iam::123456789012:role/polaris-warehouse-access",
+          "userArn": "arn:aws:iam::123456789012:role/polaris-server",
+          "externalId": "polaris-prod",
+          "region": "us-east-1"
+        },
+        "properties": { "default-base-location": "s3://warehouse-bucket/prod/" }
+      }'
+```
+
+The role ARN is validated against the pattern enforced by `AwsStorageConfigurationInfo`; an
+ill-formed ARN is rejected at catalog creation time.
+
+## Server-side encryption with KMS
+
+When the bucket uses SSE-KMS, supply the key Polaris should use for writes and the full set of
+keys it is allowed to read from:
+
+```json
+"storageConfigInfo": {
+  "storageType": "S3",
+  "roleArn": "...",
+  "region": "us-east-1",
+  "currentKmsKey": "arn:aws:kms:us-east-1:123456789012:key/aaaa-bbbb",
+  "allowedKmsKeys": [
+    "arn:aws:kms:us-east-1:123456789012:key/aaaa-bbbb",
+    "arn:aws:kms:us-east-1:123456789012:key/cccc-dddd"
+  ]
+}
+```
+
+The IAM role's policy must include `kms:GenerateDataKey` and `kms:Decrypt` on every key listed in
+`allowedKmsKeys`, and the key policy must grant the same to the role principal.
+
+If the deployment does not use KMS, set `kmsUnavailable` to `true` so Polaris will not request
+KMS-related session permissions:
+
+```json
+"kmsUnavailable": true
+```
+
+## S3-compatible endpoints
+
+Polaris can also be pointed at S3-compatible object stores (MinIO, Ceph RGW, Apache Ozone S3
+gateway). Two additional fields are relevant:
+
+- `endpoint` — the S3 API endpoint Polaris and its clients should call.
+- `endpointInternal` — optional, used by the Polaris server when the in-cluster endpoint differs
+  from the one returned to clients.
+- `pathStyleAccess` — set to `true` for backends that do not support virtual-host-style addressing.
+- `stsEndpoint` — STS endpoint; defaults to `endpointInternal` then `endpoint` when not set.
+- `stsUnavailable` — set to `true` when the backend does not implement STS. Polaris then skips
+  credential vending and clients fall back to long-lived credentials.
+
+```json
+"storageConfigInfo": {
+  "storageType": "S3",
+  "endpoint": "https://s3.internal.example.com",
+  "pathStyleAccess": true,
+  "stsUnavailable": true,
+  "region": "us-east-1"
+}
+```
+
+## Client configuration
+
+Engines connect through the Iceberg REST API and let Polaris vend credentials at table-load time;
+they do not need static AWS credentials when STS is available.
+
+Spark example:
+
+```properties
+spark.sql.catalog.warehouse_s3=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.warehouse_s3.type=rest
+spark.sql.catalog.warehouse_s3.uri=https://<polaris-host>/api/catalog
+spark.sql.catalog.warehouse_s3.warehouse=warehouse_s3
+spark.sql.catalog.warehouse_s3.header.X-Iceberg-Access-Delegation=vended-credentials
+```
+
+Trino connector properties:
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=https://<polaris-host>/api/catalog
+iceberg.rest-catalog.warehouse=warehouse_s3
+iceberg.rest-catalog.vended-credentials-enabled=true
+```
+
+For PyIceberg, use `rest` catalog type and rely on the vended `s3.access-key-id`,
+`s3.secret-access-key`, and `s3.session-token` properties returned by Polaris.
+
+## Verifying the setup
+
+A successful end-to-end test should be possible without giving the client any long-lived AWS
+credentials:
+
+```sql
+CREATE NAMESPACE warehouse_s3.demo;
+CREATE TABLE warehouse_s3.demo.t (id BIGINT, name STRING) USING iceberg;
+INSERT INTO warehouse_s3.demo.t VALUES (1, 'hello');
+SELECT * FROM warehouse_s3.demo.t;
+```
+
+If `INSERT` or `SELECT` fails with a 403, the most common causes are:
+
+- The IAM role's trust policy does not match the `userArn` / `externalId` Polaris is presenting.
+- The role grants S3 permissions but is missing the KMS actions for `currentKmsKey`.
+- The bucket policy denies access from outside a specific VPC endpoint.
+
+Polaris logs the assumed-role STS request at debug level, which is the fastest way to confirm
+which identity is being presented.

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -117,16 +117,41 @@ KMS-related session permissions:
 
 ## S3-compatible endpoints
 
-Polaris can also be pointed at S3-compatible object stores (MinIO, Ceph RGW, Apache Ozone S3
-gateway). Two additional fields are relevant:
+Polaris can be pointed at S3-compatible object stores (MinIO, Ceph RGW, Apache Ozone S3 gateway).
+The available fields are:
 
 - `endpoint` — the S3 API endpoint Polaris and its clients should call.
 - `endpointInternal` — optional, used by the Polaris server when the in-cluster endpoint differs
   from the one returned to clients.
 - `pathStyleAccess` — set to `true` for backends that do not support virtual-host-style addressing.
 - `stsEndpoint` — STS endpoint; defaults to `endpointInternal` then `endpoint` when not set.
-- `stsUnavailable` — set to `true` when the backend does not implement STS. Polaris then skips
-  credential vending and clients fall back to long-lived credentials.
+- `stsUnavailable` — set to `true` when the backend does not implement STS.
+
+How clients receive credentials depends on whether the backend implements STS.
+
+### Backends with STS support (e.g. AWS S3, MinIO)
+
+Leave `stsUnavailable` unset (or `false`). Polaris will assume the role and vend short-lived,
+subscoped credentials to the client at table-load time when the client sends
+`X-Iceberg-Access-Delegation: vended-credentials`. This is the recommended deployment for AWS S3
+and any compatible backend that exposes the STS API.
+
+```json
+"storageConfigInfo": {
+  "storageType": "S3",
+  "endpoint": "https://s3.internal.example.com",
+  "pathStyleAccess": true,
+  "region": "us-east-1"
+}
+```
+
+### Backends without STS support (e.g. Apache Ozone S3 gateway, Ceph RGW without STS enabled)
+
+Set `stsUnavailable: true`. Polaris will then skip subscoped credential vending, and clients must
+authenticate to the object store directly with long-lived credentials. Because the vended-credential
+path is disabled, the client must omit the `X-Iceberg-Access-Delegation` header and supply its own
+access key / secret to the underlying FileIO. The Polaris guides for [Apache Ozone][ozone-guide]
+and [Ceph][ceph-guide] show this pattern.
 
 ```json
 "storageConfigInfo": {
@@ -137,6 +162,9 @@ gateway). Two additional fields are relevant:
   "region": "us-east-1"
 }
 ```
+
+[ozone-guide]: ../../../../guides/ozone/
+[ceph-guide]: ../../../../guides/ceph/
 
 ## Client configuration
 
@@ -164,9 +192,9 @@ The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls
 hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback
 is slated for removal in a future Iceberg release.
 
-For Trino, use the Iceberg connector with the REST catalog. The properties below match what the
-[local Ozone + Polaris + Trino blog post](../../../../blog/2026/04/04/local-open-data-lakehouse-k3d-ozone-polaris-trino)
-uses against Polaris:
+For Trino, use the Iceberg connector with the REST catalog. Two groups of properties are
+required: the REST/OAuth2 settings for talking to Polaris, and the native S3 filesystem settings
+that Trino uses to read the vended credentials.
 
 ```properties
 connector.name=iceberg
@@ -177,11 +205,41 @@ iceberg.rest-catalog.security=OAUTH2
 iceberg.rest-catalog.oauth2.credential=<client-id>:<client-secret>
 iceberg.rest-catalog.oauth2.scope=PRINCIPAL_ROLE:ALL
 iceberg.rest-catalog.oauth2.server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens
+iceberg.rest-catalog.vended-credentials-enabled=true
+fs.native-s3.enabled=true
+s3.region=us-east-1
 ```
 
-For PyIceberg, use the `rest` catalog type. Polaris returns the vended S3 properties
-(`s3.access-key-id`, `s3.secret-access-key`, `s3.session-token`) to the client at table-load time,
-so static credentials should not be configured on the PyIceberg side.
+When pointing at an S3-compatible endpoint, also set:
+
+```properties
+s3.endpoint=https://s3.internal.example.com
+s3.path-style-access=true
+```
+
+For PyIceberg, use the `rest` catalog type. The same Polaris-side properties (`uri`, `warehouse`,
+`credential`, `scope`, `oauth2-server-uri`) apply, and the vended-credential header must be
+forwarded as a REST header:
+
+```python
+from pyiceberg.catalog.rest import RestCatalog
+
+cat = RestCatalog(
+    name="polaris",
+    **{
+        "uri": "https://<polaris-host>/api/catalog",
+        "warehouse": "warehouse_s3",
+        "credential": "<client-id>:<client-secret>",
+        "scope": "PRINCIPAL_ROLE:ALL",
+        "oauth2-server-uri": "https://<polaris-host>/api/catalog/v1/oauth/tokens",
+        "header.X-Iceberg-Access-Delegation": "vended-credentials",
+    },
+)
+```
+
+Polaris returns the vended S3 properties (`s3.access-key-id`, `s3.secret-access-key`,
+`s3.session-token`) to the client at table-load time, so static credentials should not be
+configured on the PyIceberg side.
 
 ## Verifying the setup
 

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -143,28 +143,45 @@ gateway). Two additional fields are relevant:
 Engines connect through the Iceberg REST API and let Polaris vend credentials at table-load time;
 they do not need static AWS credentials when STS is available.
 
-Spark example:
+Spark example, matching the property names used by the existing MinIO / RustFS guides:
 
-```properties
-spark.sql.catalog.warehouse_s3=org.apache.iceberg.spark.SparkCatalog
-spark.sql.catalog.warehouse_s3.type=rest
-spark.sql.catalog.warehouse_s3.uri=https://<polaris-host>/api/catalog
-spark.sql.catalog.warehouse_s3.warehouse=warehouse_s3
-spark.sql.catalog.warehouse_s3.header.X-Iceberg-Access-Delegation=vended-credentials
+```shell
+bin/spark-sql \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.1,org.apache.iceberg:iceberg-aws-bundle:1.10.1 \
+    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+    --conf spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.polaris.type=rest \
+    --conf spark.sql.catalog.polaris.uri=https://<polaris-host>/api/catalog \
+    --conf spark.sql.catalog.polaris.oauth2-server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens \
+    --conf spark.sql.catalog.polaris.token-refresh-enabled=false \
+    --conf spark.sql.catalog.polaris.warehouse=warehouse_s3 \
+    --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
+    --conf spark.sql.catalog.polaris.credential=<client-id>:<client-secret> \
+    --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=vended-credentials
 ```
 
-Trino connector properties:
+The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls back to a
+hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback
+is slated for removal in a future Iceberg release.
+
+For Trino, use the Iceberg connector with the REST catalog. The properties below match what the
+[local Ozone + Polaris + Trino blog post](../../../../blog/2026/04/04/local-open-data-lakehouse-k3d-ozone-polaris-trino)
+uses against Polaris:
 
 ```properties
 connector.name=iceberg
 iceberg.catalog.type=rest
 iceberg.rest-catalog.uri=https://<polaris-host>/api/catalog
 iceberg.rest-catalog.warehouse=warehouse_s3
-iceberg.rest-catalog.vended-credentials-enabled=true
+iceberg.rest-catalog.security=OAUTH2
+iceberg.rest-catalog.oauth2.credential=<client-id>:<client-secret>
+iceberg.rest-catalog.oauth2.scope=PRINCIPAL_ROLE:ALL
+iceberg.rest-catalog.oauth2.server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens
 ```
 
-For PyIceberg, use `rest` catalog type and rely on the vended `s3.access-key-id`,
-`s3.secret-access-key`, and `s3.session-token` properties returned by Polaris.
+For PyIceberg, use the `rest` catalog type. Polaris returns the vended S3 properties
+(`s3.access-key-id`, `s3.secret-access-key`, `s3.session-token`) to the client at table-load time,
+so static credentials should not be configured on the PyIceberg side.
 
 ## Verifying the setup
 

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -194,10 +194,10 @@ hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the aut
 is slated for removal in a future Iceberg release.
 
 For Trino, use the Iceberg connector with the REST catalog. The REST/OAuth2 properties talk to
-Polaris; the native S3 filesystem properties consume the vended credentials. Polaris itself
-returns `endpoint`, `path-style-access`, and `region` in the catalog config response, so the
-client-side `s3.*` block below is only needed where Trino requires it to be explicit (for
-example, on S3-compatible endpoints where the default AWS endpoint resolver does not apply).
+Polaris, and Polaris vends the endpoint, path-style flag, and region together with the scoped
+credentials (`s3.endpoint`, `s3.path-style-access`, `client.region` in the load-table response),
+so they do not need to be repeated on the client. The native S3 filesystem still has to be
+enabled on the Trino side:
 
 ```properties
 connector.name=iceberg
@@ -210,14 +210,6 @@ iceberg.rest-catalog.oauth2.scope=PRINCIPAL_ROLE:ALL
 iceberg.rest-catalog.oauth2.server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens
 iceberg.rest-catalog.vended-credentials-enabled=true
 fs.native-s3.enabled=true
-s3.region=us-east-1
-```
-
-For S3-compatible endpoints, set the endpoint and path-style flag explicitly on the Trino side:
-
-```properties
-s3.endpoint=https://s3.internal.example.com
-s3.path-style-access=true
 ```
 
 For PyIceberg, use the `rest` catalog type. The same Polaris-side properties (`uri`, `warehouse`,
@@ -258,7 +250,7 @@ SELECT * FROM warehouse_s3.demo.t;
 
 If `INSERT` or `SELECT` fails with a 403, the most common causes are:
 
-- The IAM role's trust policy does not match the `userArn` / `externalId` Polaris is presenting.
+- The IAM role's trust policy does not match the `roleArn` / `externalId` Polaris is presenting.
 - The role grants S3 permissions but is missing the KMS actions for `currentKmsKey`.
 - The bucket policy denies access from outside a specific VPC endpoint.
 

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -32,7 +32,74 @@ and the bucket itself must be set up before the catalog is created.
 This page is limited to native Polaris authentication. External identity providers are also
 supported but are not yet covered here; the configuration patterns below remain otherwise the same.
 
-## IAM role and trust policy
+## IAM identities involved
+
+Three distinct IAM identities take part in the S3 credential-vending flow. Conflating them is the
+most common source of `AccessDenied` errors at catalog creation or table load.
+
+| # | Identity | Used by | Purpose |
+|---|----------|---------|---------|
+| 1 | Polaris service identity | Polaris server process | Sign every `sts:AssumeRole` request Polaris makes |
+| 2 | Catalog access role | Polaris (assumed) | Hold the actual S3 / KMS permissions on the catalog bucket |
+| 3 | Vended credentials | Iceberg client (Spark/Trino/PyIceberg) | Short-lived session keys returned by Polaris at table-load time |
+
+At runtime the client calls Polaris to load a table, Polaris signs an `sts:AssumeRole` request
+as identity 1 against identity 2, AWS STS returns scoped temporary credentials (identity 3), and
+the client uses those credentials to talk to S3 and KMS directly.
+
+Identity 1 is configured once at Polaris deployment time. Identity 2 is created per catalog and
+its ARN is registered when the catalog is created. Identity 3 is generated on every table load
+and is never persisted.
+
+## Polaris service identity
+
+The Polaris server itself needs an AWS identity to call STS on the catalog access role. This is
+configured outside Polaris — through the standard AWS SDK credentials chain — and is independent
+of any catalog.
+
+Pick whichever discovery mechanism matches the deployment:
+
+- **EKS / IRSA** — annotate the Polaris ServiceAccount with the IAM role ARN
+  (`eks.amazonaws.com/role-arn`). The pod receives a projected token and exchanges it for STS
+  credentials automatically.
+- **EC2** — attach an IAM instance profile to the EC2 instance. The SDK reads credentials from
+  IMDS.
+- **Static credentials** — set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optionally
+  `AWS_SESSION_TOKEN` and `AWS_REGION` in the Polaris container's environment. Suitable for local
+  development only.
+
+Any other AWS compute environment that participates in the standard AWS SDK credentials chain
+should also work, though the patterns above are the ones we have validated.
+
+Whichever mechanism is used, the resulting identity needs a single permission to talk to STS:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::123456789012:role/polaris-warehouse-access"
+    }
+  ]
+}
+```
+
+`Resource` should list every catalog access role Polaris is expected to assume; use a wildcard
+(for example `arn:aws:iam::123456789012:role/polaris-*`) only when role names follow a strict
+naming convention that the AWS account owner controls.
+
+The ARN of this identity is the `Principal` that the catalog access role's trust policy must
+trust — see the next section. One easy mistake is to update the catalog role's permissions
+without also adding the Polaris service identity to its trust policy; the symptom is
+`STS:AssumeRole` returning `AccessDenied` even though the catalog role has correct S3
+permissions.
+
+For an end-to-end deployment example that exercises this identity on EC2, see
+[Deploying Polaris on AWS]({{% relref "../../getting-started/deploying-polaris/cloud-deploy/deploy-aws" %}}).
+
+## Catalog access role and trust policy
 
 Polaris assumes a customer-managed IAM role via STS when a client requests credentials. The role
 must:

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -50,19 +50,28 @@ export AZURE_CLIENT_ID=<appId>
 export AZURE_CLIENT_SECRET=<password>
 ```
 
-In a container deployment, set the same three variables on the Polaris container/pod. The
-`Storage Blob Data Contributor` role at storage-account scope is what allows Polaris to issue SAS
-tokens for any container under that account; you can scope the role narrower (single container)
-when you need to confine a single Polaris catalog to one container.
+In a Kubernetes deployment, do not embed `AZURE_CLIENT_SECRET` in the pod spec as plain text.
+Store the client secret in a Kubernetes `Secret` (or an external secret store referenced by an
+operator like the Azure Key Vault provider) and project it into the Polaris container with
+`envFrom`/`valueFrom: secretKeyRef`. The same applies to the bootstrap credentials in
+`POLARIS_BOOTSTRAP_CREDENTIALS`.
+
+The `Storage Blob Data Contributor` role at storage-account scope lets Polaris issue SAS tokens
+for any container under that account; scope the role narrower (single container) when you want to
+confine a single Polaris catalog to one container.
 
 ## Storage account requirements
 
 The storage account that backs the catalog should be configured with:
 
-- **Hierarchical namespace (HNS)** enabled — this turns the account into ADLS Gen2 and is required
-  for directory-aware operations (rename, recursive list) that Iceberg relies on for atomic
-  metadata commits. If HNS is disabled, set `hierarchical: false` so Polaris will request flat-blob
-  permissions only and avoid scoping SAS tokens to non-existent directory ACLs.
+- **Hierarchical namespace (HNS)** is not strictly required by Polaris or Iceberg for table
+  operations themselves. Its main effect is on how narrowly Polaris can scope a vended SAS token:
+  with HNS enabled, Polaris can downscope a token to the directory (folder) that backs the
+  requested namespace or table; without HNS the token can only be scoped at the container level.
+  Production deployments that need per-namespace isolation should enable HNS.
+- The `hierarchical` field in `storageConfigInfo` must match the actual state of the storage
+  account. If they disagree, vended tokens are scoped against directory ACLs that do not exist
+  on the storage side and runtime access errors result.
 - A **container** that will hold the catalog's namespaces and tables (for example `warehouse`).
   Polaris does not create the container itself.
 - **Firewall** rules that permit traffic from the Polaris control plane and from the engines that
@@ -99,10 +108,10 @@ curl -X POST https://<polaris-host>/management/v1/catalogs \
 `default-base-location` must use the `abfss://` scheme together with the ADLS Gen2 endpoint
 (`<account>.dfs.core.windows.net`). The `wasbs://` scheme is not supported.
 
-`AzureStorageConfigurationInfo` also accepts `multiTenantAppName` and `consentUrl`. These are
-used by managed Polaris deployments that present a single multi-tenant Azure AD application to
-many customer tenants; in a self-hosted deployment that authenticates with its own service
-principal they can be omitted.
+`AzureStorageConfigurationInfo` also accepts `multiTenantAppName` and `consentUrl`. Current
+Apache Polaris code does not use these fields when communicating with Azure APIs; they are
+informational and can be omitted in self-hosted deployments that authenticate with a service
+principal as described above.
 
 ## SAS token scoping and HNS ACLs
 

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -163,10 +163,28 @@ iceberg.rest-catalog.oauth2.scope=PRINCIPAL_ROLE:ALL
 iceberg.rest-catalog.oauth2.server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens
 ```
 
-For PyIceberg, use the `rest` catalog type. Polaris vends per-account SAS tokens to the FileIO at
-table-load time. The credentials are returned under keys of the form
-`adls.sas-token.<storage-account>` (with optional `dfs.core.windows.net` /
-`blob.core.windows.net` suffixes when scoping requires it), as defined in
+For PyIceberg, use the `rest` catalog type and forward the vended-credential header as a REST
+header:
+
+```python
+from pyiceberg.catalog.rest import RestCatalog
+
+cat = RestCatalog(
+    name="polaris",
+    **{
+        "uri": "https://<polaris-host>/api/catalog",
+        "warehouse": "warehouse_azure",
+        "credential": "<client-id>:<client-secret>",
+        "scope": "PRINCIPAL_ROLE:ALL",
+        "oauth2-server-uri": "https://<polaris-host>/api/catalog/v1/oauth/tokens",
+        "header.X-Iceberg-Access-Delegation": "vended-credentials",
+    },
+)
+```
+
+Polaris vends per-account SAS tokens to the FileIO at table-load time. The credentials are
+returned under keys of the form `adls.sas-token.<storage-account>` (with optional
+`dfs.core.windows.net` / `blob.core.windows.net` suffixes when scoping requires it), as defined in
 `StorageAccessProperty`. The PyIceberg client picks these up directly; no static account key or
 SAS token needs to be configured.
 
@@ -184,7 +202,13 @@ If any operation fails:
 - Errors from Azure AD (`AADSTS*`) usually mean the service principal credentials in
   `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID` are wrong, the secret has expired,
   or the principal has no role assignment on the storage account.
-- 403 from `dfs.core.windows.net` paths typically points at an HNS ACL mismatch on the base
-  location, or the role assignment is at a narrower scope than the path being accessed.
+- `Failed to get subscoped credentials` with `Status code 403` and an
+  `AuthorizationPermissionMismatch` Azure error body means the service principal does not have a
+  data-plane role (`Storage Blob Data Contributor` or equivalent) at a scope that covers the path
+  being accessed. Granting the role on the storage account — or the specific container — and
+  waiting for RBAC propagation resolves it.
+- 403 from `dfs.core.windows.net` paths with no Azure error code typically points at an HNS ACL
+  mismatch on the base location when HNS is enabled and a narrow ACL is in place on the
+  directory.
 - 404 on container-level operations indicates that the container does not yet exist; Polaris does
   not create containers, only directories and blobs underneath them.

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -1,0 +1,154 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: Configuring Azure Blob Cloud Storage
+linkTitle: Configuring Azure Blob Cloud Storage
+type: docs
+weight: 620
+---
+
+This page covers configuring Azure Blob Storage and Azure Data Lake Storage Gen2 (ADLS Gen2) as
+the storage backend for a Polaris catalog. Polaris vends short-lived SAS tokens to clients after
+authenticating itself against a customer Azure AD tenant; the multi-tenant application that
+represents Polaris must be admitted to that tenant before catalog operations succeed.
+
+## Tenant admission
+
+Polaris runs as a multi-tenant Azure AD application. Before it can vend credentials for a bucket
+in a customer tenant, an Azure AD administrator of that tenant must consent to the application.
+On catalog creation Polaris returns a `consentUrl` that points at the standard Microsoft consent
+endpoint; opening that URL with an account that has tenant-admin privileges grants the application
+the role assignments required to read and write the storage account.
+
+The same fields are surfaced by `AzureStorageConfigurationInfo`:
+
+- `tenantId` — the Azure AD tenant that owns the storage account.
+- `multiTenantAppName` — the application identifier Polaris will use; provided by your Polaris
+  deployment.
+- `consentUrl` — the URL the tenant admin must visit.
+
+Until consent has been granted, `loadTable` and similar operations will fail with an Azure AD
+`AADSTS65001` or `AADSTS700016` error.
+
+## Storage account requirements
+
+The storage account that backs the catalog should be configured with:
+
+- **Hierarchical namespace (HNS)** enabled — this turns the account into ADLS Gen2 and is required
+  for directory-aware operations (rename, recursive list) that Iceberg relies on for atomic
+  metadata commits. If HNS is disabled, set `hierarchical: false` so Polaris will request flat-blob
+  permissions only and avoid scoping SAS tokens to non-existent directory ACLs.
+- **Storage Blob Data Contributor** role granted to the Polaris application on the account (or on
+  the specific container if you want to scope access narrowly). Polaris cannot vend a token wider
+  than the role assignment it holds.
+- **Firewall** rules that permit traffic from the Polaris control plane and from the engines that
+  will read the data. SAS tokens do not bypass storage-account firewalls.
+
+## Catalog storage configuration
+
+```bash
+curl -X POST https://<polaris-host>/management/v1/catalogs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "type": "INTERNAL",
+        "name": "warehouse_azure",
+        "storageConfigInfo": {
+          "storageType": "AZURE",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "multiTenantAppName": "polaris-storage",
+          "hierarchical": true
+        },
+        "properties": {
+          "default-base-location": "abfss://warehouse@example.dfs.core.windows.net/prod/"
+        }
+      }'
+```
+
+The response includes `consentUrl`. Send it to the tenant administrator and wait for consent
+before issuing further requests against the catalog.
+
+`default-base-location` must use the `abfss://` scheme together with the ADLS Gen2 endpoint
+(`<account>.dfs.core.windows.net`). The `wasbs://` scheme is not supported.
+
+## SAS token scoping and HNS ACLs
+
+When HNS is enabled (`hierarchical: true`), Polaris narrows each vended SAS token to the directory
+that backs the requested namespace or table. The ADLS Gen2 ACL on that directory must include the
+Polaris application as well as any extra principals that should read the data outside of vended
+credentials.
+
+A common failure mode is a token that grants object-level permissions but is denied by a
+directory-level ACL. The 403 returned by ADLS includes the path that was denied; align the ACL on
+that exact prefix to recover.
+
+When HNS is disabled, set `hierarchical: false`. Polaris will then issue SAS tokens scoped at the
+container level rather than per-directory; this is acceptable for small deployments but does not
+restrict cross-namespace access.
+
+## Client configuration
+
+Engines call Polaris through the Iceberg REST API and receive SAS-token properties at table-load
+time; they do not need static Azure credentials when consent is in place.
+
+Spark with the Azure file-system driver:
+
+```properties
+spark.sql.catalog.warehouse_azure=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.warehouse_azure.type=rest
+spark.sql.catalog.warehouse_azure.uri=https://<polaris-host>/api/catalog
+spark.sql.catalog.warehouse_azure.warehouse=warehouse_azure
+spark.sql.catalog.warehouse_azure.header.X-Iceberg-Access-Delegation=vended-credentials
+spark.sql.catalog.warehouse_azure.io-impl=org.apache.iceberg.azure.adlsv2.ADLSFileIO
+```
+
+The Spark application must include `iceberg-azure` (or `iceberg-azure-bundle`) and
+`hadoop-azure` on the classpath; Polaris itself does not ship these jars to the engine.
+
+Trino:
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=https://<polaris-host>/api/catalog
+iceberg.rest-catalog.warehouse=warehouse_azure
+iceberg.rest-catalog.vended-credentials-enabled=true
+```
+
+For PyIceberg, use the `rest` catalog type and rely on the `adls.sas-token` property returned by
+Polaris.
+
+## Verifying the setup
+
+After consent has been granted:
+
+```sql
+CREATE NAMESPACE warehouse_azure.demo;
+CREATE TABLE warehouse_azure.demo.t (id BIGINT, name STRING) USING iceberg;
+INSERT INTO warehouse_azure.demo.t VALUES (1, 'hello');
+SELECT * FROM warehouse_azure.demo.t;
+```
+
+If any operation fails:
+
+- `AADSTS` errors usually mean consent has not been granted or `tenantId` is wrong.
+- 403 from `dfs.core.windows.net` paths typically points at an HNS ACL mismatch on the base
+  location.
+- 404 on container-level operations indicates that the container does not yet exist; Polaris does
+  not create containers, only directories and blobs underneath them.

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -107,32 +107,51 @@ restrict cross-namespace access.
 Engines call Polaris through the Iceberg REST API and receive SAS-token properties at table-load
 time; they do not need static Azure credentials when consent is in place.
 
-Spark with the Azure file-system driver:
+Spark example, matching the property names used by the existing MinIO / RustFS guides:
 
-```properties
-spark.sql.catalog.warehouse_azure=org.apache.iceberg.spark.SparkCatalog
-spark.sql.catalog.warehouse_azure.type=rest
-spark.sql.catalog.warehouse_azure.uri=https://<polaris-host>/api/catalog
-spark.sql.catalog.warehouse_azure.warehouse=warehouse_azure
-spark.sql.catalog.warehouse_azure.header.X-Iceberg-Access-Delegation=vended-credentials
-spark.sql.catalog.warehouse_azure.io-impl=org.apache.iceberg.azure.adlsv2.ADLSFileIO
+```shell
+bin/spark-sql \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.1,org.apache.iceberg:iceberg-azure-bundle:1.10.1 \
+    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+    --conf spark.sql.catalog.polaris=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.polaris.type=rest \
+    --conf spark.sql.catalog.polaris.uri=https://<polaris-host>/api/catalog \
+    --conf spark.sql.catalog.polaris.oauth2-server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens \
+    --conf spark.sql.catalog.polaris.token-refresh-enabled=false \
+    --conf spark.sql.catalog.polaris.warehouse=warehouse_azure \
+    --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
+    --conf spark.sql.catalog.polaris.credential=<client-id>:<client-secret> \
+    --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=vended-credentials \
+    --conf spark.sql.catalog.polaris.io-impl=org.apache.iceberg.azure.adlsv2.ADLSFileIO
 ```
 
-The Spark application must include `iceberg-azure` (or `iceberg-azure-bundle`) and
-`hadoop-azure` on the classpath; Polaris itself does not ship these jars to the engine.
+The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls back to a
+hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback
+is slated for removal in a future Iceberg release.
 
-Trino:
+The Spark application must include the Iceberg Azure bundle (or `iceberg-azure` and the matching
+Hadoop / Azure jars) on the classpath; Polaris does not ship these jars to the engine.
+
+For Trino, use the Iceberg connector with the REST catalog, in the same shape as the AWS S3
+example on the sibling page:
 
 ```properties
 connector.name=iceberg
 iceberg.catalog.type=rest
 iceberg.rest-catalog.uri=https://<polaris-host>/api/catalog
 iceberg.rest-catalog.warehouse=warehouse_azure
-iceberg.rest-catalog.vended-credentials-enabled=true
+iceberg.rest-catalog.security=OAUTH2
+iceberg.rest-catalog.oauth2.credential=<client-id>:<client-secret>
+iceberg.rest-catalog.oauth2.scope=PRINCIPAL_ROLE:ALL
+iceberg.rest-catalog.oauth2.server-uri=https://<polaris-host>/api/catalog/v1/oauth/tokens
 ```
 
-For PyIceberg, use the `rest` catalog type and rely on the `adls.sas-token` property returned by
-Polaris.
+For PyIceberg, use the `rest` catalog type. Polaris vends per-account SAS tokens to the FileIO at
+table-load time. The credentials are returned under keys of the form
+`adls.sas-token.<storage-account>` (with optional `dfs.core.windows.net` /
+`blob.core.windows.net` suffixes when scoping requires it), as defined in
+`StorageAccessProperty`. The PyIceberg client picks these up directly; no static account key or
+SAS token needs to be configured.
 
 ## Verifying the setup
 

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -24,27 +24,36 @@ weight: 620
 ---
 
 This page covers configuring Azure Blob Storage and Azure Data Lake Storage Gen2 (ADLS Gen2) as
-the storage backend for a Polaris catalog. Polaris vends short-lived SAS tokens to clients after
-authenticating itself against a customer Azure AD tenant; the multi-tenant application that
-represents Polaris must be admitted to that tenant before catalog operations succeed.
+the storage backend for a Polaris catalog. Polaris authenticates against Azure with the credentials
+of a service principal that has data-plane access to the target storage account, and then vends
+short-lived SAS tokens to clients on each table-load request.
 
-## Tenant admission
+## Service principal and Polaris credentials
 
-Polaris runs as a multi-tenant Azure AD application. Before it can vend credentials for a bucket
-in a customer tenant, an Azure AD administrator of that tenant must consent to the application.
-On catalog creation Polaris returns a `consentUrl` that points at the standard Microsoft consent
-endpoint; opening that URL with an account that has tenant-admin privileges grants the application
-the role assignments required to read and write the storage account.
+Polaris uses the Azure SDK's `DefaultAzureCredential` chain, which by default reads the
+service-principal credentials from environment variables. Create a service principal with data
+access to the storage account and pass its credentials to the Polaris process:
 
-The same fields are surfaced by `AzureStorageConfigurationInfo`:
+```bash
+# Replace <subscription>, <resource-group>, <storage-account> with your values.
+az ad sp create-for-rbac \
+  --name polaris-storage \
+  --role "Storage Blob Data Contributor" \
+  --scopes "/subscriptions/<subscription>/resourceGroups/<resource-group>/providers/Microsoft.Storage/storageAccounts/<storage-account>"
+```
 
-- `tenantId` — the Azure AD tenant that owns the storage account.
-- `multiTenantAppName` — the application identifier Polaris will use; provided by your Polaris
-  deployment.
-- `consentUrl` — the URL the tenant admin must visit.
+The command prints `appId`, `password`, and `tenant`. Set these on the Polaris server:
 
-Until consent has been granted, `loadTable` and similar operations will fail with an Azure AD
-`AADSTS65001` or `AADSTS700016` error.
+```bash
+export AZURE_TENANT_ID=<tenant>
+export AZURE_CLIENT_ID=<appId>
+export AZURE_CLIENT_SECRET=<password>
+```
+
+In a container deployment, set the same three variables on the Polaris container/pod. The
+`Storage Blob Data Contributor` role at storage-account scope is what allows Polaris to issue SAS
+tokens for any container under that account; you can scope the role narrower (single container)
+when you need to confine a single Polaris catalog to one container.
 
 ## Storage account requirements
 
@@ -54,44 +63,52 @@ The storage account that backs the catalog should be configured with:
   for directory-aware operations (rename, recursive list) that Iceberg relies on for atomic
   metadata commits. If HNS is disabled, set `hierarchical: false` so Polaris will request flat-blob
   permissions only and avoid scoping SAS tokens to non-existent directory ACLs.
-- **Storage Blob Data Contributor** role granted to the Polaris application on the account (or on
-  the specific container if you want to scope access narrowly). Polaris cannot vend a token wider
-  than the role assignment it holds.
+- A **container** that will hold the catalog's namespaces and tables (for example `warehouse`).
+  Polaris does not create the container itself.
 - **Firewall** rules that permit traffic from the Polaris control plane and from the engines that
   will read the data. SAS tokens do not bypass storage-account firewalls.
 
 ## Catalog storage configuration
+
+With the service principal in place on the server, create the catalog with the storage account's
+tenant ID and the `abfss://` location:
 
 ```bash
 curl -X POST https://<polaris-host>/management/v1/catalogs \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-        "type": "INTERNAL",
-        "name": "warehouse_azure",
-        "storageConfigInfo": {
-          "storageType": "AZURE",
-          "tenantId": "00000000-0000-0000-0000-000000000000",
-          "multiTenantAppName": "polaris-storage",
-          "hierarchical": true
-        },
-        "properties": {
-          "default-base-location": "abfss://warehouse@example.dfs.core.windows.net/prod/"
+        "catalog": {
+          "type": "INTERNAL",
+          "name": "warehouse_azure",
+          "properties": {
+            "default-base-location": "abfss://warehouse@example.dfs.core.windows.net/prod/"
+          },
+          "storageConfigInfo": {
+            "storageType": "AZURE",
+            "tenantId": "00000000-0000-0000-0000-000000000000",
+            "hierarchical": true,
+            "allowedLocations": [
+              "abfss://warehouse@example.dfs.core.windows.net/"
+            ]
+          }
         }
       }'
 ```
 
-The response includes `consentUrl`. Send it to the tenant administrator and wait for consent
-before issuing further requests against the catalog.
-
 `default-base-location` must use the `abfss://` scheme together with the ADLS Gen2 endpoint
 (`<account>.dfs.core.windows.net`). The `wasbs://` scheme is not supported.
+
+`AzureStorageConfigurationInfo` also accepts `multiTenantAppName` and `consentUrl`. These are
+used by managed Polaris deployments that present a single multi-tenant Azure AD application to
+many customer tenants; in a self-hosted deployment that authenticates with its own service
+principal they can be omitted.
 
 ## SAS token scoping and HNS ACLs
 
 When HNS is enabled (`hierarchical: true`), Polaris narrows each vended SAS token to the directory
 that backs the requested namespace or table. The ADLS Gen2 ACL on that directory must include the
-Polaris application as well as any extra principals that should read the data outside of vended
+service principal as well as any extra principals that should read the data outside of vended
 credentials.
 
 A common failure mode is a token that grants object-level permissions but is denied by a
@@ -105,7 +122,7 @@ restrict cross-namespace access.
 ## Client configuration
 
 Engines call Polaris through the Iceberg REST API and receive SAS-token properties at table-load
-time; they do not need static Azure credentials when consent is in place.
+time; they do not need static Azure credentials on the client side.
 
 Spark example, matching the property names used by the existing MinIO / RustFS guides:
 
@@ -155,8 +172,6 @@ SAS token needs to be configured.
 
 ## Verifying the setup
 
-After consent has been granted:
-
 ```sql
 CREATE NAMESPACE warehouse_azure.demo;
 CREATE TABLE warehouse_azure.demo.t (id BIGINT, name STRING) USING iceberg;
@@ -166,8 +181,10 @@ SELECT * FROM warehouse_azure.demo.t;
 
 If any operation fails:
 
-- `AADSTS` errors usually mean consent has not been granted or `tenantId` is wrong.
+- Errors from Azure AD (`AADSTS*`) usually mean the service principal credentials in
+  `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID` are wrong, the secret has expired,
+  or the principal has no role assignment on the storage account.
 - 403 from `dfs.core.windows.net` paths typically points at an HNS ACL mismatch on the base
-  location.
+  location, or the role assignment is at a narrower scope than the path being accessed.
 - 404 on container-level operations indicates that the container does not yet exist; Polaris does
   not create containers, only directories and blobs underneath them.


### PR DESCRIPTION
## Summary
Adds production configuration pages for AWS S3 and Azure Blob storage backends, mirroring the existing GCS page. Implements Option 1 of #1325 as agreed with @flyrain. GCS page enhancement and skill.md are intentionally left for follow-up PRs.

Two new pages under `site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/`:
- `configuring-aws-s3-cloud-storage-specific.md`
- `configuring-azure-blob-cloud-storage-specific.md`

Each covers server-side `storageConfigInfo` fields, client wiring for Spark / Trino / PyIceberg, and a verification SQL snippet.

## Verified end-to-end while writing this
- MinIO + Polaris + Spark / Trino / PyIceberg 0.11.1: CREATE / INSERT / SELECT round-trips. Findings folded into the page (the required `vended-credentials-enabled` and native-S3 properties for Trino, and the `header.X-Iceberg-Access-Delegation` REST header for PyIceberg).
- Ceph RGW with STS disabled: produced `Failed to get subscoped credentials` STS 400 — informed the new "Backends without STS support" subsection.
- ADLS Gen2 (HNS) with a service principal: happy-path round-trip.
- ADLS Gen2 with the SP's `Storage Blob Data Contributor` removed: reproduced `AuthorizationPermissionMismatch` 403 — informed the Azure troubleshooting bullet.

AWS IAM trust-policy / KMS specifics and HNS directory-ACL behavior are described conservatively based on docs and the corresponding Polaris classes rather than from a live test against those exact features.

## Test plan
- [x] Hugo site build succeeds locally (186 pages, no errors)
- [x] Both new pages appear in the production-config sidebar
- [ ] CI Hugo build passes
- [ ] Reviewers confirm the conservative bullets (AWS IAM/KMS, Azure HNS ACL) match operational reality