### PR TITLE
Rename Community menu "Community Page" item to "Overview"

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -127,7 +127,7 @@ menu:
     - name: "Community"
       identifier: "community"
       weight: 300
-    - name: "Community Page"
+    - name: "Overview"
       parent: "community"
       url: "/community/"
       weight: 10


### PR DESCRIPTION
For consistency with other dropdown menus, which all use "Overview" as their first item.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
