### PR TITLE
Fix binary distribution getting-started guide

### DIFF
--- a/site/content/in-dev/unreleased/getting-started/binary-distribution.md
+++ b/site/content/in-dev/unreleased/getting-started/binary-distribution.md
@@ -29,11 +29,12 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 
 ## Running
 
-Download and extract the binary distribution:
+Download the [latest release](https://polaris.apache.org/downloads/latest/) and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.3.0-incubating/polaris-bin-1.3.0-incubating.tgz | tar xz
-cd polaris-bin-1.3.0-incubating
+POLARIS_VERSION=1.5.0
+curl -Lf https://downloads.apache.org/polaris/${POLARIS_VERSION}/polaris-bin-${POLARIS_VERSION}.tgz | tar xzf -
+cd polaris-bin-${POLARIS_VERSION}
 ```
 
 Start the Polaris server:
@@ -42,7 +43,9 @@ Start the Polaris server:
 bin/server
 ```
 
-The server will start and listen on http://localhost:8182. Health and metrics endpoints are available under /q.
+The server will start and listen on http://localhost:8181 (main REST APIs) and http://localhost:8182 (management interface, for health checks and metrics). 
+
+Health and metrics endpoints are available under http://localhost:8182/q/health and http://localhost:8182/q/metrics respectively.
 
 You can verify the server is running by checking the health endpoint:
 


### PR DESCRIPTION
Fixes #4477.

This change fixes the following issues with the binary distribution getting-started guide.

* The script to download and extract the binary distribution was outdated (and inaccurate for some flavors of `tar`).
* The ports were wrong.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
