### PR TITLE
NoSQL: vertx async exec test coverage + rare race fix

### DIFF
--- a/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
@@ -26,6 +26,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.polaris.nosql.async.AsyncConfiguration.DEFAULT_MAX_THREADS;
 import static org.apache.polaris.nosql.async.AsyncConfiguration.DEFAULT_THREAD_KEEP_ALIVE;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.vertx.core.Vertx;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -90,6 +91,8 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
             // keep-alive time
             asyncConfiguration.threadKeepAlive().orElse(DEFAULT_THREAD_KEEP_ALIVE).toMillis(),
             MILLISECONDS,
+            // Avoid queueing work before reaching maxThreads; SynchronousQueue makes the pool grow
+            // up to the configured maximum instead of buffering tasks behind too few workers.
             new SynchronousQueue<>(),
             // thread factory
             r -> {
@@ -131,6 +134,15 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
     return format("Runnable '%s' rejected against pool ID %s / '%s'", r, poolId, executor);
   }
 
+  @VisibleForTesting
+  void taskSubmittedHook(Future<?> future) {}
+
+  @VisibleForTesting
+  void taskRunHook() {}
+
+  @VisibleForTesting
+  void taskTrackedHook(Cancelable<?> cancelable) {}
+
   @PreDestroy
   @Override
   public void close() {
@@ -152,8 +164,11 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
   public <R> Cancelable<R> schedule(Callable<R> callable, Duration delay) {
     checkState(!shutdown, "Must not schedule new tasks after shutdown of pool %s", poolId);
     checkArgument(delay.compareTo(MAX_DURATION) < 0, "Delay is limited to %s", MAX_DURATION);
-    var cf = new CancelableFuture<R>(callable, Math.max(delay.toMillis(), 0L));
+    var delayMillis = Math.max(delay.toMillis(), 0L);
+    var cf = new CancelableFuture<>(callable, delayMillis > 0L);
     tasks.add(cf);
+    taskTrackedHook(cf);
+    cf.startScheduled(delayMillis);
     return cf;
   }
 
@@ -166,18 +181,28 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
         initialDelay.compareTo(MAX_DURATION) < 0, "Initial delay is limited to %s", MAX_DURATION);
     checkArgument(delay.compareTo(MAX_DURATION) < 0, "Delay is limited to %s", MAX_DURATION);
 
-    var cf =
-        new CancelableFuture<Void>(
-            runnable, Math.max(initialDelay.toMillis(), 0L), Math.max(delay.toMillis(), 1L));
+    var cf = new CancelableFuture<Void>(runnable);
     tasks.add(cf);
