### PR TITLE
Enable Copilot for PR reviews

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,11 @@ github:
 
   del_branch_on_merge: true
 
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: false
+
   protected_branches:
     main:
       required_pull_request_reviews:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+When reviewing pull requests, stay silent unless the diff gives a concrete
+reason to believe a high-value documentation, security, or test coverage update
+may be missing.
+
+Only comment when you can name the changed behavior, the likely impacted
+documentation or test area, and why the diff suggests an omission.
+
+Prefer no comment over speculative advice. Do not state that documentation,
+tests, security, or implementation are correct or complete. Use cautious
+language such as "Please check whether..." or "A human reviewer should verify..."
+
+No comment is not approval and does not imply that the PR is correct, complete,
+sufficiently tested, secure, or fully documented.

--- a/.github/instructions/generated-files.instructions.md
+++ b/.github/instructions/generated-files.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "**"
+---
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+Avoid detailed review comments on generated files. If a generated file appears
+stale or inconsistent, point reviewers to the likely source input or generator
+instead of proposing manual edits to generated output.
+
+For generated documentation, OpenAPI output, configuration references, Helm
+schema/docs, or generated clients, prefer comments such as "Please check whether
+the generator or source input needs to be updated and regenerated."
+
+Do not ask reviewers to update generated, checked-out, or build-time-only release
+documentation unless those files are present in the PR diff.

--- a/.github/instructions/polaris-review-omissions.instructions.md
+++ b/.github/instructions/polaris-review-omissions.instructions.md
@@ -1,0 +1,45 @@
+---
+applyTo: "**"
+---
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+Look for changes that may need human review for missing documentation, tests, or
+security notes.
+
+Comment only when the diff changes one of these areas and no matching update is
+visible:
+
+- security boundaries, authentication, authorization, secrets, credentials,
+  trust assumptions, external integrations, storage access, network exposure, or
+  privilege model
+- coding-agent expectations, contribution workflow, build/test commands, review
+  policy, or repository conventions
+- user-visible behavior, configuration, CLI behavior, Helm behavior, APIs,
+  deployment behavior, or operational guidance
+
+Likely documentation targets include `SECURITY-THREAT-MODEL.md`, `SECURITY.md`,
+`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, Helm README files,
+`site/content/in-dev/**`, and user-facing site docs tracked in this repository
+under `site/content/**`. Do not ask reviewers to update generated or
+build-time-only release docs unless those files are present in the PR diff.
+
+When reviewing updates to an existing PR, do not repeat prior comments. Only
+comment on newly introduced or newly changed risks visible in the latest diff.

--- a/.github/scripts/check-copilot-instructions.sh
+++ b/.github/scripts/check-copilot-instructions.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+readonly max_chars="${COPILOT_INSTRUCTIONS_MAX_CHARS:-3500}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+mapfile -t instruction_files < <(
+  {
+    [[ -f .github/copilot-instructions.md ]] && printf '%s\n' .github/copilot-instructions.md
+    find .github/instructions -type f -name '*.instructions.md' 2>/dev/null || true
+  } | sort
+)
+
+if [[ "${#instruction_files[@]}" -eq 0 ]]; then
+  echo "No Copilot instruction files found."
+  exit 0
+fi
+
+failed=0
+
+for file in "${instruction_files[@]}"; do
+  chars="$(wc -m < "$file" | tr -d '[:space:]')"
+  remaining=$((max_chars - chars))
+
+  if ((chars > max_chars)); then
+    echo "ERROR: $file has $chars characters, exceeding limit $max_chars."
+    failed=1
+  else
+    echo "$file: $chars characters ($remaining remaining)"
+  fi
+
+  if [[ "$file" == .github/instructions/*.instructions.md ]]; then
+    if [[ "$(sed -n '1p' "$file")" != "---" ]] ||
+      ! sed -n '2,/^---$/p' "$file" | grep -q '^applyTo:'; then
+      echo "ERROR: $file must start with YAML frontmatter containing applyTo."
+      failed=1
+    fi
+  fi
+done
+
+exit "$failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             echo "ERROR: Configuration reference is out of date. Please run './gradlew :polaris-config-docs-site:copyConfigSectionsToSite' and commit the changes."
             exit 1
           fi
+      - name: Verify Copilot instructions
+        run: .github/scripts/check-copilot-instructions.sh
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
       - name: Archive test results


### PR DESCRIPTION
This change opts the Apache Polaris repository in to GitHub Copilot code review through `.asf.yaml` for initial non-draft PR reviews.

The repository instructions ask Copilot to stay quiet unless the diff gives a concrete reason to suspect a missing documentation, test, or security-review update. The instructions focus on omission detection rather than certifying code correctness, test sufficiency, or documentation completeness.

A CI check validates that Copilot instruction files keep path-specific frontmatter, and conservative size limits (there's a limit on the byte-size of GH Copilot instructions).

Copilot review comments are advisory only, and not authoritative for merge readiness.