### PR TITLE
chore: bump Spark base image from 3.5.6 to 3.5.8

### DIFF
--- a/plugins/spark/v3.5/getting-started/notebooks/Dockerfile
+++ b/plugins/spark/v3.5/getting-started/notebooks/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM docker.io/apache/spark:3.5.6-java17
+FROM docker.io/apache/spark:3.5.8-java17
 
 ENV PYSPARK_PYTHON=/home/spark/venv/bin/python \
     PYTHONPATH="${SPARK_HOME}/python/:${SPARK_HOME}/python/lib/py4j-0.10.9.7-src.zip:/home/spark/venv/lib/python3.10/site-packages"

--- a/plugins/spark/v3.5/regtests/Dockerfile
+++ b/plugins/spark/v3.5/regtests/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM docker.io/apache/spark:3.5.6-java17
+FROM docker.io/apache/spark:3.5.8-java17
 
 ARG POLARIS_HOST=polaris \
     CURRENT_SCALA_VERSION=2.12

--- a/regtests/Dockerfile
+++ b/regtests/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM docker.io/apache/spark:3.5.6-java17-python3
+FROM docker.io/apache/spark:3.5.8-java17-python3
 
 ARG POLARIS_HOST=polaris
 

--- a/site/content/guides/spark/notebooks/Dockerfile
+++ b/site/content/guides/spark/notebooks/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM docker.io/apache/spark:3.5.6-java17
+FROM docker.io/apache/spark:3.5.8-java17
 
 ENV PYSPARK_PYTHON=/home/spark/venv/bin/python \
     PYTHONPATH="${SPARK_HOME}/python/:${SPARK_HOME}/python/lib/py4j-0.10.9.7-src.zip:/home/spark/venv/lib/python3.10/site-packages"


### PR DESCRIPTION
Updates Apache Spark base images from 3.5.6 to 3.5.8 in Spark-related Dockerfiles.

Files updated:

* regtests/Dockerfile
* plugins/spark/v3.5/regtests/Dockerfile
* plugins/spark/v3.5/getting-started/notebooks/Dockerfile
* site/content/guides/spark/notebooks/Dockerfile

This is a patch-level Spark update with no expected API or behavior changes.

## Checklist

* [x] 🧪 Manually verified updated Docker image versions in all affected Dockerfiles
* [ ] 🧾 Updated `CHANGELOG.md` (not needed)
* [ ] 📚 Updated documentation (not needed)
