### PR TITLE
GH-2356: Allow external catalogs to be created without storageConfigInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ application-local.properties
 .cursor/
 .opencode/
 skills-lock.json
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added support for **Apache Ranger** as an external authorizer (Beta).
 
 ### Changes
+- `storageConfigInfo` is no longer required when creating external catalogs. Internal catalogs still require it.
 - Improved Python CLI error messages and exit codes for invalid arguments and configuration errors.
 - Removed unused `PolarisAuthorizableOperation` values: `REVOKE_PRINCIPAL_GRANT_FROM_PRINCIPAL_ROLE`, `REVOKE_PRINCIPAL_ROLE_GRANT_FROM_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_ROOT`, `ADD_PRINCIPAL_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL`, `ADD_PRINCIPAL_ROLE_GRANT_TO_PRINCIPAL_ROLE`, `LIST_GRANTS_ON_PRINCIPAL_ROLE`, `ADD_CATALOG_ROLE_GRANT_TO_CATALOG_ROLE`, `REVOKE_CATALOG_ROLE_GRANT_FROM_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG_ROLE`, `LIST_GRANTS_ON_CATALOG`, `LIST_GRANTS_ON_NAMESPACE`, `LIST_GRANTS_ON_TABLE`, `LIST_GRANTS_ON_VIEW`.
 - Changed deprecated APIs in JUnit 5. This change will force downstream projects that pull in the Polaris test packages to adopt JUnit 6.

--- a/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
+++ b/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
@@ -55,13 +55,15 @@ public class CatalogSerializationTest {
   @Test
   public void testJsonFormat() throws JsonProcessingException {
     Catalog catalog =
-        new Catalog(
-            Catalog.TypeEnum.INTERNAL,
-            TEST_CATALOG_NAME,
-            new CatalogProperties(TEST_LOCATION),
-            AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
-                .setRoleArn(TEST_ROLE_ARN)
-                .build());
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(TEST_CATALOG_NAME)
+            .setProperties(new CatalogProperties(TEST_LOCATION))
+            .setStorageConfigInfo(
+                AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                    .setRoleArn(TEST_ROLE_ARN)
+                    .build())
+            .build();
 
     String json = mapper.writeValueAsString(catalog);
 
@@ -82,14 +84,16 @@ public class CatalogSerializationTest {
   @Test
   public void testJsonFormatWithKmsProperties() throws JsonProcessingException {
     Catalog catalog =
-        new Catalog(
-            Catalog.TypeEnum.INTERNAL,
-            TEST_CATALOG_NAME,
-            new CatalogProperties(TEST_LOCATION),
-            AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
-                .setRoleArn(TEST_ROLE_ARN)
-                .setCurrentKmsKey(KMS_KEY)
-                .build());
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(TEST_CATALOG_NAME)
+            .setProperties(new CatalogProperties(TEST_LOCATION))
+            .setStorageConfigInfo(
+                AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                    .setRoleArn(TEST_ROLE_ARN)
+                    .setCurrentKmsKey(KMS_KEY)
+                    .build())
+            .build();
 
     String json = mapper.writeValueAsString(catalog);
 
@@ -108,53 +112,91 @@ public class CatalogSerializationTest {
                 + "}}");
   }
 
+  @Test
+  public void testExternalCatalogWithoutStorageConfig() throws JsonProcessingException {
+    Catalog catalog =
+        ExternalCatalog.builder()
+            .setType(Catalog.TypeEnum.EXTERNAL)
+            .setName(TEST_CATALOG_NAME)
+            .setProperties(new CatalogProperties(TEST_LOCATION))
+            .build();
+
+    String json = mapper.writeValueAsString(catalog);
+    Catalog deserialized = mapper.readValue(json, Catalog.class);
+
+    assertThat(deserialized).usingRecursiveComparison().isEqualTo(catalog);
+    assertThat(json).doesNotContain("storageConfigInfo");
+  }
+
   private static Stream<Arguments> catalogTestCases() {
     Stream<Arguments> basicCases =
         Stream.of(
             Arguments.of(
                 "Basic catalog",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL,
-                    TEST_CATALOG_NAME,
-                    new CatalogProperties(TEST_LOCATION),
-                    AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
-                        .setRoleArn(TEST_ROLE_ARN)
-                        .build())),
-            Arguments.of("Null fields", new Catalog(Catalog.TypeEnum.INTERNAL, null, null, null)),
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName(TEST_CATALOG_NAME)
+                    .setProperties(new CatalogProperties(TEST_LOCATION))
+                    .setStorageConfigInfo(
+                        AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                            .setRoleArn(TEST_ROLE_ARN)
+                            .build())
+                    .build()),
+            Arguments.of(
+                "Null fields",
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName(null)
+                    .setProperties(null)
+                    .build()),
             Arguments.of(
                 "Long name",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL,
-                    "a".repeat(1000),
-                    new CatalogProperties(TEST_LOCATION),
-                    null)),
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName("a".repeat(1000))
+                    .setProperties(new CatalogProperties(TEST_LOCATION))
+                    .build()),
             Arguments.of(
                 "Unicode characters",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL, "测试目录", new CatalogProperties(TEST_LOCATION), null)),
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName("测试目录")
+                    .setProperties(new CatalogProperties(TEST_LOCATION))
+                    .build()),
             Arguments.of(
                 "Empty strings",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL,
-                    "",
-                    new CatalogProperties(""),
-                    new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))),
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName("")
+                    .setProperties(new CatalogProperties(""))
+                    .setStorageConfigInfo(
+                        new AwsStorageConfigInfo(StorageConfigInfo.StorageTypeEnum.S3))
+                    .build()),
             Arguments.of(
                 "Special characters",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL,
-                    "test\"catalog",
-                    new CatalogProperties(TEST_LOCATION),
-                    AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
-                        .setRoleArn(TEST_ROLE_ARN)
-                        .build())),
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName("test\"catalog")
+                    .setProperties(new CatalogProperties(TEST_LOCATION))
+                    .setStorageConfigInfo(
+                        AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                            .setRoleArn(TEST_ROLE_ARN)
+                            .build())
+                    .build()),
             Arguments.of(
                 "Whitespace",
-                new Catalog(
-                    Catalog.TypeEnum.INTERNAL,
-                    "  test  catalog  ",
-                    new CatalogProperties("  " + TEST_LOCATION + "  "),
-                    null)));
+                PolarisCatalog.builder()
+                    .setType(Catalog.TypeEnum.INTERNAL)
+                    .setName("  test  catalog  ")
+                    .setProperties(new CatalogProperties("  " + TEST_LOCATION + "  "))
+                    .build()),
+            Arguments.of(
+                "External catalog without storage config",
+                ExternalCatalog.builder()
+                    .setType(Catalog.TypeEnum.EXTERNAL)
+                    .setName(TEST_CATALOG_NAME)
+                    .setProperties(new CatalogProperties(TEST_LOCATION))
+                    .build()));
 
     Stream<Arguments> arnCases =
         Stream.of(
@@ -165,13 +207,15 @@ public class CatalogSerializationTest {
                 arn ->
                     Arguments.of(
                         "ARN: " + arn,
-                        new Catalog(
-                            Catalog.TypeEnum.INTERNAL,
-                            TEST_CATALOG_NAME,
-                            new CatalogProperties(TEST_LOCATION),
-                            AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
-                                .setRoleArn(arn)
-                                .build())));
+                        PolarisCatalog.builder()
+                            .setType(Catalog.TypeEnum.INTERNAL)
+                            .setName(TEST_CATALOG_NAME)
+                            .setProperties(new CatalogProperties(TEST_LOCATION))
+                            .setStorageConfigInfo(
+                                AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                                    .setRoleArn(arn)
+                                    .build())
+                            .build()));
 
     return Stream.concat(basicCases, arnCases);
   }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -399,6 +399,29 @@ public class PolarisManagementServiceIntegrationTest {
   }
 
   @Test
