### PR TITLE
Replace System.out.println with SLF4J logging in ServiceProducers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ServiceProducers.java
@@ -305,14 +305,13 @@ public class ServiceProducers {
                   "Realm '{}' automatically bootstrapped, credentials taken from root credentials set provided via the {} configuration property, not printed to stdout.");
             } else {
               log.log(
-                  "Realm '{}' automatically bootstrapped, credentials were not present in root credentials set provided via the {} configuration property, see separate message printed to stdout.");
-              String msg =
-                  String.format(
-                      "realm: %1$s root principal credentials: %2$s:%3$s",
-                      realm,
-                      principalSecrets.getPrincipalClientId(),
-                      principalSecrets.getMainSecret());
-              System.out.println(msg);
+                  "Realm '{}' automatically bootstrapped, credentials were not present in root credentials set provided via the {} configuration property, credentials are logged separately.");
+
+              LOGGER.info(
+                  "realm: {} root principal credentials: {}:{}",
+                  realm,
+                  principalSecrets.getPrincipalClientId(),
+                  principalSecrets.getMainSecret());
             }
           });
 


### PR DESCRIPTION
## What changes were proposed in this PR?

Replaced `System.out.println` usage in `ServiceProducers`
with proper SLF4J logging for consistency with the rest
of the Polaris codebase.

Also updated the related log message to avoid referring
to stdout directly.

## Why are the changes needed?

Polaris uses SLF4J-based structured logging throughout
the project. Using SLF4J here improves consistency and
avoids direct stdout printing in runtime services.

## Does this PR introduce any user-facing change?

No.

