### PR TITLE
fix(catalog): return 404 instead of 503 when drop races with concurrent delete

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -432,6 +432,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     if (!dropEntityResult.isSuccess()) {
       switch (dropEntityResult.getReturnStatus()) {
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+        case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
           return false;
 
         case BaseResult.ReturnStatus.ENTITY_UNDROPPABLE:
@@ -681,6 +682,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
           throw new NamespaceNotEmptyException("Namespace %s is not empty", namespace);
 
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+        case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
           return false;
 
         default:
@@ -883,6 +885,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     if (!dropEntityResult.isSuccess()) {
       switch (dropEntityResult.getReturnStatus()) {
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+        case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
           return false;
 
         case BaseResult.ReturnStatus.ENTITY_UNDROPPABLE:

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -432,7 +432,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     if (!dropEntityResult.isSuccess()) {
       switch (dropEntityResult.getReturnStatus()) {
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+          return false;
+
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
+          LOGGER.debug(
+              "Catalog path cannot be resolved for {}, treating as dropped; extraInfo={}",
+              tableIdentifier,
+              dropEntityResult.getExtraInformation());
           return false;
 
         case BaseResult.ReturnStatus.ENTITY_UNDROPPABLE:

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -688,7 +688,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
           throw new NamespaceNotEmptyException("Namespace %s is not empty", namespace);
 
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+          return false;
+
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
+          LOGGER.debug(
+              "Catalog path cannot be resolved for {}, treating as dropped; extraInfo={}",
+              namespace,
+              dropEntityResult.getExtraInformation());
           return false;
 
         default:
@@ -891,7 +897,13 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     if (!dropEntityResult.isSuccess()) {
       switch (dropEntityResult.getReturnStatus()) {
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
+          return false;
+
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
+          LOGGER.debug(
+              "Catalog path cannot be resolved for {}, treating as dropped; extraInfo={}",
+              identifier,
+              dropEntityResult.getExtraInformation());
           return false;
 
         case BaseResult.ReturnStatus.ENTITY_UNDROPPABLE:

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -2080,6 +2080,70 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
         .hasMessageContaining("cannot be dropped");
   }
 
+  @Test
+  public void testDropTableWithCatalogPathCannotBeResolved() {
+    catalog.createNamespace(NS);
+    catalog.buildTable(TABLE, SCHEMA).create();
+
+    PolarisMetaStoreManager spiedManager = spy(metaStoreManager);
+    doReturn(new DropEntityResult(BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED, null))
+        .when(spiedManager)
+        .dropEntityIfExists(any(), anyList(), any(), anyMap(), anyBoolean());
+
+    IcebergCatalog spiedCatalog = newIcebergCatalog(CATALOG_NAME, spiedManager, fileIOFactory);
+    spiedCatalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+
+    boolean result = spiedCatalog.dropTable(TABLE, false);
+    Assertions.assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testDropViewWithCatalogPathCannotBeResolved() {
+    catalog.createNamespace(NS);
+    catalog
+        .buildView(TABLE)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS)
+        .withQuery("spark", "SELECT * FROM ns.tbl")
+        .create();
+
+    PolarisMetaStoreManager spiedManager = spy(metaStoreManager);
+    doReturn(new DropEntityResult(BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED, null))
+        .when(spiedManager)
+        .dropEntityIfExists(any(), anyList(), any(), anyMap(), anyBoolean());
+
+    IcebergCatalog spiedCatalog = newIcebergCatalog(CATALOG_NAME, spiedManager, fileIOFactory);
+    spiedCatalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+
+    boolean result = spiedCatalog.dropView(TABLE);
+    Assertions.assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testDropNamespaceWithCatalogPathCannotBeResolved() {
+    catalog.createNamespace(NS);
+
+    PolarisMetaStoreManager spiedManager = spy(metaStoreManager);
+    doReturn(new DropEntityResult(BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED, null))
+        .when(spiedManager)
+        .dropEntityIfExists(any(), anyList(), any(), anyMap(), anyBoolean());
+
+    IcebergCatalog spiedCatalog = newIcebergCatalog(CATALOG_NAME, spiedManager, fileIOFactory);
+    spiedCatalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+
+    boolean result = spiedCatalog.dropNamespace(NS);
+    Assertions.assertThat(result).isFalse();
+  }
+
   private TableMetadata createSampleTableMetadata(String tableLocation) {
     Schema schema =
         new Schema(


### PR DESCRIPTION
When a table/view/namespace is concurrently deleted by another request, dropEntityIfExists returns CATALOG_PATH_CANNOT_BE_RESOLVED. Previously this fell through to the default case and threw ServiceFailureException (HTTP 503). The entity is simply gone — this should be treated the same as ENTITY_NOT_FOUND (return false / 404), not a service failure.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
