### PR TITLE
Synchronize onComplete calls in InMemoryBufferEventListener (closes #4497)

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -56,15 +56,8 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
       Caffeine.newBuilder()
           .expireAfterAccess(Duration.ofHours(1))
           .evictionListener(
-              (String realmId, UnicastProcessor<?> processor, RemovalCause cause) -> {
-                // onComplete is not synchronized in smallrye-mutiny's UnicastProcessor,
-                // unlike onNext. Acquire the processor's intrinsic monitor (the same one
-                // onNext uses) so that eviction-driven onComplete and concurrent
-                // processEvent-driven onNext mutually exclude.
-                synchronized (processor) {
-                  processor.onComplete();
-                }
-              })
+              (String realmId, UnicastProcessor<?> processor, RemovalCause cause) ->
+                  completeSynchronized(processor))
           .build(this::createProcessor);
 
   @Override
@@ -75,18 +68,23 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
 
   @PreDestroy
   public void shutdown() {
-    // Same rationale as the eviction listener: hold the processor's monitor so
-    // shutdown-driven onComplete cannot race a concurrent processEvent-driven onNext.
-    processors
-        .asMap()
-        .values()
-        .forEach(
-            p -> {
-              synchronized (p) {
-                p.onComplete();
-              }
-            });
+    processors.asMap().values().forEach(InMemoryBufferEventListener::completeSynchronized);
     processors.invalidateAll(); // doesn't call the eviction listener
+  }
+
+  /**
+   * Calls {@link UnicastProcessor#onComplete()} while holding the processor's intrinsic monitor.
+   *
+   * <p>smallrye-mutiny's {@code UnicastProcessor.onNext} is method-{@code synchronized} on the
+   * processor instance; {@code onComplete} is not. Acquiring the same intrinsic monitor here
+   * restores symmetric mutual exclusion between concurrent {@code onNext} (from {@code
+   * processEvent}) and {@code onComplete} (from eviction or shutdown). Wrapping the pattern as an
+   * invariant keeps the synchronization requirement structurally visible to future maintainers.
+   */
+  private static void completeSynchronized(UnicastProcessor<?> processor) {
+    synchronized (processor) {
+      processor.onComplete();
+    }
   }
 
   protected UnicastProcessor<PolarisEvent> createProcessor(String realmId) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -56,8 +56,15 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
       Caffeine.newBuilder()
           .expireAfterAccess(Duration.ofHours(1))
           .evictionListener(
-              (String realmId, UnicastProcessor<?> processor, RemovalCause cause) ->
-                  processor.onComplete())
+              (String realmId, UnicastProcessor<?> processor, RemovalCause cause) -> {
+                // onComplete is not synchronized in smallrye-mutiny's UnicastProcessor,
+                // unlike onNext. Acquire the processor's intrinsic monitor (the same one
+                // onNext uses) so that eviction-driven onComplete and concurrent
+                // processEvent-driven onNext mutually exclude.
+                synchronized (processor) {
+                  processor.onComplete();
+                }
+              })
           .build(this::createProcessor);
 
   @Override
@@ -68,7 +75,17 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
 
   @PreDestroy
   public void shutdown() {
-    processors.asMap().values().forEach(UnicastProcessor::onComplete);
+    // Same rationale as the eviction listener: hold the processor's monitor so
+    // shutdown-driven onComplete cannot race a concurrent processEvent-driven onNext.
+    processors
+        .asMap()
+        .values()
+        .forEach(
+            p -> {
+              synchronized (p) {
+                p.onComplete();
+              }
+            });
     processors.invalidateAll(); // doesn't call the eviction listener
   }
 


### PR DESCRIPTION
## Summary

`UnicastProcessor.onNext()` is declared `public synchronized void` in smallrye-mutiny, but `onComplete()` is not synchronized. The two methods can therefore interleave: a concurrent `processEvent` (onNext) and eviction-driven `onComplete` on the same processor have no mutual exclusion, which can silently drop events at the eviction boundary.

This PR wraps both `onComplete()` call sites (the Caffeine eviction listener and the `shutdown()` loop) in `synchronized (processor) { ... }` blocks so they acquire the same intrinsic monitor that `onNext()` uses. `processEvent` itself does not change.

## Background

Surfaced during review of #4487 by @nandorKollar. @adutra agreed it warranted its own PR. Race interleaving details are in #4497.

## Test plan

No new test in this PR. The race window is microseconds at the eviction boundary, controlled by Caffeine's internal cleanup thread; a deterministic test of this interleaving is not portable. The fix is a small synchronization-only diff (+20 / -3) that reviewers can verify by inspection.

Existing tests pass locally:
- `InMemoryBufferEventListenerBufferSizeTest` (4 tests)
- `InMemoryBufferEventListenerBufferTimeTest` (1 test)
- `InMemoryBufferEventListenerIntegrationTest` (1 test)

Closes #4497.