### PR TITLE
NoSQL: Fix MongoDB silent reference creation with duplicates

### DIFF
--- a/persistence/nosql/persistence/db/mongodb/src/main/java/org/apache/polaris/persistence/nosql/mongodb/MongoDbBackend.java
+++ b/persistence/nosql/persistence/db/mongodb/src/main/java/org/apache/polaris/persistence/nosql/mongodb/MongoDbBackend.java
@@ -62,6 +62,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.ReturnDocument;
@@ -334,7 +335,7 @@ final class MongoDbBackend implements Backend {
     }
     var docs = newRefs.stream().map(r -> newReferenceDoc(realmId, r)).toList();
     try {
-      refs().insertMany(docs);
+      refs().insertMany(docs, new InsertManyOptions().ordered(false));
     } catch (MongoBulkWriteException e) {
       if (e.getWriteErrors().stream().anyMatch(we -> we.getCategory() != DUPLICATE_KEY)) {
         throw unhandledException(e);

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
@@ -164,10 +164,12 @@ public abstract class AbstractPersistenceTests {
 
     soft.assertThat(existingRefNames).allSatisfy(refName -> persistence().fetchReference(refName));
 
-    var allRefNames =
+    var newRefNames =
         IntStream.range(numExisting, numRefs)
             .mapToObj(i -> refNamePrefix + "_all_" + i)
             .collect(Collectors.toSet());
+    var allRefNames = new HashSet<>(existingRefNames);
+    allRefNames.addAll(newRefNames);
 
     persistence().createReferencesSilent(allRefNames);
 


### PR DESCRIPTION
The contract of `createReferences` says that all given reference will eventually exist once the function returns normally, but the missing Mongo specific `ordered(false)` prevented that.

This is a correctness/contract fix.