### PR TITLE
Migrate remaining modules to JSpecify null annotations

### DIFF
--- a/extensions/auth/opa/impl/build.gradle.kts
+++ b/extensions/auth/opa/impl/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
 
+  compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)

--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -21,8 +21,6 @@ package org.apache.polaris.extension.auth.opa;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -60,6 +58,8 @@ import org.apache.polaris.extension.auth.opa.model.ImmutableResource;
 import org.apache.polaris.extension.auth.opa.model.ImmutableResourceEntity;
 import org.apache.polaris.extension.auth.opa.model.ResourceEntity;
 import org.apache.polaris.extension.auth.opa.token.BearerTokenProvider;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * OPA-based implementation of {@link PolarisAuthorizer}.
@@ -90,9 +90,9 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
    * @param tokenProvider Token provider for authentication (optional)
    */
   public OpaPolarisAuthorizer(
-      @Nonnull URI policyUri,
-      @Nonnull CloseableHttpClient httpClient,
-      @Nonnull ObjectMapper objectMapper,
+      @NonNull URI policyUri,
+      @NonNull CloseableHttpClient httpClient,
+      @NonNull ObjectMapper objectMapper,
       @Nullable BearerTokenProvider tokenProvider) {
 
     this.policyUri = policyUri;
@@ -109,14 +109,14 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
    */
   @Override
   public void resolveAuthorizationInputs(
-      @Nonnull AuthorizationState authzState, @Nonnull AuthorizationRequest request) {
+      @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
     authzState.getResolutionManifest().resolveAll();
   }
 
   @Override
-  @Nonnull
+  @NonNull
   public AuthorizationDecision authorize(
-      @Nonnull AuthorizationState authzState, @Nonnull AuthorizationRequest request) {
+      @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
     boolean allowed =
         queryOpa(
             buildOpaAuthorizationInput(
@@ -144,9 +144,9 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
    */
   @Override
   public void authorizeOrThrow(
-      @Nonnull PolarisPrincipal polarisPrincipal,
-      @Nonnull Set<PolarisBaseEntity> activatedEntities,
-      @Nonnull PolarisAuthorizableOperation authzOp,
+      @NonNull PolarisPrincipal polarisPrincipal,
+      @NonNull Set<PolarisBaseEntity> activatedEntities,
+      @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable PolarisResolvedPathWrapper target,
       @Nullable PolarisResolvedPathWrapper secondary) {
     authorizeOrThrow(
@@ -171,9 +171,9 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
    */
   @Override
   public void authorizeOrThrow(
-      @Nonnull PolarisPrincipal polarisPrincipal,
-      @Nonnull Set<PolarisBaseEntity> activatedEntities,
-      @Nonnull PolarisAuthorizableOperation authzOp,
+      @NonNull PolarisPrincipal polarisPrincipal,
+      @NonNull Set<PolarisBaseEntity> activatedEntities,
+      @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
     boolean allowed =
@@ -345,7 +345,7 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
         .build();
   }
 
-  @Nonnull
+  @NonNull
   private List<ResourceEntity> toResourceEntitiesFromResolvedPaths(
       @Nullable List<PolarisResolvedPathWrapper> paths) {
     if (paths == null || paths.isEmpty()) {
@@ -361,7 +361,7 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
     return entities;
   }
 
-  @Nonnull
+  @NonNull
   private List<ResourceEntity> toResourceEntitiesFromSecurables(
       @Nullable List<PolarisSecurable> securables) {
     if (securables == null || securables.isEmpty()) {

--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/BearerTokenProvider.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/BearerTokenProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.extension.auth.opa.token;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for providing bearer tokens for authentication.
@@ -38,8 +38,7 @@ public interface BearerTokenProvider extends AutoCloseable {
    *
    * @return the bearer token, or null if no token is available
    */
-  @Nullable
-  String getToken();
+  @Nullable String getToken();
 
   /**
    * Clean up any resources used by this token provider. Should be called when the provider is no

--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkState;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.polaris.nosql.async.AsyncExec;
 import org.apache.polaris.nosql.async.Cancelable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/StaticBearerTokenProvider.java
+++ b/extensions/auth/opa/impl/src/main/java/org/apache/polaris/extension/auth/opa/token/StaticBearerTokenProvider.java
@@ -21,7 +21,7 @@ package org.apache.polaris.extension.auth.opa.token;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Strings;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /** A simple token provider that returns a static string value. */
 public record StaticBearerTokenProvider(String token) implements BearerTokenProvider {
@@ -31,7 +31,7 @@ public record StaticBearerTokenProvider(String token) implements BearerTokenProv
   }
 
   @Override
-  public @Nonnull String getToken() {
+  public @NonNull String getToken() {
     return token;
   }
 }

--- a/extensions/auth/ranger/impl/build.gradle.kts
+++ b/extensions/auth/ranger/impl/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")
 
-  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)
   compileOnly(libs.smallrye.config.core)

--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -19,8 +19,6 @@
 package org.apache.polaris.extension.auth.ranger;
 
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +44,8 @@ import org.apache.ranger.authz.model.RangerAuthzResult;
 import org.apache.ranger.authz.model.RangerMultiAuthzRequest;
 import org.apache.ranger.authz.model.RangerMultiAuthzResult;
 import org.apache.ranger.authz.model.RangerUserInfo;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,21 +82,21 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
 
   @Override
   public void resolveAuthorizationInputs(
-      @Nonnull AuthorizationState authzState, @Nonnull AuthorizationRequest request) {
+      @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
     throw new UnsupportedOperationException("resolveAuthorizationInputs is not implemented yet");
   }
 
   @Override
-  public @Nonnull AuthorizationDecision authorize(
-      @Nonnull AuthorizationState authzState, @Nonnull AuthorizationRequest request) {
+  public @NonNull AuthorizationDecision authorize(
+      @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
     throw new UnsupportedOperationException("authorize is not implemented yet");
   }
 
   @Override
   public void authorizeOrThrow(
-      @Nonnull PolarisPrincipal polarisPrincipal,
-      @Nonnull Set<PolarisBaseEntity> activatedEntities,
-      @Nonnull PolarisAuthorizableOperation authzOp,
+      @NonNull PolarisPrincipal polarisPrincipal,
+      @NonNull Set<PolarisBaseEntity> activatedEntities,
+      @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable PolarisResolvedPathWrapper target,
       @Nullable PolarisResolvedPathWrapper secondary) {
     authorizeOrThrow(
@@ -109,9 +109,9 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
 
   @Override
   public void authorizeOrThrow(
-      @Nonnull PolarisPrincipal polarisPrincipal,
-      @Nonnull Set<PolarisBaseEntity> activatedEntities,
-      @Nonnull PolarisAuthorizableOperation authzOp,
+      @NonNull PolarisPrincipal polarisPrincipal,
+      @NonNull Set<PolarisBaseEntity> activatedEntities,
+      @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
 
@@ -156,8 +156,8 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
   }
 
   private boolean isAccessAuthorized(
-      @Nonnull PolarisPrincipal principal,
-      @Nonnull PolarisAuthorizableOperation authzOp,
+      @NonNull PolarisPrincipal principal,
+      @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries)
       throws RangerAuthzException {

--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
   compileOnly("com.fasterxml.jackson.core:jackson-core")
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
-  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)
   compileOnly(platform(libs.opentelemetry.instrumentation.bom.alpha))

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -21,7 +21,6 @@ package org.apache.polaris.persistence.relational.jdbc;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import jakarta.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +43,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
+import org.apache.polaris.persistence.relational.jdbc.QueryGenerator.PreparedQuery;
 import org.apache.polaris.persistence.relational.jdbc.models.Converter;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,8 +148,7 @@ public class DatasourceOperations {
    * @throws SQLException : Exception during the query execution.
    */
   public <T> List<T> executeSelect(
-      @Nonnull QueryGenerator.PreparedQuery query, @Nonnull Converter<T> converterInstance)
-      throws SQLException {
+      @NonNull PreparedQuery query, @NonNull Converter<T> converterInstance) throws SQLException {
     ArrayList<T> results = new ArrayList<>();
     executeSelectOverStream(query, converterInstance, stream -> stream.forEach(results::add));
     return results;
@@ -165,9 +165,9 @@ public class DatasourceOperations {
    * @throws SQLException : Exception during the query execution.
    */
   public <T> void executeSelectOverStream(
-      @Nonnull QueryGenerator.PreparedQuery query,
-      @Nonnull Converter<T> converterInstance,
-      @Nonnull Consumer<Stream<T>> consumer)
+      @NonNull PreparedQuery query,
+      @NonNull Converter<T> converterInstance,
+      @NonNull Consumer<Stream<T>> consumer)
       throws SQLException {
     withRetries(
         () -> {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -21,8 +21,6 @@ package org.apache.polaris.persistence.relational.jdbc;
 import static org.apache.polaris.persistence.relational.jdbc.QueryGenerator.PreparedQuery;
 
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -80,6 +78,8 @@ import org.apache.polaris.persistence.relational.jdbc.models.ModelPolicyMappingR
 import org.apache.polaris.persistence.relational.jdbc.models.ModelPrincipalAuthenticationData;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelScanMetricsReport;
 import org.apache.polaris.persistence.relational.jdbc.models.SchemaVersion;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,14 +113,14 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public long generateNewId(@Nonnull PolarisCallContext callCtx) {
+  public long generateNewId(@NonNull PolarisCallContext callCtx) {
     return IdGenerator.getIdGenerator().nextId();
   }
 
   @Override
   public void writeEntity(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisBaseEntity entity,
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
       boolean nameOrParentChanged,
       PolarisBaseEntity originalEntity) {
     try {
@@ -139,8 +139,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void writeEntities(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull List<PolarisBaseEntity> entities,
+      @NonNull PolarisCallContext callCtx,
+      @NonNull List<PolarisBaseEntity> entities,
       List<PolarisBaseEntity> originalEntities) {
     try {
       datasourceOperations.runWithinTransaction(
@@ -174,8 +174,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   private void persistEntity(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisBaseEntity entity,
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
       PolarisBaseEntity originalEntity,
       Connection connection,
       QueryAction queryAction)
@@ -256,7 +256,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void writeToGrantRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec) {
+      @NonNull PolarisCallContext callCtx, @NonNull PolarisGrantRecord grantRec) {
     ModelGrantRecord modelGrantRecord = ModelGrantRecord.fromGrantRecord(grantRec);
     try {
       List<Object> values =
@@ -271,7 +271,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void writeEvents(@Nonnull List<PolarisEvent> events) {
+  public void writeEvents(@NonNull List<PolarisEvent> events) {
     if (events.isEmpty()) {
       return; // or throw if empty list is invalid
     }
@@ -328,7 +328,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteEntity(@Nonnull PolarisCallContext callCtx, @Nonnull PolarisBaseEntity entity) {
+  public void deleteEntity(@NonNull PolarisCallContext callCtx, @NonNull PolarisBaseEntity entity) {
     ModelEntity modelEntity = ModelEntity.fromEntity(entity, schemaVersion);
     Map<String, Object> params =
         Map.of(
@@ -350,7 +350,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteFromGrantRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisGrantRecord grantRec) {
+      @NonNull PolarisCallContext callCtx, @NonNull PolarisGrantRecord grantRec) {
     ModelGrantRecord modelGrantRecord = ModelGrantRecord.fromGrantRecord(grantRec);
     try {
       Map<String, Object> whereClause =
@@ -367,10 +367,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteAllEntityGrantRecords(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisEntityCore entity,
-      @Nonnull List<PolarisGrantRecord> grantsOnGrantee,
-      @Nonnull List<PolarisGrantRecord> grantsOnSecurable) {
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisEntityCore entity,
+      @NonNull List<PolarisGrantRecord> grantsOnGrantee,
+      @NonNull List<PolarisGrantRecord> grantsOnSecurable) {
     try {
       datasourceOperations.executeUpdate(
           QueryGenerator.generateDeleteQueryForEntityGrantRecords(entity, realmId));
@@ -381,7 +381,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void deleteAll(@Nonnull PolarisCallContext callCtx) {
+  public void deleteAll(@NonNull PolarisCallContext callCtx) {
     try {
       Map<String, Object> params = Map.of("realm_id", realmId);
       datasourceOperations.runWithinTransaction(
@@ -416,7 +416,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public PolarisBaseEntity lookupEntity(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode) {
+      @NonNull PolarisCallContext callCtx, long catalogId, long entityId, int typeCode) {
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "type_code", typeCode, "realm_id", realmId);
     return getPolarisBaseEntity(
@@ -426,11 +426,11 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public PolarisBaseEntity lookupEntityByName(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
       int typeCode,
-      @Nonnull String name) {
+      @NonNull String name) {
     Map<String, Object> params =
         Map.of(
             "catalog_id",
@@ -468,10 +468,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisBaseEntity> lookupEntities(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
+      @NonNull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
     if (entityIds == null || entityIds.isEmpty()) return new ArrayList<>();
     PreparedQuery query =
         QueryGenerator.generateSelectQueryWithEntityIds(realmId, schemaVersion, entityIds);
@@ -488,10 +488,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisChangeTrackingVersions> lookupEntityVersions(
-      @Nonnull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
+      @NonNull PolarisCallContext callCtx, List<PolarisEntityId> entityIds) {
     Map<PolarisEntityId, ModelEntity> idToEntityMap =
         lookupEntities(callCtx, entityIds).stream()
             .filter(Objects::nonNull)
@@ -554,15 +554,15 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         queryProjections, ModelEntity.TABLE_NAME, whereEquals, whereGreater, orderByColumnName);
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public Page<EntityNameLookupRecord> listEntities(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PolarisEntitySubType entitySubType,
-      @Nonnull PageToken pageToken) {
+      @NonNull PolarisEntityType entityType,
+      @NonNull PolarisEntitySubType entitySubType,
+      @NonNull PageToken pageToken) {
     try {
       PreparedQuery query =
           buildEntityQuery(
@@ -587,17 +587,17 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public <T> Page<T> listFullEntities(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long catalogId,
       long parentId,
-      @Nonnull PolarisEntityType entityType,
-      @Nonnull PolarisEntitySubType entitySubType,
-      @Nonnull Predicate<PolarisBaseEntity> entityFilter,
-      @Nonnull Function<PolarisBaseEntity, T> transformer,
-      @Nonnull PageToken pageToken) {
+      @NonNull PolarisEntityType entityType,
+      @NonNull PolarisEntitySubType entitySubType,
+      @NonNull Predicate<PolarisBaseEntity> entityFilter,
+      @NonNull Function<PolarisBaseEntity, T> transformer,
+      @NonNull PageToken pageToken) {
     try {
       PreparedQuery query =
           buildEntityQuery(
@@ -624,7 +624,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public int lookupEntityGrantRecordsVersion(
-      @Nonnull PolarisCallContext callCtx, long catalogId, long entityId) {
+      @NonNull PolarisCallContext callCtx, long catalogId, long entityId) {
 
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "realm_id", realmId);
@@ -637,7 +637,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public PolarisGrantRecord lookupGrantRecord(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long securableCatalogId,
       long securableId,
       long granteeCatalogId,
@@ -677,10 +677,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisGrantRecord> loadAllGrantRecordsOnSecurable(
-      @Nonnull PolarisCallContext callCtx, long securableCatalogId, long securableId) {
+      @NonNull PolarisCallContext callCtx, long securableCatalogId, long securableId) {
     Map<String, Object> params =
         Map.of(
             "securable_catalog_id",
@@ -705,10 +705,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisGrantRecord> loadAllGrantRecordsOnGrantee(
-      @Nonnull PolarisCallContext callCtx, long granteeCatalogId, long granteeId) {
+      @NonNull PolarisCallContext callCtx, long granteeCatalogId, long granteeId) {
     Map<String, Object> params =
         Map.of(
             "grantee_catalog_id", granteeCatalogId, "grantee_id", granteeId, "realm_id", realmId);
@@ -730,7 +730,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public boolean hasChildren(
-      @Nonnull PolarisCallContext callContext,
+      @NonNull PolarisCallContext callContext,
       PolarisEntityType optionalEntityType,
       long catalogId,
       long parentId) {
@@ -793,7 +793,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public <T extends PolarisEntity & LocationBasedEntity>
       Optional<Optional<String>> hasOverlappingSiblings(
-          @Nonnull PolarisCallContext callContext, T entity) {
+          @NonNull PolarisCallContext callContext, T entity) {
     if (this.schemaVersion < 2) {
       return Optional.empty();
     }
@@ -835,7 +835,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPrincipalSecrets loadPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId) {
+      @NonNull PolarisCallContext callCtx, @NonNull String clientId) {
     Map<String, Object> params = Map.of("principal_client_id", clientId, "realm_id", realmId);
     try {
       var results =
@@ -857,10 +857,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public PolarisPrincipalSecrets generateNewPrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String principalName, long principalId) {
+      @NonNull PolarisCallContext callCtx, @NonNull String principalName, long principalId) {
     // ensure principal client id is unique
     PolarisPrincipalSecrets principalSecrets;
     ModelPrincipalAuthenticationData lookupPrincipalSecrets;
@@ -906,9 +906,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPrincipalSecrets storePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long principalId,
-      @Nonnull String resolvedClientId,
+      @NonNull String resolvedClientId,
       String customClientSecret) {
     PolarisPrincipalSecrets principalSecrets =
         new PolarisPrincipalSecrets(principalId, resolvedClientId, customClientSecret);
@@ -945,11 +945,11 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPrincipalSecrets rotatePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull String clientId,
+      @NonNull PolarisCallContext callCtx,
+      @NonNull String clientId,
       long principalId,
       boolean reset,
-      @Nonnull String oldSecretHash) {
+      @NonNull String oldSecretHash) {
     // load the existing secrets
     PolarisPrincipalSecrets principalSecrets = loadPrincipalSecrets(callCtx, clientId);
 
@@ -1005,7 +1005,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deletePrincipalSecrets(
-      @Nonnull PolarisCallContext callCtx, @Nonnull String clientId, long principalId) {
+      @NonNull PolarisCallContext callCtx, @NonNull String clientId, long principalId) {
     Map<String, Object> params =
         Map.of("principal_client_id", clientId, "principal_id", principalId, "realm_id", realmId);
     try {
@@ -1027,7 +1027,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void writeToPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+      @NonNull PolarisCallContext callCtx, @NonNull PolarisPolicyMappingRecord record) {
     try {
       datasourceOperations.runWithinTransaction(
           connection -> {
@@ -1062,9 +1062,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   private boolean handleInheritablePolicy(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisPolicyMappingRecord record,
-      @Nonnull PreparedQuery insertQuery,
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisPolicyMappingRecord record,
+      @NonNull PreparedQuery insertQuery,
       Connection connection)
       throws SQLException {
     List<PolarisPolicyMappingRecord> existingRecords =
@@ -1117,7 +1117,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteFromPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx, @Nonnull PolarisPolicyMappingRecord record) {
+      @NonNull PolarisCallContext callCtx, @NonNull PolarisPolicyMappingRecord record) {
     var modelPolicyMappingRecord = ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
     try {
       Map<String, Object> objectMap =
@@ -1136,10 +1136,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public void deleteAllEntityPolicyMappingRecords(
-      @Nonnull PolarisCallContext callCtx,
-      @Nonnull PolarisBaseEntity entity,
-      @Nonnull List<PolarisPolicyMappingRecord> mappingOnTarget,
-      @Nonnull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
+      @NonNull List<PolarisPolicyMappingRecord> mappingOnTarget,
+      @NonNull List<PolarisPolicyMappingRecord> mappingOnPolicy) {
     try {
       Map<String, Object> queryParams = new LinkedHashMap<>();
       if (entity.getType() == PolarisEntityType.POLICY) {
@@ -1166,7 +1166,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Nullable
   @Override
   public PolarisPolicyMappingRecord lookupPolicyMappingRecord(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,
       int policyTypeCode,
@@ -1194,10 +1194,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     return results.size() == 1 ? results.getFirst() : null;
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,
       int policyTypeCode) {
@@ -1216,10 +1216,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllPoliciesOnTarget(
-      @Nonnull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
+      @NonNull PolarisCallContext callCtx, long targetCatalogId, long targetId) {
     Map<String, Object> params =
         Map.of("target_catalog_id", targetCatalogId, "target_id", targetId, "realm_id", realmId);
     return fetchPolicyMappingRecords(
@@ -1227,10 +1227,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public List<PolarisPolicyMappingRecord> loadAllTargetsOnPolicy(
-      @Nonnull PolarisCallContext callCtx,
+      @NonNull PolarisCallContext callCtx,
       long policyCatalogId,
       long policyId,
       int policyTypeCode) {
@@ -1264,7 +1264,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   @Override
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> createStorageIntegration(
-          @Nonnull PolarisCallContext callCtx,
+          @NonNull PolarisCallContext callCtx,
           long catalogId,
           long entityId,
           PolarisStorageConfigurationInfo polarisStorageConfigurationInfo) {
@@ -1274,15 +1274,15 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
   @Override
   public <T extends PolarisStorageConfigurationInfo> void persistStorageIntegrationIfNeeded(
-      @Nonnull PolarisCallContext callContext,
-      @Nonnull PolarisBaseEntity entity,
+      @NonNull PolarisCallContext callContext,
+      @NonNull PolarisBaseEntity entity,
       @Nullable PolarisStorageIntegration<T> storageIntegration) {}
 
   @Nullable
   @Override
   public <T extends PolarisStorageConfigurationInfo>
       PolarisStorageIntegration<T> loadPolarisStorageIntegration(
-          @Nonnull PolarisCallContext callContext, @Nonnull PolarisBaseEntity entity) {
+          @NonNull PolarisCallContext callContext, @NonNull PolarisBaseEntity entity) {
     PolarisStorageConfigurationInfo storageConfig =
         BaseMetaStoreManager.extractStorageConfiguration(diagnostics, entity);
     return storageIntegrationProvider.getStorageIntegrationForConfig(storageConfig);
@@ -1303,20 +1303,20 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   @Override
-  public void writeScanReport(@Nonnull ScanMetricsRecord record) {
+  public void writeScanReport(@NonNull ScanMetricsRecord record) {
     ModelScanMetricsReport model = ModelScanMetricsReport.fromRecord(record, realmId);
     writeScanMetricsReport(model);
   }
 
   @Override
-  public void writeCommitReport(@Nonnull CommitMetricsRecord record) {
+  public void writeCommitReport(@NonNull CommitMetricsRecord record) {
     ModelCommitMetricsReport model = ModelCommitMetricsReport.fromRecord(record, realmId);
     writeCommitMetricsReport(model);
   }
 
   // ========== Internal Metrics JDBC methods ==========
 
-  private void writeScanMetricsReport(@Nonnull ModelScanMetricsReport report) {
+  private void writeScanMetricsReport(@NonNull ModelScanMetricsReport report) {
     DatasourceOperations metricsOps = getMetricsDatasource();
     try {
       PreparedQuery pq =
@@ -1332,7 +1332,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     }
   }
 
-  private void writeCommitMetricsReport(@Nonnull ModelCommitMetricsReport report) {
+  private void writeCommitMetricsReport(@NonNull ModelCommitMetricsReport report) {
     DatasourceOperations metricsOps = getMetricsDatasource();
     try {
       PreparedQuery pq =

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -21,7 +21,6 @@ package org.apache.polaris.persistence.relational.jdbc;
 import static org.apache.polaris.core.auth.AuthBootstrapUtil.createPolarisPrincipalForRealm;
 
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
@@ -57,6 +56,7 @@ import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -19,8 +19,6 @@
 package org.apache.polaris.persistence.relational.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +32,8 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelGrantRecord;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class to generate parameterized SQL queries (SELECT, INSERT, UPDATE, DELETE). Ensures
@@ -60,9 +60,9 @@ public class QueryGenerator {
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
   public static PreparedQuery generateSelectQuery(
-      @Nonnull List<String> projections,
-      @Nonnull String tableName,
-      @Nonnull Map<String, Object> whereClause) {
+      @NonNull List<String> projections,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereClause) {
     return generateSelectQuery(projections, tableName, whereClause, Map.of(), null);
   }
 
@@ -76,10 +76,10 @@ public class QueryGenerator {
    * @throws IllegalArgumentException if any whereClause column isn't in projections.
    */
   public static PreparedQuery generateSelectQuery(
-      @Nonnull List<String> projections,
-      @Nonnull String tableName,
-      @Nonnull Map<String, Object> whereEquals,
-      @Nonnull Map<String, Object> whereGreater,
+      @NonNull List<String> projections,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater,
       @Nullable String orderByColumn) {
     QueryFragment where =
         generateWhereClause(new HashSet<>(projections), whereEquals, whereGreater);
@@ -95,7 +95,7 @@ public class QueryGenerator {
    * @return A DELETE query removing all grants for this entity.
    */
   public static PreparedQuery generateDeleteQueryForEntityGrantRecords(
-      @Nonnull PolarisEntityCore entity, @Nonnull String realmId) {
+      @NonNull PolarisEntityCore entity, @NonNull String realmId) {
     String where =
         """
              WHERE (
@@ -119,7 +119,7 @@ public class QueryGenerator {
    * @throws IllegalArgumentException if entityIds is empty.
    */
   public static PreparedQuery generateSelectQueryWithEntityIds(
-      @Nonnull String realmId, int schemaVersion, @Nonnull List<PolarisEntityId> entityIds) {
+      @NonNull String realmId, int schemaVersion, @NonNull List<PolarisEntityId> entityIds) {
     if (entityIds.isEmpty()) {
       throw new IllegalArgumentException("Empty entity ids");
     }
@@ -148,8 +148,8 @@ public class QueryGenerator {
    * @return INSERT query with value bindings.
    */
   public static PreparedQuery generateInsertQuery(
-      @Nonnull List<String> allColumns,
-      @Nonnull String tableName,
+      @NonNull List<String> allColumns,
+      @NonNull String tableName,
       List<Object> values,
       String realmId) {
     List<String> finalColumns = new ArrayList<>(allColumns);
@@ -179,10 +179,10 @@ public class QueryGenerator {
    * @return UPDATE query with parameter values.
    */
   public static PreparedQuery generateUpdateQuery(
-      @Nonnull List<String> allColumns,
-      @Nonnull String tableName,
-      @Nonnull List<Object> values,
-      @Nonnull Map<String, Object> whereClause) {
+      @NonNull List<String> allColumns,
+      @NonNull String tableName,
+      @NonNull List<Object> values,
+      @NonNull Map<String, Object> whereClause) {
     List<Object> bindingParams = new ArrayList<>(values);
     QueryFragment where = generateWhereClause(new HashSet<>(allColumns), whereClause, Map.of());
     String setClause = allColumns.stream().map(c -> c + " = ?").collect(Collectors.joining(", "));
@@ -210,14 +210,14 @@ public class QueryGenerator {
    * @return UPDATE query with parameter bindings.
    */
   public static PreparedQuery generateUpdateQuery(
-      @Nonnull List<String> tableColumns,
-      @Nonnull String tableName,
-      @Nonnull Map<String, Object> setClause,
-      @Nonnull Map<String, Object> whereEquals,
-      @Nonnull Map<String, Object> whereGreater,
-      @Nonnull Map<String, Object> whereLess,
-      @Nonnull Set<String> whereIsNull,
-      @Nonnull Set<String> whereIsNotNull) {
+      @NonNull List<String> tableColumns,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> setClause,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater,
+      @NonNull Map<String, Object> whereLess,
+      @NonNull Set<String> whereIsNull,
+      @NonNull Set<String> whereIsNotNull) {
     if (setClause.isEmpty()) {
       throw new IllegalArgumentException("Empty setClause");
     }
@@ -255,9 +255,9 @@ public class QueryGenerator {
    * @return DELETE query with parameter bindings.
    */
   public static PreparedQuery generateDeleteQuery(
-      @Nonnull List<String> tableColumns,
-      @Nonnull String tableName,
-      @Nonnull Map<String, Object> whereClause) {
+      @NonNull List<String> tableColumns,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereClause) {
     QueryFragment where = generateWhereClause(new HashSet<>(tableColumns), whereClause, Map.of());
     return new PreparedQuery(
         "DELETE FROM " + getFullyQualifiedTableName(tableName) + where.sql(), where.parameters());
@@ -268,13 +268,13 @@ public class QueryGenerator {
    * IS NULL, IS NOT NULL).
    */
   public static PreparedQuery generateDeleteQuery(
-      @Nonnull List<String> tableColumns,
-      @Nonnull String tableName,
-      @Nonnull Map<String, Object> whereEquals,
-      @Nonnull Map<String, Object> whereGreater,
-      @Nonnull Map<String, Object> whereLess,
-      @Nonnull Set<String> whereIsNull,
-      @Nonnull Set<String> whereIsNotNull) {
+      @NonNull List<String> tableColumns,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater,
+      @NonNull Map<String, Object> whereLess,
+      @NonNull Set<String> whereIsNull,
+      @NonNull Set<String> whereIsNotNull) {
     Set<String> columns = new HashSet<>(tableColumns);
     QueryFragment where =
         generateWhereClauseExtended(
@@ -284,9 +284,9 @@ public class QueryGenerator {
   }
 
   private static PreparedQuery generateSelectQuery(
-      @Nonnull List<String> columnNames,
-      @Nonnull String tableName,
-      @Nonnull String filter,
+      @NonNull List<String> columnNames,
+      @NonNull String tableName,
+      @NonNull String filter,
       @Nullable String orderByColumn) {
     String sql =
         "SELECT "
@@ -302,15 +302,15 @@ public class QueryGenerator {
 
   @VisibleForTesting
   static QueryFragment generateWhereClause(
-      @Nonnull Set<String> tableColumns,
-      @Nonnull Map<String, Object> whereEquals,
-      @Nonnull Map<String, Object> whereGreater) {
+      @NonNull Set<String> tableColumns,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater) {
     return generateWhereClauseExtended(
         tableColumns, whereEquals, whereGreater, Map.of(), Set.of(), Set.of());
   }
 
   private static void validateColumns(
-      @Nonnull Set<String> tableColumns, @Nonnull Set<String> columns) {
+      @NonNull Set<String> tableColumns, @NonNull Set<String> columns) {
     for (String column : columns) {
       if (!tableColumns.contains(column) && !column.equals("realm_id")) {
         throw new IllegalArgumentException("Invalid query column: " + column);
@@ -320,12 +320,12 @@ public class QueryGenerator {
 
   @VisibleForTesting
   static QueryFragment generateWhereClauseExtended(
-      @Nonnull Set<String> tableColumns,
-      @Nonnull Map<String, Object> whereEquals,
-      @Nonnull Map<String, Object> whereGreater,
-      @Nonnull Map<String, Object> whereLess,
-      @Nonnull Set<String> whereIsNull,
-      @Nonnull Set<String> whereIsNotNull) {
+      @NonNull Set<String> tableColumns,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater,
+      @NonNull Map<String, Object> whereLess,
+      @NonNull Set<String> whereIsNull,
+      @NonNull Set<String> whereIsNotNull) {
     validateColumns(tableColumns, whereEquals.keySet());
     validateColumns(tableColumns, whereGreater.keySet());
     validateColumns(tableColumns, whereLess.keySet());

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
@@ -16,7 +16,6 @@
  */
 package org.apache.polaris.persistence.relational.jdbc.idempotency;
 
-import jakarta.annotation.Nonnull;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -36,13 +35,14 @@ import org.apache.polaris.persistence.relational.jdbc.QueryGenerator;
 import org.apache.polaris.persistence.relational.jdbc.RelationalJdbcConfiguration;
 import org.apache.polaris.persistence.relational.jdbc.models.Converter;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelIdempotencyRecord;
+import org.jspecify.annotations.NonNull;
 
 public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
 
   private final DatasourceOperations datasourceOperations;
 
   public RelationalJdbcIdempotencyStore(
-      @Nonnull DataSource dataSource, @Nonnull RelationalJdbcConfiguration cfg)
+      @NonNull DataSource dataSource, @NonNull RelationalJdbcConfiguration cfg)
       throws SQLException {
     this.datasourceOperations = new DatasourceOperations(dataSource, cfg);
   }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
@@ -20,7 +20,6 @@ package org.apache.polaris.persistence.relational.jdbc.models;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -29,6 +28,7 @@ import java.util.Map;
 import org.apache.polaris.core.persistence.metrics.CommitMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.jspecify.annotations.Nullable;
 
 /** Model class for commit_metrics_report table - stores commit metrics as first-class entities. */
 @PolarisImmutable
@@ -114,25 +114,19 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
 
   long getTimestampMs();
 
-  @Nullable
-  String getPrincipalName();
+  @Nullable String getPrincipalName();
 
-  @Nullable
-  String getRequestId();
+  @Nullable String getRequestId();
 
-  @Nullable
-  String getOtelTraceId();
+  @Nullable String getOtelTraceId();
 
-  @Nullable
-  String getOtelSpanId();
+  @Nullable String getOtelSpanId();
 
-  @Nullable
-  String getReportTraceId();
+  @Nullable String getReportTraceId();
 
   long getSnapshotId();
 
-  @Nullable
-  Long getSequenceNumber();
+  @Nullable Long getSequenceNumber();
 
   String getOperation();
 
@@ -172,8 +166,7 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
 
   int getAttempts();
 
-  @Nullable
-  String getMetadata();
+  @Nullable String getMetadata();
 
   @Override
   default ModelCommitMetricsReport fromResultSet(ResultSet rs) throws SQLException {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -19,7 +19,6 @@
 
 package org.apache.polaris.persistence.relational.jdbc.models;
 
-import jakarta.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -28,6 +27,7 @@ import java.util.Map;
 import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.jspecify.annotations.Nullable;
 
 @PolarisImmutable
 public interface ModelEvent extends Converter<PolarisEvent> {
@@ -80,8 +80,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   String getEventId();
 
   // id of the request that generated this event
-  @Nullable
-  String getRequestId();
+  @Nullable String getRequestId();
 
   // event type that was created
   String getEventType();
@@ -90,8 +89,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   long getTimestampMs();
 
   // polaris principal who took this action
-  @Nullable
-  String getPrincipalName();
+  @Nullable String getPrincipalName();
 
   // Enum that states the type of resource was being operated on
   PolarisEvent.ResourceType getResourceType();

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelIdempotencyRecord.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelIdempotencyRecord.java
@@ -18,7 +18,6 @@
 
 package org.apache.polaris.persistence.relational.jdbc.models;
 
-import jakarta.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -28,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.polaris.core.entity.IdempotencyRecord;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.jspecify.annotations.Nullable;
 
 /**
  * JDBC model for {@link IdempotencyRecord} mirroring the {@code idempotency_records} table.
@@ -97,30 +97,23 @@ public interface ModelIdempotencyRecord extends Converter<IdempotencyRecord> {
 
   String getResourceId();
 
-  @Nullable
-  Integer getHttpStatus();
+  @Nullable Integer getHttpStatus();
 
-  @Nullable
-  String getErrorSubtype();
+  @Nullable String getErrorSubtype();
 
-  @Nullable
-  String getResponseSummary();
+  @Nullable String getResponseSummary();
 
-  @Nullable
-  String getResponseHeaders();
+  @Nullable String getResponseHeaders();
 
-  @Nullable
-  Instant getFinalizedAt();
+  @Nullable Instant getFinalizedAt();
 
   Instant getCreatedAt();
 
   Instant getUpdatedAt();
 
-  @Nullable
-  Instant getHeartbeatAt();
+  @Nullable Instant getHeartbeatAt();
 
-  @Nullable
-  String getExecutorId();
+  @Nullable String getExecutorId();
 
   Instant getExpiresAt();
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
@@ -20,7 +20,6 @@ package org.apache.polaris.persistence.relational.jdbc.models;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -30,6 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.polaris.core.persistence.metrics.ScanMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.jspecify.annotations.Nullable;
 
 /** Model class for scan_metrics_report table - stores scan metrics as first-class entities. */
 @PolarisImmutable
@@ -115,35 +115,25 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
 
   long getTimestampMs();
 
-  @Nullable
-  String getPrincipalName();
+  @Nullable String getPrincipalName();
 
-  @Nullable
-  String getRequestId();
+  @Nullable String getRequestId();
 
-  @Nullable
-  String getOtelTraceId();
+  @Nullable String getOtelTraceId();
 
-  @Nullable
-  String getOtelSpanId();
+  @Nullable String getOtelSpanId();
 
-  @Nullable
-  String getReportTraceId();
+  @Nullable String getReportTraceId();
 
-  @Nullable
-  Long getSnapshotId();
+  @Nullable Long getSnapshotId();
 
-  @Nullable
-  Integer getSchemaId();
+  @Nullable Integer getSchemaId();
 
-  @Nullable
-  String getFilterExpression();
+  @Nullable String getFilterExpression();
 
-  @Nullable
-  String getProjectedFieldIds();
+  @Nullable String getProjectedFieldIds();
 
-  @Nullable
-  String getProjectedFieldNames();
+  @Nullable String getProjectedFieldNames();
 
   long getResultDataFiles();
 
@@ -177,8 +167,7 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
 
   long getTotalDeleteFileSizeBytes();
 
-  @Nullable
-  String getMetadata();
+  @Nullable String getMetadata();
 
   @Override
   default ModelScanMetricsReport fromResultSet(ResultSet rs) throws SQLException {

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     exclude("org.slf4j", "jul-to-slf4j")
   }
 
-  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.validation.api)
 
   compileOnly(project(":polaris-immutables"))

--- a/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
+++ b/plugins/spark/v3.5/spark/src/main/java/org/apache/polaris/spark/rest/GenericTable.java
@@ -18,11 +18,11 @@
  */
 package org.apache.polaris.spark.rest;
 
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import org.apache.iceberg.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 
 // TODO: auto generate the class based on spec
 @Value.Builder

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 }
 
 dependencies {
+  compileOnly(libs.jspecify)
   implementation(project(":polaris-core"))
   implementation(project(":polaris-version"))
   implementation(project(":polaris-api-management-service"))

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/config/AdminToolProducers.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.admintool.config;
 
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
@@ -35,6 +34,7 @@ import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageIntegration;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
+import org.jspecify.annotations.Nullable;
 
 public class AdminToolProducers {
 

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
   implementation(libs.swagger.jaxrs)
   implementation(libs.microprofile.fault.tolerance.api)
 
+  compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.annotation.api)
 
   implementation(platform(libs.google.cloud.storage.bom))

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -24,8 +24,6 @@ import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNam
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
 import com.google.common.base.Strings;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -125,6 +123,8 @@ import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.service.config.ReservedProperties;
 import org.apache.polaris.service.types.PolicyIdentifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,14 +154,14 @@ public class PolarisAdminService {
 
   @Inject
   public PolarisAdminService(
-      @Nonnull CallContext callContext,
-      @Nonnull ResolutionManifestFactory resolutionManifestFactory,
-      @Nonnull PolarisMetaStoreManager metaStoreManager,
-      @Nonnull UserSecretsManager userSecretsManager,
-      @Nonnull ServiceIdentityProvider serviceIdentityProvider,
-      @Nonnull PolarisPrincipal principal,
-      @Nonnull PolarisAuthorizer authorizer,
-      @Nonnull ReservedProperties reservedProperties) {
+      @NonNull CallContext callContext,
+      @NonNull ResolutionManifestFactory resolutionManifestFactory,
+      @NonNull PolarisMetaStoreManager metaStoreManager,
+      @NonNull UserSecretsManager userSecretsManager,
+      @NonNull ServiceIdentityProvider serviceIdentityProvider,
+      @NonNull PolarisPrincipal principal,
+      @NonNull PolarisAuthorizer authorizer,
+      @NonNull ReservedProperties reservedProperties) {
     this.callContext = callContext;
     this.realmConfig = callContext.getRealmConfig();
     this.resolutionManifestFactory = resolutionManifestFactory;
@@ -691,7 +691,7 @@ public class PolarisAdminService {
    * @see #extractSecretReferences
    */
   private boolean requiresSecretReferenceExtraction(
-      @Nonnull ConnectionConfigInfo connectionConfigInfo) {
+      @NonNull ConnectionConfigInfo connectionConfigInfo) {
     return connectionConfigInfo.getAuthenticationParameters().getAuthenticationType()
         != AuthenticationParameters.AuthenticationTypeEnum.IMPLICIT;
   }
@@ -817,7 +817,7 @@ public class PolarisAdminService {
     }
   }
 
-  public @Nonnull CatalogEntity getCatalog(String name) {
+  public @NonNull CatalogEntity getCatalog(String name) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_CATALOG;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
@@ -878,7 +878,7 @@ public class PolarisAdminService {
     }
   }
 
-  public @Nonnull CatalogEntity updateCatalog(String name, UpdateCatalogRequest updateRequest) {
+  public @NonNull CatalogEntity updateCatalog(String name, UpdateCatalogRequest updateRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.UPDATE_CATALOG;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.CATALOG);
@@ -1015,7 +1015,7 @@ public class PolarisAdminService {
     }
   }
 
-  public @Nonnull PrincipalEntity getPrincipal(String name) {
+  public @NonNull PrincipalEntity getPrincipal(String name) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_PRINCIPAL;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.PRINCIPAL);
@@ -1023,7 +1023,7 @@ public class PolarisAdminService {
     return getPrincipalByName(resolutionManifest, name);
   }
 
-  public @Nonnull PrincipalEntity updatePrincipal(
+  public @NonNull PrincipalEntity updatePrincipal(
       String name, UpdatePrincipalRequest updateRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.UPDATE_PRINCIPAL;
     PolarisResolutionManifest resolutionManifest =
@@ -1062,7 +1062,7 @@ public class PolarisAdminService {
     return returnedEntity;
   }
 
-  private @Nonnull PrincipalWithCredentials resetCredentialsHelper(
+  private @NonNull PrincipalWithCredentials resetCredentialsHelper(
       PolarisResolutionManifest resolutionManifest,
       String principalName,
       String customClientId,
@@ -1136,7 +1136,7 @@ public class PolarisAdminService {
             newSecrets.getPrincipalClientId(), newSecrets.getMainSecret()));
   }
 
-  private @Nonnull PrincipalWithCredentials rotateOrResetCredentialsHelper(
+  private @NonNull PrincipalWithCredentials rotateOrResetCredentialsHelper(
       PolarisResolutionManifest resolutionManifest, String principalName, boolean shouldReset) {
     PrincipalEntity currentPrincipalEntity = getPrincipalByName(resolutionManifest, principalName);
 
@@ -1182,7 +1182,7 @@ public class PolarisAdminService {
             newSecrets.getPrincipalClientId(), newSecrets.getMainSecret()));
   }
 
-  public @Nonnull PrincipalWithCredentials rotateCredentials(String principalName) {
+  public @NonNull PrincipalWithCredentials rotateCredentials(String principalName) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.ROTATE_CREDENTIALS;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicTopLevelEntityOperationOrThrow(
@@ -1191,7 +1191,7 @@ public class PolarisAdminService {
     return rotateOrResetCredentialsHelper(resolutionManifest, principalName, false);
   }
 
-  public @Nonnull PrincipalWithCredentials resetCredentials(
+  public @NonNull PrincipalWithCredentials resetCredentials(
       String principalName, ResetPrincipalRequest resetPrincipalRequest) {
     FeatureConfiguration.enforceFeatureEnabledOrThrow(
         realmConfig, FeatureConfiguration.ENABLE_CREDENTIAL_RESET);
@@ -1268,7 +1268,7 @@ public class PolarisAdminService {
     }
   }
 
-  public @Nonnull PrincipalRoleEntity getPrincipalRole(String name) {
+  public @NonNull PrincipalRoleEntity getPrincipalRole(String name) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_PRINCIPAL_ROLE;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicTopLevelEntityOperationOrThrow(op, name, PolarisEntityType.PRINCIPAL_ROLE);
@@ -1276,7 +1276,7 @@ public class PolarisAdminService {
     return getPrincipalRoleByName(resolutionManifest, name);
   }
 
-  public @Nonnull PrincipalRoleEntity updatePrincipalRole(
+  public @NonNull PrincipalRoleEntity updatePrincipalRole(
       String name, UpdatePrincipalRoleRequest updateRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.UPDATE_PRINCIPAL_ROLE;
     PolarisResolutionManifest resolutionManifest =
@@ -1388,7 +1388,7 @@ public class PolarisAdminService {
     }
   }
 
-  public @Nonnull CatalogRoleEntity getCatalogRole(String catalogName, String name) {
+  public @NonNull CatalogRoleEntity getCatalogRole(String catalogName, String name) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.GET_CATALOG_ROLE;
     PolarisResolutionManifest resolutionManifest =
         authorizeBasicCatalogRoleOperationOrThrow(op, catalogName, name);
@@ -1396,7 +1396,7 @@ public class PolarisAdminService {
     return getCatalogRoleByName(resolutionManifest, name);
   }
 
-  public @Nonnull CatalogRoleEntity updateCatalogRole(
+  public @NonNull CatalogRoleEntity updateCatalogRole(
       String catalogName, String name, UpdateCatalogRoleRequest updateRequest) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.UPDATE_CATALOG_ROLE;
     PolarisResolutionManifest resolutionManifest =
@@ -1564,7 +1564,7 @@ public class PolarisAdminService {
    * @return list of grantees or securables matching the filter
    */
   private List<PolarisEntity> buildEntitiesFromGrantResults(
-      @Nonnull LoadGrantsResult grantList,
+      @NonNull LoadGrantsResult grantList,
       boolean grantees,
       PolarisEntityType entityType,
       @Nullable Function<PolarisGrantRecord, Boolean> grantFilter) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/PolarisCredential.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/PolarisCredential.java
@@ -19,9 +19,9 @@
 package org.apache.polaris.service.auth;
 
 import io.quarkus.security.credential.Credential;
-import jakarta.annotation.Nullable;
 import java.util.Set;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A Quarkus Security {@link Credential} exposing Polaris-specific attributes: the principal id,
@@ -49,17 +49,14 @@ public interface PolarisCredential extends Credential {
   }
 
   /** The principal id, or null if unknown. Used for principal lookups by id. */
-  @Nullable
-  Long getPrincipalId();
+  @Nullable Long getPrincipalId();
 
   /** The principal name, or null if unknown. Used for principal lookups by name. */
-  @Nullable
-  String getPrincipalName();
+  @Nullable String getPrincipalName();
 
   /** The principal roles, or empty if the principal has no roles. */
   Set<String> getPrincipalRoles();
 
   /** The access token of the current user, or null if not applicable. */
-  @Nullable
-  String getToken();
+  @Nullable String getToken();
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/external/mapping/ClaimsLocator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/external/mapping/ClaimsLocator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.auth.external.mapping;
 
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonString;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jspecify.annotations.Nullable;
 
 /** A utility class for locating claims in a JWT token by path. */
 @ApplicationScoped

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/InternalPolarisToken.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/InternalPolarisToken.java
@@ -19,12 +19,12 @@
 package org.apache.polaris.service.auth.internal.broker;
 
 import com.google.common.base.Splitter;
-import jakarta.annotation.Nonnull;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.service.auth.PolarisCredential;
 import org.immutables.value.Value;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A specialized {@link PolarisCredential} used for internal authentication, when Polaris is the
@@ -50,12 +50,12 @@ abstract class InternalPolarisToken implements PolarisCredential {
         .build();
   }
 
-  @Nonnull // switch from nullable to non-nullable
+  @NonNull // switch from nullable to non-nullable
   @Override
   @SuppressWarnings("NullableProblems")
   public abstract String getPrincipalName();
 
-  @Nonnull // switch from nullable to non-nullable
+  @NonNull // switch from nullable to non-nullable
   @Override
   @SuppressWarnings("NullableProblems")
   public abstract Long getPrincipalId();

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/LocalRSAKeyProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/LocalRSAKeyProvider.java
@@ -18,12 +18,12 @@
  */
 package org.apache.polaris.service.auth.internal.broker;
 
-import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +32,11 @@ record LocalRSAKeyProvider(PublicKey publicKey, PrivateKey privateKey) implement
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LocalRSAKeyProvider.class);
 
-  LocalRSAKeyProvider(@Nonnull KeyPair keyPair) {
+  LocalRSAKeyProvider(@NonNull KeyPair keyPair) {
     this(keyPair.getPublic(), keyPair.getPrivate());
   }
 
-  static LocalRSAKeyProvider fromFiles(@Nonnull Path publicKeyFile, @Nonnull Path privateKeyFile) {
+  static LocalRSAKeyProvider fromFiles(@NonNull Path publicKeyFile, @NonNull Path privateKeyFile) {
     return new LocalRSAKeyProvider(
         readPublicKeyFile(publicKeyFile), readPrivateKeyFile(privateKeyFile));
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenResponse.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenResponse.java
@@ -18,10 +18,10 @@
  */
 package org.apache.polaris.service.auth.internal.broker;
 
-import jakarta.annotation.Nullable;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.service.auth.internal.service.OAuthError;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 
 @PolarisImmutable
 public interface TokenResponse {
@@ -38,17 +38,14 @@ public interface TokenResponse {
     return ImmutableTokenResponse.builder().error(error).build();
   }
 
-  @Nullable
-  OAuthError getError();
+  @Nullable OAuthError getError();
 
-  @Nullable
-  String getAccessToken();
+  @Nullable String getAccessToken();
 
   @Value.Default
   default int getExpiresIn() {
     return 0;
   }
 
-  @Nullable
-  String getTokenType();
+  @Nullable String getTokenType();
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/service/OAuthTokenErrorResponse.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/service/OAuthTokenErrorResponse.java
@@ -19,8 +19,8 @@
 package org.apache.polaris.service.auth.internal.service;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.annotation.Nullable;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.jspecify.annotations.Nullable;
 
 /** An OAuth Error Token Response as defined by the Iceberg REST API OpenAPI Spec. */
 @PolarisImmutable

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/AccessDelegationMode.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/AccessDelegationMode.java
@@ -19,13 +19,13 @@
 package org.apache.polaris.service.catalog;
 
 import com.google.common.base.Functions;
-import jakarta.annotation.Nullable;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/AccessDelegationModeResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/AccessDelegationModeResolver.java
@@ -18,11 +18,11 @@
  */
 package org.apache.polaris.service.catalog;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Optional;
 import org.apache.polaris.core.entity.CatalogEntity;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Resolves the optimal {@link AccessDelegationMode} to use based on the client's requested modes
@@ -43,7 +43,6 @@ public interface AccessDelegationModeResolver {
    *     AccessDelegationMode#VENDED_CREDENTIALS} on an external catalog whose credential vending
    *     feature is disabled).
    */
-  @Nonnull
-  Optional<AccessDelegationMode> resolve(
-      @Nonnull EnumSet<AccessDelegationMode> requestedModes, @Nullable CatalogEntity catalogEntity);
+  @NonNull Optional<AccessDelegationMode> resolve(
+      @NonNull EnumSet<AccessDelegationMode> requestedModes, @Nullable CatalogEntity catalogEntity);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/DefaultAccessDelegationModeResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/DefaultAccessDelegationModeResolver.java
@@ -21,8 +21,6 @@ package org.apache.polaris.service.catalog;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.REMOTE_SIGNING;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.EnumSet;
@@ -32,6 +30,8 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +83,8 @@ public class DefaultAccessDelegationModeResolver implements AccessDelegationMode
   }
 
   @Override
-  public @Nonnull Optional<AccessDelegationMode> resolve(
-      @Nonnull EnumSet<AccessDelegationMode> requestedModes,
+  public @NonNull Optional<AccessDelegationMode> resolve(
+      @NonNull EnumSet<AccessDelegationMode> requestedModes,
       @Nullable CatalogEntity catalogEntity) {
 
     // Case 1: No valid delegation mode found, or none requested
@@ -209,7 +209,7 @@ public class DefaultAccessDelegationModeResolver implements AccessDelegationMode
    * @param catalogEntity The catalog entity to check
    * @return true if STS is available or the storage type doesn't require STS
    */
-  private boolean isCredentialVendingAvailable(@Nonnull CatalogEntity catalogEntity) {
+  private boolean isCredentialVendingAvailable(@NonNull CatalogEntity catalogEntity) {
     PolarisStorageConfigurationInfo storageConfig = catalogEntity.getStorageConfigurationInfo();
 
     if (storageConfig == null) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/LocationUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/LocationUtils.java
@@ -22,8 +22,8 @@ package org.apache.polaris.service.catalog.common;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import jakarta.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A collection of utilities related to table locations CODE_COPIED_TO_POLARIS From Apache Iceberg
@@ -46,7 +46,7 @@ public class LocationUtils {
    * @param fileName file.txt
    * @return 1001/1001/1001/10011001
    */
-  public static String computeHash(@Nonnull String fileName) {
+  public static String computeHash(@NonNull String fileName) {
     HashCode hashCode = HASH_FUNC.hashString(fileName, StandardCharsets.UTF_8);
 
     // {@link Integer#toBinaryString} excludes leading zeros, which we want to preserve.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -27,7 +27,6 @@ import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundE
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.lang.reflect.Field;
@@ -91,6 +90,7 @@ import org.apache.iceberg.view.ViewRepresentation;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -31,8 +31,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -147,6 +145,8 @@ import org.apache.polaris.service.events.PolarisEventType;
 import org.apache.polaris.service.task.TaskExecutor;
 import org.apache.polaris.service.types.NotificationRequest;
 import org.apache.polaris.service.types.NotificationType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -572,8 +572,8 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
   }
 
-  private static @Nonnull String resolveLocationForPath(
-      @Nonnull PolarisDiagnostics diagnostics, List<PolarisEntity> parentPath) {
+  private static @NonNull String resolveLocationForPath(
+      @NonNull PolarisDiagnostics diagnostics, List<PolarisEntity> parentPath) {
     // always take the first object. If it has the base-location, stop there
     AtomicBoolean foundBaseLocation = new AtomicBoolean(false);
     return parentPath.reversed().stream()
@@ -592,7 +592,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   private static @Nullable String baseLocation(
-      @Nonnull PolarisDiagnostics diagnostics, PolarisEntity entity) {
+      @NonNull PolarisDiagnostics diagnostics, PolarisEntity entity) {
     if (entity.getType().equals(PolarisEntityType.CATALOG)) {
       CatalogEntity catEntity = CatalogEntity.of(entity);
       String catalogDefaultBaseLocation = catEntity.getBaseLocation();
@@ -2544,7 +2544,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   @SuppressWarnings("FormatStringAnnotation")
-  private @Nonnull DropEntityResult dropTableLike(
+  private @NonNull DropEntityResult dropTableLike(
       PolarisEntitySubType subType,
       TableIdentifier identifier,
       Map<String, String> storageProperties,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -30,8 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.inject.Instance;
 import java.io.Closeable;
 import java.time.Clock;
@@ -134,6 +132,8 @@ import org.apache.polaris.service.http.IcebergHttpUtil;
 import org.apache.polaris.service.http.IfNoneMatch;
 import org.apache.polaris.service.reporting.PolarisMetricsReporter;
 import org.apache.polaris.service.types.NotificationRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1314,7 +1314,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     catalogHandlerUtils().renameView(viewCatalog, request);
   }
 
-  private @Nonnull LoadTableResponse filterResponseToSnapshots(
+  private @NonNull LoadTableResponse filterResponseToSnapshots(
       LoadTableResponse loadTableResponse, String snapshots) {
     if (snapshots == null || snapshots.equalsIgnoreCase(SNAPSHOTS_ALL)) {
       return loadTableResponse;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.catalog.io;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.HashMap;
@@ -28,6 +27,7 @@ import java.util.Map;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A default FileIO factory implementation for creating Iceberg {@link FileIO} instances with
@@ -45,9 +45,9 @@ public class DefaultFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull StorageAccessConfig storageAccessConfig,
-      @Nonnull String ioImplClassName,
-      @Nonnull Map<String, String> properties) {
+      @NonNull StorageAccessConfig storageAccessConfig,
+      @NonNull String ioImplClassName,
+      @NonNull Map<String, String> properties) {
 
     // Get subcoped creds
     properties = new HashMap<>(properties);
@@ -65,7 +65,7 @@ public class DefaultFileIOFactory implements FileIOFactory {
 
   @VisibleForTesting
   FileIO loadFileIOInternal(
-      @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
+      @NonNull String ioImplClassName, @NonNull Map<String, String> properties) {
     return new ExceptionMappingFileIO(CatalogUtil.loadFileIO(ioImplClassName, properties, null));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/FileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/FileIOFactory.java
@@ -18,11 +18,11 @@
  */
 package org.apache.polaris.service.catalog.io;
 
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import java.util.Map;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Interface for providing a way to construct FileIO objects, such as for reading/writing S3.
@@ -44,7 +44,7 @@ public interface FileIOFactory {
    * @return a configured FileIO instance.
    */
   FileIO loadFileIO(
-      @Nonnull StorageAccessConfig storageAccessConfig,
-      @Nonnull String ioImplClassName,
-      @Nonnull Map<String, String> properties);
+      @NonNull StorageAccessConfig storageAccessConfig,
+      @NonNull String ioImplClassName,
+      @NonNull Map<String, String> properties);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/StorageAccessConfigProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/StorageAccessConfigProvider.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.io;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageCredentialsVendor;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,11 +85,11 @@ public class StorageAccessConfigProvider {
    *     config found
    */
   public StorageAccessConfig getStorageAccessConfig(
-      @Nonnull TableIdentifier tableIdentifier,
-      @Nonnull Set<String> tableLocations,
-      @Nonnull Set<PolarisStorageActions> storageActions,
-      @Nonnull Optional<String> refreshCredentialsEndpoint,
-      @Nonnull PolarisResolvedPathWrapper resolvedPath) {
+      @NonNull TableIdentifier tableIdentifier,
+      @NonNull Set<String> tableLocations,
+      @NonNull Set<PolarisStorageActions> storageActions,
+      @NonNull Optional<String> refreshCredentialsEndpoint,
+      @NonNull PolarisResolvedPathWrapper resolvedPath) {
     LOGGER
         .atDebug()
         .addKeyValue("tableIdentifier", tableIdentifier)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
@@ -19,12 +19,12 @@
 package org.apache.polaris.service.catalog.io;
 
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.jspecify.annotations.NonNull;
 
 /** A {@link FileIOFactory} that translates WASB paths to ABFS ones */
 @ApplicationScoped
@@ -40,9 +40,9 @@ public class WasbTranslatingFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull StorageAccessConfig accessConfig,
-      @Nonnull String ioImplClassName,
-      @Nonnull Map<String, String> properties) {
+      @NonNull StorageAccessConfig accessConfig,
+      @NonNull String ioImplClassName,
+      @NonNull Map<String, String> properties) {
     return new WasbTranslatingFileIO(
         defaultFileIOFactory.loadFileIO(accessConfig, ioImplClassName, properties));
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -25,7 +25,6 @@ import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundE
 import static org.apache.polaris.service.types.PolicyAttachmentTarget.TypeEnum.CATALOG;
 
 import com.google.common.base.Strings;
-import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,6 +65,7 @@ import org.apache.polaris.service.types.ApplicablePolicy;
 import org.apache.polaris.service.types.Policy;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 import org.apache.polaris.service.types.PolicyIdentifier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandler.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.policy;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 
 import com.google.common.base.Strings;
-import jakarta.annotation.Nullable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -50,6 +49,7 @@ import org.apache.polaris.service.types.LoadPolicyResponse;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 import org.apache.polaris.service.types.PolicyIdentifier;
 import org.apache.polaris.service.types.UpdatePolicyRequest;
+import org.jspecify.annotations.Nullable;
 
 @PolarisImmutable
 @SuppressWarnings("immutables:incompat")

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.policy;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
-import jakarta.annotation.Nonnull;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -29,12 +28,13 @@ import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
+import org.jspecify.annotations.NonNull;
 
 public class PolicyCatalogUtils {
 
   public static PolarisResolvedPathWrapper getResolvedPathWrapper(
-      @Nonnull PolarisResolutionManifestCatalogView resolutionManifest,
-      @Nonnull PolicyAttachmentTarget target) {
+      @NonNull PolarisResolutionManifestCatalogView resolutionManifest,
+      @NonNull PolicyAttachmentTarget target) {
     return switch (target.getType()) {
       // get the current catalog entity, since policy cannot apply across catalog at this moment
       case CATALOG -> resolutionManifest.getResolvedReferenceCatalogEntity();

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/validation/IcebergPropertiesValidation.java
@@ -22,13 +22,13 @@ import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_INSECURE
 import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_SPECIFYING_FILE_IO_IMPL;
 import static org.apache.polaris.core.config.FeatureConfiguration.SUPPORTED_CATALOG_STORAGE_TYPES;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,13 +36,13 @@ public class IcebergPropertiesValidation {
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergPropertiesValidation.class);
 
   public static void validateIcebergProperties(
-      @Nonnull RealmConfig realmConfig, @Nonnull Map<String, String> properties) {
+      @NonNull RealmConfig realmConfig, @NonNull Map<String, String> properties) {
     determineFileIOClassName(realmConfig, properties, null);
   }
 
   public static String determineFileIOClassName(
-      @Nonnull RealmConfig realmConfig,
-      @Nonnull Map<String, String> properties,
+      @NonNull RealmConfig realmConfig,
+      @NonNull Map<String, String> properties,
       @Nullable PolarisStorageConfigurationInfo storageConfigurationInfo) {
     var ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/DefaultConfigurationStore.java
@@ -19,14 +19,14 @@
 package org.apache.polaris.service.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.polaris.core.config.RealmConfigurationSource;
 import org.apache.polaris.core.context.RealmContext;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public class DefaultConfigurationStore
   }
 
   @Override
-  public @Nullable Object getConfigValue(@Nonnull RealmContext realmContext, String configName) {
+  public @Nullable Object getConfigValue(@NonNull RealmContext realmContext, String configName) {
     String realm = realmContext.getRealmIdentifier();
     LOGGER.debug("Get configuration value for {} with realm {}", configName, realm);
     return Optional.ofNullable(realmOverrides.getOrDefault(realm, Map.of()).get(configName))
@@ -57,7 +57,7 @@ public class DefaultConfigurationStore
   }
 
   @Override
-  public <T> @Nullable T getConfiguration(@Nonnull RealmContext realmContext, String configName) {
+  public <T> @Nullable T getConfiguration(@NonNull RealmContext realmContext, String configName) {
     @SuppressWarnings("unchecked")
     T value = (T) getConfigValue(realmContext, configName);
     return value;

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/DefaultPolarisCredentialManager.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/DefaultPolarisCredentialManager.java
@@ -20,7 +20,6 @@
 package org.apache.polaris.service.credentials;
 
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
@@ -34,6 +33,7 @@ import org.apache.polaris.core.credentials.PolarisCredentialManager;
 import org.apache.polaris.core.credentials.connection.ConnectionCredentialVendor;
 import org.apache.polaris.core.credentials.connection.ConnectionCredentials;
 import org.apache.polaris.service.credentials.connection.AuthType;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Default implementation of {@link PolarisCredentialManager} responsible for retrieving credentials
@@ -72,8 +72,8 @@ public class DefaultPolarisCredentialManager implements PolarisCredentialManager
   }
 
   @Override
-  public @Nonnull ConnectionCredentials getConnectionCredentials(
-      @Nonnull ConnectionConfigInfoDpo connectionConfig) {
+  public @NonNull ConnectionCredentials getConnectionCredentials(
+      @NonNull ConnectionConfigInfoDpo connectionConfig) {
 
     AuthenticationType authType =
         connectionConfig.getAuthenticationParameters().getAuthenticationType();

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/BearerConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/BearerConnectionCredentialVendor.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.service.credentials.connection;
 
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -32,6 +31,7 @@ import org.apache.polaris.core.credentials.connection.ConnectionCredentialVendor
 import org.apache.polaris.core.credentials.connection.ConnectionCredentials;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.service.credentials.CredentialVendorPriorities;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Connection credential vendor for Bearer token authentication.
@@ -59,8 +59,8 @@ public class BearerConnectionCredentialVendor implements ConnectionCredentialVen
   }
 
   @Override
-  public @Nonnull ConnectionCredentials getConnectionCredentials(
-      @Nonnull ConnectionConfigInfoDpo connectionConfig) {
+  public @NonNull ConnectionCredentials getConnectionCredentials(
+      @NonNull ConnectionConfigInfoDpo connectionConfig) {
 
     // Validate authentication parameters type
     Preconditions.checkArgument(

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/ImplicitConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/ImplicitConnectionCredentialVendor.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.service.credentials.connection;
 
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import java.util.Map;
@@ -30,6 +29,7 @@ import org.apache.polaris.core.credentials.connection.CatalogAccessProperty;
 import org.apache.polaris.core.credentials.connection.ConnectionCredentialVendor;
 import org.apache.polaris.core.credentials.connection.ConnectionCredentials;
 import org.apache.polaris.service.credentials.CredentialVendorPriorities;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Connection credential vendor for Implicit (no authentication) type.
@@ -50,8 +50,8 @@ import org.apache.polaris.service.credentials.CredentialVendorPriorities;
 public class ImplicitConnectionCredentialVendor implements ConnectionCredentialVendor {
 
   @Override
-  public @Nonnull ConnectionCredentials getConnectionCredentials(
-      @Nonnull ConnectionConfigInfoDpo connectionConfig) {
+  public @NonNull ConnectionCredentials getConnectionCredentials(
+      @NonNull ConnectionConfigInfoDpo connectionConfig) {
 
     // Validate authentication parameters type
     Preconditions.checkArgument(

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/OAuthClientCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/OAuthClientCredentialVendor.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.credentials.connection;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -33,6 +32,7 @@ import org.apache.polaris.core.credentials.connection.ConnectionCredentialVendor
 import org.apache.polaris.core.credentials.connection.ConnectionCredentials;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.service.credentials.CredentialVendorPriorities;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Connection credential vendor for OAuth 2.0 Client Credentials authentication.
@@ -62,8 +62,8 @@ public class OAuthClientCredentialVendor implements ConnectionCredentialVendor {
   }
 
   @Override
-  public @Nonnull ConnectionCredentials getConnectionCredentials(
-      @Nonnull ConnectionConfigInfoDpo connectionConfig) {
+  public @NonNull ConnectionCredentials getConnectionCredentials(
+      @NonNull ConnectionConfigInfoDpo connectionConfig) {
 
     // Validate authentication parameters type
     Preconditions.checkArgument(

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.credentials.connection;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -38,6 +37,7 @@ import org.apache.polaris.core.identity.credential.ServiceIdentityCredential;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.storage.aws.StsClientProvider;
 import org.apache.polaris.service.credentials.CredentialVendorPriorities;
+import org.jspecify.annotations.NonNull;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
@@ -79,8 +79,8 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
   }
 
   @Override
-  public @Nonnull ConnectionCredentials getConnectionCredentials(
-      @Nonnull ConnectionConfigInfoDpo connectionConfig) {
+  public @NonNull ConnectionCredentials getConnectionCredentials(
+      @NonNull ConnectionConfigInfoDpo connectionConfig) {
 
     // Validate and extract authentication parameters
     Preconditions.checkArgument(
@@ -142,7 +142,7 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
   }
 
   @VisibleForTesting
-  StsClient getStsClient(@Nonnull SigV4AuthenticationParametersDpo sigv4Params) {
+  StsClient getStsClient(@NonNull SigV4AuthenticationParametersDpo sigv4Params) {
     // Get STS client from the provider (potentially pooled)
     // The Polaris service identity credentials are set on the AssumeRole request via
     // overrideConfiguration, not on the STS client itself

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergJsonProcessingExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergJsonProcessingExceptionMapper.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.annotations.VisibleForTesting;
-import jakarta.annotation.Nullable;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -36,6 +35,7 @@ import jakarta.ws.rs.ext.Provider;
 import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/http/IfNoneMatch.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/http/IfNoneMatch.java
@@ -18,14 +18,14 @@
  */
 package org.apache.polaris.service.http;
 
-import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
 
 /** Logical representation of an HTTP compliant If-None-Match header. */
-public record IfNoneMatch(boolean isWildcard, @Nonnull List<String> eTags) {
+public record IfNoneMatch(boolean isWildcard, @NonNull List<String> eTags) {
 
   private static final String WILDCARD_HEADER_VALUE = "*";
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/identity/AwsIamServiceIdentityConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/identity/AwsIamServiceIdentityConfiguration.java
@@ -19,13 +19,13 @@
 
 package org.apache.polaris.service.identity;
 
-import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.AwsIamServiceIdentityInfo;
 import org.apache.polaris.core.admin.model.ServiceIdentityInfo;
 import org.apache.polaris.core.identity.ServiceIdentityType;
 import org.apache.polaris.core.identity.credential.AwsIamServiceIdentityCredential;
 import org.apache.polaris.core.secrets.SecretReference;
+import org.jspecify.annotations.NonNull;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -111,7 +111,7 @@ public interface AwsIamServiceIdentityConfiguration extends ResolvableServiceIde
    */
   @Override
   default Optional<AwsIamServiceIdentityCredential> asServiceIdentityCredential(
-      @Nonnull SecretReference secretReference) {
+      @NonNull SecretReference secretReference) {
     return Optional.of(
         new AwsIamServiceIdentityCredential(secretReference, iamArn(), awsCredentialsProvider()));
   }
@@ -123,7 +123,7 @@ public interface AwsIamServiceIdentityConfiguration extends ResolvableServiceIde
    *
    * @return the constructed AWS credentials provider
    */
-  @Nonnull
+  @NonNull
   default AwsCredentialsProvider awsCredentialsProvider() {
     if (accessKeyId().isPresent() && secretAccessKey().isPresent()) {
       if (sessionToken().isPresent()) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/identity/ResolvableServiceIdentityConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/identity/ResolvableServiceIdentityConfiguration.java
@@ -19,12 +19,12 @@
 
 package org.apache.polaris.service.identity;
 
-import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.ServiceIdentityInfo;
 import org.apache.polaris.core.identity.ServiceIdentityType;
 import org.apache.polaris.core.identity.credential.ServiceIdentityCredential;
 import org.apache.polaris.core.secrets.SecretReference;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Represents a service identity configuration that can be converted into a fully initialized {@link
@@ -69,7 +69,7 @@ public interface ResolvableServiceIdentityConfiguration {
    * @return an optional service identity credential, or empty if required configuration is missing
    */
   default Optional<? extends ServiceIdentityCredential> asServiceIdentityCredential(
-      @Nonnull SecretReference secretReference) {
+      @NonNull SecretReference secretReference) {
     return Optional.empty();
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/identity/provider/DefaultServiceIdentityProvider.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/identity/provider/DefaultServiceIdentityProvider.java
@@ -20,7 +20,6 @@
 package org.apache.polaris.service.identity.provider;
 
 import com.google.common.annotations.VisibleForTesting;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -38,6 +37,7 @@ import org.apache.polaris.core.secrets.SecretReference;
 import org.apache.polaris.service.identity.RealmServiceIdentityConfiguration;
 import org.apache.polaris.service.identity.ResolvableServiceIdentityConfiguration;
 import org.apache.polaris.service.identity.ServiceIdentityConfiguration;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Default implementation of {@link ServiceIdentityProvider} that provides service identity
@@ -73,7 +73,7 @@ public class DefaultServiceIdentityProvider implements ServiceIdentityProvider {
 
   @Override
   public Optional<ServiceIdentityInfoDpo> allocateServiceIdentity(
-      @Nonnull ConnectionConfigInfo connectionConfig) {
+      @NonNull ConnectionConfigInfo connectionConfig) {
     if (config == null || connectionConfig.getAuthenticationParameters() == null) {
       return Optional.empty();
     }
@@ -95,7 +95,7 @@ public class DefaultServiceIdentityProvider implements ServiceIdentityProvider {
 
   @Override
   public Optional<ServiceIdentityInfo> getServiceIdentityInfo(
-      @Nonnull ServiceIdentityInfoDpo serviceIdentityInfo) {
+      @NonNull ServiceIdentityInfoDpo serviceIdentityInfo) {
     if (config == null) {
       return Optional.empty();
     }
@@ -113,7 +113,7 @@ public class DefaultServiceIdentityProvider implements ServiceIdentityProvider {
 
   @Override
   public Optional<ServiceIdentityCredential> getServiceIdentityCredential(
-      @Nonnull ServiceIdentityInfoDpo serviceIdentityInfo) {
+      @NonNull ServiceIdentityInfoDpo serviceIdentityInfo) {
     if (config == null) {
       return Optional.empty();
     }

--- a/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/metrics/PolarisValueExpressionResolver.java
@@ -19,12 +19,12 @@
 package org.apache.polaris.service.metrics;
 
 import io.micrometer.common.annotation.ValueExpressionResolver;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @ApplicationScoped
 public class PolarisValueExpressionResolver implements ValueExpressionResolver {
@@ -33,7 +33,7 @@ public class PolarisValueExpressionResolver implements ValueExpressionResolver {
 
   @Override
   @Nullable
-  public String resolve(@Nonnull String expression, @Nullable Object parameter) {
+  public String resolve(@NonNull String expression, @Nullable Object parameter) {
     // TODO maybe replace with CEL of some expression engine and make this more generic
     if (metricsConfiguration.realmIdTag().enableInApiMetrics()
         && parameter instanceof RealmContext realmContext

--- a/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/persistence/InMemoryPolarisMetaStoreManagerFactory.java
@@ -19,8 +19,6 @@
 package org.apache.polaris.service.persistence;
 
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
@@ -38,6 +36,8 @@ import org.apache.polaris.core.persistence.transactional.TransactionalPersistenc
 import org.apache.polaris.core.persistence.transactional.TreeMapMetaStore;
 import org.apache.polaris.core.persistence.transactional.TreeMapTransactionalPersistenceImpl;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @ApplicationScoped
 @Identifier("in-memory")
@@ -65,16 +65,16 @@ public class InMemoryPolarisMetaStoreManagerFactory
   }
 
   @Override
-  protected TreeMapMetaStore createBackingStore(@Nonnull PolarisDiagnostics diagnostics) {
+  protected TreeMapMetaStore createBackingStore(@NonNull PolarisDiagnostics diagnostics) {
     return new TreeMapMetaStore(diagnostics);
   }
 
   @Override
   protected TransactionalPersistence createMetaStoreSession(
-      @Nonnull TreeMapMetaStore store,
-      @Nonnull RealmContext realmContext,
+      @NonNull TreeMapMetaStore store,
+      @NonNull RealmContext realmContext,
       @Nullable RootCredentialsSet rootCredentialsSet,
-      @Nonnull PolarisDiagnostics diagnostics) {
+      @NonNull PolarisDiagnostics diagnostics) {
     return new TreeMapTransactionalPersistenceImpl(
         diagnostics, store, storageIntegration, secretsGenerator(realmContext, rootCredentialsSet));
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java
@@ -22,8 +22,6 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
@@ -47,6 +45,8 @@ import org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import org.apache.polaris.core.storage.gcp.GcpCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 @ApplicationScoped
@@ -133,24 +133,24 @@ public class PolarisStorageIntegrationProviderImpl implements PolarisStorageInte
             new PolarisStorageIntegration<>((T) polarisStorageConfigurationInfo, "file") {
               @Override
               public StorageAccessConfig getSubscopedCreds(
-                  @Nonnull RealmConfig realmConfig,
+                  @NonNull RealmConfig realmConfig,
                   boolean allowListOperation,
-                  @Nonnull Set<String> allowedReadLocations,
-                  @Nonnull Set<String> allowedWriteLocations,
-                  @Nonnull PolarisPrincipal polarisPrincipal,
+                  @NonNull Set<String> allowedReadLocations,
+                  @NonNull Set<String> allowedWriteLocations,
+                  @NonNull PolarisPrincipal polarisPrincipal,
                   Optional<String> refreshCredentialsEndpoint,
-                  @Nonnull CredentialVendingContext credentialVendingContext) {
+                  @NonNull CredentialVendingContext credentialVendingContext) {
                 // FILE storage does not support credential vending
                 return StorageAccessConfig.builder().supportsCredentialVending(false).build();
               }
 
               @Override
-              public @Nonnull Map<String, Map<PolarisStorageActions, ValidationResult>>
+              public @NonNull Map<String, Map<PolarisStorageActions, ValidationResult>>
                   validateAccessToLocations(
-                      @Nonnull RealmConfig realmConfig,
-                      @Nonnull T storageConfig,
-                      @Nonnull Set<PolarisStorageActions> actions,
-                      @Nonnull Set<String> locations) {
+                      @NonNull RealmConfig realmConfig,
+                      @NonNull T storageConfig,
+                      @NonNull Set<PolarisStorageActions> actions,
+                      @NonNull Set<String> locations) {
                 return Map.of();
               }
             };

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -24,8 +24,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.quarkus.runtime.Startup;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.enterprise.inject.Instance;
@@ -58,6 +56,8 @@ import org.apache.polaris.service.events.PolarisEventMetadata;
 import org.apache.polaris.service.events.PolarisEventMetadataFactory;
 import org.apache.polaris.service.events.PolarisEventType;
 import org.apache.polaris.service.tracing.TracingFilter;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,7 +162,7 @@ public class TaskExecutorImpl implements TaskExecutor {
     tryHandleTask(taskEntityId, clone, eventMetadata, null, 1);
   }
 
-  private @Nonnull CompletableFuture<Void> tryHandleTask(
+  private @NonNull CompletableFuture<Void> tryHandleTask(
       long taskEntityId,
       CallContext callContext,
       PolarisEventMetadata eventMetadata,

--- a/runtime/service/src/main/java/org/apache/polaris/service/tracing/DefaultRequestIdGenerator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/tracing/DefaultRequestIdGenerator.java
@@ -20,11 +20,11 @@
 package org.apache.polaris.service.tracing;
 
 import io.smallrye.mutiny.Uni;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Default implementation of {@link RequestIdGenerator}, striking a balance between randomness and
@@ -46,7 +46,7 @@ public class DefaultRequestIdGenerator implements RequestIdGenerator {
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public String toString() {
       return String.format("%s_%019d", uuid(), counter());
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -25,7 +25,6 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
@@ -90,6 +89,7 @@ import org.apache.polaris.service.storage.PolarisStorageIntegrationProviderImpl;
 import org.apache.polaris.service.task.TaskExecutor;
 import org.apache.polaris.service.types.PolicyIdentifier;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -442,7 +442,7 @@ public abstract class PolarisAuthzTestBase {
     Assertions.assertThat(result.isSuccess()).isTrue();
   }
 
-  protected @Nonnull PrincipalEntity rotateAndRefreshPrincipal(
+  protected @NonNull PrincipalEntity rotateAndRefreshPrincipal(
       PolarisMetaStoreManager metaStoreManager,
       String principalName,
       PrincipalWithCredentialsCredentials credentials,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import io.quarkus.test.junit.QuarkusMock;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -164,6 +163,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.configuration.PreferredAssumptionException;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -2191,9 +2191,9 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
             new FileIOFactory() {
               @Override
               public FileIO loadFileIO(
-                  @Nonnull StorageAccessConfig accessConfig,
-                  @Nonnull String ioImplClassName,
-                  @Nonnull Map<String, String> properties) {
+                  @NonNull StorageAccessConfig accessConfig,
+                  @NonNull String ioImplClassName,
+                  @NonNull Map<String, String> properties) {
                 return measured.loadFileIO(
                     accessConfig, "org.apache.iceberg.inmemory.InMemoryFileIO", Map.of());
               }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import jakarta.annotation.Nonnull;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +50,7 @@ import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
 import org.apache.polaris.service.task.TaskFileIOSupplier;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -108,7 +108,7 @@ public class FileIOFactoryTest {
                 new DefaultFileIOFactory() {
                   @Override
                   FileIO loadFileIOInternal(
-                      @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
+                      @NonNull String ioImplClassName, @NonNull Map<String, String> properties) {
                     // properties should contain credentials
                     Assertions.assertThat(properties)
                         .containsEntry(S3FileIOProperties.ACCESS_KEY_ID, TEST_ACCESS_KEY)

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskTestUtils.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskTestUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.task;
 
-import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
@@ -56,6 +55,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.TaskEntity;
+import org.jspecify.annotations.NonNull;
 
 public class TaskTestUtils {
   static ManifestFile manifestFile(
@@ -143,7 +143,7 @@ public class TaskTestUtils {
     return tableMetadata;
   }
 
-  static @Nonnull TestSnapshot newSnapshot(
+  static @NonNull TestSnapshot newSnapshot(
       FileIO fileIO,
       String manifestListLocation,
       long sequenceNumber,

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.service.catalog.io;
 
-import jakarta.annotation.Nonnull;
 import jakarta.enterprise.inject.Vetoed;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -28,6 +27,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A FileIOFactory that measures the number of bytes read, files written, and files deleted. It can
@@ -52,9 +52,9 @@ public class MeasuredFileIOFactory implements FileIOFactory {
 
   @Override
   public FileIO loadFileIO(
-      @Nonnull StorageAccessConfig storageAccessConfig,
-      @Nonnull String ioImplClassName,
-      @Nonnull Map<String, String> properties) {
+      @NonNull StorageAccessConfig storageAccessConfig,
+      @NonNull String ioImplClassName,
+      @NonNull Map<String, String> properties) {
     loadFileIOExceptionSupplier.ifPresent(
         s -> {
           throw s.get();

--- a/tools/config-docs/generator/build.gradle.kts
+++ b/tools/config-docs/generator/build.gradle.kts
@@ -24,6 +24,7 @@ description = "Generates Polaris reference docs"
 val genTesting by configurations.creating
 
 dependencies {
+  compileOnly(libs.jspecify)
   implementation(project(":polaris-config-docs-annotations"))
   implementation(project(":polaris-core")) { isTransitive = false }
 

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PolarisConfigurationInfo.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PolarisConfigurationInfo.java
@@ -18,7 +18,7 @@
  */
 package org.apache.polaris.docs.generator;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Holds information about a PolarisConfiguration (FeatureConfiguration or

--- a/tools/misc-types/build.gradle.kts
+++ b/tools/misc-types/build.gradle.kts
@@ -26,6 +26,7 @@ description =
   "Misc types used in configurations and converters for microprofile-config & Jackson, exposes no runtime dependencies"
 
 dependencies {
+  compileOnly(libs.jspecify)
   compileOnly(libs.smallrye.config.core)
   compileOnly(platform(libs.quarkus.bom))
   compileOnly("io.quarkus:quarkus-core")

--- a/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
+++ b/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
@@ -24,12 +24,12 @@ import static java.util.Locale.ROOT;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.spi.Converter;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Type representing a memory size in bytes, using 1024 as the multiplier for kilo, mega, etc.
@@ -84,7 +84,7 @@ public abstract class MemorySize {
       return bytes;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public BigInteger asBigInteger() {
       return BigInteger.valueOf(bytes);
@@ -124,7 +124,7 @@ public abstract class MemorySize {
   static final class MemorySizeBig extends MemorySize {
     private final BigInteger bytes;
 
-    MemorySizeBig(@Nonnull BigInteger bytes) {
+    MemorySizeBig(@NonNull BigInteger bytes) {
       this.bytes = bytes;
     }
 
@@ -133,7 +133,7 @@ public abstract class MemorySize {
       return bytes.longValueExact();
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public BigInteger asBigInteger() {
       return bytes;
@@ -216,7 +216,7 @@ public abstract class MemorySize {
             value));
   }
 
-  @Nonnull
+  @NonNull
   public abstract BigInteger asBigInteger();
 
   /**

--- a/tools/misc-types/src/test/java/org/apache/polaris/misc/types/memorysize/TestMemorySize.java
+++ b/tools/misc-types/src/test/java/org/apache/polaris/misc/types/memorysize/TestMemorySize.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfigBuilder;
-import jakarta.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +39,7 @@ import org.apache.polaris.immutables.PolarisImmutable;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -180,12 +180,10 @@ public class TestMemorySize {
     @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT)
     MemorySize implicitInt();
 
-    @Nullable
-    MemorySize implicitNull();
+    @Nullable MemorySize implicitNull();
 
     @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT)
-    @Nullable
-    MemorySize implicitIntNull();
+    @Nullable MemorySize implicitIntNull();
 
     Optional<MemorySize> optionalEmpty();
 


### PR DESCRIPTION
Migrates the remaining modules from Jakarta `@Nullable`/`@Nonnull` to JSpecify `@Nullable`/`@NonNull`. This completes the migration started in #4130 and #4240. After this PR, there are no Jakarta nullness annotations left in the codebase.

Part of #4124

### Changes

Mechanical import swap across runtime/service, runtime/admin, extensions, plugins, tools, and persistence/relational-jdbc. One manual fix where `@NonNull QueryGenerator.PreparedQuery` needed a short import due to TYPE_USE scoping.

Added explicit `compileOnly(libs.jspecify)` where needed and removed `jakarta.annotation.api` from modules that only used it for nullness annotations.

### Testing

Verified with `./gradlew spotlessCheck compileJava compileTestJava compileTestFixturesJava` - all pass, no warnings.

### Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: #4124
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)