### PR TITLE
Upgrade Iceberg to 1.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@
 [versions]
 checkstyle = "13.4.2"
 hadoop = "3.5.0"
-iceberg = "1.10.1" # Ensure to update the iceberg version in regtests and getting-started to keep them up-to-date
+iceberg = "1.11.0" # Ensure to update the iceberg version in regtests and getting-started to keep them up-to-date
 immutables = "2.12.2"
 jmh = "1.37"
 picocli = "4.7.7"

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -53,7 +53,7 @@ import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.NoSuchWarehouseException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.rest.RESTSessionCatalog;
@@ -276,9 +276,8 @@ public class PolarisApplicationIntegrationTest {
   @Test
   public void testConfigureCatalogCaseSensitive() {
     assertThatThrownBy(() -> newSessionCatalog("TESTCONFIGURECATALOGCASESENSITIVE"))
-        .isInstanceOf(RESTException.class)
-        .hasMessage(
-            "Unable to process: Unable to find warehouse TESTCONFIGURECATALOGCASESENSITIVE");
+        .isInstanceOf(NoSuchWarehouseException.class)
+        .hasMessageContaining("Unable to find warehouse TESTCONFIGURECATALOGCASESENSITIVE");
   }
 
   @Test

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -34,6 +34,7 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -118,9 +119,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -2604,4 +2607,20 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
       genericTableApi.purge(currentCatalogName, ns);
     }
   }
+
+  @Test
+  @Disabled("Test is not compatible with REST catalogs")
+  @Override
+  public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) {}
+
+  @Test
+  @Disabled("Feature is not implemented yet")
+  @Override
+  public void createTableInUniqueLocation() {}
+
+  @Test
+  @Disabled(
+      "Test is not compatible with Polaris: rename-table op does not change the table location")
+  @Override
+  public void dropAfterRenameDoesntCorruptTable() {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -223,4 +224,19 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
         .isNotNull()
         .startsWith(customLocation);
   }
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerView() {}
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerExistingView() {}
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerViewThatAlreadyExistsAsTable() {}
 }

--- a/plugins/pluginlibs.versions.toml
+++ b/plugins/pluginlibs.versions.toml
@@ -18,7 +18,7 @@
 #
 
 [versions]
-iceberg = "1.10.0"
+iceberg = "1.11.0"
 spark35 = "3.5.6"
 scala212 = "2.12.19"
 scala213 = "2.13.15"

--- a/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/SparkCatalogTest.java
+++ b/plugins/spark/v3.5/spark/src/test/java/org/apache/polaris/spark/SparkCatalogTest.java
@@ -158,6 +158,7 @@ public class SparkCatalogTest {
         .thenReturn("/tmp/test-warehouse");
     Mockito.when(mockedSession.sparkContext()).thenReturn(mockedContext);
     Mockito.when(mockedContext.applicationId()).thenReturn("appId");
+    Mockito.when(mockedContext.appName()).thenReturn("test-app");
     Mockito.when(mockedContext.sparkUser()).thenReturn("test-user");
     Mockito.when(mockedContext.version()).thenReturn("3.5");
 

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -31,7 +31,7 @@ if [ -z "${SPARK_HOME}" ]; then
 fi
 SPARK_CONF="${SPARK_HOME}/conf/spark-defaults.conf"
 DERBY_HOME="/tmp/derby"
-ICEBERG_VERSION="1.10.1"
+ICEBERG_VERSION="1.11.0"
 export PYTHONPATH="${SPARK_HOME}/python/:${SPARK_HOME}/python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH"
 
 # Ensure binaries are downloaded locally

--- a/regtests/t_pyspark/src/iceberg_spark.py
+++ b/regtests/t_pyspark/src/iceberg_spark.py
@@ -75,8 +75,8 @@ class IcebergSparkSession:
     """Initial method for Iceberg Spark session. Creates a Spark session with specified configs.
     """
     packages = [
-      "org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.1",
-      "org.apache.iceberg:iceberg-aws-bundle:1.10.1",
+      "org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.11.0",
+      "org.apache.iceberg:iceberg-aws-bundle:1.11.0",
     ]
     excludes = ["org.checkerframework:checker-qual", "com.google.errorprone:error_prone_annotations"]
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.catalog.Namespace;
@@ -129,6 +130,7 @@ public class IcebergCatalogAdapter
   public Response createNamespace(
       String prefix,
       CreateNamespaceRequest createNamespaceRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     validateIcebergProperties(realmConfig, createNamespaceRequest.properties());
@@ -213,7 +215,11 @@ public class IcebergCatalogAdapter
 
   @Override
   public Response dropNamespace(
-      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      UUID idempotencyKey,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     Namespace ns =
         NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
     return withCatalog(
@@ -230,6 +236,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     updateNamespacePropertiesRequest.validate();
@@ -263,6 +270,7 @@ public class IcebergCatalogAdapter
       String namespace,
       CreateTableRequest createTableRequest,
       String accessDelegationMode,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     createTableRequest.validate();
@@ -321,6 +329,7 @@ public class IcebergCatalogAdapter
       String accessDelegationMode,
       String ifNoneMatchString,
       String snapshots,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     EnumSet<AccessDelegationMode> delegationModes =
@@ -389,6 +398,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String table,
+      UUID idempotencyKey,
       Boolean purgeRequested,
       RealmContext realmContext,
       SecurityContext securityContext) {
@@ -413,6 +423,8 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       RegisterTableRequest registerTableRequest,
+      String accessDelegationMode,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     registerTableRequest.validate();
@@ -434,6 +446,7 @@ public class IcebergCatalogAdapter
   public Response renameTable(
       String prefix,
       RenameTableRequest renameTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     EntityNameValidator.validateIdentifier(renameTableRequest.destination());
@@ -452,6 +465,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String table,
       CommitTableRequest commitTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     commitTableRequest.updates().stream()
@@ -526,6 +540,8 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String table,
+      String planId,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns =
@@ -544,6 +560,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String view,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns =
@@ -577,6 +594,7 @@ public class IcebergCatalogAdapter
       String prefix,
       String namespace,
       String view,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     Namespace ns =
@@ -595,6 +613,7 @@ public class IcebergCatalogAdapter
   public Response renameView(
       String prefix,
       RenameTableRequest renameTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     EntityNameValidator.validateIdentifier(renameTableRequest.destination());
@@ -613,6 +632,7 @@ public class IcebergCatalogAdapter
       String namespace,
       String view,
       CommitViewRequest commitViewRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     UpdateTableRequest revisedRequest =
@@ -635,6 +655,7 @@ public class IcebergCatalogAdapter
   public Response commitTransaction(
       String prefix,
       CommitTransactionRequest commitTransactionRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     commitTransactionRequest.tableChanges().stream()

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergRestCatalogEventServiceDelegator.java
@@ -27,6 +27,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
+import java.util.UUID;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
@@ -91,6 +92,7 @@ public class IcebergRestCatalogEventServiceDelegator
   public Response createNamespace(
       String prefix,
       CreateNamespaceRequest createNamespaceRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -104,7 +106,8 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.CREATE_NAMESPACE_REQUEST, createNamespaceRequest)));
     }
     Response resp =
-        delegate.createNamespace(prefix, createNamespaceRequest, realmContext, securityContext);
+        delegate.createNamespace(
+            prefix, createNamespaceRequest, idempotencyKey, realmContext, securityContext);
     CreateNamespaceResponse createNamespaceResponse = (CreateNamespaceResponse) resp.getEntity();
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_CREATE_NAMESPACE)) {
       polarisEventDispatcher.dispatch(
@@ -214,7 +217,11 @@ public class IcebergRestCatalogEventServiceDelegator
 
   @Override
   public Response dropNamespace(
-      String prefix, String namespace, RealmContext realmContext, SecurityContext securityContext) {
+      String prefix,
+      String namespace,
+      UUID idempotencyKey,
+      RealmContext realmContext,
+      SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.BEFORE_DROP_NAMESPACE)) {
       polarisEventDispatcher.dispatch(
@@ -228,7 +235,8 @@ public class IcebergRestCatalogEventServiceDelegator
                       NamespaceUtils.splitNamespace(
                           namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR))));
     }
-    Response resp = delegate.dropNamespace(prefix, namespace, realmContext, securityContext);
+    Response resp =
+        delegate.dropNamespace(prefix, namespace, idempotencyKey, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_DROP_NAMESPACE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -246,6 +254,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -265,7 +274,12 @@ public class IcebergRestCatalogEventServiceDelegator
     }
     Response resp =
         delegate.updateProperties(
-            prefix, namespace, updateNamespacePropertiesRequest, realmContext, securityContext);
+            prefix,
+            namespace,
+            updateNamespacePropertiesRequest,
+            idempotencyKey,
+            realmContext,
+            securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_UPDATE_NAMESPACE_PROPERTIES)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -287,6 +301,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String namespace,
       CreateTableRequest createTableRequest,
       String accessDelegationMode,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -309,6 +324,7 @@ public class IcebergRestCatalogEventServiceDelegator
             namespace,
             createTableRequest,
             accessDelegationMode,
+            idempotencyKey,
             realmContext,
             securityContext);
     if (!createTableRequest.stageCreate()
@@ -368,6 +384,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String accessDelegationMode,
       String ifNoneMatchString,
       String snapshots,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -394,6 +411,7 @@ public class IcebergRestCatalogEventServiceDelegator
             accessDelegationMode,
             ifNoneMatchString,
             snapshots,
+            referencedBy,
             realmContext,
             securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_LOAD_TABLE)) {
@@ -449,6 +467,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       String table,
+      UUID idempotencyKey,
       Boolean purgeRequested,
       RealmContext realmContext,
       SecurityContext securityContext) {
@@ -468,7 +487,14 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.PURGE_REQUESTED, purgeRequested)));
     }
     Response resp =
