### PR TITLE
NoSQL: Bypass decorators during retention scans

### DIFF
--- a/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/MaintenanceServiceImpl.java
+++ b/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/MaintenanceServiceImpl.java
@@ -549,7 +549,7 @@ class MaintenanceServiceImpl implements MaintenanceService {
   private boolean identifyAgainstRealm(String realmId, AllRetained allRetained) {
     LOGGER.info("Identifying referenced data in realm '{}'", realmId);
 
-    var pers = realmPersistenceFactory.newBuilder().realmId(realmId).build();
+    var pers = realmPersistenceFactory.newBuilder().realmId(realmId).skipDecorators().build();
     var collector = new RetainedCollectorImpl(pers, allRetained, objTypeRetainedIdentifiers);
 
     boolean any = false;


### PR DESCRIPTION
Build the maintenance persistence view with decorators skipped during retention scans.

Maintenance should not warm or churn the normal caching layers while it is just walking retained state.
