### PR TITLE
Fix incorrect String.format specifiers

### DIFF
--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -162,7 +162,7 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
               && inputOptions.rootCredentialsOptions.stdinOptions.printCredentials) {
             String msg =
                 String.format(
-                    "realm: %1s root principal credentials: %2s:%3s",
+                    "realm: %1$s root principal credentials: %2$s:%3$s",
                     result.getKey(),
                     result.getValue().getPrincipalSecrets().getPrincipalClientId(),
                     result.getValue().getPrincipalSecrets().getMainSecret());

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -308,7 +308,7 @@ public class ServiceProducers {
                   "Realm '{}' automatically bootstrapped, credentials were not present in root credentials set provided via the {} configuration property, see separate message printed to stdout.");
               String msg =
                   String.format(
-                      "realm: %1s root principal credentials: %2s:%3s",
+                      "realm: %1$s root principal credentials: %2$s:%3$s",
                       realm,
                       principalSecrets.getPrincipalClientId(),
                       principalSecrets.getMainSecret());


### PR DESCRIPTION
Fix incorrect format specifiers (`%1s` → `%1$s`). While actual values are typically long enough to avoid visible padding, the original placeholders were semantically wrong.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>


<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
