### PR TITLE
NoSQL: Fix persistence test extension resource resolution

### DIFF
--- a/persistence/nosql/persistence/testextension/src/main/java/org/apache/polaris/persistence/nosql/testextension/PersistenceTestExtension.java
+++ b/persistence/nosql/persistence/testextension/src/main/java/org/apache/polaris/persistence/nosql/testextension/PersistenceTestExtension.java
@@ -26,6 +26,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
 import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
 import java.time.Duration;
@@ -120,10 +121,10 @@ public class PersistenceTestExtension
   private Object resolve(
       PolarisPersistence annotation, Class<?> type, ExtensionContext extensionContext) {
 
-    if (MonotonicClock.class.isAssignableFrom(type)) {
+    if (MonotonicClock.class == type) {
       return getOrCreateMonotonicClock(extensionContext);
     }
-    if (IdGenerator.class.isAssignableFrom(type)) {
+    if (IdGenerator.class == type || SnowflakeIdGenerator.class == type) {
       return getOrCreateSnowflakeIdGenerator(extensionContext);
     }
 
@@ -133,13 +134,13 @@ public class PersistenceTestExtension
         "Cannot find backend spec for %s",
         extensionContext.getRequiredTestClass());
 
-    if (BackendTestFactory.class.isAssignableFrom(type)) {
+    if (BackendTestFactory.class == type) {
       return getOrCreateBackendTestFactory(extensionContext, backendSpec);
     }
-    if (Backend.class.isAssignableFrom(type)) {
+    if (Backend.class == type) {
       return getOrCreateBackend(extensionContext, backendSpec);
     }
-    if (Persistence.class.isAssignableFrom(type)) {
+    if (Persistence.class == type) {
       return createPersistence(annotation, extensionContext, backendSpec);
     }
 
@@ -161,22 +162,30 @@ public class PersistenceTestExtension
   public boolean supportsParameter(
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
-    return parameterContext.isAnnotated(PolarisPersistence.class);
+    return parameterContext.isAnnotated(PolarisPersistence.class)
+        && isValidFieldCandidate(parameterContext.getParameter().getType());
   }
 
-  private void assertValidFieldCandidate(Field field) {
-    if (!IdGenerator.class.isAssignableFrom(field.getType())
-        && !MonotonicClock.class.isAssignableFrom(field.getType())
-        && !Persistence.class.isAssignableFrom(field.getType())
-        && !Backend.class.isAssignableFrom(field.getType())
-        && !BackendTestFactory.class.isAssignableFrom(field.getType())) {
-      throw new ExtensionConfigurationException(
-          "Unsupported field type " + field.getType().getName());
+  @VisibleForTesting
+  void assertValidFieldCandidate(Field field) {
+    var fieldType = field.getType();
+    if (!isValidFieldCandidate(fieldType)) {
+      throw new ExtensionConfigurationException("Unsupported field type " + fieldType.getName());
     }
     if (isPrivate(field)) {
       throw new ExtensionConfigurationException(
           String.format("field [%s] must not be private.", field));
     }
+  }
+
+  @VisibleForTesting
+  static boolean isValidFieldCandidate(Class<?> fieldType) {
+    return IdGenerator.class == fieldType
+        || SnowflakeIdGenerator.class == fieldType
+        || MonotonicClock.class == fieldType
+        || Persistence.class == fieldType
+        || Backend.class == fieldType
+        || BackendTestFactory.class == fieldType;
   }
 
   private MonotonicClock getOrCreateMonotonicClock(ExtensionContext extensionContext) {
@@ -213,7 +222,8 @@ public class PersistenceTestExtension
         SnowflakeIdGenerator.class);
   }
 
-  private BackendTestFactory getOrCreateBackendTestFactory(
+  @VisibleForTesting
+  BackendTestFactory getOrCreateBackendTestFactory(
       ExtensionContext extensionContext, BackendSpec backendSpec) {
     var store = extensionContext.getRoot().getStore(NAMESPACE);
     var existingResource = store.get(KEY_BACKEND_TEST_FACTORY, WrappedResource.class);

--- a/persistence/nosql/persistence/testextension/src/main/java/org/apache/polaris/persistence/nosql/testextension/PersistenceTestExtension.java
+++ b/persistence/nosql/persistence/testextension/src/main/java/org/apache/polaris/persistence/nosql/testextension/PersistenceTestExtension.java
@@ -165,11 +165,11 @@ public class PersistenceTestExtension
   }
 
   private void assertValidFieldCandidate(Field field) {
-    if (!field.getType().isAssignableFrom(SnowflakeIdGenerator.class)
-        && !field.getType().isAssignableFrom(MonotonicClock.class)
-        && !field.getType().isAssignableFrom(Persistence.class)
-        && !field.getType().isAssignableFrom(Backend.class)
-        && !field.getType().isAssignableFrom(BackendTestFactory.class)) {
+    if (!IdGenerator.class.isAssignableFrom(field.getType())
+        && !MonotonicClock.class.isAssignableFrom(field.getType())
+        && !Persistence.class.isAssignableFrom(field.getType())
+        && !Backend.class.isAssignableFrom(field.getType())
+        && !BackendTestFactory.class.isAssignableFrom(field.getType())) {
       throw new ExtensionConfigurationException(
           "Unsupported field type " + field.getType().getName());
     }
@@ -216,7 +216,7 @@ public class PersistenceTestExtension
   private BackendTestFactory getOrCreateBackendTestFactory(
       ExtensionContext extensionContext, BackendSpec backendSpec) {
     var store = extensionContext.getRoot().getStore(NAMESPACE);
-    var existingResource = store.get(KEY_BACKEND, WrappedResource.class);
+    var existingResource = store.get(KEY_BACKEND_TEST_FACTORY, WrappedResource.class);
     var existing =
         existingResource != null ? existingResource.<BackendTestFactory>resource() : null;
     if (existing != null) {

--- a/persistence/nosql/persistence/testextension/src/test/java/org/apache/polaris/persistence/nosql/testextension/TestPersistenceTestExtension.java
+++ b/persistence/nosql/persistence/testextension/src/test/java/org/apache/polaris/persistence/nosql/testextension/TestPersistenceTestExtension.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.nosql.testextension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.ids.impl.MonotonicClockImpl;
+import org.apache.polaris.persistence.nosql.api.backend.Backend;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class TestPersistenceTestExtension {
+  private final PersistenceTestExtension extension = new PersistenceTestExtension();
+
+  @Test
+  public void acceptsCompatibleSubtypeFields() throws Exception {
+    var field = FieldFixtures.class.getDeclaredField("clock");
+
+    assertThatCode(() -> invokeAssertValidFieldCandidate(field)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void rejectsUnsupportedSupertypes() throws Exception {
+    var field = FieldFixtures.class.getDeclaredField("unsupported");
+
+    assertThatThrownBy(() -> invokeAssertValidFieldCandidate(field))
+        .isInstanceOf(ExtensionConfigurationException.class)
+        .hasMessage("Unsupported field type java.lang.Object");
+  }
+
+  @Test
+  public void backendTestFactoryUsesDedicatedStoreKey() throws Throwable {
+    var store = new MapStore();
+    var context = extensionContext(store.store());
+    var backendSpec = BackendSpecCarrier.class.getAnnotation(BackendSpec.class);
+
+    var backend =
+        (Backend)
+            Proxy.newProxyInstance(
+                Backend.class.getClassLoader(),
+                new Class<?>[] {Backend.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("close")) {
+                    return null;
+                  }
+                  if (method.getName().equals("type")) {
+                    return "dummy";
+                  }
+                  throw new UnsupportedOperationException(method.getName());
+                });
+    var existingFactory = new DummyBackendTestFactory("dummy");
+
+    store.put(
+        PersistenceTestExtension.KEY_BACKEND,
+        new PersistenceTestExtension.WrappedResource(backend));
+    store.put(
+        PersistenceTestExtension.KEY_BACKEND_TEST_FACTORY,
+        new PersistenceTestExtension.WrappedResource(existingFactory));
+
+    var resolvedFactory = invokeGetOrCreateBackendTestFactory(context, backendSpec);
+
+    assertThat(resolvedFactory).isSameAs(existingFactory);
+  }
+
+  private void invokeAssertValidFieldCandidate(Field field) throws Throwable {
+    try {
+      var method =
+          PersistenceTestExtension.class.getDeclaredMethod(
+              "assertValidFieldCandidate", Field.class);
+      method.setAccessible(true);
+      method.invoke(extension, field);
+    } catch (InvocationTargetException e) {
+      throw e.getCause();
+    }
+  }
+
+  private BackendTestFactory invokeGetOrCreateBackendTestFactory(
+      ExtensionContext extensionContext, BackendSpec backendSpec) throws Throwable {
+    try {
+      var method =
+          PersistenceTestExtension.class.getDeclaredMethod(
+              "getOrCreateBackendTestFactory", ExtensionContext.class, BackendSpec.class);
+      method.setAccessible(true);
+      return (BackendTestFactory) method.invoke(extension, extensionContext, backendSpec);
+    } catch (InvocationTargetException e) {
+      throw e.getCause();
+    }
+  }
+
+  private ExtensionContext extensionContext(ExtensionContext.Store store) {
+    return (ExtensionContext)
+        Proxy.newProxyInstance(
+            ExtensionContext.class.getClassLoader(),
+            new Class<?>[] {ExtensionContext.class},
+            (proxy, method, args) -> {
+              return switch (method.getName()) {
+                case "getRoot" -> proxy;
+                case "getStore" -> store;
+                case "getParent" -> Optional.empty();
+                case "getTestClass" -> Optional.of(BackendSpecCarrier.class);
+                case "getRequiredTestClass" -> BackendSpecCarrier.class;
+                default -> throw new UnsupportedOperationException(method.getName());
+              };
+            });
+  }
+
+  static final class MapStore {
+    private final Map<Object, Object> values = new HashMap<>();
+    private final ExtensionContext.Store store =
+        (ExtensionContext.Store)
+            Proxy.newProxyInstance(
+                ExtensionContext.Store.class.getClassLoader(),
+                new Class<?>[] {ExtensionContext.Store.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "get" -> values.get(args[0]);
+                    case "put" -> {
+                      values.put(args[0], args[1]);
+                      yield null;
+                    }
+                    case "remove" -> values.remove(args[0]);
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+
+    ExtensionContext.Store store() {
+      return store;
+    }
+
+    public void put(Object key, Object value) {
+      values.put(key, value);
+    }
+  }
+
+  static final class DummyBackendTestFactory implements BackendTestFactory {
+    private final String name;
+
+    DummyBackendTestFactory(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public Backend createNewBackend() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public String name() {
+      return name;
+    }
+  }
+
+  @BackendSpec(name = "dummy")
+  static class BackendSpecCarrier {}
+
+  static class FieldFixtures {
+    @PolarisPersistence MonotonicClockImpl clock;
+    @PolarisPersistence Object unsupported;
+  }
+}

--- a/persistence/nosql/persistence/testextension/src/test/java/org/apache/polaris/persistence/nosql/testextension/TestPersistenceTestExtension.java
+++ b/persistence/nosql/persistence/testextension/src/test/java/org/apache/polaris/persistence/nosql/testextension/TestPersistenceTestExtension.java
@@ -21,35 +21,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.polaris.ids.impl.MonotonicClockImpl;
+import org.apache.polaris.ids.api.IdGenerator;
+import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.ids.api.SnowflakeIdGenerator;
+import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.backend.Backend;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestPersistenceTestExtension {
   private final PersistenceTestExtension extension = new PersistenceTestExtension();
 
-  @Test
-  public void acceptsCompatibleSubtypeFields() throws Exception {
-    var field = FieldFixtures.class.getDeclaredField("clock");
-
-    assertThatCode(() -> invokeAssertValidFieldCandidate(field)).doesNotThrowAnyException();
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "monotonicClock",
+        "idGenerator",
+        "snowflakeIdGenerator",
+        "backendTestFactory",
+        "backend",
+        "persistence"
+      })
+  public void acceptsCompatibleSubtypeFields(String fieldName) throws Exception {
+    var field = FieldFixtures.class.getDeclaredField(fieldName);
+    assertThat(PersistenceTestExtension.isValidFieldCandidate(field.getType())).isTrue();
+    assertThatCode(() -> extension.assertValidFieldCandidate(field)).doesNotThrowAnyException();
   }
 
-  @Test
-  public void rejectsUnsupportedSupertypes() throws Exception {
-    var field = FieldFixtures.class.getDeclaredField("unsupported");
+  @ParameterizedTest
+  @ValueSource(strings = {"unsupported", "unsupportedDummyBackendTestFactory"})
+  public void rejectsUnsupportedSupertypes(String fieldName) throws Exception {
+    var field = FieldFixtures.class.getDeclaredField(fieldName);
 
-    assertThatThrownBy(() -> invokeAssertValidFieldCandidate(field))
+    assertThatThrownBy(() -> extension.assertValidFieldCandidate(field))
         .isInstanceOf(ExtensionConfigurationException.class)
-        .hasMessage("Unsupported field type java.lang.Object");
+        .hasMessageStartingWith("Unsupported field type ");
   }
 
   @Test
@@ -81,34 +94,9 @@ public class TestPersistenceTestExtension {
         PersistenceTestExtension.KEY_BACKEND_TEST_FACTORY,
         new PersistenceTestExtension.WrappedResource(existingFactory));
 
-    var resolvedFactory = invokeGetOrCreateBackendTestFactory(context, backendSpec);
+    var resolvedFactory = extension.getOrCreateBackendTestFactory(context, backendSpec);
 
     assertThat(resolvedFactory).isSameAs(existingFactory);
-  }
-
-  private void invokeAssertValidFieldCandidate(Field field) throws Throwable {
-    try {
-      var method =
-          PersistenceTestExtension.class.getDeclaredMethod(
-              "assertValidFieldCandidate", Field.class);
-      method.setAccessible(true);
-      method.invoke(extension, field);
-    } catch (InvocationTargetException e) {
-      throw e.getCause();
-    }
-  }
-
-  private BackendTestFactory invokeGetOrCreateBackendTestFactory(
-      ExtensionContext extensionContext, BackendSpec backendSpec) throws Throwable {
-    try {
-      var method =
-          PersistenceTestExtension.class.getDeclaredMethod(
-              "getOrCreateBackendTestFactory", ExtensionContext.class, BackendSpec.class);
-      method.setAccessible(true);
-      return (BackendTestFactory) method.invoke(extension, extensionContext, backendSpec);
-    } catch (InvocationTargetException e) {
-      throw e.getCause();
-    }
   }
 
   private ExtensionContext extensionContext(ExtensionContext.Store store) {
@@ -183,8 +171,15 @@ public class TestPersistenceTestExtension {
   @BackendSpec(name = "dummy")
   static class BackendSpecCarrier {}
 
+  @SuppressWarnings("unused")
   static class FieldFixtures {
-    @PolarisPersistence MonotonicClockImpl clock;
+    @PolarisPersistence MonotonicClock monotonicClock;
+    @PolarisPersistence IdGenerator idGenerator;
+    @PolarisPersistence SnowflakeIdGenerator snowflakeIdGenerator;
+    @PolarisPersistence BackendTestFactory backendTestFactory;
+    @PolarisPersistence Backend backend;
+    @PolarisPersistence Persistence persistence;
+    @PolarisPersistence DummyBackendTestFactory unsupportedDummyBackendTestFactory;
     @PolarisPersistence Object unsupported;
   }
 }


### PR DESCRIPTION
Fix the test extension so it resolves resources from the actual test context instead of whichever class loader happens to win.

The old lookup was brittle and made the extension sensitive to execution environment and module layout.