-        delegate.dropTable(prefix, namespace, table, purgeRequested, realmContext, securityContext);
+        delegate.dropTable(
+            prefix,
+            namespace,
+            table,
+            idempotencyKey,
+            purgeRequested,
+            realmContext,
+            securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_DROP_TABLE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -488,6 +514,8 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       RegisterTableRequest registerTableRequest,
+      String accessDelegationMode,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -505,7 +533,13 @@ public class IcebergRestCatalogEventServiceDelegator
     }
     Response resp =
         delegate.registerTable(
-            prefix, namespace, registerTableRequest, realmContext, securityContext);
+            prefix,
+            namespace,
+            registerTableRequest,
+            accessDelegationMode,
+            idempotencyKey,
+            realmContext,
+            securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REGISTER_TABLE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -524,6 +558,7 @@ public class IcebergRestCatalogEventServiceDelegator
   public Response renameTable(
       String prefix,
       RenameTableRequest renameTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -536,7 +571,9 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.CATALOG_NAME, catalogName)
                   .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     }
-    Response resp = delegate.renameTable(prefix, renameTableRequest, realmContext, securityContext);
+    Response resp =
+        delegate.renameTable(
+            prefix, renameTableRequest, idempotencyKey, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_RENAME_TABLE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -555,6 +592,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String namespace,
       String table,
       CommitTableRequest commitTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -573,7 +611,13 @@ public class IcebergRestCatalogEventServiceDelegator
     }
     Response resp =
         delegate.updateTable(
-            prefix, namespace, table, commitTableRequest, realmContext, securityContext);
+            prefix,
+            namespace,
+            table,
+            commitTableRequest,
+            idempotencyKey,
+            realmContext,
+            securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_UPDATE_TABLE)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -666,6 +710,8 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       String table,
+      String planId,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -682,7 +728,8 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.TABLE_NAME, table)));
     }
     Response resp =
-        delegate.loadCredentials(prefix, namespace, table, realmContext, securityContext);
+        delegate.loadCredentials(
+            prefix, namespace, table, planId, referencedBy, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_LOAD_CREDENTIALS)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -701,6 +748,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       String view,
+      String referencedBy,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -716,7 +764,8 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.NAMESPACE, namespaceObj)
                   .put(EventAttributes.VIEW_NAME, view)));
     }
-    Response resp = delegate.loadView(prefix, namespace, view, realmContext, securityContext);
+    Response resp =
+        delegate.loadView(prefix, namespace, view, referencedBy, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_LOAD_VIEW)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -770,6 +819,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String prefix,
       String namespace,
       String view,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -785,7 +835,8 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.NAMESPACE, namespaceObj)
                   .put(EventAttributes.VIEW_NAME, view)));
     }
-    Response resp = delegate.dropView(prefix, namespace, view, realmContext, securityContext);
+    Response resp =
+        delegate.dropView(prefix, namespace, view, idempotencyKey, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_DROP_VIEW)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -803,6 +854,7 @@ public class IcebergRestCatalogEventServiceDelegator
   public Response renameView(
       String prefix,
       RenameTableRequest renameTableRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -815,7 +867,9 @@ public class IcebergRestCatalogEventServiceDelegator
                   .put(EventAttributes.CATALOG_NAME, catalogName)
                   .put(EventAttributes.RENAME_TABLE_REQUEST, renameTableRequest)));
     }
-    Response resp = delegate.renameView(prefix, renameTableRequest, realmContext, securityContext);
+    Response resp =
+        delegate.renameView(
+            prefix, renameTableRequest, idempotencyKey, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_RENAME_VIEW)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -834,6 +888,7 @@ public class IcebergRestCatalogEventServiceDelegator
       String namespace,
       String view,
       CommitViewRequest commitViewRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -852,7 +907,13 @@ public class IcebergRestCatalogEventServiceDelegator
     }
     Response resp =
         delegate.replaceView(
-            prefix, namespace, view, commitViewRequest, realmContext, securityContext);
+            prefix,
+            namespace,
+            view,
+            commitViewRequest,
+            idempotencyKey,
+            realmContext,
+            securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REPLACE_VIEW)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(
@@ -872,6 +933,7 @@ public class IcebergRestCatalogEventServiceDelegator
   public Response commitTransaction(
       String prefix,
       CommitTransactionRequest commitTransactionRequest,
+      UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
     String catalogName = prefixParser.prefixToCatalogName(prefix);
@@ -898,7 +960,8 @@ public class IcebergRestCatalogEventServiceDelegator
       }
     }
     Response resp =
-        delegate.commitTransaction(prefix, commitTransactionRequest, realmContext, securityContext);
+        delegate.commitTransaction(
+            prefix, commitTransactionRequest, idempotencyKey, realmContext, securityContext);
     if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_COMMIT_TRANSACTION)) {
       polarisEventDispatcher.dispatch(
           new PolarisEvent(

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisS3InteroperabilityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisS3InteroperabilityTest.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.ForbiddenException;
@@ -134,6 +135,7 @@ public class PolarisS3InteroperabilityTest {
             .createNamespace(
                 catalogName,
                 createNamespaceRequest,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -165,6 +167,7 @@ public class PolarisS3InteroperabilityTest {
                 namespace,
                 createTableRequest,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -179,6 +182,7 @@ public class PolarisS3InteroperabilityTest {
                 null,
                 null,
                 "ALL",
+                null,
                 services.realmContext(),
                 services.securityContext())) {
       return response.readEntity(LoadTableResponse.class);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -44,6 +44,7 @@ import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -167,8 +168,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -2730,4 +2733,20 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
       }
     }
   }
+
+  @Test
+  @Disabled("Test is not compatible with REST catalogs")
+  @Override
+  public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) {}
+
+  @Test
+  @Disabled("Feature is not implemented yet")
+  @Override
+  public void createTableInUniqueLocation() {}
+
+  @Test
+  @Disabled(
+      "Test is not compatible with Polaris: rename-table op does not change the table location")
+  @Override
+  public void dropAfterRenameDoesntCorruptTable() {}
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogViewTest.java
@@ -74,6 +74,7 @@ import org.assertj.core.configuration.PreferredAssumptionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
@@ -276,4 +277,19 @@ public abstract class AbstractIcebergCatalogViewTest extends ViewCatalogTests<Ic
             afterRefreshEvent.attributes().getRequired(EventAttributes.VIEW_IDENTIFIER))
         .isEqualTo(TestData.TABLE);
   }
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerView() {}
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerExistingView() {}
+
+  @Test
+  @Disabled("Polaris REST catalog does not support view registration")
+  @Override
+  public void registerViewThatAlreadyExistsAsTable() {}
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.core.Response;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
@@ -182,6 +183,7 @@ public class CommitTransactionEventTest {
             .createNamespace(
                 catalog,
                 createNamespaceRequest,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -202,6 +204,7 @@ public class CommitTransactionEventTest {
             namespace,
             createTableRequest,
             null,
+            new UUID(0L, 0L) /* TODO UUID v7 */,
             services.realmContext(),
             services.securityContext());
   }
@@ -240,6 +243,7 @@ public class CommitTransactionEventTest {
           .commitTransaction(
               catalog,
               generateCommitTransactionRequest(shouldFail, table1Name, table2Name),
+              new UUID(0L, 0L) /* TODO UUID v7 */,
               testServices.realmContext(),
               testServices.securityContext());
     } catch (Exception ignored) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -102,6 +102,7 @@ public class IcebergAllowedLocationTest {
                     namespace,
                     createTableRequest,
                     null,
+                    new UUID(0L, 0L) /* TODO UUID v7 */,
                     services.realmContext(),
                     services.securityContext()));
   }
@@ -131,6 +132,7 @@ public class IcebergAllowedLocationTest {
                 namespace,
                 createTableRequest,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext());
 
@@ -167,6 +169,7 @@ public class IcebergAllowedLocationTest {
                     namespace,
                     createTableRequest,
                     "vended-credentials",
+                    new UUID(0L, 0L) /* TODO UUID v7 */,
                     services.realmContext(),
                     services.securityContext()));
   }
@@ -197,6 +200,7 @@ public class IcebergAllowedLocationTest {
                 namespace,
                 createTableRequest,
                 "vended-credentials",
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
@@ -232,6 +236,7 @@ public class IcebergAllowedLocationTest {
                     namespace,
                     createTableRequest,
                     null,
+                    new UUID(0L, 0L) /* TODO UUID v7 */,
                     services.realmContext(),
                     services.securityContext()));
   }