+    taskTrackedHook(cf);
+    cf.startPeriodic(Math.max(initialDelay.toMillis(), 1L), Math.max(delay.toMillis(), 1L));
     return cf;
   }
 
   private final class CancelableFuture<R> implements Cancelable<R>, Runnable {
-    private final long timerId;
+    private sealed interface TimerState permits NotStarted, Canceled, Started {}
 
-    /** Flag whether {@link #timerId} is valid and the Vert.X timer needs to be canceled. */
-    private final boolean hasTimerId;
+    private enum NotStarted implements TimerState {
+      INSTANCE
+    }
+
+    private enum Canceled implements TimerState {
+      INSTANCE
+    }
+
+    private record Started(long timerId) implements TimerState {}
+
+    private final AtomicReference<TimerState> timerState =
+        new AtomicReference<>(NotStarted.INSTANCE);
 
     private final CompletableFuture<R> completable = new CompletableFuture<>();
     private final Runnable runnable;
@@ -189,34 +214,46 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
     // Track in-flight submission to allow cancelling/interrupting
     private final AtomicReference<Future<?>> runningFuture = new AtomicReference<>();
 
-    CancelableFuture(Runnable runnable, long initialMillis, long delayMillis) {
-      initialMillis = Math.max(initialMillis, 1L);
-      delayMillis = Math.max(delayMillis, 1L);
+    /** Constructor for periodic tasks. */
+    CancelableFuture(Runnable runnable) {
       this.runnable = requireNonNull(runnable, "Runnable must not be null");
-      this.callable = this::runnable;
-      this.timerId = vertx.setPeriodic(initialMillis, delayMillis, this::execAsync);
-      this.hasTimerId = true;
+      this.callable =
+          () -> {
+            runnable.run();
+            return null;
+          };
+      this.timerState.set(NotStarted.INSTANCE);
       this.periodic = true;
     }
 
-    CancelableFuture(Callable<R> callable, long delayMillis) {
+    /** Constructor for one-shot tasks. */
+    CancelableFuture(Callable<R> callable, boolean delayed) {
       this.runnable = null;
       this.callable = requireNonNull(callable, "Callable must not be null");
       this.periodic = false;
-      if (delayMillis > 0) {
-        this.hasTimerId = true;
-        this.timerId = vertx.setTimer(delayMillis, this::execAsync);
-      } else {
-        // Execute immediately
-        this.hasTimerId = false;
-        this.timerId = 0L;
-        execAsync(-1L);
-      }
+      this.timerState.set(delayed ? NotStarted.INSTANCE : Canceled.INSTANCE);
     }
 
-    private R runnable() {
-      runnable.run();
-      return null;
+    void startScheduled(long delayMillis) {
+      if (delayMillis <= 0) {
+        execAsync(-1L);
+        return;
+      }
+      setTimer(vertx.setTimer(delayMillis, this::execAsync));
+    }
+
+    void startPeriodic(long initialMillis, long delayMillis) {
+      initialMillis = Math.max(initialMillis, 1L);
+      delayMillis = Math.max(delayMillis, 1L);
+      setTimer(vertx.setPeriodic(initialMillis, delayMillis, this::execAsync));
+    }
+
+    private void setTimer(long timerId) {
+      if (!timerState.compareAndSet(NotStarted.INSTANCE, new Started(timerId))) {
+        vertx.cancelTimer(timerId);
+      } else if (cancelledOrShutdown()) {
+        cancelTimer();
+      }
     }
 
     @SuppressWarnings("FutureReturnValueIgnored")
@@ -226,26 +263,25 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
         return;
       }
       // Skip overlapping periodic executions
-      if (periodic && running.get()) {
+      if (periodic && !running.compareAndSet(false, true)) {
         return;
       }
       try {
         var f = executorService.submit(this);
         runningFuture.set(f);
-      } catch (RejectedExecutionException rex) {
-        completable.completeExceptionally(rex);
+        VertxAsyncExec.this.taskSubmittedHook(f);
+      } catch (Throwable e) {
+        completable.completeExceptionally(e);
+        running.set(false);
         cancel();
       }
     }
 
     @Override
     public void run() {
+      VertxAsyncExec.this.taskRunHook();
       if (cancelledOrShutdown()) {
         cancel();
-        return;
-      }
-      if (periodic && !running.compareAndSet(false, true)) {
-        // Defensive: in case a race got us here while running
         return;
       }
       try {
@@ -270,7 +306,8 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
     }
 
     private void cancelTimer() {
-      if (hasTimerId) {
+      var previous = timerState.getAndSet(Canceled.INSTANCE);
+      if (previous instanceof Started(long timerId)) {
         vertx.cancelTimer(timerId);
       }
     }

--- a/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
@@ -165,7 +165,7 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
     checkState(!shutdown, "Must not schedule new tasks after shutdown of pool %s", poolId);
     checkArgument(delay.compareTo(MAX_DURATION) < 0, "Delay is limited to %s", MAX_DURATION);
     var delayMillis = Math.max(delay.toMillis(), 0L);
-    var cf = new CancelableFuture<>(callable, delayMillis > 0L);
+    var cf = new CancelableFuture<>(callable);
     tasks.add(cf);
     taskTrackedHook(cf);
     cf.startScheduled(delayMillis);
@@ -222,16 +222,14 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
             runnable.run();
             return null;
           };
-      this.timerState.set(NotStarted.INSTANCE);
       this.periodic = true;
     }
 
     /** Constructor for one-shot tasks. */
-    CancelableFuture(Callable<R> callable, boolean delayed) {
+    CancelableFuture(Callable<R> callable) {
       this.runnable = null;
       this.callable = requireNonNull(callable, "Callable must not be null");
       this.periodic = false;
-      this.timerState.set(delayed ? NotStarted.INSTANCE : Canceled.INSTANCE);
     }
 
     void startScheduled(long delayMillis) {
@@ -271,9 +269,13 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
         runningFuture.set(f);
         VertxAsyncExec.this.taskSubmittedHook(f);
       } catch (Throwable e) {
+        cancelTimer();
+        runningFuture.set(null);
+        if (periodic) {
+          running.set(false);
+        }
         completable.completeExceptionally(e);
-        running.set(false);
-        cancel();
+        tasks.remove(this);
       }
     }
 

--- a/persistence/nosql/async/vertx/src/test/java/org/apache/polaris/nosql/async/vertx/TestVertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/test/java/org/apache/polaris/nosql/async/vertx/TestVertxAsyncExec.java
@@ -18,12 +18,145 @@
  */
 package org.apache.polaris.nosql.async.vertx;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Vertx;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.polaris.nosql.async.AsyncConfiguration;
 import org.apache.polaris.nosql.async.AsyncExecTestBase;
+import org.apache.polaris.nosql.async.Cancelable;
+import org.junit.jupiter.api.Test;
 
 public class TestVertxAsyncExec extends AsyncExecTestBase {
+  @Inject Vertx vertx;
+  @Inject AsyncConfiguration asyncConfiguration;
+
   @Override
   protected void threadAssertion() {
     var t = Thread.currentThread();
     soft.assertThat(t.getName()).startsWith(VertxAsyncExec.EXECUTOR_THREAD_NAME_PREFIX);
+  }
+
+  @Test
+  public void periodicTaskDoesNotSubmitAgainWhenPreviousRunIsPending() throws Exception {
+    var submissions = new AtomicInteger();
+    var runHooks = new AtomicInteger();
+    var firstRunStarted = new CountDownLatch(1);
+    var releaseFirstRun = new CountDownLatch(1);
+    var secondSubmission = new CountDownLatch(1);
+
+    try (var executor =
+        new VertxAsyncExec(vertx, asyncConfiguration) {
+          @Override
+          void taskSubmittedHook(Future<?> future) {
+            if (submissions.incrementAndGet() == 2) {
+              secondSubmission.countDown();
+            }
+          }
+
+          @Override
+          void taskRunHook() {
+            if (runHooks.incrementAndGet() == 1) {
+              firstRunStarted.countDown();
+              try {
+                assertThat(releaseFirstRun.await(5, SECONDS)).isTrue();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              }
+            }
+          }
+        }) {
+      var periodic =
+          executor.schedulePeriodic(() -> {}, Duration.ofMillis(1), Duration.ofMillis(1));
+
+      assertThat(firstRunStarted.await(5, SECONDS)).isTrue();
+      assertThat(secondSubmission.await(100, MILLISECONDS)).isFalse();
+
+      releaseFirstRun.countDown();
+      periodic.cancel();
+    }
+  }
+
+  @Test
+  public void immediateTaskIsTrackedBeforeExecution() {
+    var tracked = new AtomicReference<Cancelable<?>>();
+
+    try (var executor =
+        new VertxAsyncExec(vertx, asyncConfiguration) {
+          @Override
+          void taskTrackedHook(Cancelable<?> cancelable) {
+            tracked.set(cancelable);
+          }
+        }) {
+      var task =
+          executor.submit(
+              () -> {
+                assertThat(tracked).hasValueSatisfying(t -> assertThat(t).isNotNull());
+                return "done";
+              });
+
+      assertThat(task.completionStage()).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("done");
+    }
+  }
+
+  @Test
+  public void delayedTaskCanBeCanceledBeforeTimerStarts() throws Exception {
+    var ran = new CountDownLatch(1);
+    var canceled = new AtomicInteger();
+
+    try (var executor =
+        new VertxAsyncExec(vertx, asyncConfiguration) {
+          @Override
+          void taskTrackedHook(Cancelable<?> cancelable) {
+            if (canceled.incrementAndGet() == 1) {
+              cancelable.cancel();
+            }
+          }
+        }) {
+      var task = executor.schedule(ran::countDown, Duration.ofMillis(1));
+
+      assertThat(ran.await(100, MILLISECONDS)).isFalse();
+      assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+    }
+  }
+
+  @Test
+  public void immediateTaskFailsWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+
+    try (var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build())) {
+      var blocker =
+          executor.submit(
+              () -> {
+                started.countDown();
+                assertThat(release.tryAcquire(5, SECONDS)).isTrue();
+                return null;
+              });
+
+      assertThat(started.await(5, SECONDS)).isTrue();
+      var rejected = executor.submit(() -> "rejected").completionStage().toCompletableFuture();
+      assertThat(rejected)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableThat()
+          .isInstanceOf(ExecutionException.class)
+          .havingCause()
+          .isInstanceOf(RejectedExecutionException.class);
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+    }
   }
 }


### PR DESCRIPTION
Improve test coverage for the Vert.X async exec implementation.

Also fixes a possible race condition: A stale timer future could be recorded after a newer periodic timer was scheduled, causing the newer timer to be canceled and the periodic task to stop.
