### PR TITLE
regtests: replace fragile awk JSON parsing with jq

### DIFF
--- a/regtests/run.sh
+++ b/regtests/run.sh
@@ -101,13 +101,13 @@ if [[ -z "$REGTEST_ROOT_BEARER_TOKEN" ]]; then
     exit 1
   fi
 
-  token=$(echo "$output" | awk -F\" '{print $4}')
+  token=$(echo "$output" | jq -r '.access_token // empty')
 
-  if [ "$token" == "unauthorized_client" ]; then
-    logred "Error: Failed to retrieve bearer token"
+  if [ -z "$token" ]; then
+    logred "Error: Failed to retrieve bearer token — response: $output"
     exit 1
   fi
-
+  
   export REGTEST_ROOT_BEARER_TOKEN=$token
 fi
 


### PR DESCRIPTION
## Summary

Replace fragile awk-based JSON token parsing in `regtests/run.sh` with `jq`.

The previous implementation assumed the OAuth access token was always the 4th quoted field in the JSON response, which is fragile and can silently break if:

* JSON field ordering changes
* the server returns a different error payload
* the response is malformed or empty

This change:

* uses `jq` to reliably extract `.access_token`
* validates that the token is non-empty before exporting it
* improves failure visibility for OAuth/authentication issues


## Checklist
Manually verified token extraction and failure handling logic in `regtests/run.sh`.
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