@@ -263,6 +268,7 @@ public class IcebergAllowedLocationTest {
                 namespace,
                 createTableRequest,
                 "vended-credentials",
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
@@ -459,6 +465,7 @@ public class IcebergAllowedLocationTest {
                 namespace,
                 createTableRequest,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext());
     assertThat(createResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -533,6 +540,7 @@ public class IcebergAllowedLocationTest {
             .createNamespace(
                 catalog,
                 createNamespaceRequest,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergOverlappingTableTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergOverlappingTableTest.java
@@ -78,6 +78,7 @@ public class IcebergOverlappingTableTest {
                 namespace,
                 createTableRequest,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       return response.getStatus();
@@ -103,6 +104,7 @@ public class IcebergOverlappingTableTest {
                 namespace,
                 createTableRequest,
                 "vended-credentials",
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       return response.getStatus();
@@ -126,6 +128,7 @@ public class IcebergOverlappingTableTest {
                 namespace,
                 createTableRequest,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       if (response.getStatus() != Response.Status.OK.getStatusCode()) {
@@ -176,6 +179,7 @@ public class IcebergOverlappingTableTest {
             .createNamespace(
                 catalog,
                 createNamespaceRequest,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -510,6 +514,7 @@ public class IcebergOverlappingTableTest {
                         namespace,
                         request,
                         null,
+                        new UUID(0L, 0L) /* TODO UUID v7 */,
                         services.realmContext(),
                         services.securityContext()))
         .isInstanceOf(AlreadyExistsException.class);
@@ -555,6 +560,7 @@ public class IcebergOverlappingTableTest {
                         namespace,
                         request2,
                         null,
+                        new UUID(0L, 0L) /* TODO UUID v7 */,
                         services.realmContext(),
                         services.securityContext()))
         .isInstanceOf(ForbiddenException.class);
@@ -599,6 +605,7 @@ public class IcebergOverlappingTableTest {
                 namespace,
                 request,
                 null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOExceptionsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOExceptionsTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
@@ -108,6 +109,7 @@ public class FileIOExceptionsTest {
             .createNamespace(
                 FileIOExceptionsTest.catalog,
                 CreateNamespaceRequest.builder().withNamespace(Namespace.of("ns1")).build(),
+                new UUID(0L, 0L) /* TODO UUID v7 */,
                 services.realmContext(),
                 services.securityContext())) {
       assertThat(res.getStatus()).isEqualTo(200);
@@ -128,7 +130,13 @@ public class FileIOExceptionsTest {
         services
             .restApi()
             .createTable(
-                catalog, "ns1", request, null, services.realmContext(), services.securityContext());
+                catalog,
+                "ns1",
+                request,
+                null,
+                new UUID(0L, 0L) /* TODO UUID v7 */,
+                services.realmContext(),
+                services.securityContext());
     res.close();
   }
 
@@ -137,7 +145,13 @@ public class FileIOExceptionsTest {
         services
             .restApi()
             .dropTable(
-                catalog, "ns1", "t1", false, services.realmContext(), services.securityContext());
+                catalog,
+                "ns1",
+                "t1",
+                new UUID(0L, 0L) /* TODO UUID v7 */,
+                false,
+                services.realmContext(),
+                services.securityContext());
     res.close();
   }
 
@@ -152,6 +166,7 @@ public class FileIOExceptionsTest {
                 null,
                 null,
                 "ALL",
+                null,
                 services.realmContext(),
                 services.securityContext());
     res.close();

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -90,6 +90,7 @@ paths:
                   warehouse: s3://bucket/warehouse/
                 defaults:
                   clients: '4'
+                idempotency-key-lifetime: PT30M
                 endpoints:
                   - GET /v1/{prefix}/namespaces/{namespace}
                   - GET /v1/{prefix}/namespaces
@@ -102,6 +103,15 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         '403':
           $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found - Warehouse provided in the `warehouse` query parameter is not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NoSuchWarehouseExample:
+                  $ref: '#/components/examples/NoSuchWarehouseError'
         '419':
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         '503':
@@ -170,9 +180,8 @@ paths:
         - $ref: '#/components/parameters/page-size'
         - name: parent
           in: query
-          description: An optional namespace, underneath which to list namespaces. If not provided or empty, all top-level namespaces should be listed. If parent is a multipart namespace, the parts must be separated by the unit separator (`0x1F`) byte.
+          description: An optional namespace, underneath which to list namespaces. If not provided, all top-level namespaces should be listed. For backward compatibility, empty string is treated as absent for now. If parent is a multipart namespace, the parts must be separated by the namespace separator as indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`). To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces. The `namespace-separator` should be provided in a url encoded form.
           required: false
-          allowEmptyValue: true
           schema:
             type: string
           example: accounting%1Ftax
@@ -204,6 +213,8 @@ paths:
       tags:
         - Catalog API
       summary: Create a namespace
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: Create a namespace, with an optional set of properties. The server might also add properties, such as `last_modified_time` etc.
       operationId: createNamespace
       requestBody:
@@ -307,6 +318,8 @@ paths:
         - Catalog API
       summary: Drop a namespace from the catalog. Namespace must be empty.
       operationId: dropNamespace
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       responses:
         '204':
           description: Success, no content
@@ -349,6 +362,8 @@ paths:
         - Catalog API
       summary: Set or remove properties on a namespace
       operationId: updateProperties
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: |-
         Set and/or remove properties on a namespace. The request body specifies a list of properties to remove and a map of key value pairs to update.
         Properties that are not in the request are not modified or removed by this call.
@@ -447,6 +462,7 @@ paths:
       operationId: createTable
       parameters:
         - $ref: '#/components/parameters/data-access'
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         required: true
         content:
@@ -472,13 +488,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         '409':
-          description: Conflict - The table already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
-                NamespaceAlreadyExists:
+                TableAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         '419':
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -494,6 +510,9 @@ paths:
       tags:
         - Catalog API
       summary: Register a table in the given namespace using given metadata file location
+      parameters:
+        - $ref: '#/components/parameters/data-access'
+        - $ref: '#/components/parameters/idempotency-key'
       description: Register a table using given metadata file location.
       operationId: registerTable
       requestBody:
@@ -521,13 +540,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         '409':
-          description: Conflict - The table already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
-                NamespaceAlreadyExists:
+                TableAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         '419':
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -557,14 +576,14 @@ paths:
         - $ref: '#/components/parameters/data-access'
         - name: If-None-Match
           in: header
-          description: An optional header that allows the server to return 304 (Not Modified) if the metadata is current. The content is the value of the ETag received in a CreateTableResponse or LoadTableResponse.
+          description: An optional header that allows the server to return 304 (Not Modified) if the metadata is current. The content is the value of the ETag received in a CreateTableResponse, LoadTableResponse or CommitTableResponse.
           required: false
           schema:
             type: string
         - in: query
           name: snapshots
           description: |-
-            The snapshots to return in the body of the metadata. Setting the value to `all` would return the full set of snapshots currently valid for the table. Setting the value to `refs` would load all snapshots referenced by branches or tags.
+            The snapshots to return in the body of the metadata via the `snapshots` field. Setting the value to `all` would return the full set of snapshots currently valid for the table. Setting the value to `refs` would load all snapshots referenced by branches or tags.
             Default if no param is provided is `all`.
           required: false
           schema:
@@ -572,6 +591,7 @@ paths:
             enum:
               - all
               - refs
+        - $ref: '#/components/parameters/referenced-by'
       responses:
         '200':
           $ref: '#/components/responses/LoadTableResponse'
@@ -603,6 +623,8 @@ paths:
         - Catalog API
       summary: Commit updates to a table
       operationId: updateTable
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: |-
         Commit updates to a table.
 
@@ -696,6 +718,7 @@ paths:
       operationId: dropTable
       description: Remove a table from the catalog
       parameters:
+        - $ref: '#/components/parameters/idempotency-key'
         - name: purgeRequested
           in: query
           required: false
@@ -767,6 +790,14 @@ paths:
         - Catalog API
       summary: Load vended credentials for a table from the catalog
       operationId: loadCredentials
+      parameters:
+        - name: planId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: The plan ID that has been used for server-side scan planning
+        - $ref: '#/components/parameters/referenced-by'
       description: Load vended credentials for a table from the catalog.
       responses:
         '200':
@@ -799,6 +830,8 @@ paths:
       tags:
         - Catalog API
       summary: Rename a table from its current name to a new name
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: Rename a table from one identifier to another. It's valid to move a table across namespaces, but the server implementation is not required to support it.
       operationId: renameTable
       requestBody:
@@ -843,7 +876,7 @@ paths:
                 summary: The requested table identifier already exists
                 value:
                   error:
-                    message: The given table already exists
+                    message: The requested table identifier already exists
                     type: AlreadyExistsException
                     code: 409
         '419':
@@ -901,6 +934,8 @@ paths:
         - Catalog API
       summary: Commit updates to multiple tables in an atomic operation
       operationId: commitTransaction
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         description: |-
           Commit updates to multiple tables in an atomic operation
@@ -1052,13 +1087,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         '409':
-          description: Conflict - The view already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
               examples:
-                NamespaceAlreadyExists:
+                ViewAlreadyExists:
                   $ref: '#/components/examples/ViewAlreadyExistsError'
         '419':
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -1084,6 +1119,8 @@ paths:
         The response also contains the view's full metadata, matching the view metadata JSON file.
 
         The catalog configuration may contain credentials that should be used for subsequent requests for the view. The configuration key "token" is used to pass an access token to be used as a bearer token for view requests. Otherwise, a token may be passed using a RFC 8693 token type as a configuration key. For example, "urn:ietf:params:oauth:token-type:jwt=<JWT-token>".
+      parameters:
+        - $ref: '#/components/parameters/referenced-by'
       responses:
         '200':
           $ref: '#/components/responses/LoadViewResponse'
@@ -1113,6 +1150,8 @@ paths:
         - Catalog API
       summary: Replace a view
       operationId: replaceView
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: Commit updates to a view.
       requestBody:
         required: true
@@ -1198,6 +1237,8 @@ paths:
       summary: Drop a view from the catalog
       operationId: dropView
       description: Remove a view from the catalog
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       responses:
         '204':
           description: Success, no content
@@ -1252,6 +1293,8 @@ paths:
       summary: Rename a view from its current name to a new name
       description: Rename a view from one identifier to another. It's valid to move a view across namespaces, but the server implementation is not required to support it.
       operationId: renameView
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         description: Current view identifier to rename and new view identifier to rename to
         content:
@@ -1294,7 +1337,7 @@ paths:
                 summary: The requested view identifier already exists
                 value:
                   error:
-                    message: The given view already exists
+                    message: The requested view identifier already exists
                     type: AlreadyExistsException
                     code: 409
         '419':
@@ -1401,6 +1444,8 @@ paths:
       summary: Create a generic table under the given namespace
       description: Create a generic table under the given namespace, and return the created table information as a response.
       operationId: createGenericTable
+      parameters:
+        - $ref: '#/components/parameters/polaris-generic-table-data-access'
       requestBody:
         required: true
         content:
@@ -1451,6 +1496,8 @@ paths:
       description: |-
         Load a generic table from the catalog under the given namespace.
         The response contains all table information passed during create.
+      parameters:
+        - $ref: '#/components/parameters/polaris-generic-table-data-access'
       responses:
         '200':
           $ref: '#/components/responses/LoadGenericTableResponse'
@@ -1958,6 +2005,11 @@ components:
             - POST /v1/{prefix}/namespaces
             - GET /v1/{prefix}/namespaces/{namespace}/tables/{table}
             - GET /v1/{prefix}/namespaces/{namespace}/views/{view}
+        idempotency-key-lifetime:
+          type: string
+          format: duration
+          description: Client reuse window for an Idempotency-Key (ISO-8601 duration, e.g., PT30M, PT24H). Interpreted as the maximum time from the first submission using a key to the last retry during which a client may reuse that key. Servers SHOULD accept retries for at least this duration and MAY include a grace period to account for delays/clock skew. Clients SHOULD NOT reuse an Idempotency-Key after this window elapses; they SHOULD generate a new key for any subsequent attempt. Presence of this field indicates the server supports Idempotency-Key semantics for mutation endpoints. If absent, clients MUST assume idempotency is not supported.
+          example: PT30M
     ErrorModel:
       type: object
       description: JSON error payload returned in a response with further details on the error
@@ -2354,7 +2406,7 @@ components:
       example: 123.456
     DecimalTypeValue:
       type: string
-      description: Decimal type values are serialized as strings. Decimals with a positive scale serialize as numeric plain  text, while decimals with a negative scale use scientific notation and the exponent will be equal to the  negated scale. For instance, a decimal with a positive scale is '123.4500', with zero scale is '2',  and with a negative scale is '2E+20'
+      description: Decimal type values are serialized as strings. Decimals with a positive scale serialize as numeric plain text, while decimals with a negative scale use scientific notation and the exponent will be equal to the negated scale. For instance, a decimal with a positive scale is '123.4500', with zero scale is '2', and with a negative scale is '2E+20'
       example: '123.4500'
     StringTypeValue:
       type: string
@@ -2365,7 +2417,7 @@ components:
       pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
       maxLength: 36
       minLength: 36
-      description: UUID type values are serialized as a 36-character lowercase string in standard UUID format as specified  by RFC-4122
+      description: UUID type values are serialized as a 36-character lowercase string in standard UUID format as specified by RFC-4122
       example: eb26bdb1-a1d8-4aa6-990e-da940875492c
     DateTypeValue:
       type: string
@@ -2382,7 +2434,7 @@ components:
       example: '2007-12-03T10:15:30.123456'
     TimestampTzTypeValue:
       type: string
-      description: TimestampTz type values follow the 'YYYY-MM-DDTHH:MM:SS.ssssss+00:00' ISO-8601 format with microsecond precision,  and a timezone offset (+00:00 for UTC)
+      description: TimestampTz type values follow the 'YYYY-MM-DDTHH:MM:SS.ssssss+00:00' ISO-8601 format with microsecond precision, and a timezone offset (+00:00 for UTC)
       example: '2007-12-03T10:15:30.123456+00:00'
     TimestampNanoTypeValue:
       type: string
@@ -2390,11 +2442,11 @@ components:
       example: '2007-12-03T10:15:30.123456789'
     TimestampTzNanoTypeValue:
       type: string
-      description: Timestamp_ns type values follow the 'YYYY-MM-DDTHH:MM:SS.sssssssss+00:00' ISO-8601 format with nanosecond  precision, and a timezone offset (+00:00 for UTC)
+      description: Timestamp_ns type values follow the 'YYYY-MM-DDTHH:MM:SS.sssssssss+00:00' ISO-8601 format with nanosecond precision, and a timezone offset (+00:00 for UTC)
       example: '2007-12-03T10:15:30.123456789+00:00'
     FixedTypeValue:
       type: string
-      description: Fixed length type values are stored and serialized as an uppercase hexadecimal string  preserving the fixed length
+      description: Fixed length type values are stored and serialized as an uppercase hexadecimal string preserving the fixed length
       example: 78797A
     BinaryTypeValue:
       type: string
@@ -2595,6 +2647,10 @@ components:
           type: integer
           format: int64
           description: The first _row_id assigned to the first row in the first data file in the first manifest
+        added-rows:
+          type: integer
+          format: int64
+          description: The upper bound of the number of rows with assigned row IDs
         summary:
           type: object
           required:
@@ -2831,22 +2887,31 @@ components:
 
         ## General Configurations
 
-        - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled 
+        - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled
+        - `scan-planning-mode`: Communicates to clients the supported planning mode. Clients should use this value to fail fast if the supported scanning mode is not available on the client. Valid values:
+          - `client`: Clients MUST use client-side scan planning
+          - `server`: Clients MUST use server-side scan planning via the `planTableScan` endpoint
 
         ## AWS Configurations
 
         The following configurations should be respected when working with tables stored in AWS S3
          - `client.region`: region to configure client for making requests to AWS
          - `s3.access-key-id`: id for credentials that provide access to the data in S3
-         - `s3.secret-access-key`: secret for credentials that provide access to data in S3 
-         - `s3.session-token`: if present, this value should be used for as the session token 
-         - `s3.remote-signing-enabled`: if `true` remote signing should be performed as described in the `s3-signer-open-api.yaml` specification
+         - `s3.secret-access-key`: secret for credentials that provide access to data in S3
+         - `s3.session-token`: if present, this value should be used for as the session token
+         - `s3.remote-signing-enabled`: if `true` remote signing should be performed as described in the `RemoteSignRequest` schema section of this spec document.
          - `s3.cross-region-access-enabled`: if `true`, S3 Cross-Region bucket access is enabled
 
         ## Storage Credentials
 
         Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
         Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
+
+        ## Remote Signing
+
+        If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
+         - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+         - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
       type: object
       required:
         - metadata
@@ -3406,6 +3471,8 @@ components:
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
         - $ref: '#/components/schemas/SetStatisticsUpdate'
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
+        - $ref: '#/components/schemas/SetPartitionStatisticsUpdate'
+        - $ref: '#/components/schemas/RemovePartitionStatisticsUpdate'
         - $ref: '#/components/schemas/RemovePartitionSpecsUpdate'
         - $ref: '#/components/schemas/RemoveSchemasUpdate'
         - $ref: '#/components/schemas/AddEncryptionKeyUpdate'
@@ -3569,7 +3636,7 @@ components:
         values:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/PrimitiveTypeValue'
     LiteralExpression:
       type: object
       required:
@@ -3591,13 +3658,12 @@ components:
         term:
           $ref: '#/components/schemas/Term'
         value:
-          type: object
+          $ref: '#/components/schemas/PrimitiveTypeValue'
     UnaryExpression:
       type: object
       required:
         - type
         - term
-        - value
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
@@ -3608,8 +3674,6 @@ components:
             - not-nan
         term:
           $ref: '#/components/schemas/Term'
-        value:
-          type: object
     CounterResult:
       type: object
       required:
@@ -3987,6 +4051,46 @@ components:
           type: object
           additionalProperties:
             type: string
+    StorageAccessConfig:
+      type: object
+      required:
+        - prefix
+        - config
+      properties:
+        prefix:
+          type: string
+          description: Indicates a storage location prefix where the configuration is relevant. Clients should choose the most specific prefix (by selecting the longest common prefix) if several configurations of the same type are available. If multiple configurations share the same longest matching prefix, the client may select any of them. However, a server should avoid generating multiple configurations for the same prefix.
+        config:
+          type: object
+          description: |
+            Storage access configurations for S3, GCP GCS, and Azure ADLS are supported. The following outlines 
+            the currently supported configuration options:
+              
+            ## S3 Configurations
+              
+            The following configurations should be respected when working with tables stored on S3, including AWS S3, S3-Compatible systems:
+              - `s3.access-key-id`: id for credentials that provide access to the data in S3
+              - `s3.secret-access-key`: secret for credentials that provide access to data in S3
+              - `s3.session-token`: if present, this value should be used for as the session token
+              - `s3.session-token-expires-at-ms`: the time the aws session token expires, in milliseconds
+              - `s3.client.region`: region to configure client for making requests to S3
+              - `s3.client.refresh-credentials-endpoint`: the endpoint to load vended credentials for a table from the catalog
+              
+            ## GCP GCS Configurations
+
+            The following configurations should be respected when working with tables stored in GCP GCS:
+              - `gcs.oauth2.token`: the gcs scoped access token
+              - `gcs.oauth2.token-expires-at`: the time the gcs access token expires, in milliseconds
+              - `gcs.oauth2.refresh-credentials-endpoint`: the endpoint to load vended credentials for a table from the catalog
+
+            ## AZURE ADLS Configuration
+
+            The following configurations should be respected when working with tables stored in AZURE ADLS:
+              - `adls.sas-token.<hostname>`: an azure shared access signature token
+              - `adls.sas-token-expires-at-ms.<hostname>`: the expiration time for the access token, in milliseconds
+              - `adls.refresh-credentials-endpoint`: the endpoint to load vended credentials for a table from the catalog
+          additionalProperties:
+            type: string
     LoadGenericTableResponse:
       description: Result used when a table is successfully loaded.
       type: object
@@ -3995,6 +4099,13 @@ components:
       properties:
         table:
           $ref: '#/components/schemas/GenericTable'
+        storage-access-configs:
+          type: array
+          description: |
+            Storage configurations required to access the table, encompassing both credentials and other necessary 
+            settings for storage access, such as the client region for S3.
+          items:
+            $ref: '#/components/schemas/StorageAccessConfig'
     PolicyType:
       description: The type of a policy
       type: string
@@ -4337,6 +4448,9 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CommitTableResponse'
+      headers:
+        etag:
+          $ref: '#/components/headers/etag'
     LoadCredentialsResponse:
       description: Table credentials result when loading credentials for a table
       content:
@@ -4404,97 +4518,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/GetApplicablePoliciesResponse'
-  parameters:
-    prefix:
-      name: prefix
-      in: path
-      schema:
-        type: string
-      required: true
-      description: An optional prefix in the path
-    page-token:
-      name: pageToken
-      in: query
-      required: false
-      allowEmptyValue: true
-      schema:
-        $ref: '#/components/schemas/PageToken'
-    page-size:
-      name: pageSize
-      in: query
-      description: For servers that support pagination, this signals an upper bound of the number of results that a client will receive. For servers that do not support pagination, clients may receive results larger than the indicated `pageSize`.
-      required: false
-      schema:
-        type: integer
-        minimum: 1
-    namespace:
-      name: namespace
-      in: path
-      required: true
-      description: A namespace identifier as a single string. Multipart namespace parts should be separated by the unit separator (`0x1F`) byte.
-      schema:
-        type: string
-      examples:
-        singlepart_namespace:
-          value: accounting
-        multipart_namespace:
-          value: accounting%1Ftax
-    data-access:
-      name: X-Iceberg-Access-Delegation
-      in: header
-      description: |
-        Optional signal to the server that the client supports delegated access via a comma-separated list of access mechanisms.  The server may choose to supply access via any or none of the requested mechanisms.
-
-        Specific properties and handling for `vended-credentials` is documented in the `LoadTableResult` schema section of this spec document.
-
-        The protocol and specification for `remote-signing` is documented in  the `s3-signer-open-api.yaml` OpenApi spec in the `aws` module.
-      required: false
-      schema:
-        type: string
-        enum:
-          - vended-credentials
-          - remote-signing
-      style: simple
-      explode: false
-      example: vended-credentials,remote-signing
-    table:
-      name: table
-      in: path
-      description: A table name
-      required: true
-      schema:
-        type: string
-      example: sales
-    view:
-      name: view
-      in: path
-      description: A view name
-      required: true
-      schema:
-        type: string
-      example: sales
-    generic-table:
-      name: generic-table
-      in: path
-      description: A generic table name
-      required: true
-      schema:
-        type: string
-      example: sales
-    policy-type:
-      name: policyType
-      in: query
-      required: false
-      allowEmptyValue: true
-      schema:
-        $ref: '#/components/schemas/PolicyType'
-    policy-name:
-      name: policy-name
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/PolicyName'
   examples:
+    NoSuchWarehouseError:
+      summary: The requested warehouse does not exist
+      value:
+        error:
+          message: The given warehouse does not exist
+          type: NoSuchWarehouseException
+          code: 404
     ListNamespacesNonEmptyExample:
       summary: A non-empty list of namespaces
       value:
@@ -4563,7 +4594,7 @@ components:
       summary: The requested table identifier already exists
       value:
         error:
-          message: The given table already exists
+          message: The requested table identifier already exists
           type: AlreadyExistsException
           code: 409
     NoSuchTableError:
@@ -4590,7 +4621,7 @@ components:
       summary: The requested view identifier already exists
       value:
         error:
-          message: The given view already exists
+          message: The requested view identifier already exists
           type: AlreadyExistsException
           code: 409
     NoSuchViewError:
@@ -4678,11 +4709,153 @@ components:
           message: The given mapping between policy and target does not exist
           type: NoSuchMappingException
           code: 404
+  parameters:
+    prefix:
+      name: prefix
+      in: path
+      schema:
+        type: string
+      required: true
+      description: An optional prefix in the path
+    page-token:
+      name: pageToken
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/PageToken'
+    page-size:
+      name: pageSize
+      in: query
+      description: For servers that support pagination, this signals an upper bound of the number of results that a client will receive. For servers that do not support pagination, clients may receive results larger than the indicated `pageSize`.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+    idempotency-key:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
+        example: 017F22E2-79B0-7CC3-98C4-DC0C0C07398F
+      description: |
+        Optional client-provided idempotency key for safe request retries.
+
+        When present, the server ensures no additional effects for requests that carry the same
+        Idempotency-Key. If a prior request with this key has been finalized, the server returns
+        an equivalent final response without re-running the operation. The response body may
+        reflect a newer state of the catalog than existed at the time of the commit.
+
+        Finalization rules:
+        - Finalize & replay: 200, 201, 204, and deterministic terminal 4xx (including 409
+          such as AlreadyExists, NamespaceNotEmpty, etc.)
+        - Do not finalize (not stored/replayed): 5xx
+
+        Key Requirements:
+        - Key format: UUIDv7 in string form (RFC 9562).
+        - The idempotency key must be globally unique (no reuse across different operations).
+        - Catalogs SHOULD NOT expire keys before the end of the advertised token lifetime.
+        - If Idempotency-Key is used, clients MUST reuse the same key when retrying the same
+          logical operation and MUST generate a new key for a different operation.
+    namespace:
+      name: namespace
+      in: path
+      required: true
+      description: A namespace identifier as a single string. Multipart namespace parts must be separated by the namespace separator as indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`). To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces. The `namespace-separator` should be provided in a url encoded form.
+      schema:
+        type: string
+      examples:
+        singlepart_namespace:
+          value: accounting
+        multipart_namespace:
+          value: accounting%1Ftax
+    data-access:
+      name: X-Iceberg-Access-Delegation
+      in: header
+      description: |
+        Optional signal to the server that the client supports delegated access via a comma-separated list of access mechanisms.  The server may choose to supply access via any or none of the requested mechanisms.
+
+        Specific properties and handling for `vended-credentials` and `remote-signing` are documented in the `LoadTableResult` schema section of this spec document.
+      required: false
+      schema:
+        type: string
+        enum:
+          - vended-credentials
+          - remote-signing
+      style: simple
+      explode: false
+      example: vended-credentials,remote-signing
+    table:
+      name: table
+      in: path
+      description: A table name
+      required: true
+      schema:
+        type: string
+      example: sales
+    referenced-by:
+      name: referenced-by
+      in: query
+      description: |-
+        A comma-separated list of fully qualified view names (namespace and view name) representing the view reference chain when an entity (table or view) is loaded via a view. The list should be ordered with the outermost view first, followed by any intermediate views it references, down to the view that directly references the entity. For a simple case where a view directly references the entity, the list contains a single view identifier. For nested views (a view referencing another view which references the entity), the list contains multiple view identifiers representing the complete dependency chain.
+        The view identifier is a composite string of the format {namespace}{separator}{viewName}. The namespace-separator (defined in /config) acts as the delimiter. When parsing, the last occurrence of this separator identifies the boundary between the namespace and the view name. Multipart namespaces must follow the encoding rules of the parent parameter in the list namespaces endpoint.
+        Multiple view identifiers are separated by commas. Servers should split the parameter value on comma characters to parse individual view identifiers. If view names contain commas, they must be url-encoded as %2C.
+        Example with multiple views (where prod%1Fanalytics is a nested namespace which has a quarterly_view which references to monthly_view which then references the entity being loaded) - prod%1Fanalytics%1Fquarterly_view,prod%1Fanalytics%1Fmonthly_view
+      required: false
+      schema:
+        type: string
+    view:
+      name: view
+      in: path
+      description: A view name
+      required: true
+      schema:
+        type: string
+      example: sales
+    polaris-generic-table-data-access:
+      name: Polaris-Generic-Table-Access-Delegation
+      in: header
+      description: |
+        Optional header indicating that the client supports delegated access using a specific mechanism. If the header is present, the server must either provide access using the requested mechanism or fail the request. If `vended-credentials` is specified, the server must return scoped storage credentials in the `storage-access-configs` field of the response.
+      required: false
+      schema:
+        type: string
+        enum:
+          - vended-credentials
+      style: simple
+      explode: false
+      example: vended-credentials
+    generic-table:
+      name: generic-table
+      in: path
+      description: A generic table name
+      required: true
+      schema:
+        type: string
+      example: sales
+    policy-type:
+      name: policyType
+      in: query
+      required: false
+      allowEmptyValue: true
+      schema:
+        $ref: '#/components/schemas/PolicyType'
+    policy-name:
+      name: policy-name
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/PolicyName'
   headers:
     etag:
       name: ETag
       in: header
-      description: Identifies a unique version of the table metadata.
+      description: |-
+        Identifies a unique version of the table metadata.
+        Implementations that support ETags should produce unique tags for responses that return different metadata content but represent the same version of table metadata.  For example, the `snapshots` query parameter may result in different metadata representations depending on whether `refs` or `all` is provided, therefore should have distinct ETags.
       required: false
       schema:
         type: string

--- a/spec/iceberg-rest-catalog-open-api.yaml
+++ b/spec/iceberg-rest-catalog-open-api.yaml
@@ -19,7 +19,8 @@
 
 # CODE_COPIED_TO_POLARIS
 
-# Apache Iceberg Version: 1.10.0
+# Apache Iceberg Version: 1.11.0
+# commit SHA: 6976e020b894f6a6777704df2b8c4458cb291ae9
 
 ---
 openapi: 3.1.1
@@ -31,7 +32,7 @@ info:
   version: 0.0.1
   description:
     Defines the specification for the first version of the REST Catalog API.
-    Implementations should ideally support both Iceberg table specs v1 and v2, with priority given to v2.
+    Implementations should ideally support all Iceberg table spec versions.
 servers:
   - url: "{scheme}://{host}/{basePath}"
     description: Server URL when the port can be inferred from the scheme
@@ -151,6 +152,7 @@ paths:
                 "defaults": {
                   "clients": "4"
                 },
+                "idempotency-key-lifetime": "PT30M",
                 "endpoints": [
                   "GET /v1/{prefix}/namespaces/{namespace}",
                   "GET /v1/{prefix}/namespaces",
@@ -165,6 +167,15 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         403:
           $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description: Not Found - Warehouse provided in the `warehouse` query parameter is not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NoSuchWarehouseExample:
+                  $ref: '#/components/examples/NoSuchWarehouseError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -199,13 +210,13 @@ paths:
         This endpoint is used for three purposes -
 
         1. To exchange client credentials (client ID and secret) for an access token
-        This uses the client credentials flow.
+           This uses the client credentials flow.
 
         2. To exchange a client token and an identity token for a more specific access token
-        This uses the token exchange flow.
+           This uses the token exchange flow.
 
         3. To exchange an access token for one with the same claims and a refreshed expiration period
-        This uses the token exchange flow.
+           This uses the token exchange flow.
 
 
         For example, a catalog client may be configured with client credentials from the OAuth2
@@ -264,10 +275,13 @@ paths:
           in: query
           description:
             An optional namespace, underneath which to list namespaces.
-            If not provided or empty, all top-level namespaces should be listed.
-            If parent is a multipart namespace, the parts must be separated by the unit separator (`0x1F`) byte.
+            If not provided, all top-level namespaces should be listed.
+            For backward compatibility, empty string is treated as absent for now.
+            If parent is a multipart namespace, the parts must be separated by the namespace separator as
+            indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`).
+            To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
+            The `namespace-separator` should be provided in a url encoded form.
           required: false
-          allowEmptyValue: true
           schema:
             type: string
           example: "accounting%1Ftax"
@@ -300,6 +314,8 @@ paths:
       tags:
         - Catalog API
       summary: Create a namespace
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Create a namespace, with an optional set of properties.
         The server might also add properties, such as `last_modified_time` etc.
@@ -410,6 +426,8 @@ paths:
         - Catalog API
       summary: Drop a namespace from the catalog. Namespace must be empty.
       operationId: dropNamespace
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       responses:
         204:
           description: Success, no content
@@ -454,6 +472,8 @@ paths:
         - Catalog API
       summary: Set or remove properties on a namespace
       operationId: updateProperties
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Set and/or remove properties on a namespace.
         The request body specifies a list of properties to remove and a map
@@ -566,6 +586,7 @@ paths:
       operationId: createTable
       parameters:
         - $ref: '#/components/parameters/data-access'
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         required: true
         content:
@@ -591,13 +612,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The table already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
-                NamespaceAlreadyExists:
+                TableAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -611,6 +632,7 @@ paths:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/data-access'
     post:
       tags:
         - Catalog API
@@ -628,7 +650,7 @@ paths:
         point-in-time scan of the latest snapshot in the table's main branch.
 
 
-        Responses must include a valid status listed below. A "cancelled" status is considered invalid for this endpoint.  
+        Responses must include a valid status listed below. A "cancelled" status is considered invalid for this endpoint.
 
         - When "completed" the planning operation has produced plan tasks and
           file scan tasks that must be returned in the response (not fetched
@@ -655,6 +677,8 @@ paths:
           needed by calling cancelPlanning. Cancellation is not necessary after
           fetchScanTasks has been used to fetch scan tasks for each plan task.
       operationId: planTableScan
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         content:
           application/json:
@@ -698,6 +722,7 @@ paths:
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
       - $ref: '#/components/parameters/plan-id'
+      - $ref: '#/components/parameters/data-access'
 
     get:
       tags:
@@ -762,6 +787,8 @@ paths:
         - Catalog API
       summary: Cancels scan planning for a plan-id
       operationId: cancelPlanning
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: >
         Cancels scan planning for a plan-id.
 
@@ -790,6 +817,7 @@ paths:
         404:
           description:
             Not Found
+            - NoSuchPlanIdException, the plan-id does not exist
             - NoSuchTableException, the table does not exist
             - NoSuchNamespaceException, the namespace does not exist
           content:
@@ -797,6 +825,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
+                PlanIdDoesNotExist:
+                  $ref: '#/components/examples/NoSuchPlanIdError'
                 TableDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
                 NamespaceDoesNotExist:
@@ -820,6 +850,8 @@ paths:
         - Catalog API
       summary: Fetches result tasks for a plan task
       operationId: fetchScanTasks
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: Fetches result tasks for a plan task.
       requestBody:
         content:
@@ -859,8 +891,6 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-
-
   /v1/{prefix}/namespaces/{namespace}/register:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -870,6 +900,9 @@ paths:
       tags:
         - Catalog API
       summary: Register a table in the given namespace using given metadata file location
+      parameters:
+        - $ref: '#/components/parameters/data-access'
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Register a table using given metadata file location.
 
@@ -899,13 +932,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The table already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
-                NamespaceAlreadyExists:
+                TableAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -947,23 +980,24 @@ paths:
           in: header
           description:
             An optional header that allows the server to return 304 (Not Modified) if the metadata
-            is current. The content is the value of the ETag received in a CreateTableResponse or
-            LoadTableResponse.
+            is current. The content is the value of the ETag received in a CreateTableResponse,
+            LoadTableResponse or CommitTableResponse.
           required: false
           schema:
             type: string
         - in: query
           name: snapshots
           description:
-            The snapshots to return in the body of the metadata. Setting the value to `all` would
-            return the full set of snapshots currently valid for the table. Setting the value to
-            `refs` would load all snapshots referenced by branches or tags.
-            
+            The snapshots to return in the body of the metadata via the `snapshots` field. Setting
+            the value to `all` would return the full set of snapshots currently valid for the table.
+            Setting the value to `refs` would load all snapshots referenced by branches or tags.
+
             Default if no param is provided is `all`.
           required: false
           schema:
             type: string
             enum: [ all, refs ]
+        - $ref: '#/components/parameters/referenced-by'
       responses:
         200:
           $ref: '#/components/responses/LoadTableResponse'
@@ -999,6 +1033,8 @@ paths:
         - Catalog API
       summary: Commit updates to a table
       operationId: updateTable
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Commit updates to a table.
 
@@ -1119,6 +1155,7 @@ paths:
       operationId: dropTable
       description: Remove a table from the catalog
       parameters:
+        - $ref: '#/components/parameters/idempotency-key'
         - name: purgeRequested
           in: query
           required: false
@@ -1196,6 +1233,14 @@ paths:
         - Catalog API
       summary: Load vended credentials for a table from the catalog
       operationId: loadCredentials
+      parameters:
+        - name: planId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: The plan ID that has been used for server-side scan planning
+        - $ref: '#/components/parameters/referenced-by'
       description: Load vended credentials for a table from the catalog.
       responses:
         200:
@@ -1223,6 +1268,40 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/sign:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+
+    post:
+      tags:
+        - Catalog API
+      summary: Remotely signs requests to object storage
+      operationId: signRequest
+      requestBody:
+        description: The request to be signed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoteSignRequest'
+        required: true
+      responses:
+        200:
+          $ref: '#/components/responses/RemoteSignResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /v1/{prefix}/tables/rename:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -1231,6 +1310,8 @@ paths:
       tags:
         - Catalog API
       summary: Rename a table from its current name to a new name
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Rename a table from one identifier to another. It's valid to move a table
         across namespaces, but the server implementation is not required to support it.
@@ -1338,6 +1419,8 @@ paths:
         - Catalog API
       summary: Commit updates to multiple tables in an atomic operation
       operationId: commitTransaction
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         description:
           Commit updates to multiple tables in an atomic operation
@@ -1515,13 +1598,13 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The view already exists
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
               examples:
-                NamespaceAlreadyExists:
+                ViewAlreadyExists:
                   $ref: '#/components/examples/ViewAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
@@ -1556,6 +1639,8 @@ paths:
         view. The configuration key "token" is used to pass an access token to be used as a bearer token
         for view requests. Otherwise, a token may be passed using a RFC 8693 token type as a configuration
         key. For example, "urn:ietf:params:oauth:token-type:jwt=<JWT-token>".
+      parameters:
+        - $ref: '#/components/parameters/referenced-by'
       responses:
         200:
           $ref: '#/components/responses/LoadViewResponse'
@@ -1587,6 +1672,8 @@ paths:
         - Catalog API
       summary: Replace a view
       operationId: replaceView
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Commit updates to a view.
       requestBody:
@@ -1688,6 +1775,8 @@ paths:
       summary: Drop a view from the catalog
       operationId: dropView
       description: Remove a view from the catalog
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       responses:
         204:
           description: Success, no content
@@ -1749,6 +1838,8 @@ paths:
         Rename a view from one identifier to another. It's valid to move a view
         across namespaces, but the server implementation is not required to support it.
       operationId: renameView
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       requestBody:
         description: Current view identifier to rename and new view identifier to rename to
         content:
@@ -1799,6 +1890,60 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/register-view:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+
+    post:
+      tags:
+        - Catalog API
+      summary: Register a view in the catalog
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
+      description:
+        Register a view in the given namespace using given metadata file location.
+
+      operationId: registerView
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterViewRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/LoadViewResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description: Not Found - The namespace specified does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NamespaceNotFound:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        409:
+          description: Conflict - The identifier already exists as a table or view
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                ViewAlreadyExists:
+                  $ref: '#/components/examples/ViewAlreadyExistsError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
 
 components:
   #######################################################
@@ -1811,7 +1956,10 @@ components:
       required: true
       description:
         A namespace identifier as a single string.
-        Multipart namespace parts should be separated by the unit separator (`0x1F`) byte.
+        Multipart namespace parts must be separated by the namespace separator as
+        indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`).
+        To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
+        The `namespace-separator` should be provided in a url encoded form.
       schema:
         type: string
       examples:
@@ -1861,14 +2009,10 @@ components:
         Optional signal to the server that the client supports delegated access
         via a comma-separated list of access mechanisms.  The server may choose
         to supply access via any or none of the requested mechanisms.
-        
-        
-        Specific properties and handling for `vended-credentials` is documented
-        in the `LoadTableResult` schema section of this spec document.
-        
-        
-        The protocol and specification for `remote-signing` is documented in 
-        the `s3-signer-open-api.yaml` OpenApi spec in the `aws` module.
+
+
+        Specific properties and handling for `vended-credentials` and `remote-signing`
+        are documented in the `LoadTableResult` schema section of this spec document.
 
       required: false
       schema:
@@ -1884,7 +2028,6 @@ components:
       name: pageToken
       in: query
       required: false
-      allowEmptyValue: true
       schema:
         $ref: '#/components/schemas/PageToken'
 
@@ -1902,10 +2045,71 @@ components:
     etag:
       name: ETag
       in: header
-      description: Identifies a unique version of the table metadata.
+      description:
+        Identifies a unique version of the table metadata.
+
+        Implementations that support ETags should produce unique tags for responses that return
+        different metadata content but represent the same version of table metadata.  For example,
+        the `snapshots` query parameter may result in different metadata representations depending
+        on whether `refs` or `all` is provided, therefore should have distinct ETags.
       required: false
       schema:
         type: string
+
+    referenced-by:
+      name: referenced-by
+      in: query
+      description:
+        A comma-separated list of fully qualified view names (namespace and view name) representing the view
+        reference chain when an entity (table or view) is loaded via a view. The list should be ordered with the outermost view
+        first, followed by any intermediate views it references, down to the view that directly references the entity.
+        For a simple case where a view directly references the entity, the list contains a single view identifier.
+        For nested views (a view referencing another view which references the entity), the list contains multiple
+        view identifiers representing the complete dependency chain.
+
+        The view identifier is a composite string of the format {namespace}{separator}{viewName}.
+        The namespace-separator (defined in /config) acts as the delimiter.
+        When parsing, the last occurrence of this separator identifies the boundary between the namespace and the view name.
+        Multipart namespaces must follow the encoding rules of the parent parameter in the list namespaces endpoint.
+
+        Multiple view identifiers are separated by commas. Servers should split the parameter value on comma characters
+        to parse individual view identifiers. If view names contain commas, they must be url-encoded as %2C.
+
+        Example with multiple views (where prod%1Fanalytics is a nested namespace which has a quarterly_view which references to monthly_view
+        which then references the entity being loaded) - prod%1Fanalytics%1Fquarterly_view,prod%1Fanalytics%1Fmonthly_view
+      required: false
+      schema:
+        type: string
+
+    idempotency-key:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
+        example: "017F22E2-79B0-7CC3-98C4-DC0C0C07398F"
+      description: |
+        Optional client-provided idempotency key for safe request retries.
+
+        When present, the server ensures no additional effects for requests that carry the same
+        Idempotency-Key. If a prior request with this key has been finalized, the server returns
+        an equivalent final response without re-running the operation. The response body may
+        reflect a newer state of the catalog than existed at the time of the commit.
+
+        Finalization rules:
+        - Finalize & replay: 200, 201, 204, and deterministic terminal 4xx (including 409
+          such as AlreadyExists, NamespaceNotEmpty, etc.)
+        - Do not finalize (not stored/replayed): 5xx
+
+        Key Requirements:
+        - Key format: UUIDv7 in string form (RFC 9562).
+        - The idempotency key must be globally unique (no reuse across different operations).
+        - Catalogs SHOULD NOT expire keys before the end of the advertised token lifetime.
+        - If Idempotency-Key is used, clients MUST reuse the same key when retrying the same
+          logical operation and MUST generate a new key for a different operation.
 
   ##############################
   # Application Schema Objects #
@@ -1970,6 +2174,18 @@ components:
             "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}",
             "GET /v1/{prefix}/namespaces/{namespace}/views/{view}"
           ]
+        idempotency-key-lifetime:
+          type: string
+          format: duration
+          description:
+            Client reuse window for an Idempotency-Key (ISO-8601 duration, e.g., PT30M, PT24H).
+            Interpreted as the maximum time from the first submission using a key to the last retry
+            during which a client may reuse that key. Servers SHOULD accept retries for at least this
+            duration and MAY include a grace period to account for delays/clock skew. Clients SHOULD NOT
+            reuse an Idempotency-Key after this window elapses; they SHOULD generate a new key for any
+            subsequent attempt. Presence of this field indicates the server supports Idempotency-Key
+            semantics for mutation endpoints. If absent, clients MUST assume idempotency is not supported.
+          example: PT30M
 
     CreateNamespaceRequest:
       type: object
@@ -2024,20 +2240,20 @@ components:
         An opaque token that allows clients to make use of pagination for list APIs
         (e.g. ListTables). Clients may initiate the first paginated request by sending an empty
         query parameter `pageToken` to the server.
-        
+
         Servers that support pagination should identify the `pageToken` parameter and return a
         `next-page-token` in the response if there are more results available.  After the initial
         request, the value of `next-page-token` from each response must be used as the `pageToken`
         parameter value for the next request. The server must return `null` value for the
         `next-page-token` in the last response.
-        
+
         Servers that support pagination must return all results in a single response with the value
         of `next-page-token` set to `null` if the query parameter `pageToken` is not set in the
         request.
-        
+
         Servers that do not support pagination should ignore the `pageToken` parameter and return
         all results in a single response. The `next-page-token` must be omitted from the response.
-        
+
         Clients must interpret either `null` or missing response value of `next-page-token` as
         the end of the listing results.
 
@@ -2246,15 +2462,12 @@ components:
       required:
         - type
         - term
-        - value
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
           enum: ["is-null", "not-null", "is-nan", "not-nan"]
         term:
           $ref: '#/components/schemas/Term'
-        value:
-          type: object
 
     LiteralExpression:
       type: object
@@ -2269,7 +2482,7 @@ components:
         term:
           $ref: '#/components/schemas/Term'
         value:
-          type: object
+          $ref: '#/components/schemas/PrimitiveTypeValue'
 
     SetExpression:
       type: object
@@ -2286,7 +2499,7 @@ components:
         values:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/PrimitiveTypeValue'
 
     Term:
       oneOf:
@@ -2402,7 +2615,7 @@ components:
           type: string
         encrypted-key-metadata:
           type: string
-          format: byte # for compatibility
+          format: byte  # for compatibility
           contentEncoding: base64
         encrypted-by-id:
           type: string
@@ -2438,6 +2651,10 @@ components:
           type: integer
           format: int64
           description: The first _row_id assigned to the first row in the first data file in the first manifest
+        added-rows:
+          type: integer
+          format: int64
+          description: The upper bound of the number of rows with assigned row IDs
         summary:
           type: object
           required:
@@ -3078,6 +3295,8 @@ components:
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
         - $ref: '#/components/schemas/SetStatisticsUpdate'
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
+        - $ref: '#/components/schemas/SetPartitionStatisticsUpdate'
+        - $ref: '#/components/schemas/RemovePartitionStatisticsUpdate'
         - $ref: '#/components/schemas/RemovePartitionSpecsUpdate'
         - $ref: '#/components/schemas/RemoveSchemasUpdate'
         - $ref: '#/components/schemas/AddEncryptionKeyUpdate'
@@ -3286,28 +3505,37 @@ components:
 
 
         The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
-        
-        
+
+
         The following configurations should be respected by clients:
-        
+
         ## General Configurations
-        
-        - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled 
-        
+
+        - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled
+        - `scan-planning-mode`: Communicates to clients the supported planning mode. Clients should use this value to fail fast if the supported scanning mode is not available on the client. Valid values:
+          - `client`: Clients MUST use client-side scan planning
+          - `server`: Clients MUST use server-side scan planning via the `planTableScan` endpoint
+
         ## AWS Configurations
-        
+
         The following configurations should be respected when working with tables stored in AWS S3
          - `client.region`: region to configure client for making requests to AWS
          - `s3.access-key-id`: id for credentials that provide access to the data in S3
-         - `s3.secret-access-key`: secret for credentials that provide access to data in S3 
-         - `s3.session-token`: if present, this value should be used for as the session token 
-         - `s3.remote-signing-enabled`: if `true` remote signing should be performed as described in the `s3-signer-open-api.yaml` specification
+         - `s3.secret-access-key`: secret for credentials that provide access to data in S3
+         - `s3.session-token`: if present, this value should be used for as the session token
+         - `s3.remote-signing-enabled`: if `true` remote signing should be performed as described in the `RemoteSignRequest` schema section of this spec document.
          - `s3.cross-region-access-enabled`: if `true`, S3 Cross-Region bucket access is enabled
 
         ## Storage Credentials
 
         Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
         Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
+
+        ## Remote Signing
+
+        If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
+         - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+         - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
       type: object
       required:
         - metadata
@@ -3373,12 +3601,24 @@ components:
             status:
               $ref: '#/components/schemas/PlanStatus'
               const: "completed"
+            storage-credentials:
+              type: array
+              description:
+                Storage credentials for accessing the files returned in the scan result.
+
+                If the server returns storage credentials as part of the completed scan
+                planning response, the expectation is for the client to use these credentials
+                to read the files returned in the FileScanTasks as part of the scan result.
+              items:
+                $ref: '#/components/schemas/StorageCredential'
 
     CompletedPlanningWithIDResult:
       type: object
       allOf:
         - $ref: '#/components/schemas/CompletedPlanningResult'
         - type: object
+          required:
+            - plan-id
           properties:
             plan-id:
               description: ID used to track a planning request
@@ -3401,6 +3641,7 @@ components:
       type: object
       required:
         - status
+        - plan-id
       properties:
         status:
           $ref: '#/components/schemas/PlanStatus'
@@ -3595,6 +3836,17 @@ components:
           type: object
           additionalProperties:
             type: string
+
+    RegisterViewRequest:
+      type: object
+      required:
+        - name
+        - metadata-location
+      properties:
+        name:
+          type: string
+        metadata-location:
+          type: string
 
     TokenType:
       type: string
@@ -4112,9 +4364,9 @@ components:
     DecimalTypeValue:
       type: string
       description:
-        "Decimal type values are serialized as strings. Decimals with a positive scale serialize as numeric plain 
-        text, while decimals with a negative scale use scientific notation and the exponent will be equal to the 
-        negated scale. For instance, a decimal with a positive scale is '123.4500', with zero scale is '2', 
+        "Decimal type values are serialized as strings. Decimals with a positive scale serialize as numeric plain
+        text, while decimals with a negative scale use scientific notation and the exponent will be equal to the
+        negated scale. For instance, a decimal with a positive scale is '123.4500', with zero scale is '2',
         and with a negative scale is '2E+20'"
       example: "123.4500"
 
@@ -4129,7 +4381,7 @@ components:
       maxLength: 36
       minLength: 36
       description:
-        "UUID type values are serialized as a 36-character lowercase string in standard UUID format as specified 
+        "UUID type values are serialized as a 36-character lowercase string in standard UUID format as specified
         by RFC-4122"
       example: "eb26bdb1-a1d8-4aa6-990e-da940875492c"
 
@@ -4155,7 +4407,7 @@ components:
     TimestampTzTypeValue:
       type: string
       description:
-        "TimestampTz type values follow the 'YYYY-MM-DDTHH:MM:SS.ssssss+00:00' ISO-8601 format with microsecond precision, 
+        "TimestampTz type values follow the 'YYYY-MM-DDTHH:MM:SS.ssssss+00:00' ISO-8601 format with microsecond precision,
         and a timezone offset (+00:00 for UTC)"
       example: "2007-12-03T10:15:30.123456+00:00"
 
@@ -4168,14 +4420,14 @@ components:
     TimestampTzNanoTypeValue:
       type: string
       description:
-        "Timestamp_ns type values follow the 'YYYY-MM-DDTHH:MM:SS.sssssssss+00:00' ISO-8601 format with nanosecond 
+        "Timestamp_ns type values follow the 'YYYY-MM-DDTHH:MM:SS.sssssssss+00:00' ISO-8601 format with nanosecond
         precision, and a timezone offset (+00:00 for UTC)"
       example: "2007-12-03T10:15:30.123456789+00:00"
 
     FixedTypeValue:
       type: string
       description:
-        "Fixed length type values are stored and serialized as an uppercase hexadecimal string 
+        "Fixed length type values are stored and serialized as an uppercase hexadecimal string
         preserving the fixed length"
       example: "78797A"
 
@@ -4201,7 +4453,7 @@ components:
       example:
         {
           "keys": [ 1, 2 ],
-          "values": [ 100,200 ]
+          "values": [ 100, 200 ]
         }
 
     ValueMap:
@@ -4403,6 +4655,14 @@ components:
           description:
             Expression used to filter the table data
           $ref: '#/components/schemas/Expression'
+        min-rows-requested:
+          description:
+            The minimum number of rows requested for the scan. This is used as a hint
+            to the server to not have to return more rows than necessary. It is not required
+            for the server to return that many rows since the scan may not produce that
+            many rows. The server can also return more rows than requested.
+          type: integer
+          format: int64
         case-sensitive:
           description: Enables case sensitive field matching for filter and select
           type: boolean
@@ -4440,14 +4700,14 @@ components:
 
         The nested field name follows these rules
         - Nested struct fields are named by concatenating field names at each
-        struct level using dot (`.`) delimiter, e.g.
-        employer.contact_info.address.zip_code
+          struct level using dot (`.`) delimiter, e.g.
+          employer.contact_info.address.zip_code
         - Nested fields in a map key are named using the keyword `key`, e.g.
-        employee_address_map.key.first_name
+          employee_address_map.key.first_name
         - Nested fields in a map value are named using the keyword `value`,
-        e.g. employee_address_map.value.zip_code
+          e.g. employee_address_map.value.zip_code
         - Nested fields in a list are named using the keyword `element`, e.g.
-        employees.element.first_name
+          employees.element.first_name
       type: string
 
     FetchScanTasksRequest:
@@ -4485,6 +4745,59 @@ components:
             residual or use the original filter.
           allOf:
             - $ref: '#/components/schemas/Expression'
+
+    MultiValuedMap:
+      description: A map of string keys where each key can map to multiple string values.
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+
+    RemoteSignRequest:
+      description: The request to be signed remotely.
+      type: object
+      required:
+        - region
+        - uri
+        - method
+        - headers
+      properties:
+        region:
+          type: string
+        uri:
+          type: string
+        method:
+          type: string
+          enum: ["PUT", "GET", "HEAD", "POST", "DELETE", "PATCH", "OPTIONS"]
+        headers:
+          $ref: '#/components/schemas/MultiValuedMap'
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        body:
+          type: string
+          description: Optional body of the request to send to the signing API. This should only be populated
+            for requests where the body of the message contains content which must be validated before a request is
+            signed, such as the S3 DeleteObjects call.
+        provider:
+          type: string
+          description: The storage provider for which the request is to be signed. The provider should correspond to
+            the scheme used for a storage native URI. For example `s3` for AWS S3 paths. For backwards compatibility,
+            if this is not specified, the provider is assumed to be `s3`.
+
+    RemoteSignResult:
+      description: The result of a remote request signing operation.
+      type: object
+      required:
+        - uri
+        - headers
+      properties:
+        uri:
+          type: string
+        headers:
+          $ref: '#/components/schemas/MultiValuedMap'
 
   #############################
   # Reusable Response Objects #
@@ -4756,6 +5069,9 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CommitTableResponse'
+      headers:
+        etag:
+          $ref: '#/components/parameters/etag'
 
     LoadCredentialsResponse:
       description: Table credentials result when loading credentials for a table
@@ -4763,6 +5079,15 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/LoadCredentialsResponse'
+
+    RemoteSignResponse:
+      description: The response containing signed & unsigned headers. The server will also send
+        a Cache-Control header, indicating whether the response can be cached (Cache-Control = ["private"])
+        or not (Cache-Control = ["no-cache"]).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RemoteSignResult'
 
   #######################################
   # Common examples of different values #
@@ -4857,6 +5182,16 @@ components:
         }
       }
 
+    NoSuchWarehouseError:
+      summary: The requested warehouse does not exist
+      value: {
+        "error": {
+          "message": "The given warehouse does not exist",
+          "type": "NoSuchWarehouseException",
+          "code": 404
+        }
+      }
+
     NoSuchNamespaceError:
       summary: The requested namespace does not exist
       value: {
@@ -4895,7 +5230,7 @@ components:
       summary: The requested table identifier already exists
       value: {
         "error": {
-          "message": "The given table already exists",
+          "message": "The requested table identifier already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }
@@ -4905,7 +5240,7 @@ components:
       summary: The requested view identifier already exists
       value: {
         "error": {
-          "message": "The given view already exists",
+          "message": "The requested view identifier already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }


### PR DESCRIPTION
**This is the first PR for bringing Iceberg 1.11 features into the `main` branch. Once this PR is merged, other features already present in the `feature/iceberg-1.11` will be cherry-picked as new PRs against `main`.**

This change upgrades the Iceberg dependency and REST spec to 1.11.0.

The newly-added test `CatalogTests.testLoadTableWithMissingMetadataFile` is not compatible with REST catalogs, see https://github.com/apache/iceberg/pull/15192. It has been disabled globally.

The newly-added test `CatalogTests.createTableInUniqueLocation` exercises a feature that is not implemented yet. It has been temporarily disabled. I created https://github.com/apache/polaris/issues/4492 to fix this.

The newly-added test `CatalogTests.dropAfterRenameDoesntCorruptTable` is not compatible with Polaris: it expects the rename-table operation to also move the table base location, which Polaris does not do. It has been disabled globally.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
