### PR TITLE
Site: Remove duplicate 'for' in markdown_testing.py print output

### DIFF
--- a/site/it/site_checks/markdown_testing.py
+++ b/site/it/site_checks/markdown_testing.py
@@ -119,7 +119,7 @@ def run_test(
 
         tee.printf(
             dedent(f"""
-            Test steps durations for for {md_file} ({"❌ FAILED" if failed else "✅ passed"}):
+            Test steps durations for {md_file} ({"❌ FAILED" if failed else "✅ passed"}):
                 .. Test: {duration_str}
                 .. Docker Compose Info: {_format_duration(docker_info_duration)}
                 .. Docker Cleanup: {_format_duration(cleanup_duration)}


### PR DESCRIPTION
Trivial typo fix in a CI tooling script. The print statement at `site/it/site_checks/markdown_testing.py:122` reads "Test steps durations for for {md_file}" - duplicate "for". Removed one to make it "Test steps durations for {md_file}". No logic change; output-only.

Originated in #3553 (CI for guides).