### PR TITLE
Fix hasListeners() always returning true when no event listeners configured

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventListeners.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventListeners.java
@@ -45,10 +45,15 @@ public class PolarisEventListeners {
   @Inject @Any Instance<PolarisEventListener> eventListeners;
   @Inject PolarisEventListenerConfiguration configuration;
 
-  private final EnumSet<PolarisEventType> enabledEventTypes = EnumSet.allOf(PolarisEventType.class);
+  private final EnumSet<PolarisEventType> enabledEventTypes = EnumSet.noneOf(PolarisEventType.class);
 
   public void onStartup(@Observes StartupEvent event) {
     var listenerTypeSet = configuration.types().orElseGet(HashSet::new);
+    if (listenerTypeSet.isEmpty()) {
+      // No listeners configured - enable all event types for backward compatibility
+      enabledEventTypes.addAll(EnumSet.allOf(PolarisEventType.class));
+      return;
+    }
     for (String enabledEventListener : listenerTypeSet) {
       var listenerConfiguration = configuration.listenerConfig().get(enabledEventListener);
       var supportedTypes =

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventListenersTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventListenersTest.java
@@ -251,6 +251,15 @@ public class PolarisEventListenersTest {
     assertTrue(consumeCatalogAndNotificationEventListener.unexpectedEvents.isEmpty());
   }
 
+  @Test
+  public void testHasListenersWhenNoListenersConfigured() {
+    // When no listeners are configured via polaris.event-listener.types,
+    // hasListeners should return true for all event types (backward compatibility)
+    for (PolarisEventType eventType : PolarisEventType.values()) {
+      assertTrue(eventDispatcher.hasListeners(eventType));
+    }
+  }
+
   private void expectEventTypes(List<PolarisEvent> events, Set<PolarisEventType> expectedTypes) {
     for (var eventTypes : expectedTypes) {
       assertEquals(


### PR DESCRIPTION
Long log:

 - Change `enabledEventTypes` initialization from `EnumSet.allOf()` to `EnumSet.noneOf()` to fix incorrect `hasListeners()` behavior
 - Add backward compatibility: when no listeners are explicitly configured, enable all event types

 BTW, the original code won’t cause any bugs, but it will make the `PolarisEventListeners` class lose its configurability.

Signed-off-by : Yongtao Huang <yongtaoh2022@gmail.com>

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
