### PR TITLE
NoSQL: Avoid deserializing lazy NoSQL index tombstones

### DIFF
--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/index/IndexKey.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/index/IndexKey.java
@@ -96,6 +96,14 @@ public final class IndexKey implements Comparable<IndexKey> {
         }
 
         @Override
+        public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+          var position = buffer.position();
+          return buffer.remaining() >= 2
+              && buffer.get(position) == ESC
+              && buffer.get(position + 1) == NULL_ESCAPED;
+        }
+
+        @Override
         public void skip(@NonNull ByteBuffer buffer) {
           IndexKey.skip(buffer);
         }

--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/index/IndexValueSerializer.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/index/IndexValueSerializer.java
@@ -34,6 +34,14 @@ public interface IndexValueSerializer<V> {
    */
   @Nullable V deserialize(@NonNull ByteBuffer buffer);
 
+  /**
+   * Determines whether the serialized value at the current {@code buffer} position represents
+   * {@code null}.
+   *
+   * <p>Implementations must not modify the caller-visible state of {@code buffer}.
+   */
+  boolean isNullSerialized(@NonNull ByteBuffer buffer);
+
   /** Skips an element, only updating the {@code buffer}'s {@link ByteBuffer#position()}. */
   void skip(@NonNull ByteBuffer buffer);
 }

--- a/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/obj/ObjRef.java
+++ b/persistence/nosql/persistence/api/src/main/java/org/apache/polaris/persistence/nosql/api/obj/ObjRef.java
@@ -71,6 +71,11 @@ public interface ObjRef {
         }
 
         @Override
+        public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+          return buffer.get(buffer.position()) == 0;
+        }
+
+        @Override
         public void skip(@NonNull ByteBuffer buffer) {
           skipObjId(buffer);
         }

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/index/TestIndexKey.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/index/TestIndexKey.java
@@ -287,6 +287,11 @@ public class TestIndexKey {
     }
 
     buffer.flip();
+    var nullProbe = buffer.duplicate();
+    soft.assertThat(INDEX_KEY_SERIALIZER.isNullSerialized(nullProbe)).isEqualTo(indexKey == null);
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, serSize);
     soft.assertThat(INDEX_KEY_SERIALIZER.deserialize(buffer.duplicate())).isEqualTo(indexKey);
 
     var skipped = buffer.duplicate();

--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestObjRef.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/obj/TestObjRef.java
@@ -197,6 +197,12 @@ public class TestObjRef {
 
     soft.assertThat(OBJ_REF_SERIALIZER.serializedSize(null)).isEqualTo(1);
 
+    var nullProbe = nullSerialized.duplicate();
+    soft.assertThat(OBJ_REF_SERIALIZER.isNullSerialized(nullProbe)).isTrue();
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, 1);
+
     soft.assertThat(OBJ_REF_SERIALIZER.deserialize(nullSerialized.duplicate())).isNull();
     var nullSkip = nullSerialized.duplicate();
     OBJ_REF_SERIALIZER.skip(nullSkip);
