### PR TITLE
 Handle failed identity resolution gracefully in PolarisEventMetadataFactory

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadataFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadataFactory.java
@@ -29,6 +29,7 @@ import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import io.quarkus.security.AuthenticationFailedException;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.service.tracing.RequestIdFilter;
@@ -105,8 +106,11 @@ public class PolarisEventMetadataFactory {
    * Resolves the current security identity if available.
    *
    * <p>Returns {@link Optional#empty()} if the identity has not been resolved yet, or if the
-   * deferred identity resolution failed (e.g. on unauthenticated endpoints where the auth pipeline
-   * throws when triggered).
+   * deferred identity resolution failed with an {@link AuthenticationFailedException} (e.g. on
+   * unauthenticated endpoints where the auth pipeline throws when triggered).
+   *
+   * <p>Other exceptions (e.g. {@link org.apache.iceberg.exceptions.ServiceFailureException}) are
+   * not suppressed and will propagate to the caller.
    */
   private Optional<SecurityIdentity> getSecurityIdentity() {
     try {
@@ -116,8 +120,11 @@ public class PolarisEventMetadataFactory {
               .subscribeAsCompletionStage()
               .getNow(null));
     } catch (CompletionException e) {
-      LOGGER.debug("Failed to resolve security identity", e);
-      return Optional.empty();
+      if (e.getCause() instanceof AuthenticationFailedException) {
+        LOGGER.debug("Failed to resolve security identity", e);
+        return Optional.empty();
+      }
+      throw e;
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadataFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadataFactory.java
@@ -28,15 +28,19 @@ import jakarta.inject.Inject;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.service.tracing.RequestIdFilter;
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.jaxrs.ContainerRequestContextImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class PolarisEventMetadataFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PolarisEventMetadataFactory.class);
 
   @Inject Clock clock;
   @Inject CurrentIdentityAssociation currentIdentityAssociation;
@@ -92,11 +96,29 @@ public class PolarisEventMetadataFactory {
    * taken place, e.g. in pre-authentication filters.
    */
   private Optional<PolarisPrincipal> getUser() {
-    SecurityIdentity identity =
-        currentIdentityAssociation.getDeferredIdentity().subscribeAsCompletionStage().getNow(null);
-    return identity == null || identity.isAnonymous()
-        ? Optional.empty()
-        : Optional.of(identity.getPrincipal(PolarisPrincipal.class));
+    return getSecurityIdentity()
+        .filter(identity -> !identity.isAnonymous())
+        .map(identity -> identity.getPrincipal(PolarisPrincipal.class));
+  }
+
+  /**
+   * Resolves the current security identity if available.
+   *
+   * <p>Returns {@link Optional#empty()} if the identity has not been resolved yet, or if the
+   * deferred identity resolution failed (e.g. on unauthenticated endpoints where the auth pipeline
+   * throws when triggered).
+   */
+  private Optional<SecurityIdentity> getSecurityIdentity() {
+    try {
+      return Optional.ofNullable(
+          currentIdentityAssociation
+              .getDeferredIdentity()
+              .subscribeAsCompletionStage()
+              .getNow(null));
+    } catch (CompletionException e) {
+      LOGGER.debug("Failed to resolve security identity", e);
+      return Optional.empty();
+    }
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventMetadataFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventMetadataFactoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.apache.polaris.core.auth.ImmutablePolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.context.RealmContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PolarisEventMetadataFactoryTest {
+
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final String TEST_REALM = "test-realm";
+
+  @Mock private CurrentIdentityAssociation currentIdentityAssociation;
+  @Mock private Instance<RealmContext> realmContext;
+  @Mock private RealmContext realmContextInstance;
+  @Mock private SecurityIdentity securityIdentity;
+
+  @InjectMocks private PolarisEventMetadataFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    factory.clock = Clock.fixed(FIXED_INSTANT, ZoneId.of("UTC"));
+    when(realmContext.isResolvable()).thenReturn(true);
+    when(realmContext.get()).thenReturn(realmContextInstance);
+    when(realmContextInstance.getRealmIdentifier()).thenReturn(TEST_REALM);
+  }
+
+  @Test
+  void createReturnsMetadataWithUserWhenIdentityResolved() {
+    PolarisPrincipal principal = ImmutablePolarisPrincipal.builder().name("test-user").build();
+    when(currentIdentityAssociation.getDeferredIdentity())
+        .thenReturn(Uni.createFrom().item(securityIdentity));
+    when(securityIdentity.isAnonymous()).thenReturn(false);
+    when(securityIdentity.getPrincipal(PolarisPrincipal.class)).thenReturn(principal);
+
+    PolarisEventMetadata metadata = factory.create();
+
+    assertThat(metadata.realmId()).isEqualTo(TEST_REALM);
+    assertThat(metadata.timestamp()).isEqualTo(FIXED_INSTANT);
+    assertThat(metadata.user()).contains(principal);
+  }
+
+  @Test
+  void createReturnsEmptyUserWhenIdentityIsAnonymous() {
+    when(currentIdentityAssociation.getDeferredIdentity())
+        .thenReturn(Uni.createFrom().item(securityIdentity));
+    when(securityIdentity.isAnonymous()).thenReturn(true);
+
+    PolarisEventMetadata metadata = factory.create();
+
+    assertThat(metadata.user()).isEmpty();
+  }
+
+  @Test
+  void createReturnsEmptyUserWhenIdentityNotYetResolved() {
+    // Simulates getNow(null) returning null because the future hasn't completed
+    when(currentIdentityAssociation.getDeferredIdentity())
+        .thenReturn(Uni.createFrom().item(() -> null));
+
+    PolarisEventMetadata metadata = factory.create();
+
+    assertThat(metadata.user()).isEmpty();
+  }
+
+  @Test
+  void createReturnsEmptyUserWhenDeferredIdentityFailsWithCompletionException() {
+    // Simulates the scenario where triggering deferred identity resolution causes
+    // the auth pipeline to fail (e.g., on unauthenticated endpoints like /oauth/tokens)
+    when(currentIdentityAssociation.getDeferredIdentity())
+        .thenReturn(
+            Uni.createFrom().failure(new RuntimeException("Authentication pipeline failed")));
+
+    PolarisEventMetadata metadata = factory.create();
+
+    assertThat(metadata.user()).isEmpty();
+    assertThat(metadata.realmId()).isEqualTo(TEST_REALM);
+    assertThat(metadata.timestamp()).isEqualTo(FIXED_INSTANT);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventMetadataFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventMetadataFactoryTest.java
@@ -19,8 +19,10 @@
 package org.apache.polaris.service.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
@@ -28,6 +30,7 @@ import jakarta.enterprise.inject.Instance;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.concurrent.CompletionException;
 import org.apache.polaris.core.auth.ImmutablePolarisPrincipal;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.RealmContext;
@@ -82,6 +85,8 @@ class PolarisEventMetadataFactoryTest {
 
     PolarisEventMetadata metadata = factory.create();
 
+    assertThat(metadata.realmId()).isEqualTo(TEST_REALM);
+    assertThat(metadata.timestamp()).isEqualTo(FIXED_INSTANT);
     assertThat(metadata.user()).isEmpty();
   }
 
@@ -89,25 +94,40 @@ class PolarisEventMetadataFactoryTest {
   void createReturnsEmptyUserWhenIdentityNotYetResolved() {
     // Simulates getNow(null) returning null because the future hasn't completed
     when(currentIdentityAssociation.getDeferredIdentity())
-        .thenReturn(Uni.createFrom().item(() -> null));
+        .thenReturn(Uni.createFrom().nothing());
 
     PolarisEventMetadata metadata = factory.create();
 
+    assertThat(metadata.realmId()).isEqualTo(TEST_REALM);
+    assertThat(metadata.timestamp()).isEqualTo(FIXED_INSTANT);
     assertThat(metadata.user()).isEmpty();
   }
 
   @Test
-  void createReturnsEmptyUserWhenDeferredIdentityFailsWithCompletionException() {
+  void createReturnsEmptyUserWhenDeferredIdentityFailsWithAuthenticationFailedException() {
     // Simulates the scenario where triggering deferred identity resolution causes
     // the auth pipeline to fail (e.g., on unauthenticated endpoints like /oauth/tokens)
     when(currentIdentityAssociation.getDeferredIdentity())
         .thenReturn(
-            Uni.createFrom().failure(new RuntimeException("Authentication pipeline failed")));
+            Uni.createFrom()
+                .failure(new AuthenticationFailedException("Authentication pipeline failed")));
 
     PolarisEventMetadata metadata = factory.create();
 
     assertThat(metadata.user()).isEmpty();
     assertThat(metadata.realmId()).isEqualTo(TEST_REALM);
     assertThat(metadata.timestamp()).isEqualTo(FIXED_INSTANT);
+  }
+
+  @Test
+  void createPropagatesCompletionExceptionForNonAuthFailures() {
+    // Non-auth exceptions (e.g. ServiceFailureException) should not be suppressed
+    RuntimeException cause = new RuntimeException("Service unavailable");
+    when(currentIdentityAssociation.getDeferredIdentity())
+        .thenReturn(Uni.createFrom().failure(cause));
+
+    assertThatThrownBy(() -> factory.create())
+        .isInstanceOf(CompletionException.class)
+        .hasCause(cause);
   }
 }


### PR DESCRIPTION
`PolarisEventMetadataFactory.create()` calls `getDeferredIdentity().subscribeAsCompletionStage().getNow(null)` to resolve the current user for event metadata. When called before authentication has completed  
  (e.g., in pre-authentication filters), this can trigger the auth pipeline, which may fail with `CompletionException` wrapping an `AuthenticationFailedException`.                                               
                                                                                                                                                                                                                  
  Previously, this exception would propagate to the caller. For example, when the rate limiter filter emits an event before rejecting a request, the leaked   
 Completion exception gets mapped to 500 instead of the intended 429.         

In general, since `user` itself is an optional field, proceed the event dispatching with a null user instead of failing directly could increase the stability and while we can still see/notice the actual error through debug log.                                                                                                                    
                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                  ## Changes                                                      
            
  - `PolarisEventMetadataFactory.java`: Refactor `getUser()` to use new `getSecurityIdentity()` helper with `CompletionException` handling and debug logging
  - `PolarisEventMetadataFactoryTest.java`: New unit test covering resolved identity, anonymous identity, not-yet-resolved identity, and failed deferred resolution                                               
                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                    
                                                                  
  - [x] New unit test `PolarisEventMetadataFactoryTest` passes (4 cases)                                                                                                                                                                            

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
