### PR TITLE
NoSQL: Java async exec test coverage

### DIFF
--- a/persistence/nosql/async/java/build.gradle.kts
+++ b/persistence/nosql/async/java/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
 
   testImplementation(testFixtures(project(":polaris-async-api")))
+
+  testCompileOnly(platform(libs.jackson.bom))
+  testCompileOnly("com.fasterxml.jackson.core:jackson-databind")
 }
 
 tasks.withType<Javadoc> { isFailOnError = false }

--- a/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
@@ -125,6 +125,8 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
             // keep-alive time
             asyncConfiguration.threadKeepAlive().orElse(DEFAULT_THREAD_KEEP_ALIVE).toMillis(),
             MILLISECONDS,
+            // Avoid queueing work before reaching maxThreads; SynchronousQueue makes the pool grow
+            // up to the configured maximum instead of buffering tasks behind too few workers.
             new SynchronousQueue<>(),
             // thread factory
             r -> {
@@ -199,6 +201,7 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
     var delayMillis = Math.max(delay.toMillis(), 0L);
     var cf = new CancelableFuture<>(callable);
     tasks.add(cf);
+    taskTrackedHook(cf);
 
     if (delayMillis > 0) {
       delayed(cf, delayMillis);
@@ -223,6 +226,7 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
 
     var cf = new CancelableFuture<Void>(runnable, delayMillis);
     tasks.add(cf);
+    taskTrackedHook(cf);
 
     if (initialMillis > 0) {
       delayed(cf, initialMillis);
@@ -253,6 +257,9 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
 
   @VisibleForTesting
   void delayedTaskRecordedHook(ScheduledFuture<?> scheduledFuture) {}
+
+  @VisibleForTesting
+  void taskTrackedHook(Cancelable<?> cancelable) {}
 
   private final class CancelableFuture<R> implements Cancelable<R>, Runnable {
     private final CompletableFuture<R> completable = new CompletableFuture<>();

--- a/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
@@ -20,14 +20,18 @@ package org.apache.polaris.nosql.async.java;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.polaris.nosql.async.AsyncConfiguration;
 import org.apache.polaris.nosql.async.AsyncExecTestBase;
+import org.apache.polaris.nosql.async.Cancelable;
 import org.junit.jupiter.api.Test;
 
 public class TestJavaPoolAsyncExec extends AsyncExecTestBase {
@@ -75,6 +79,75 @@ public class TestJavaPoolAsyncExec extends AsyncExecTestBase {
       assertThat(secondTimer)
           .hasValueSatisfying(timer -> assertThat(timer.isCancelled()).isFalse());
       periodic.cancel();
+    }
+  }
+
+  @Test
+  public void immediateTaskIsTrackedBeforeExecution() {
+    var tracked = new AtomicReference<Cancelable<?>>();
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().build()) {
+          @Override
+          void taskTrackedHook(Cancelable<?> cancelable) {
+            tracked.set(cancelable);
+          }
+        }) {
+      var task =
+          executor.submit(
+              () -> {
+                assertThat(tracked).hasValueSatisfying(t -> assertThat(t).isNotNull());
+                return "done";
+              });
+
+      assertThat(task.completionStage()).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("done");
+    }
+  }
+
+  @Test
+  public void delayedTaskCanBeCanceledBeforeTimerIsRecorded() {
+    var ran = new CountDownLatch(1);
+    var canceled = new AtomicInteger();
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().build()) {
+          @Override
+          void taskTrackedHook(Cancelable<?> cancelable) {
+            if (canceled.incrementAndGet() == 1) {
+              cancelable.cancel();
+            }
+          }
+        }) {
+      var task = executor.schedule(ran::countDown, Duration.ofMillis(1));
+
+      assertThat(ran.await(100, MILLISECONDS)).isFalse();
+      assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void immediateTaskRejectedWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+
+    try (var executor = new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build())) {
+      var blocker =
+          executor.submit(
+              () -> {
+                started.countDown();
+                assertThat(release.tryAcquire(5_000, MILLISECONDS)).isTrue();
+                return null;
+              });
+
+      assertThat(started.await(5_000, MILLISECONDS)).isTrue();
+      assertThatThrownBy(() -> executor.submit(() -> "rejected"))
+          .isInstanceOf(RejectedExecutionException.class);
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
     }
   }
 }


### PR DESCRIPTION
This change literally only adds more test coverage for the Java based async exect implementation, no functional changes.