### PR TITLE
AGENTS.md: disclose AI assistance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@ A human author is responsible for every change an agent produces. See
 [CONTRIBUTING.md](CONTRIBUTING.md#guidelines-for-ai-assisted-contributions) for the
 full AI-assisted contribution policy.
 
+If AI assistance was used to prepare a change, include this disclosure in the PR
+description:
+
+> AI assistance was used to prepare this change. I have reviewed and understand
+> the full diff, and I take responsibility for the contribution.
+
+Do not describe AI tools as authors or co-authors. Do not include model names,
+model versions, prompts, or reasoning settings unless a maintainer explicitly asks
+for them during review. The human PR author is responsible for the contribution.
+
 This document has two types of rules:
 - **Hard gate** — mechanically verifiable, blocking. If it fails, do not submit.
 - **Discipline** — behavioral rule for how you work. Not mechanically verifiable,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,16 +27,6 @@ A human author is responsible for every change an agent produces. See
 [CONTRIBUTING.md](CONTRIBUTING.md#guidelines-for-ai-assisted-contributions) for the
 full AI-assisted contribution policy.
 
-If AI assistance was used to prepare a change, include this disclosure in the PR
-description:
-
-> AI assistance was used to prepare this change. I have reviewed and understand
-> the full diff, and I take responsibility for the contribution.
-
-Do not describe AI tools as authors or co-authors. Do not include model names,
-model versions, prompts, or reasoning settings unless a maintainer explicitly asks
-for them during review. The human PR author is responsible for the contribution.
-
 This document has two types of rules:
 - **Hard gate** — mechanically verifiable, blocking. If it fails, do not submit.
 - **Discipline** — behavioral rule for how you work. Not mechanically verifiable,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,13 @@ Contributors may use a variety of tools when preparing changes to Polaris, inclu
 * Regardless of how a change is produced, the individual submitting the pull request is considered the author of the contribution and is fully responsible for it.
 * The pull request author **must understand the implementation end-to-end** and be able to **explain and justify the design and code** during review.
 * Tools, including AI systems, **are not** considered contributors. **Responsibility and authorship remain with the human** submitting the change.
+  Do not list AI tools as authors or co-authors, and do not include model names,
+  model versions, prompts, or reasoning settings unless a maintainer explicitly asks
+  for them during review.
 * Contributors are encouraged to **disclose** significant AI assistance in the pull request description for transparency.
+  A suitable disclosure is:
+  > AI assistance was used to prepare this change. I have reviewed and understand
+  > the full diff, and I take responsibility for the contribution.
 * **Respect ASF policy**. Contributors are responsible for ensuring generated code can be contributed to Polaris under ASF license and [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).
 
 ## Java version requirements


### PR DESCRIPTION
A best-effort change to let agents disclose the AI assistance in PR descriptions.