### PR TITLE
CLI: Add display version support for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Changed deprecated APIs in JUnit 5. This change will force downstream projects that pull in the Polaris test packages to adopt JUnit 6.
 - Added client id collision check during reset.
 - The `nosql maintenance-run` admin command now rejects a new run when the latest recorded maintenance run is still unfinished, unless the operator explicitly passes `--supersede-run=<run-id>`.
+- Added version option to Polaris CLI.
 
 ### Deprecations
 - The configuration option `polaris.event-listener.type` is deprecated and will be removed later. Please use `polaris.event-listener.types` instead.

--- a/client/python/.openapi-generator-ignore
+++ b/client/python/.openapi-generator-ignore
@@ -30,6 +30,7 @@ LICENSE
 NOTICE
 
 # Source code
+apache_polaris/__init__.py
 apache_polaris/cli/
 
 # Tests

--- a/client/python/apache_polaris/__init__.py
+++ b/client/python/apache_polaris/__init__.py
@@ -20,6 +20,6 @@
 from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = version(__name__)
+    __version__ = version("apache_polaris")
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/client/python/apache_polaris/__init__.py
+++ b/client/python/apache_polaris/__init__.py
@@ -17,3 +17,9 @@
 # under the License.
 #
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/client/python/apache_polaris/cli/__init__.py
+++ b/client/python/apache_polaris/cli/__init__.py
@@ -16,3 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/client/python/apache_polaris/cli/__init__.py
+++ b/client/python/apache_polaris/cli/__init__.py
@@ -16,10 +16,3 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-from importlib.metadata import version, PackageNotFoundError
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/client/python/apache_polaris/cli/options/parser.py
+++ b/client/python/apache_polaris/cli/options/parser.py
@@ -19,6 +19,7 @@
 import argparse
 from typing import List, Optional, Dict, Any, Union
 
+from apache_polaris import __version__
 from apache_polaris.cli.constants import Arguments, DEFAULT_HEADER
 from apache_polaris.cli.exceptions import CliError
 from apache_polaris.cli.options.option_tree import OptionTree, Option, Argument
@@ -146,6 +147,11 @@ class Parser(object):
             prog="polaris",
             usage="polaris [-h] [options] COMMAND ...",
             formatter_class=PolarisHelpFormatter,
+        )
+        parser.add_argument(
+            "--version",
+            action="version",
+            version=f"%(prog)s {__version__}",
         )
         Parser._add_arguments(parser, Parser._ROOT_ARGUMENTS, "Global Options")
 

--- a/client/python/tests/test_parser_basic.py
+++ b/client/python/tests/test_parser_basic.py
@@ -18,6 +18,7 @@
 #
 
 import unittest
+from apache_polaris import __version__
 from cli_test_utils import CLITestBase, INVALID_ARGS
 from apache_polaris.cli.exceptions import CliError
 from apache_polaris.cli.command import Command
@@ -148,6 +149,9 @@ class TestParserBasic(CLITestBase):
         self.check_usage_output(
             lambda: Parser.parse(["catalogs", "create", "something", "--help"])
         )
+
+    def test_version(self) -> None:
+        self.check_usage_output(lambda: Parser.parse(["--version"]), needle=f"polaris {__version__}")
 
     def test_global_flag_anywhere(self) -> None:
         # Test that global flags work when placed after subcommands


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR adds display version support for polaris CLI. This was inspired by the RC release validation performed by @dimas-b where he had to get version via pip instead:
```
$ venv/bin/pip show apache-polaris
Name: apache-polaris
Version: 1.5.0
Summary: Apache Polaris
Home-page:
Author:
Author-email: Apache Software Foundation <[dev@polaris.apache.org](mailto:dev@polaris.apache.org)>
License: Apache-2.0
```

Here is the sample output with this option:
```sh
➜  polaris git:(cli_version) ./polaris --version
polaris 1.4.0
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
