### PR TITLE
Update apache/hive Docker tag to v4.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ hadoop-client-api = { module = "org.apache.hadoop:hadoop-client-api", version.re
 hadoop-client-runtime = { module = "org.apache.hadoop:hadoop-client-runtime", version.ref = "hadoop" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 hawkular-agent-prometheus-scraper = { module = "org.hawkular.agent:prometheus-scraper", version = "0.23.0.Final" }
-hive-metastore = { module = "org.apache.hive:hive-metastore", version = "3.1.3" }
+hive-metastore = { module = "org.apache.hive:hive-metastore", version = "4.2.0" }
 iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
 immutables-builder = { module = "org.immutables:builder", version.ref = "immutables" }
 immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }

--- a/tools/hms-testcontainer/src/main/resources/org/apache/polaris/test/hms/Dockerfile-hms-version
+++ b/tools/hms-testcontainer/src/main/resources/org/apache/polaris/test/hms/Dockerfile-hms-version
@@ -18,4 +18,4 @@
 #
 
 # The FROM line is managed by Renovate.
-FROM apache/hive:4.0.1
+FROM apache/hive:4.2.0


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR fixes https://github.com/apache/polaris/pull/4333. There were 3 issues identified last time when I checked this:
```
1. the base image for hive change (changed from Debian to RedHat and the install curl is no longer valid also not needed as RedHat image has those pre-packaged)
  - this got resolved by https://github.com/apache/polaris/pull/4361/changes
2. Iceberg 1.10.0 doesn't yet support Hive 4.2.0 (it will be in 1.11.0)
  - this got resolved by https://github.com/apache/polaris/pull/4491 
3. We will need to bump HMS version as well
  - this was attempted to be fixed by https://github.com/apache/polaris/pull/3726 but later got reverted via https://github.com/apache/polaris/pull/3741 due to the above issues
```

Now as Iceberg 1.11.0 is in and custom docker image got fixed, we are ready for hive/hms 4.2.0.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
