### PR TITLE
NoSQL: Honor unsupported MongoDB realm deletion

### DIFF
--- a/persistence/nosql/persistence/db/mongodb/src/main/java/org/apache/polaris/persistence/nosql/mongodb/MongoDbBackend.java
+++ b/persistence/nosql/persistence/db/mongodb/src/main/java/org/apache/polaris/persistence/nosql/mongodb/MongoDbBackend.java
@@ -175,6 +175,9 @@ final class MongoDbBackend implements Backend {
 
   @Override
   public void deleteRealms(Set<String> realmIds) {
+    if (!supportsRealmDeletion()) {
+      throw new UnsupportedOperationException("Realm deletion is not enabled for this backend");
+    }
     if (realmIds.isEmpty()) {
       return;
     }

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/AbstractPersistenceTests.java
@@ -664,6 +664,14 @@ public abstract class AbstractPersistenceTests {
   }
 
   @Test
+  public void backendRealmDeletionUnsupported() {
+    Assumptions.assumeThat(backend.supportsRealmDeletion()).isFalse();
+
+    soft.assertThatThrownBy(() -> backend.deleteRealms(Set.of("unsupported-realm-deletion-test")))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
   public void backendRealmDeletion(
       @PolarisPersistence Persistence one,
       @PolarisPersistence Persistence two,


### PR DESCRIPTION
The `Backend` interface supports two modes of deleting a realm: immediate deletion, which translates to a "deletion by key-prefix", and via the maintenance service. Production deployments prefer the latter approach.

This is an API contract hardening to fail prefix-deletion, if it is not explicitly enabled.