### PR TITLE
NoSQL: Fix batched multipart NoSQL object fetches

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/PersistenceImplementation.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/PersistenceImplementation.java
@@ -252,14 +252,19 @@ public final class PersistenceImplementation implements Persistence {
       }
 
       var numParts = f.realNumParts();
-      if (numParts > fetched.size()) {
+      if (numParts > 1) {
         // The value of ObjId.numParts() is inconsistent with the real number of parts.
         // There are more parts that need to be fetched.
         fetchIds.clear();
-        for (var p = fetched.size(); p < numParts; p++) {
-          fetchIds.add(persistId(id.id(), p));
+        for (var p = 1; p < numParts; p++) {
+          var partId = persistId(id.id(), p);
+          if (!fetched.containsKey(partId)) {
+            fetchIds.add(partId);
+          }
         }
-        fetched.putAll(backend.fetch(realmId, fetchIds));
+        if (!fetchIds.isEmpty()) {
+          fetched.putAll(backend.fetch(realmId, fetchIds));
+        }
       }
       var fetchedObjTypeId = f.type();
       try (var in =

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
@@ -488,6 +488,44 @@ public abstract class AbstractPersistenceTests {
   }
 
   @Test
+  public void fetchManyHugeObjectsWithWrongPartHints() {
+    var binaryLen = persistence().maxSerializedValueSize() + 1024;
+    var data1 = new byte[binaryLen];
+    var data2 = new byte[binaryLen];
+    ThreadLocalRandom.current().nextBytes(data1);
+    ThreadLocalRandom.current().nextBytes(data2);
+
+    var obj1 =
+        persistence()
+            .write(
+                SimpleTestObj.builder()
+                    .id(persistence().generateId())
+                    .numParts(0)
+                    .binary(data1)
+                    .build(),
+                SimpleTestObj.class);
+    var obj2 =
+        persistence()
+            .write(
+                SimpleTestObj.builder()
+                    .id(persistence().generateId())
+                    .numParts(0)
+                    .binary(data2)
+                    .build(),
+                SimpleTestObj.class);
+
+    soft.assertThat(obj1.numParts()).isGreaterThan(1);
+    soft.assertThat(obj2.numParts()).isGreaterThan(1);
+    soft.assertThat(
+            persistence()
+                .fetchMany(
+                    SimpleTestObj.class,
+                    objRef(obj1.type(), obj1.id(), 0),
+                    objRef(obj2.type(), obj2.id(), 0)))
+        .containsExactly(obj1, obj2);
+  }
+
+  @Test
   public void conditionalObjects() {
     var nonVersionedObj1 =
         SimpleTestObj.builder()


### PR DESCRIPTION
The NoSQL backend has a hard size limit for individual rows. Objects that exceed this limit are split across multiple database rows. The number of "parts" is noted as a _hint_ in the object-id. In case that hint is wrong, which can happen when such large objects are _updated_ (replaced), the fetch/read logic can behave wrong. This change fixes this behavior.

There is currently no use case for updating/replacing such objects, so this is a proactive hardening fix.