@@ -214,6 +220,11 @@ public class TestObjRef {
     soft.assertThat(buffer.remaining()).isEqualTo(0);
 
     buffer.flip();
+    var nullProbe = buffer.duplicate();
+    soft.assertThat(OBJ_REF_SERIALIZER.isNullSerialized(nullProbe)).isEqualTo(objRef == null);
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, serSize);
     soft.assertThat(OBJ_REF_SERIALIZER.deserialize(buffer.duplicate())).isEqualTo(objRef);
 
     var skipped = buffer.duplicate();

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/AbstractIndexElement.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/AbstractIndexElement.java
@@ -24,7 +24,7 @@ import org.apache.polaris.persistence.nosql.api.index.IndexElem;
 abstract class AbstractIndexElement<V> extends IndexElem<V> implements InternalIndexElement<V> {
 
   @Override
-  public boolean hasNonNullValue() {
+  public boolean hasValue() {
     return valueNullable() != null;
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/AbstractIndexElement.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/AbstractIndexElement.java
@@ -24,6 +24,11 @@ import org.apache.polaris.persistence.nosql.api.index.IndexElem;
 abstract class AbstractIndexElement<V> extends IndexElem<V> implements InternalIndexElement<V> {
 
   @Override
+  public boolean hasNonNullValue() {
+    return valueNullable() != null;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper("StoreIndexElement")
         .omitNullValues()

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexElementIter.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexElementIter.java
@@ -39,8 +39,7 @@ final class IndexElementIter<V> extends AbstractIterator<Index.Element<V>> {
   protected Index.Element<V> computeNext() {
     while (delegate.hasNext()) {
       var next = delegate.next();
-      var value = next.valueNullable();
-      if (value != null) {
+      if (next.hasNonNullValue()) {
         return next;
       }
     }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexElementIter.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexElementIter.java
@@ -39,7 +39,7 @@ final class IndexElementIter<V> extends AbstractIterator<Index.Element<V>> {
   protected Index.Element<V> computeNext() {
     while (delegate.hasNext()) {
       var next = delegate.next();
-      if (next.hasNonNullValue()) {
+      if (next.hasValue()) {
         return next;
       }
     }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -953,7 +953,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     @Override
     public String toString() {
       var k = key;
-      var c = materializedContent();
+      var c = contentIfMaterialized();
       if (k != null && c != null) {
         return super.toString();
       }
@@ -975,7 +975,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     }
 
     @Nullable
-    private V materializedContent() {
+    private V contentIfMaterialized() {
       var state = CONTENT_STATE.get(this);
       if (state == VALUE_STATE_UNMATERIALIZED
           || state == VALUE_STATE_NULL

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -935,7 +935,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
         return null;
       }
       if (state != VALUE_STATE_UNMATERIALIZED && state != VALUE_STATE_PRESENT) {
-        return materializedContent(state);
+        return uncheckedCast(state);
       }
       var c = serializer.deserialize(serializedThreadSafe().limit(endOffset).position(valueOffset));
       contentState = c == null ? VALUE_STATE_NULL : c;
@@ -968,17 +968,17 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     @Nullable
     private V materializedContent() {
-      return materializedContent(contentState);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nullable
-    private V materializedContent(Object state) {
+      var state = contentState;
       if (state == VALUE_STATE_UNMATERIALIZED
           || state == VALUE_STATE_NULL
           || state == VALUE_STATE_PRESENT) {
         return null;
       }
+      return uncheckedCast(state);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <V> V uncheckedCast(Object state) {
       return (V) state;
     }
   }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -595,7 +595,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
         for (var el : elements) {
           ByteBuffer keyBuf = null;
           if (isLazyElementImpl(el)) {
-            var lazyEl = (LazyIndexElement) el;
+            var lazyEl = (LazyIndexElement<V>) el;
             // The purpose of this 'if'-branch is to determine whether it can serialize the
             // 'IndexKey' by _not_ fully materializing the `IndexKey`. This is possible if (and
             // only if!) the current and the previous element are `LazyStoreIndexElement`s, where
@@ -686,8 +686,8 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     var first = true;
     var previousKeyLen = 0;
-    LazyIndexElement predecessor = null;
-    LazyIndexElement previous = null;
+    LazyIndexElement<V> predecessor = null;
+    LazyIndexElement<V> previous = null;
 
     while (serialized.remaining() > 0) {
       var strip = first ? 0 : readVarInt(serialized);
@@ -710,8 +710,8 @@ final class IndexImpl<V> implements IndexSpi<V> {
       // It has no predecessor that would be needed to re-construct (aka materialize) the full key.
       var elementPredecessor = prefixLen > 0 ? predecessor : null;
       var element =
-          new LazyIndexElement(
-              elementPredecessor, previous, keyOffset, prefixLen, valueOffset, endOffset);
+          new LazyIndexElement<V>(
+              this, elementPredecessor, previous, keyOffset, prefixLen, valueOffset, endOffset);
       if (elementPredecessor == null) {
         predecessor = element;
       } else if (predecessor.prefixLen > prefixLen) {
@@ -735,8 +735,8 @@ final class IndexImpl<V> implements IndexSpi<V> {
    * prefixLen==0}) can easily become very long in the order of many thousands "hops", which makes
    * key materialization overly expensive.
    */
-  private LazyIndexElement cutPredecessor(
-      LazyIndexElement predecessor, int prefixLen, LazyIndexElement previous) {
+  private LazyIndexElement<V> cutPredecessor(
+      LazyIndexElement<V> predecessor, int prefixLen, LazyIndexElement<V> previous) {
     if (predecessor != null) {
       if (predecessor.prefixLen < prefixLen) {
         // If the current element's prefixLen is higher, let the current element's predecessor point
@@ -756,7 +756,9 @@ final class IndexImpl<V> implements IndexSpi<V> {
     return predecessor;
   }
 
-  private final class LazyIndexElement extends AbstractIndexElement<V> {
+  private static final class LazyIndexElement<V> extends AbstractIndexElement<V> {
+    final IndexImpl<V> idx;
+
     /**
      * Points to the predecessor (in index order) that has a required part of the index-key needed
      * to deserialize. In other words, if multiple index-elements have the same {@code prefixLen},
@@ -776,13 +778,13 @@ final class IndexImpl<V> implements IndexSpi<V> {
      *  IndexElement #6 { prefixLen = 3, key = "bbcaaa", predecessor = #5 }
      * </pre></code>
      */
-    final LazyIndexElement predecessor;
+    final LazyIndexElement<V> predecessor;
 
     /**
      * The previous element in the order of deserialization. This is needed later during
      * serialization.
      */
-    final LazyIndexElement previous;
+    final LazyIndexElement<V> previous;
 
     /** Number of bytes for this element's key that are held by its predecessor(s). */
     final int prefixLen;
@@ -813,12 +815,14 @@ final class IndexImpl<V> implements IndexSpi<V> {
     private static final Object VALUE_STATE_PRESENT = new Object();
 
     LazyIndexElement(
-        LazyIndexElement predecessor,
-        LazyIndexElement previous,
+        IndexImpl<V> idx,
+        LazyIndexElement<V> predecessor,
+        LazyIndexElement<V> previous,
         int keyOffset,
         int prefixLen,
         int valueOffset,
         int endOffset) {
+      this.idx = idx;
       this.predecessor = predecessor;
       this.previous = previous;
       this.keyOffset = keyOffset;
@@ -836,12 +840,12 @@ final class IndexImpl<V> implements IndexSpi<V> {
       }
 
       return keySerBuffer
-          .put(serializedNotThreadSafe().limit(valueOffset).position(keyOffset))
+          .put(idx.serializedNotThreadSafe().limit(valueOffset).position(keyOffset))
           .flip();
     }
 
     private IndexKey materializeKey() {
-      var serialized = serializedThreadSafe();
+      var serialized = idx.serializedThreadSafe();
 
       var suffixLen = valueOffset - keyOffset;
       var suffix = serialized.limit(valueOffset).position(keyOffset);
@@ -859,7 +863,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     }
 
     private void prefixKey(
-        ByteBuffer serialized, LazyIndexElement me, int remaining, ByteBuffer keyBuffer) {
+        ByteBuffer serialized, LazyIndexElement<V> me, int remaining, ByteBuffer keyBuffer) {
       // This loop could be easier written using recursion. However, recursion is way more expensive
       // than this loop. Since this code is on a very hot code path, it is worth it.
       for (var e = me.predecessor; e != null; e = e.predecessor) {
@@ -891,7 +895,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     @Override
     public void serializeContent(IndexValueSerializer<V> ser, ByteBuffer target) {
-      target.put(serializedNotThreadSafe().limit(endOffset).position(valueOffset));
+      target.put(idx.serializedNotThreadSafe().limit(endOffset).position(valueOffset));
     }
 
     @Override
@@ -919,8 +923,8 @@ final class IndexImpl<V> implements IndexSpi<V> {
         return true;
       }
       var nonNull =
-          !serializer.isNullSerialized(
-              serializedThreadSafe().limit(endOffset).position(valueOffset));
+          !idx.serializer.isNullSerialized(
+              idx.serializedThreadSafe().limit(endOffset).position(valueOffset));
       if (contentState == VALUE_STATE_UNMATERIALIZED) {
         contentState = nonNull ? VALUE_STATE_PRESENT : VALUE_STATE_NULL;
       }
@@ -937,7 +941,9 @@ final class IndexImpl<V> implements IndexSpi<V> {
       if (state != VALUE_STATE_UNMATERIALIZED && state != VALUE_STATE_PRESENT) {
         return uncheckedCast(state);
       }
-      var c = serializer.deserialize(serializedThreadSafe().limit(endOffset).position(valueOffset));
+      var c =
+          idx.serializer.deserialize(
+              idx.serializedThreadSafe().limit(endOffset).position(valueOffset));
       contentState = c == null ? VALUE_STATE_NULL : c;
       return c;
     }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -810,7 +810,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     private static final Object VALUE_STATE_UNMATERIALIZED = new Object();
     private static final Object VALUE_STATE_NULL = new Object();
-    private static final Object VALUE_STATE_NON_NULL = new Object();
+    private static final Object VALUE_STATE_PRESENT = new Object();
 
     LazyIndexElement(
         LazyIndexElement predecessor,
@@ -910,7 +910,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     }
 
     @Override
-    public boolean hasNonNullValue() {
+    public boolean hasValue() {
       var state = contentState;
       if (state == VALUE_STATE_NULL) {
         return false;
@@ -922,7 +922,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
           !serializer.isNullSerialized(
               serializedThreadSafe().limit(endOffset).position(valueOffset));
       if (contentState == VALUE_STATE_UNMATERIALIZED) {
-        contentState = nonNull ? VALUE_STATE_NON_NULL : VALUE_STATE_NULL;
+        contentState = nonNull ? VALUE_STATE_PRESENT : VALUE_STATE_NULL;
       }
       return nonNull;
     }
@@ -934,7 +934,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
       if (state == VALUE_STATE_NULL) {
         return null;
       }
-      if (state != VALUE_STATE_UNMATERIALIZED && state != VALUE_STATE_NON_NULL) {
+      if (state != VALUE_STATE_UNMATERIALIZED && state != VALUE_STATE_PRESENT) {
         return materializedContent(state);
       }
       var c = serializer.deserialize(serializedThreadSafe().limit(endOffset).position(valueOffset));
@@ -976,7 +976,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     private V materializedContent(Object state) {
       if (state == VALUE_STATE_UNMATERIALIZED
           || state == VALUE_STATE_NULL
-          || state == VALUE_STATE_NON_NULL) {
+          || state == VALUE_STATE_PRESENT) {
         return null;
       }
       return (V) state;

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.polaris.persistence.nosql.api.index.Index;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.api.index.IndexValueSerializer;
@@ -643,9 +644,6 @@ final class IndexImpl<V> implements IndexSpi<V> {
     return target;
   }
 
-  // IntelliJ warns "Condition 'el.getClass() == LazyStoreIndexElement.class' is always 'false'",
-  // which is a false positive (see below as well).
-  @SuppressWarnings("ConstantValue")
   private boolean isLazyElementImpl(InternalIndexElement<V> el) {
     return el.getClass() == LazyIndexElement.class;
   }
@@ -810,6 +808,11 @@ final class IndexImpl<V> implements IndexSpi<V> {
      */
     private volatile Object contentState = VALUE_STATE_UNMATERIALIZED;
 
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<LazyIndexElement, Object> CONTENT_STATE =
+        AtomicReferenceFieldUpdater.newUpdater(
+            LazyIndexElement.class, Object.class, "contentState");
+
     private static final Object VALUE_STATE_UNMATERIALIZED = new Object();
     private static final Object VALUE_STATE_NULL = new Object();
     private static final Object VALUE_STATE_PRESENT = new Object();
@@ -915,7 +918,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     @Override
     public boolean hasValue() {
-      var state = contentState;
+      var state = CONTENT_STATE.get(this);
       if (state == VALUE_STATE_NULL) {
         return false;
       }
@@ -925,16 +928,15 @@ final class IndexImpl<V> implements IndexSpi<V> {
       var nonNull =
           !idx.serializer.isNullSerialized(
               idx.serializedThreadSafe().limit(endOffset).position(valueOffset));
-      if (contentState == VALUE_STATE_UNMATERIALIZED) {
-        contentState = nonNull ? VALUE_STATE_PRESENT : VALUE_STATE_NULL;
-      }
+      CONTENT_STATE.compareAndSet(
+          this, VALUE_STATE_UNMATERIALIZED, nonNull ? VALUE_STATE_PRESENT : VALUE_STATE_NULL);
       return nonNull;
     }
 
     @Override
     @Nullable
     public V valueNullable() {
-      var state = contentState;
+      var state = CONTENT_STATE.get(this);
       if (state == VALUE_STATE_NULL) {
         return null;
       }
@@ -944,7 +946,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
       var c =
           idx.serializer.deserialize(
               idx.serializedThreadSafe().limit(endOffset).position(valueOffset));
-      contentState = c == null ? VALUE_STATE_NULL : c;
+      CONTENT_STATE.set(this, c == null ? VALUE_STATE_NULL : c);
       return c;
     }
 
@@ -974,7 +976,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
 
     @Nullable
     private V materializedContent() {
-      var state = contentState;
+      var state = CONTENT_STATE.get(this);
       if (state == VALUE_STATE_UNMATERIALIZED
           || state == VALUE_STATE_NULL
           || state == VALUE_STATE_PRESENT) {

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -802,10 +802,15 @@ final class IndexImpl<V> implements IndexSpi<V> {
     /** The materialized key or {@code null}. */
     private IndexKey key;
 
-    /** The materialized content or {@code null}. */
-    private V content;
+    /**
+     * Holds either one of the {@code VALUE_STATE_*} sentinels or a materialized non-{@code null}
+     * content value.
+     */
+    private volatile Object contentState = VALUE_STATE_UNMATERIALIZED;
 
-    private boolean hasContent;
+    private static final Object VALUE_STATE_UNMATERIALIZED = new Object();
+    private static final Object VALUE_STATE_NULL = new Object();
+    private static final Object VALUE_STATE_NON_NULL = new Object();
 
     LazyIndexElement(
         LazyIndexElement predecessor,
@@ -905,25 +910,42 @@ final class IndexImpl<V> implements IndexSpi<V> {
     }
 
     @Override
+    public boolean hasNonNullValue() {
+      var state = contentState;
+      if (state == VALUE_STATE_NULL) {
+        return false;
+      }
+      if (state != VALUE_STATE_UNMATERIALIZED) {
+        return true;
+      }
+      var nonNull =
+          !serializer.isNullSerialized(
+              serializedThreadSafe().limit(endOffset).position(valueOffset));
+      if (contentState == VALUE_STATE_UNMATERIALIZED) {
+        contentState = nonNull ? VALUE_STATE_NON_NULL : VALUE_STATE_NULL;
+      }
+      return nonNull;
+    }
+
+    @Override
     @Nullable
     public V valueNullable() {
-      var c = content;
-      if (c == null) {
-        if (!hasContent) {
-          c =
-              content =
-                  serializer.deserialize(
-                      serializedThreadSafe().limit(endOffset).position(valueOffset));
-          hasContent = true;
-        }
+      var state = contentState;
+      if (state == VALUE_STATE_NULL) {
+        return null;
       }
+      if (state != VALUE_STATE_UNMATERIALIZED && state != VALUE_STATE_NON_NULL) {
+        return materializedContent(state);
+      }
+      var c = serializer.deserialize(serializedThreadSafe().limit(endOffset).position(valueOffset));
+      contentState = c == null ? VALUE_STATE_NULL : c;
       return c;
     }
 
     @Override
     public String toString() {
       var k = key;
-      var c = content;
+      var c = materializedContent();
       if (k != null && c != null) {
         return super.toString();
       }
@@ -942,6 +964,22 @@ final class IndexImpl<V> implements IndexSpi<V> {
       }
 
       return sb.toString();
+    }
+
+    @Nullable
+    private V materializedContent() {
+      return materializedContent(contentState);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private V materializedContent(Object state) {
+      if (state == VALUE_STATE_UNMATERIALIZED
+          || state == VALUE_STATE_NULL
+          || state == VALUE_STATE_NON_NULL) {
+        return null;
+      }
+      return (V) state;
     }
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/InternalIndexElement.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/InternalIndexElement.java
@@ -47,5 +47,7 @@ interface InternalIndexElement<V> extends Index.Element<V> {
 
   int contentSerializedSize(IndexValueSerializer<V> ser);
 
+  boolean hasNonNullValue();
+
   @Nullable V valueNullable();
 }

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/InternalIndexElement.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/InternalIndexElement.java
@@ -47,7 +47,7 @@ interface InternalIndexElement<V> extends Index.Element<V> {
 
   int contentSerializedSize(IndexValueSerializer<V> ser);
 
-  boolean hasNonNullValue();
+  boolean hasValue();
 
   @Nullable V valueNullable();
 }

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/ObjTestValue.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/ObjTestValue.java
@@ -85,6 +85,11 @@ final class ObjTestValue {
         }
 
         @Override
+        public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+          return VarInt.readVarInt(buffer.duplicate()) == 0;
+        }
+
+        @Override
         @NonNull
         public ByteBuffer serialize(@Nullable ObjTestValue value, @NonNull ByteBuffer target) {
           if (value == null) {

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
@@ -1062,7 +1062,7 @@ public class TestIndexImpl {
     var deserialized = deserializeStoreIndex(index.serialize(), serializer);
     var element = deserialized.getElement(key1);
 
-    soft.assertThat(element.hasNonNullValue()).isFalse();
+    soft.assertThat(element.hasValue()).isFalse();
     soft.assertThat(nullProbeCalls).hasValue(1);
     soft.assertThat(deserializeCalls).hasValue(0);
 
@@ -1101,7 +1101,7 @@ public class TestIndexImpl {
                             }
                             for (var iter = 0; iter < 1_000; iter++) {
                               if ((iter & 1) == 0) {
-                                if (!element.hasNonNullValue()) {
+                                if (!element.hasValue()) {
                                   throw new AssertionError("Unexpected null-value state");
                                 }
                               } else if (!value1.equals(element.valueNullable())) {
@@ -1118,7 +1118,7 @@ public class TestIndexImpl {
       CompletableFuture.allOf(futures).get(30, TimeUnit.SECONDS);
     }
 
-    soft.assertThat(element.hasNonNullValue()).isTrue();
+    soft.assertThat(element.hasValue()).isTrue();
     soft.assertThat(element.valueNullable()).isEqualTo(value1);
   }
 

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
@@ -39,6 +39,7 @@ import static org.apache.polaris.persistence.nosql.impl.indexes.Util.asHex;
 import static org.apache.polaris.persistence.nosql.impl.indexes.Util.randomObjId;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
@@ -47,16 +48,21 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.polaris.persistence.nosql.api.index.Index;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
+import org.apache.polaris.persistence.nosql.api.index.IndexValueSerializer;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.apache.polaris.persistence.varint.VarInt;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -924,6 +930,198 @@ public class TestIndexImpl {
     }
   }
 
+  @Test
+  void iteratorSkipsLazyNullValuesWithoutDeserializingNonNullValues() {
+    var deserializeCalls = new AtomicInteger();
+    var nullProbeCalls = new AtomicInteger();
+    IndexValueSerializer<String> serializer =
+        new IndexValueSerializer<>() {
+          @Override
+          public int serializedSize(@Nullable String value) {
+            if (value == null) {
+              return 1;
+            }
+            var bytes = value.getBytes(UTF_8);
+            return VarInt.varIntLen(bytes.length) + bytes.length;
+          }
+
+          @Override
+          public @NonNull ByteBuffer serialize(@Nullable String value, @NonNull ByteBuffer target) {
+            if (value == null) {
+              return target.put((byte) 0);
+            }
+            var bytes = value.getBytes(UTF_8);
+            return VarInt.putVarInt(target, bytes.length).put(bytes);
+          }
+
+          @Override
+          public @Nullable String deserialize(@NonNull ByteBuffer buffer) {
+            deserializeCalls.incrementAndGet();
+            var len = VarInt.readVarInt(buffer);
+            if (len == 0) {
+              return null;
+            }
+            var bytes = new byte[len];
+            buffer.get(bytes);
+            return new String(bytes, UTF_8);
+          }
+
+          @Override
+          public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+            nullProbeCalls.incrementAndGet();
+            return VarInt.readVarInt(buffer.duplicate()) == 0;
+          }
+
+          @Override
+          public void skip(@NonNull ByteBuffer buffer) {
+            var len = VarInt.readVarInt(buffer);
+            if (len > 0) {
+              buffer.position(buffer.position() + len);
+            }
+          }
+        };
+
+    var index = newStoreIndex(serializer);
+    var key1 = key("a");
+    var key2 = key("b");
+    var key3 = key("c");
+    index.add(indexElement(key1, "alpha"));
+    index.add(indexElement(key2, (String) null));
+    index.add(indexElement(key3, "charlie"));
+
+    var deserialized = deserializeStoreIndex(index.serialize(), serializer);
+
+    var iteratedKeys = new ArrayList<IndexKey>();
+    deserialized.iterator().forEachRemaining(element -> iteratedKeys.add(element.key()));
+
+    soft.assertThat(iteratedKeys).containsExactly(key1, key3);
+    soft.assertThat(nullProbeCalls).hasValue(3);
+    soft.assertThat(deserializeCalls).hasValue(0);
+
+    var first = deserialized.iterator().next();
+    soft.assertThat(first.key()).isEqualTo(key1);
+    soft.assertThat(first.value()).isEqualTo("alpha");
+    soft.assertThat(deserializeCalls).hasValue(1);
+  }
+
+  @Test
+  void hasNonNullValueMarksLazyNullValueWithoutDeserializingIt() {
+    var deserializeCalls = new AtomicInteger();
+    var nullProbeCalls = new AtomicInteger();
+    IndexValueSerializer<String> serializer =
+        new IndexValueSerializer<>() {
+          @Override
+          public int serializedSize(@Nullable String value) {
+            if (value == null) {
+              return 1;
+            }
+            var bytes = value.getBytes(UTF_8);
+            return VarInt.varIntLen(bytes.length) + bytes.length;
+          }
+
+          @Override
+          public @NonNull ByteBuffer serialize(@Nullable String value, @NonNull ByteBuffer target) {
+            if (value == null) {
+              return target.put((byte) 0);
+            }
+            var bytes = value.getBytes(UTF_8);
+            return VarInt.putVarInt(target, bytes.length).put(bytes);
+          }
+
+          @Override
+          public @Nullable String deserialize(@NonNull ByteBuffer buffer) {
+            deserializeCalls.incrementAndGet();
+            var len = VarInt.readVarInt(buffer);
+            if (len == 0) {
+              return null;
+            }
+            var bytes = new byte[len];
+            buffer.get(bytes);
+            return new String(bytes, UTF_8);
+          }
+
+          @Override
+          public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+            nullProbeCalls.incrementAndGet();
+            return VarInt.readVarInt(buffer.duplicate()) == 0;
+          }
+
+          @Override
+          public void skip(@NonNull ByteBuffer buffer) {
+            var len = VarInt.readVarInt(buffer);
+            if (len > 0) {
+              buffer.position(buffer.position() + len);
+            }
+          }
+        };
+
+    var index = newStoreIndex(serializer);
+    var key1 = key("a");
+    index.add(indexElement(key1, (String) null));
+
+    var deserialized = deserializeStoreIndex(index.serialize(), serializer);
+    var element = deserialized.getElement(key1);
+
+    soft.assertThat(element.hasNonNullValue()).isFalse();
+    soft.assertThat(nullProbeCalls).hasValue(1);
+    soft.assertThat(deserializeCalls).hasValue(0);
+
+    soft.assertThat(element.valueNullable()).isNull();
+    soft.assertThat(nullProbeCalls).hasValue(1);
+    soft.assertThat(deserializeCalls).hasValue(0);
+  }
+
+  @Test
+  void lazyValueStateRemainsConsistentAcrossThreads() throws Exception {
+    var index = newStoreIndex(OBJ_REF_SERIALIZER);
+    var key1 = key("a");
+    var value1 = Util.randomObjId();
+    index.add(indexElement(key1, value1));
+
+    var deserialized = deserializeStoreIndex(index.serialize(), OBJ_REF_SERIALIZER);
+    var element = deserialized.getElement(key1);
+
+    var threads = Runtime.getRuntime().availableProcessors();
+
+    try (var executor = Executors.newFixedThreadPool(threads)) {
+      var latch = new CountDownLatch(threads);
+      var start = new Semaphore(0);
+
+      var futures =
+          IntStream.range(0, threads)
+              .mapToObj(
+                  i ->
+                      CompletableFuture.runAsync(
+                          () -> {
+                            latch.countDown();
+                            try {
+                              start.acquire();
+                            } catch (InterruptedException e) {
+                              throw new RuntimeException(e);
+                            }
+                            for (var iter = 0; iter < 1_000; iter++) {
+                              if ((iter & 1) == 0) {
+                                if (!element.hasNonNullValue()) {
+                                  throw new AssertionError("Unexpected null-value state");
+                                }
+                              } else if (!value1.equals(element.valueNullable())) {
+                                throw new AssertionError("Unexpected materialized value");
+                              }
+                            }
+                          },
+                          executor))
+              .toArray(CompletableFuture[]::new);
+
+      latch.await();
+      start.release(threads);
+
+      CompletableFuture.allOf(futures).get(30, TimeUnit.SECONDS);
+    }
+
+    soft.assertThat(element.hasNonNullValue()).isTrue();
+    soft.assertThat(element.valueNullable()).isEqualTo(value1);
+  }
+
   // The following multithreaded "tests" are only there to verify that no ByteBuffer related
   // exceptions are thrown.
 
@@ -959,7 +1157,34 @@ public class TestIndexImpl {
 
   @Test
   public void multithreadedIterator() throws Exception {
-    multithreaded(ts -> ts.keyIndex().iterator().forEachRemaining(el -> {}), 50);
+    var numKeys = 2_048;
+    var everyFourthIsNull = new AtomicInteger();
+    var expectedCount = numKeys - numKeys / 4;
+    var indexTestSet =
+        KeyIndexTestSet.<ObjRef>newGenerator()
+            .keySet(ImmutableRandomUuidKeySet.builder().numKeys(numKeys).build())
+            .elementSupplier(
+                key ->
+                    indexElement(
+                        key,
+                        everyFourthIsNull.getAndIncrement() % 4 == 0 ? null : Util.randomObjId()))
+            .elementSerializer(OBJ_REF_SERIALIZER)
+            .build()
+            .generateIndexTestSet();
+
+    multithreaded(
+        indexTestSet,
+        ts -> {
+          var count = 0;
+          for (Index.Element<ObjRef> element : ts.keyIndex()) {
+            count++;
+          }
+          if (count != expectedCount) {
+            throw new AssertionError(
+                format("Expected %s non-null elements, got %s", expectedCount, count));
+          }
+        },
+        50);
   }
 
   void multithreaded(Consumer<KeyIndexTestSet<ObjRef>> worker, int iterationsPerThread)
@@ -971,6 +1196,15 @@ public class TestIndexImpl {
             .elementSerializer(OBJ_REF_SERIALIZER)
             .build()
             .generateIndexTestSet();
+
+    multithreaded(indexTestSet, worker, iterationsPerThread);
+  }
+
+  void multithreaded(
+      KeyIndexTestSet<ObjRef> indexTestSet,
+      Consumer<KeyIndexTestSet<ObjRef>> worker,
+      int iterationsPerThread)
+      throws Exception {
 
     var threads = Runtime.getRuntime().availableProcessors();
 

--- a/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/catalog/EntityIdSetSerializer.java
+++ b/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/catalog/EntityIdSetSerializer.java
@@ -83,6 +83,11 @@ final class EntityIdSetSerializer implements IndexValueSerializer<EntityIdSet> {
   }
 
   @Override
+  public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+    return readVarInt(buffer.duplicate()) == 0;
+  }
+
+  @Override
   public void skip(@NonNull ByteBuffer buffer) {
     var num = readVarInt(buffer);
     for (int i = 0; i < num; i++) {

--- a/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/changes/ChangeSerializer.java
+++ b/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/changes/ChangeSerializer.java
@@ -51,6 +51,15 @@ final class ChangeSerializer implements IndexValueSerializer<Change> {
           .findAndAddModules()
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
           .build();
+  private static final byte[] NULL;
+
+  static {
+    try {
+      NULL = MAPPER.writeValueAsBytes(null);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   @Override
   public int serializedSize(@Nullable Change value) {
@@ -88,6 +97,16 @@ final class ChangeSerializer implements IndexValueSerializer<Change> {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+    var dup = buffer.duplicate();
+    var len = readVarInt(dup);
+    if (len != NULL.length) {
+      return false;
+    }
+    return dup.limit(dup.position() + len).mismatch(ByteBuffer.wrap(NULL)) == -1;
   }
 
   @Override

--- a/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/realm/PolicyMappingSerializer.java
+++ b/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/realm/PolicyMappingSerializer.java
@@ -100,6 +100,11 @@ final class PolicyMappingSerializer implements IndexValueSerializer<PolicyMappin
   }
 
   @Override
+  public boolean isNullSerialized(@NonNull ByteBuffer buffer) {
+    return false;
+  }
+
+  @Override
   public void skip(@NonNull ByteBuffer buffer) {
     var num = readVarInt(buffer);
     for (int i = 0; i < num; i++) {

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/catalog/TestEntityIdSet.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/catalog/TestEntityIdSet.java
@@ -63,6 +63,12 @@ public class TestEntityIdSet {
         .containsExactly(serSize + 10, 0);
 
     buffer.flip();
+    var nullProbe = buffer.duplicate();
+    soft.assertThat(ENTITY_ID_SET_SERIALIZER.isNullSerialized(nullProbe))
+        .isEqualTo(objIds == null || objIds.entityIds().isEmpty());
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, serSize + 10);
 
     soft.assertThat(buffer)
         .extracting(ByteBuffer::position, ByteBuffer::remaining)

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/changes/TestChanges.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/changes/TestChanges.java
@@ -51,6 +51,11 @@ public class TestChanges {
         .containsExactly(serSize + 10, 0);
 
     buffer.flip();
+    var nullProbe = buffer.duplicate();
+    soft.assertThat(CHANGE_SERIALIZER.isNullSerialized(nullProbe)).isEqualTo(mapping == null);
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, serSize + 10);
 
     soft.assertThat(buffer)
         .extracting(ByteBuffer::position, ByteBuffer::remaining)

--- a/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/realm/TestPolicyMapping.java
+++ b/persistence/nosql/persistence/metastore-types/src/test/java/org/apache/polaris/persistence/nosql/coretypes/realm/TestPolicyMapping.java
@@ -52,6 +52,11 @@ public class TestPolicyMapping {
         .containsExactly(serSize + 10, 0);
 
     buffer.flip();
+    var nullProbe = buffer.duplicate();
+    soft.assertThat(POLICY_MAPPING_SERIALIZER.isNullSerialized(nullProbe)).isFalse();
+    soft.assertThat(nullProbe)
+        .extracting(ByteBuffer::position, ByteBuffer::remaining)
+        .containsExactly(0, serSize + 10);
 
     soft.assertThat(buffer)
         .extracting(ByteBuffer::position, ByteBuffer::remaining)


### PR DESCRIPTION
Add a cheap serialized null probe for index values and use that in the public iterator path.

The earlier iterator change (#4018) made lazy indexes deserialize every value just to skip tombstones, which was the wrong tradeoff for key-heavy scans. This keeps tombstone filtering without forcing full value materialization.