### PR TITLE
Forbid special characters in entity names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
     - Names consisting solely of `.` or `..`
     - Names containing control (invisible) characters
     - Names with leading or trailing whitespace
-    - Names containing any of these characters: `/\:*?"<>|#`
+    - Names containing any of these characters: <code>/\:*?"<>|#+`</code>
 
 ### New Features
 - Added `SESSION_NAME_FIELDS_IN_SUBSCOPED_CREDENTIAL` feature flag for AWS credential vending. Operators can now configure an ordered list of fields (`realm`, `catalog`, `namespace`, `table`, `principal`) to compose structured STS role session names (e.g. `p-acme-hr_catalog-employee-etl_writer`). Session names are sanitized and proportionally truncated to the AWS 64-character limit. When unset, existing `INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL` behaviour is preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Breaking changes
 - The `MaintenanceService.performMaintenance()` signature now requires an explicit `OptionalLong overrideRunId` argument to supersede the latest unfinished maintenance run.
+- The REST layer now enforces stricter validation for entity names (including namespaces, tables, views, and generic tables). Requests containing invalid names will be rejected with an HTTP 400 error. Existing clients should verify and rename entities before upgrading if their names fall into the following forbidden categories:
+    - Empty strings
+    - Names consisting solely of `.` or `..`
+    - Names containing control (invisible) characters
+    - Names with leading or trailing whitespace
+    - Names containing any of these characters: `/\:*?"<>|#`
 
 ### New Features
 - Added `SESSION_NAME_FIELDS_IN_SUBSCOPED_CREDENTIAL` feature flag for AWS credential vending. Operators can now configure an ordered list of fields (`realm`, `catalog`, `namespace`, `table`, `principal`) to compose structured STS role session names (e.g. `p-acme-hr_catalog-employee-etl_writer`). Session names are sanitized and proportionally truncated to the AWS 64-character limit. When unset, existing `INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL` behaviour is preserved.

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -126,7 +126,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
@@ -2442,7 +2442,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testCreateNamespaceRejectsInvalidName(String badName) {
     try (Response res =
         catalogApi
@@ -2454,7 +2454,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testCreateTableRejectsInvalidName(String badName) {
     Namespace ns = Namespace.of("ns_create_table_bad");
     restCatalog.createNamespace(ns);
@@ -2476,7 +2476,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testRegisterTableRejectsInvalidName(String badName) {
     Namespace ns = Namespace.of("ns_register_bad");
     restCatalog.createNamespace(ns);
@@ -2500,7 +2500,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testCreateViewRejectsInvalidName(String badName) {
     Namespace ns = Namespace.of("ns_create_view_bad");
     restCatalog.createNamespace(ns);
@@ -2538,7 +2538,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testRenameTableRejectsInvalidDestinationName(String badName) {
     Namespace ns = Namespace.of("ns_rename_table_bad");
     restCatalog.createNamespace(ns);
@@ -2562,7 +2562,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testRenameViewRejectsInvalidDestinationName(String badName) {
     Namespace ns = Namespace.of("ns_rename_view_bad");
     restCatalog.createNamespace(ns);
@@ -2591,7 +2591,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"bad/name", " leading", "trailing "})
+  @MethodSource("invalidEntityNames")
   public void testCreateGenericTableRejectsInvalidName(String badName) {
     Namespace ns = Namespace.of("ns_generic_bad");
     restCatalog.createNamespace(ns);
@@ -2615,6 +2615,31 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
     } finally {
       genericTableApi.purge(currentCatalogName, ns);
     }
+  }
+
+  static Stream<String> invalidEntityNames() {
+    return Stream.of(
+        "bad/name",
+        "bad\\name",
+        "bad:name",
+        "bad*name",
+        "bad?name",
+        "bad\"name",
+        "bad<name",
+        "bad>name",
+        "bad|name",
+        "bad#name",
+        "bad\tname",
+        "bad\nname",
+        "bad\rname",
+        "bad\u0001name",
+        "bad\u001fname",
+        "bad\u007fname",
+        "bad\u009fname",
+        ".",
+        "..",
+        " leading",
+        "trailing ");
   }
 
   @Test

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -159,6 +159,8 @@ dependencies {
 
   testImplementation(libs.awaitility)
 
+  testImplementation(libs.junit.pioneer)
+
   testImplementation(platform(libs.testcontainers.bom))
   testImplementation("org.testcontainers:testcontainers")
   testImplementation("org.testcontainers:testcontainers-postgresql")

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -51,7 +51,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -375,41 +375,6 @@ public class RestCatalogMinIOSpecialIT {
     }
   }
 
-  @Test
-  public void testVendedCredentialsFailClosedForWildcardTableIdentifiers() throws IOException {
-    try (RESTCatalog restCatalog =
-        createCatalog(
-            Optional.of(endpoint),
-            Optional.of(endpoint),
-            true,
-            Optional.empty(),
-            Optional.of(VENDED_CREDENTIALS),
-            true,
-            Optional.of(TEST_REGION),
-            Optional.of(TEST_ROLE_ARN),
-            Optional.of(true))) {
-      Namespace targetNamespace = Namespace.of("foo");
-      Namespace checkedNamespace = Namespace.of("*");
-      TableIdentifier targetId = TableIdentifier.of(targetNamespace, "target");
-      TableIdentifier checkedId = TableIdentifier.of(checkedNamespace, "*");
-      restCatalog.createNamespace(targetNamespace);
-      restCatalog.createNamespace(checkedNamespace);
-      restCatalog.createTable(targetId, SCHEMA);
-
-      try {
-        assertThatThrownBy(() -> restCatalog.createTable(checkedId, SCHEMA))
-            .hasMessageContaining("Access Denied");
-      } finally {
-        if (restCatalog.tableExists(checkedId)) {
-          restCatalog.dropTable(checkedId);
-        }
-        if (restCatalog.tableExists(targetId)) {
-          restCatalog.dropTable(targetId);
-        }
-      }
-    }
-  }
-
   private void assertLoadTableWithVendedCredentialsFailsWithKmsError(TableIdentifier id) {
     assertThatThrownBy(
             () ->

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
  *   <li>is not null or empty;
  *   <li>is not {@code .} or {@code ..};
  *   <li>does not contain ISO control characters (U+0000–U+001F or U+007F–U+009F);
- *   <li>does not contain any of: {@code / \ : * ? " < > | #};
+ *   <li>does not contain any of: {@code / \ : * ? " < > | # + `};
  *   <li>does not start or end with whitespace.
  * </ul>
  */
@@ -39,10 +39,10 @@ public final class EntityNameValidator {
 
   /**
    * Characters forbidden in entity names beyond control characters and leading/trailing whitespace.
-   * Covers characters rejected or strongly discouraged by S3, GCS, Azure, and Windows filesystem
-   * semantics.
+   * Covers characters rejected or strongly discouraged by S3, GCS, Azure, Windows filesystem
+   * semantics, URL encoding, and shell/template/SQL quoting.
    */
-  private static final String FORBIDDEN_CHARS = "/\\:*?\"<>|#";
+  private static final String FORBIDDEN_CHARS = "/\\:*?\"<>|#+`";
 
   /** Validates a single entity name (table, view, namespace level, ...). */
   public static void validateName(String name) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.catalog.validation;
 
+import java.util.regex.Pattern;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 
@@ -44,6 +45,8 @@ public final class EntityNameValidator {
    */
   private static final String FORBIDDEN_CHARS = "/\\:*?\"<>|#+`";
 
+  private static final Pattern CONTROL_CHARS = Pattern.compile("\\p{C}");
+
   /** Validates a single entity name (table, view, namespace level, ...). */
   public static void validateName(String name) {
     if (name == null || name.isEmpty()) {
@@ -57,7 +60,8 @@ public final class EntityNameValidator {
       if (Character.isISOControl(c)) {
         throw new IllegalArgumentException(
             String.format(
-                "Entity name must not contain control characters (U+%04X): %s", (int) c, name));
+                "Entity name must not contain control characters (U+%04X): %s",
+                (int) c, sanitizeForMessage(name)));
       }
       if (FORBIDDEN_CHARS.indexOf(c) >= 0) {
         throw new IllegalArgumentException("Entity name must not contain '" + c + "': " + name);
@@ -79,5 +83,11 @@ public final class EntityNameValidator {
   public static void validateIdentifier(TableIdentifier identifier) {
     validateNamespace(identifier.namespace());
     validateName(identifier.name());
+  }
+
+  private static String sanitizeForMessage(String name) {
+    return CONTROL_CHARS
+        .matcher(name)
+        .replaceAll(m -> String.format("\\\\u%04X", (int) m.group().charAt(0)));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/EntityNameValidator.java
@@ -27,7 +27,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
  *
  * <ul>
  *   <li>is not null or empty;
- *   <li>does not contain a forward slash ({@code /});
+ *   <li>is not {@code .} or {@code ..};
+ *   <li>does not contain ISO control characters (U+0000–U+001F or U+007F–U+009F);
+ *   <li>does not contain any of: {@code / \ : * ? " < > | #};
  *   <li>does not start or end with whitespace.
  * </ul>
  */
@@ -35,17 +37,35 @@ public final class EntityNameValidator {
 
   private EntityNameValidator() {}
 
+  /**
+   * Characters forbidden in entity names beyond control characters and leading/trailing whitespace.
+   * Covers characters rejected or strongly discouraged by S3, GCS, Azure, and Windows filesystem
+   * semantics.
+   */
+  private static final String FORBIDDEN_CHARS = "/\\:*?\"<>|#";
+
   /** Validates a single entity name (table, view, namespace level, ...). */
   public static void validateName(String name) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("Entity name must not be empty");
     }
-    if (name.indexOf('/') >= 0) {
-      throw new IllegalArgumentException("Entity name must not contain '/': " + name);
+    if (name.equals(".") || name.equals("..")) {
+      throw new IllegalArgumentException("Entity name must not be '.' or '..'");
     }
-    if (!name.equals(name.strip())) {
-      throw new IllegalArgumentException(
-          "Entity name must not have leading or trailing whitespace: " + name);
+    for (int i = 0; i < name.length(); i++) {
+      char c = name.charAt(i);
+      if (Character.isISOControl(c)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Entity name must not contain control characters (U+%04X): %s", (int) c, name));
+      }
+      if (FORBIDDEN_CHARS.indexOf(c) >= 0) {
+        throw new IllegalArgumentException("Entity name must not contain '" + c + "': " + name);
+      }
+      if ((i == 0 || i == name.length() - 1) && Character.isWhitespace(c)) {
+        throw new IllegalArgumentException(
+            "Entity name must not have leading or trailing whitespace: " + name);
+      }
     }
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
@@ -77,7 +77,9 @@ class EntityNameValidatorTest {
   void validateNameRejectsControlC0Characters(int codePoint) {
     assertThatThrownBy(() -> EntityNameValidator.validateName("name" + (char) codePoint))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Entity name must not contain control characters");
+        .hasMessageContaining(
+            "Entity name must not contain control characters (U+%04X): name\\u%04X",
+            codePoint, codePoint);
   }
 
   @ParameterizedTest
@@ -85,7 +87,9 @@ class EntityNameValidatorTest {
   void validateNameRejectsControlC1Characters(int codePoint) {
     assertThatThrownBy(() -> EntityNameValidator.validateName("name" + (char) codePoint))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Entity name must not contain control characters");
+        .hasMessageContaining(
+            "Entity name must not contain control characters (U+%04X): name\\u%04X",
+            codePoint, codePoint);
   }
 
   @ParameterizedTest

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.params.IntRangeSource;
 
 class EntityNameValidatorTest {
 
@@ -53,7 +54,7 @@ class EntityNameValidatorTest {
   void validateNameRejectsNullOrEmpty(String name) {
     assertThatThrownBy(() -> EntityNameValidator.validateName(name))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("empty");
+        .hasMessageContaining("Entity name must not be empty");
   }
 
   @ParameterizedTest
@@ -61,15 +62,58 @@ class EntityNameValidatorTest {
   void validateNameRejectsSlash(String name) {
     assertThatThrownBy(() -> EntityNameValidator.validateName(name))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("'/'");
+        .hasMessageContaining("Entity name must not contain '/'");
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {" lead", "trail ", " both ", "\ttab", "line\n", " ", "\t", "\n"})
+  @ValueSource(strings = {" lead", "trail ", " both ", " "})
   void validateNameRejectsSurroundingWhitespace(String name) {
     assertThatThrownBy(() -> EntityNameValidator.validateName(name))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("whitespace");
+        .hasMessageContaining("Entity name must not have leading or trailing whitespace");
+  }
+
+  @ParameterizedTest
+  @IntRangeSource(from = 0x00, to = 0x1F)
+  void validateNameRejectsControlC0Characters(int codePoint) {
+    assertThatThrownBy(() -> EntityNameValidator.validateName("name" + (char) codePoint))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Entity name must not contain control characters");
+  }
+
+  @ParameterizedTest
+  @IntRangeSource(from = 0x7F, to = 0x9F)
+  void validateNameRejectsControlC1Characters(int codePoint) {
+    assertThatThrownBy(() -> EntityNameValidator.validateName("name" + (char) codePoint))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Entity name must not contain control characters");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "back\\slash",
+        "co:lon",
+        "as*terisk",
+        "ques?tion",
+        "quo\"te",
+        "les<s",
+        "grea>ter",
+        "pi|pe",
+        "ha#sh",
+      })
+  void validateNameRejectsForbiddenChars(String name) {
+    assertThatThrownBy(() -> EntityNameValidator.validateName(name))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Entity name must not contain '");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {".", ".."})
+  void validateNameRejectsDotOrDotDot(String name) {
+    assertThatThrownBy(() -> EntityNameValidator.validateName(name))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Entity name must not be '.' or '..'");
   }
 
   @Test
@@ -90,21 +134,21 @@ class EntityNameValidatorTest {
     assertThatThrownBy(
             () -> EntityNameValidator.validateNamespace(Namespace.of("ns1", "bad/level")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("'/'");
+        .hasMessageContaining("Entity name must not contain '/'");
   }
 
   @Test
   void validateNamespaceRejectsEmptyLevel() {
     assertThatThrownBy(() -> EntityNameValidator.validateNamespace(Namespace.of("ns1", "")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("empty");
+        .hasMessageContaining("Entity name must not be empty");
   }
 
   @Test
   void validateNamespaceRejectsLevelWithSurroundingWhitespace() {
     assertThatThrownBy(() -> EntityNameValidator.validateNamespace(Namespace.of("ns1", " bad ")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("whitespace");
+        .hasMessageContaining("Entity name must not have leading or trailing whitespace");
   }
 
   @Test
@@ -123,7 +167,7 @@ class EntityNameValidatorTest {
                 EntityNameValidator.validateIdentifier(
                     TableIdentifier.of(Namespace.of("ns1", "bad/level"), "table")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("'/'");
+        .hasMessageContaining("Entity name must not contain '/'");
   }
 
   @Test
@@ -133,6 +177,6 @@ class EntityNameValidatorTest {
                 EntityNameValidator.validateIdentifier(
                     TableIdentifier.of(Namespace.of("ns1"), " bad ")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("whitespace");
+        .hasMessageContaining("Entity name must not have leading or trailing whitespace");
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/validation/EntityNameValidatorTest.java
@@ -42,7 +42,6 @@ class EntityNameValidatorTest {
         "with.dot",
         "café",
         "日本語",
-        "a+b",
         "percent%20encoded",
       })
   void validateNameAccepts(String name) {
@@ -101,6 +100,8 @@ class EntityNameValidatorTest {
         "grea>ter",
         "pi|pe",
         "ha#sh",
+        "plu+s",
+        "back`tick",
       })
   void validateNameRejectsForbiddenChars(String name) {
     assertThatThrownBy(() -> EntityNameValidator.validateName(name))

--- a/site/content/in-dev/unreleased/entities.md
+++ b/site/content/in-dev/unreleased/entities.md
@@ -24,6 +24,22 @@ weight: 400
 
 This page documents various entities that can be managed in Apache Polaris.
 
+## Entity name constraints
+
+The REST layer enforces the following rules for entity names (namespace levels, table names, view names, and generic table names). Names that violate these rules are rejected with HTTP 400.
+
+A valid entity name:
+
+- is not empty;
+- is not `.` or `..`;
+- does not contain ISO control characters (U+0000–U+001F or U+007F–U+009F);
+- does not contain any of the following characters: <code>/\:*?"<>|#+`</code>;
+- does not start or end with whitespace.
+
+These constraints apply to **create**, **register**, and **rename** operations. Existing entities whose names pre-date this validation are not affected by read or update operations.
+
+[Policy](#policy) names are subject to stricter constraints; see below.
+
 ## Catalog
 
 A catalog is a top-level entity in Polaris that may contain other entities like [namespaces](#namespace) and [tables](#table). These map directly to [Apache Iceberg catalogs](https://iceberg.apache.org/terms/#catalog).
@@ -96,6 +112,8 @@ Each catalog role may have multiple [privileges](#privilege) granted to it, and 
 ## Policy
 
 Polaris policy is a set of rules governing actions on specified resources under predefined conditions. Polaris support policy for Iceberg table compaction, snapshot expiry, row-level access control, and custom policy definitions.
+
+Policy names may only contain letters (`A–Z`, `a–z`), digits (`0–9`), hyphens (`-`), and underscores (`_`). Names that do not match this pattern are rejected with HTTP 400.
 
 Policy can be applied at catalog level, namespace level, or table level. Policy inheritance can be achieved by attaching one to a higher-level scope, such as namespace or catalog. As a result, tables registered under those entities do not need to be declared individually for the same policy. If a table or a namespace requires a different policy, user can assign a different policy, hence overriding policy of the same type declared at the higher level entities.
 


### PR DESCRIPTION
This change explicitly forbids a few characters that are rejected or strongly discouraged by S3, GCS, Azure, and Windows filesystems:

* ISO control characters (U+0000–U+001F or U+007F–U+009F)
* Special characters: `/ \ : * ? " < > | #`
* Entity names of `.` or `..`

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