+  public void testCreateExternalCatalogWithoutStorageConfig() {
+    String catalogName = client.newEntityName("testCreateExternalCatalogWithoutStorageConfig");
+    Catalog catalog =
+        ExternalCatalog.builder()
+            .setType(Catalog.TypeEnum.EXTERNAL)
+            .setName(catalogName)
+            .setProperties(new CatalogProperties("s3://my-bucket/path/to/data"))
+            .build();
+    try (Response response =
+        managementApi.request("v1/catalogs").post(Entity.json(new CreateCatalogRequest(catalog)))) {
+      assertThat(response).returns(CREATED.getStatusCode(), Response::getStatus);
+    }
+    try (Response response =
+        managementApi.request("v1/catalogs/{cat}", Map.of("cat", catalogName)).get()) {
+      assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+      Catalog fetched = response.readEntity(Catalog.class);
+      assertThat(fetched.getName()).isEqualTo(catalogName);
+      assertThat(fetched.getType()).isEqualTo(Catalog.TypeEnum.EXTERNAL);
+      assertThat(fetched.getStorageConfigInfo()).isNull();
+    }
+  }
+
+  @Test
   public void testCreateCatalogWithUnparsableJson() {
     String catalogString = "{\"catalog\": {{\"bad data}";
     try (Response response =

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -567,12 +567,15 @@ public class PolarisAdminService {
   /** Get all locations where data for a `CatalogEntity` may be stored */
   private Set<String> getCatalogLocations(CatalogEntity catalogEntity) {
     HashSet<String> catalogLocations = new HashSet<>();
-    catalogLocations.add(terminateWithSlash(catalogEntity.getBaseLocation()));
+    String baseLocation = terminateWithSlash(catalogEntity.getBaseLocation());
+    if (baseLocation != null) {
+      catalogLocations.add(baseLocation);
+    }
     if (catalogEntity.getStorageConfigurationInfo() != null) {
-      catalogLocations.addAll(
-          catalogEntity.getStorageConfigurationInfo().getAllowedLocations().stream()
-              .map(this::terminateWithSlash)
-              .toList());
+      catalogEntity.getStorageConfigurationInfo().getAllowedLocations().stream()
+          .map(this::terminateWithSlash)
+          .filter(Objects::nonNull)
+          .forEach(catalogLocations::add);
     }
     return catalogLocations;
   }
@@ -596,6 +599,12 @@ public class PolarisAdminService {
     boolean allowOverlappingCatalogUrls =
         realmConfig.getConfig(FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS);
     if (allowOverlappingCatalogUrls) {
+      return false;
+    }
+
+    if (catalogEntity.isExternal()
+        && catalogEntity.getStorageConfigurationInfo() == null
+        && catalogEntity.getBaseLocation() == null) {
       return false;
     }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisServiceImpl.java
@@ -127,7 +127,13 @@ public class PolarisServiceImpl
   public Response createCatalog(
       CreateCatalogRequest request, RealmContext realmContext, SecurityContext securityContext) {
     Catalog catalog = request.getCatalog();
-    validateStorageConfig(catalog.getStorageConfigInfo());
+    if (catalog.getType() == Catalog.TypeEnum.INTERNAL && catalog.getStorageConfigInfo() == null) {
+      throw new IllegalArgumentException(
+          "Invalid value: createCatalog.arg0.catalog.storageConfigInfo: must not be null");
+    }
+    if (catalog.getStorageConfigInfo() != null) {
+      validateStorageConfig(catalog.getStorageConfigInfo());
+    }
     validateExternalCatalog(catalog);
     validateCatalogProperties(catalog.getProperties());
     Catalog newCatalog =

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -111,6 +111,54 @@ public class ManagementServiceTest {
   }
 
   @Test
+  public void testCreateInternalCatalogWithoutStorageConfigFails() {
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName("internal-no-storage")
+            .setProperties(new CatalogProperties("s3://bucket/path/to/data"))
+            .build();
+    assertThatThrownBy(
+            () ->
+                services
+                    .catalogsApi()
+                    .createCatalog(
+                        new CreateCatalogRequest(catalog),
+                        services.realmContext(),
+                        services.securityContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid value: createCatalog.arg0.catalog.storageConfigInfo: must not be null");
+  }
+
+  @Test
+  public void testCreateExternalCatalogWithoutStorageConfig() {
+    Catalog catalog =
+        ExternalCatalog.builder()
+            .setType(Catalog.TypeEnum.EXTERNAL)
+            .setName("external-no-storage")
+            .setProperties(new CatalogProperties("s3://bucket/path/to/data"))
+            .build();
+    try (Response response =
+        services
+            .catalogsApi()
+            .createCatalog(
+                new CreateCatalogRequest(catalog),
+                services.realmContext(),
+                services.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
+    }
+    try (Response response =
+        services
+            .catalogsApi()
+            .getCatalog(
+                "external-no-storage", services.realmContext(), services.securityContext())) {
+      Catalog fetched = response.readEntity(Catalog.class);
+      assertThat(fetched.getStorageConfigInfo()).isNull();
+    }
+  }
+
+  @Test
   public void testCreateCatalogWithDisallowedS3Endpoints() {
     AwsStorageConfigInfo.Builder storageConfig =
         AwsStorageConfigInfo.builder()

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -882,7 +882,6 @@ components:
       required:
         - name
         - type
-        - storageConfigInfo
         - properties
       discriminator:
         propertyName: type
@@ -895,6 +894,8 @@ components:
       type: object
       allOf:
         - $ref: "#/components/schemas/Catalog"
+      required:
+        - storageConfigInfo
       description: The base catalog type - this contains all the fields necessary to construct an INTERNAL catalog
 
     ExternalCatalog:


### PR DESCRIPTION
## Summary

  Makes `storageConfigInfo` optional for external catalogs. External catalogs may delegate storage management entirely to an external system, making `storageConfigInfo` unnecessary at
  creation time. Internal catalogs continue to require it.

  ### Changes

  - Removed `storageConfigInfo` from base `Catalog` schema's `required` list in the OpenAPI spec
  - Added `storageConfigInfo` as required on `PolarisCatalog` (INTERNAL type) only
  - Added explicit server-side validation in `PolarisServiceImpl` rejecting INTERNAL catalogs without storage config
  - Fixed null-safety in `getCatalogLocations` and `catalogOverlapsWithExistingCatalog` for catalogs without storage config
  - Added unit and integration tests for both the happy path (external without storage) and the rejection path (internal without storage)

  ## Test plan

  - [x] Unit test: `ManagementServiceTest.testCreateExternalCatalogWithoutStorageConfig` — verifies external catalog creation succeeds and round-trips correctly
  - [x] Unit test: `ManagementServiceTest.testCreateInternalCatalogWithoutStorageConfigFails` — verifies internal catalog rejection with correct error message
  - [x] Unit test: `CatalogSerializationTest.testExternalCatalogWithoutStorageConfig` — verifies JSON serialization omits null `storageConfigInfo`
  - [x] Integration test: `PolarisManagementServiceIntegrationTest.testCreateExternalCatalogWithoutStorageConfig` — end-to-end REST validation