### PR TITLE
NoSQL: Let maintenance remove stale policy mappings and grant records

### DIFF
--- a/persistence/nosql/authz/api/src/main/java/org/apache/polaris/persistence/nosql/authz/api/Acl.java
+++ b/persistence/nosql/authz/api/src/main/java/org/apache/polaris/persistence/nosql/authz/api/Acl.java
@@ -31,6 +31,8 @@ public interface Acl {
 
   void forEach(@NonNull BiConsumer<String, AclEntry> consumer);
 
+  boolean isEmpty();
+
   interface AclBuilder {
     @CanIgnoreReturnValue
     AclBuilder from(@NonNull Acl instance);

--- a/persistence/nosql/authz/impl/src/main/java/org/apache/polaris/persistence/nosql/authz/impl/AclImpl.java
+++ b/persistence/nosql/authz/impl/src/main/java/org/apache/polaris/persistence/nosql/authz/impl/AclImpl.java
@@ -39,6 +39,11 @@ record AclImpl(Object2ObjectHashMap<String, AclEntry> map) implements Acl {
   }
 
   @Override
+  public boolean isEmpty() {
+    return map.isEmpty();
+  }
+
+  @Override
   public void forEach(@NonNull BiConsumer<String, AclEntry> consumer) {
     map.forEach(consumer);
   }

--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestAclImpl.java
@@ -52,6 +52,12 @@ public class TestAclImpl {
   @MethodSource
   public void acl(Acl acl) throws Exception {
     String json = mapper.writeValueAsString(acl);
+
+    var notEmpty = new boolean[1];
+    acl.forEach((roleId, aclEntry) -> notEmpty[0] = true);
+
+    soft.assertThat(acl.isEmpty()).isEqualTo(!notEmpty[0]);
+
     soft.assertThat(mapper.readValue(json, Acl.class)).isEqualTo(acl);
   }
 

--- a/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/RetainedCollectorImpl.java
+++ b/persistence/nosql/persistence/maintenance/impl/src/main/java/org/apache/polaris/persistence/nosql/maintenance/impl/RetainedCollectorImpl.java
@@ -84,6 +84,12 @@ final class RetainedCollectorImpl implements Persistence, RetainedCollector {
     return this;
   }
 
+  @NonNull
+  @Override
+  public Persistence nonRecordingRealmPersistence() {
+    return persistence;
+  }
+
   @Override
   public void retainObject(@NonNull ObjRef objRef) {
     if (!currentNesting.add(objRef.id())) {

--- a/persistence/nosql/persistence/maintenance/spi/src/main/java/org/apache/polaris/persistence/nosql/maintenance/spi/RetainedCollector.java
+++ b/persistence/nosql/persistence/maintenance/spi/src/main/java/org/apache/polaris/persistence/nosql/maintenance/spi/RetainedCollector.java
@@ -60,6 +60,18 @@ public interface RetainedCollector {
   @NonNull Persistence realmPersistence();
 
   /**
+   * {@link Persistence Persistence} configured for the current {@linkplain #realm() realm}, without
+   * automatic retain side effects.
+   *
+   * <p>Use this view for maintenance-time cleanup commits that must not mark everything they touch
+   * as retained.
+   *
+   * <p>The returned {@link Persistence Persistence} bypasses the cache to avoid polluting the
+   * production cache with accesses from the maintenance service.
+   */
+  @NonNull Persistence nonRecordingRealmPersistence();
+
+  /**
    * Instruct the maintenance service to retain the reference with the given name.
    *
    * <p>References that are fetched via {@link #realmPersistence()} are automatically marked to be

--- a/persistence/nosql/persistence/metastore-maintenance/build.gradle.kts
+++ b/persistence/nosql/persistence/metastore-maintenance/build.gradle.kts
@@ -27,6 +27,7 @@ description = "Polaris NoSQL persistence core types"
 dependencies {
   implementation(project(":polaris-core"))
   implementation(project(":polaris-persistence-nosql-api"))
+  implementation(project(":polaris-persistence-nosql-authz-api"))
   implementation(project(":polaris-idgen-api"))
   implementation(project(":polaris-persistence-nosql-maintenance-api"))
   implementation(project(":polaris-persistence-nosql-maintenance-spi"))

--- a/persistence/nosql/persistence/metastore-maintenance/src/main/java/org/apache/polaris/persistence/nosql/metastore/maintenance/CatalogRetainedIdentifier.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/main/java/org/apache/polaris/persistence/nosql/metastore/maintenance/CatalogRetainedIdentifier.java
@@ -19,8 +19,9 @@
 package org.apache.polaris.persistence.nosql.metastore.maintenance;
 
 import static java.lang.String.format;
+import static org.apache.polaris.persistence.nosql.api.index.IndexKey.INDEX_KEY_SERIALIZER;
 import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.OBJ_REF_SERIALIZER;
-import static org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogRolesObj.CATALOG_ROLES_REF_NAME_PATTERN;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
 import static org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogStateObj.CATALOG_STATE_REF_NAME_PATTERN;
 import static org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogsObj.CATALOGS_REF_NAME;
 import static org.apache.polaris.persistence.nosql.coretypes.principals.PrincipalRolesObj.PRINCIPAL_ROLES_REF_NAME;
@@ -39,26 +40,43 @@ import static org.apache.polaris.persistence.nosql.metastore.maintenance.Catalog
 import static org.apache.polaris.persistence.nosql.metastore.maintenance.CatalogsMaintenanceConfig.DEFAULT_PRINCIPALS_RETAIN;
 import static org.apache.polaris.persistence.nosql.metastore.maintenance.CatalogsMaintenanceConfig.DEFAULT_PRINCIPAL_ROLES_RETAIN;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.ids.api.MonotonicClock;
 import org.apache.polaris.maintenance.cel.CelReferenceContinuePredicate;
+import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.exceptions.ReferenceNotFoundException;
+import org.apache.polaris.persistence.nosql.api.index.Index;
 import org.apache.polaris.persistence.nosql.api.index.IndexContainer;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.api.obj.BaseCommitObj;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.apache.polaris.persistence.nosql.authz.api.Acl;
+import org.apache.polaris.persistence.nosql.authz.api.Privileges;
 import org.apache.polaris.persistence.nosql.coretypes.ContainerObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.GrantTriplet;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogRolesObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogStateObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogsObj;
+import org.apache.polaris.persistence.nosql.coretypes.mapping.EntityObjMappings;
 import org.apache.polaris.persistence.nosql.coretypes.principals.PrincipalRolesObj;
 import org.apache.polaris.persistence.nosql.coretypes.principals.PrincipalsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.ImmediateTasksObj;
+import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.RealmGrantsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.RootObj;
@@ -73,15 +91,30 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CatalogRetainedIdentifier.class);
 
+  /**
+   * Local batch size for stale cross-reference cleanup commits. The generic maintenance SPI does
+   * not currently expose specialized tuning for this identifier, and this value is intentionally
+   * not made externally configurable: each batch rewrites inline index state on a shared realm ref,
+   * so the batch size must stay conservatively bounded.
+   */
+  @VisibleForTesting static final int STALE_CLEANUP_BATCH_SIZE = 64;
+
+  private static final IndexKey POLICY_MAPPINGS_ENTITY_PREFIX_KEY =
+      IndexKey.key(ByteBuffer.wrap(new byte[] {'E'}));
+
   private final CatalogsMaintenanceConfig catalogsMaintenanceConfig;
   private final MonotonicClock monotonicClock;
+  private final Privileges privileges;
 
   @SuppressWarnings("CdiInjectionPointsInspection")
   @Inject
   CatalogRetainedIdentifier(
-      CatalogsMaintenanceConfig catalogsMaintenanceConfig, MonotonicClock monotonicClock) {
+      CatalogsMaintenanceConfig catalogsMaintenanceConfig,
+      MonotonicClock monotonicClock,
+      Privileges privileges) {
     this.catalogsMaintenanceConfig = catalogsMaintenanceConfig;
     this.monotonicClock = monotonicClock;
+    this.privileges = privileges;
   }
 
   @Override
@@ -92,10 +125,12 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
   @Override
   public boolean identifyRetained(@NonNull RetainedCollector collector) {
 
-    // Note: References & objects retrieved via the `Persistence` instance returned by the
-    // `RetainedCollector` are automatically retained (no need to call collector.retain*()
-    // explicitly).
+    // Note: References & objects retrieved via the `Persistence` instance returned by
+    // `RetainedCollector.realmPersistence()` are automatically retained (no need to call
+    // collector.retain*() explicitly).
     var persistence = collector.realmPersistence();
+
+    cleanupPass(collector);
 
     // per realm
 
@@ -195,12 +230,9 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
               continue;
             }
 
-            perCatalog(
-                "catalog roles",
-                CATALOG_ROLES_REF_NAME_PATTERN,
+            perCatalogRoles(
                 catalogObj,
                 catalogsMaintenanceConfig.catalogRolesRetain().orElse(DEFAULT_CATALOG_ROLES_RETAIN),
-                CatalogRolesObj.class,
                 CatalogRolesObj::nameToObjRef,
                 collector,
                 catalogRolesObj -> collector.indexRetain(catalogRolesObj.stableIdToName()));
@@ -259,6 +291,16 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
     return true;
   }
 
+  private void cleanupPass(@NonNull RetainedCollector collector) {
+    // This `cleanupPersistence` is used for operations that shall not record touched references or
+    // objects as "to be retained", such as this cleanup pass.
+    var cleanupPersistence = collector.nonRecordingRealmPersistence();
+    var entityLookup = new EntityLookupCache(cleanupPersistence);
+
+    cleanupStaleGrantRecords(cleanupPersistence, entityLookup);
+    cleanupStalePolicyMappings(cleanupPersistence, entityLookup);
+  }
+
   @SuppressWarnings({"LoggingSimilarMessage", "SameParameterValue"})
   private <O extends BaseCommitObj> void perRealm(
       String what,
@@ -302,25 +344,27 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
         });
   }
 
-  private <O extends BaseCommitObj> void perCatalog(
-      String what,
-      String refNamePattern,
+  private void perCatalogRoles(
       CatalogObj catalogObj,
       String celRetainExpr,
-      Class<O> objClazz,
-      Function<O, IndexContainer<ObjRef>> indexContainerFunction,
+      Function<CatalogRolesObj, IndexContainer<ObjRef>> indexContainerFunction,
       RetainedCollector collector,
-      Consumer<O> objConsumer) {
+      Consumer<CatalogRolesObj> objConsumer) {
     LOGGER.info(
-        "Identifying {} for catalog '{}' ({})...", what, catalogObj.name(), catalogObj.stableId());
+        "Identifying {} for catalog '{}' ({})...",
+        "catalog roles",
+        catalogObj.name(),
+        catalogObj.stableId());
     ignoreReferenceNotFound(
         () -> {
           var persistence = collector.realmPersistence();
-          var refName = format(refNamePattern, catalogObj.stableId());
+          var refName =
+              format(CatalogRolesObj.CATALOG_ROLES_REF_NAME_PATTERN, catalogObj.stableId());
           var historyContinue =
-              new CelReferenceContinuePredicate<O>(refName, persistence, celRetainExpr);
+              new CelReferenceContinuePredicate<CatalogRolesObj>(
+                  refName, persistence, celRetainExpr);
           collector.refRetainIndexToSingleObj(
-              refName, objClazz, historyContinue, indexContainerFunction, objConsumer);
+              refName, CatalogRolesObj.class, historyContinue, indexContainerFunction, objConsumer);
         });
   }
 
@@ -331,4 +375,351 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
       LOGGER.debug("Reference not found: {}", e.getMessage());
     }
   }
+
+  private void cleanupStaleGrantRecords(Persistence persistence, EntityLookupCache entityLookup) {
+    LOGGER.info("Cleaning stale grant records...");
+    ignoreReferenceNotFound(
+        () -> {
+          IndexKey continuation = null;
+          while (true) {
+            var refObj =
+                persistence.fetchReferenceHead(REALM_GRANTS_REF_NAME, RealmGrantsObj.class);
+            if (refObj.isEmpty()) {
+              return;
+            }
+
+            var batch =
+                scanStaleGrantRecords(
+                    persistence,
+                    refObj.get().acls().indexForRead(persistence, OBJ_REF_SERIALIZER),
+                    continuation,
+                    entityLookup);
+            if (batch.candidates().isEmpty()) {
+              return;
+            }
+
+            var cleaned = commitGrantCleanup(persistence, batch.candidates());
+            LOGGER.debug("Removed {} stale grant ACL entries in this batch", cleaned);
+
+            if (batch.exhausted()) {
+              return;
+            }
+            continuation = batch.lastScannedKey();
+          }
+        });
+  }
+
+  private GrantCleanupBatch scanStaleGrantRecords(
+      Persistence persistence,
+      Index<ObjRef> index,
+      IndexKey continuation,
+      EntityLookupCache entityLookup) {
+    var candidates = new ArrayList<GrantCleanupCandidate>();
+    var iter = index.iterator(continuation, null, false);
+    var skipContinuation = continuation != null;
+    IndexKey lastScannedKey = null;
+    while (iter.hasNext()) {
+      var elem = iter.next();
+      var aclKey = elem.key();
+      if (skipContinuation && aclKey.equals(continuation)) {
+        skipContinuation = false;
+        continue;
+      }
+      skipContinuation = false;
+      lastScannedKey = aclKey;
+
+      var anchor = GrantTriplet.fromRoleName(aclKey.toString());
+      if (!entityLookup.entityExists(anchor.catalogId(), anchor.id(), anchor.typeCode())) {
+        candidates.add(new GrantCleanupCandidate(aclKey, List.of(), true));
+      } else {
+        var aclObj = persistence.fetch(elem.value(), AclObj.class);
+        if (aclObj == null) {
+          continue;
+        }
+
+        var staleRoleIds = new ArrayList<String>();
+        aclObj
+            .acl()
+            .forEach(
+                (roleId, entry) -> {
+                  var role = GrantTriplet.fromRoleName(roleId);
+                  if (!entityLookup.entityExists(role.catalogId(), role.id(), role.typeCode())) {
+                    staleRoleIds.add(roleId);
+                  }
+                });
+        if (!staleRoleIds.isEmpty()) {
+          candidates.add(new GrantCleanupCandidate(aclKey, staleRoleIds, false));
+        }
+      }
+
+      if (candidates.size() >= STALE_CLEANUP_BATCH_SIZE) {
+        return new GrantCleanupBatch(candidates, lastScannedKey, false);
+      }
+    }
+    return new GrantCleanupBatch(candidates, lastScannedKey, true);
+  }
+
+  private int commitGrantCleanup(
+      Persistence persistence, List<GrantCleanupCandidate> grantCleanupCandidates) {
+    return persistence
+        .createCommitter(REALM_GRANTS_REF_NAME, RealmGrantsObj.class, Integer.class)
+        .synchronizingLocally()
+        .commitRuntimeException(
+            (state, refObjSupplier) -> {
+              var refObj = refObjSupplier.get();
+              if (refObj.isEmpty()) {
+                return state.noCommit(0);
+              }
+
+              var aclIndex =
+                  refObj.get().acls().asUpdatableIndex(state.persistence(), OBJ_REF_SERIALIZER);
+              var changed = false;
+              var cleaned = 0;
+              for (var candidate : grantCleanupCandidates) {
+                if (candidate.removeAcl()) {
+                  if (aclIndex.remove(candidate.aclKey())) {
+                    changed = true;
+                    cleaned++;
+                  }
+                  continue;
+                }
+
+                var aclRef = aclIndex.get(candidate.aclKey());
+                if (aclRef == null) {
+                  continue;
+                }
+
+                var currentAclObj = state.persistence().fetch(aclRef, AclObj.class);
+                if (currentAclObj == null) {
+                  continue;
+                }
+
+                var aclBuilder = privileges.newAclBuilder().from(currentAclObj.acl());
+                candidate.staleRoleIds().forEach(aclBuilder::removeEntry);
+                var updatedAcl = aclBuilder.build();
+                if (currentAclObj.acl().equals(updatedAcl)) {
+                  continue;
+                }
+
+                if (aclIsEmpty(updatedAcl)) {
+                  if (aclIndex.remove(candidate.aclKey())) {
+                    changed = true;
+                    cleaned++;
+                  }
+                  continue;
+                }
+
+                AclObj updatedAclObj =
+                    AclObj.builder()
+                        .from(currentAclObj)
+                        .id(state.persistence().generateId())
+                        .acl(updatedAcl)
+                        .build();
+                updatedAclObj =
+                    state.writeOrReplace(
+                        "acl-" + currentAclObj.securableId(), updatedAclObj, AclObj.class);
+                aclIndex.put(candidate.aclKey(), objRef(updatedAclObj));
+                changed = true;
+                cleaned++;
+              }
+
+              if (!changed) {
+                return state.noCommit(0);
+              }
+
+              var builder = RealmGrantsObj.builder().from(refObj.get());
+              builder.acls(aclIndex.toIndexed("idx-sec-", state::writeOrReplace));
+              return state.commitResult(cleaned, builder, refObj);
+            })
+        .orElse(0);
+  }
+
+  private void cleanupStalePolicyMappings(Persistence persistence, EntityLookupCache entityLookup) {
+    LOGGER.info("Cleaning stale policy mappings...");
+    ignoreReferenceNotFound(
+        () -> {
+          IndexKey continuation = null;
+          while (true) {
+            var refObj =
+                persistence.fetchReferenceHead(POLICY_MAPPINGS_REF_NAME, PolicyMappingsObj.class);
+            if (refObj.isEmpty()) {
+              return;
+            }
+
+            var batch =
+                scanStalePolicyMappings(
+                    refObj
+                        .get()
+                        .policyMappings()
+                        .indexForRead(persistence, POLICY_MAPPING_SERIALIZER),
+                    continuation,
+                    entityLookup);
+            if (batch.candidates().isEmpty()) {
+              return;
+            }
+
+            var cleaned = commitPolicyMappingsCleanup(persistence, batch.candidates());
+            LOGGER.debug("Removed {} stale policy mappings in this batch", cleaned);
+
+            if (batch.exhausted()) {
+              return;
+            }
+            continuation = batch.lastScannedKey();
+          }
+        });
+  }
+
+  private PolicyMappingsCleanupBatch scanStalePolicyMappings(
+      Index<PolicyMapping> index, IndexKey continuation, EntityLookupCache entityLookup) {
+    var candidates = new ArrayList<PolicyMappingsObj.KeyByEntity>();
+    var lower = continuation != null ? continuation : POLICY_MAPPINGS_ENTITY_PREFIX_KEY;
+    var iter = index.iterator(lower, null, false);
+    var skipContinuation = continuation != null;
+    IndexKey lastScannedKey = null;
+    while (iter.hasNext()) {
+      var elem = iter.next();
+      var key = elem.key();
+      if (skipContinuation && key.equals(continuation)) {
+        skipContinuation = false;
+        continue;
+      }
+      skipContinuation = false;
+
+      var mappingKey = PolicyMappingsObj.PolicyMappingKey.fromIndexKey(key);
+      if (!(mappingKey instanceof PolicyMappingsObj.KeyByEntity entityKey)) {
+        break;
+      }
+
+      lastScannedKey = key;
+      if (!entityLookup.policyExists(entityKey.policyCatalogId(), entityKey.policyId())
+          || !entityLookup.policyTargetExists(entityKey.entityCatalogId(), entityKey.entityId())) {
+        candidates.add(entityKey);
+      }
+
+      if (candidates.size() >= STALE_CLEANUP_BATCH_SIZE) {
+        return new PolicyMappingsCleanupBatch(candidates, lastScannedKey, false);
+      }
+    }
+    return new PolicyMappingsCleanupBatch(candidates, lastScannedKey, true);
+  }
+
+  private int commitPolicyMappingsCleanup(
+      Persistence persistence, List<PolicyMappingsObj.KeyByEntity> staleMappings) {
+    return persistence
+        .createCommitter(POLICY_MAPPINGS_REF_NAME, PolicyMappingsObj.class, Integer.class)
+        .synchronizingLocally()
+        .commitRuntimeException(
+            (state, refObjSupplier) -> {
+              var refObj = refObjSupplier.get();
+              if (refObj.isEmpty()) {
+                return state.noCommit(0);
+              }
+
+              var mappingsIndex =
+                  refObj
+                      .get()
+                      .policyMappings()
+                      .asUpdatableIndex(state.persistence(), POLICY_MAPPING_SERIALIZER);
+              var changed = false;
+              var cleaned = 0;
+              for (var keyByEntity : staleMappings) {
+                var removedForward = mappingsIndex.remove(keyByEntity.toIndexKey());
+                var removedReverse = mappingsIndex.remove(keyByEntity.reverse().toIndexKey());
+                if (removedForward || removedReverse) {
+                  changed = true;
+                  cleaned++;
+                }
+              }
+
+              if (!changed) {
+                return state.noCommit(0);
+              }
+
+              var builder = PolicyMappingsObj.builder().from(refObj.get());
+              builder.policyMappings(mappingsIndex.toIndexed("mappings", state::writeOrReplace));
+              return state.commitResult(cleaned, builder, refObj);
+            })
+        .orElse(0);
+  }
+
+  private static boolean aclIsEmpty(Acl acl) {
+    var hasEntries = new boolean[1];
+    acl.forEach((roleId, entry) -> hasEntries[0] = true);
+    return !hasEntries[0];
+  }
+
+  private record PolicyMappingsCleanupBatch(
+      List<PolicyMappingsObj.KeyByEntity> candidates, IndexKey lastScannedKey, boolean exhausted) {}
+
+  private record GrantCleanupBatch(
+      List<GrantCleanupCandidate> candidates, IndexKey lastScannedKey, boolean exhausted) {}
+
+  private record GrantCleanupCandidate(
+      IndexKey aclKey, List<String> staleRoleIds, boolean removeAcl) {}
+
+  private static final class EntityLookupCache {
+    private final Persistence persistence;
+    private final Map<RefIndexKey, Optional<Index<IndexKey>>> stableIdIndices = new HashMap<>();
+
+    private EntityLookupCache(Persistence persistence) {
+      this.persistence = persistence;
+    }
+
+    private boolean policyExists(long catalogId, long policyId) {
+      return entityExists(catalogId, policyId, PolarisEntityType.POLICY.getCode());
+    }
+
+    private boolean policyTargetExists(long entityCatalogId, long entityId) {
+      if (entityCatalogId == 0L || entityCatalogId == entityId) {
+        return entityExists(0L, entityId, PolarisEntityType.CATALOG.getCode());
+      }
+      return catalogContentExists(entityCatalogId, entityId);
+    }
+
+    private boolean catalogContentExists(long catalogId, long entityId) {
+      return stableIdIndex(
+              new RefIndexKey(
+                  format(CATALOG_STATE_REF_NAME_PATTERN, catalogId), CatalogStateObj.class))
+          .map(index -> index.contains(IndexKey.key(entityId)))
+          .orElse(false);
+    }
+
+    private boolean entityExists(long catalogId, long entityId, int entityTypeCode) {
+      if (entityTypeCode == PolarisEntityType.ROOT.getCode()) {
+        return catalogId == PolarisEntityConstants.getNullId()
+            && entityId == PolarisEntityConstants.getRootEntityId();
+      }
+      if (entityTypeCode == PolarisEntityType.NULL_TYPE.getCode()) {
+        return false;
+      }
+
+      var mapping = EntityObjMappings.byEntityTypeCode(entityTypeCode);
+      var fixedCatalogId = mapping.fixCatalogId(catalogId);
+      return stableIdIndex(
+              new RefIndexKey(
+                  mapping.refNameForCatalog(fixedCatalogId), mapping.containerObjTypeClass()))
+          .map(index -> index.contains(IndexKey.key(entityId)))
+          .orElse(false);
+    }
+
+    private Optional<Index<IndexKey>> stableIdIndex(RefIndexKey key) {
+      return stableIdIndices.computeIfAbsent(
+          key,
+          k -> {
+            try {
+              return persistence
+                  .fetchReferenceHead(k.refName(), k.containerClass())
+                  .map(
+                      container ->
+                          container
+                              .stableIdToName()
+                              .indexForRead(persistence, INDEX_KEY_SERIALIZER));
+            } catch (ReferenceNotFoundException e) {
+              return Optional.empty();
+            }
+          });
+    }
+  }
+
+  private record RefIndexKey(String refName, Class<? extends ContainerObj> containerClass) {}
 }

--- a/persistence/nosql/persistence/metastore-maintenance/src/main/java/org/apache/polaris/persistence/nosql/metastore/maintenance/CatalogRetainedIdentifier.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/main/java/org/apache/polaris/persistence/nosql/metastore/maintenance/CatalogRetainedIdentifier.java
@@ -63,7 +63,6 @@ import org.apache.polaris.persistence.nosql.api.index.IndexContainer;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.api.obj.BaseCommitObj;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
-import org.apache.polaris.persistence.nosql.authz.api.Acl;
 import org.apache.polaris.persistence.nosql.authz.api.Privileges;
 import org.apache.polaris.persistence.nosql.coretypes.ContainerObj;
 import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
@@ -233,7 +232,6 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
             perCatalogRoles(
                 catalogObj,
                 catalogsMaintenanceConfig.catalogRolesRetain().orElse(DEFAULT_CATALOG_ROLES_RETAIN),
-                CatalogRolesObj::nameToObjRef,
                 collector,
                 catalogRolesObj -> collector.indexRetain(catalogRolesObj.stableIdToName()));
 
@@ -347,7 +345,6 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
   private void perCatalogRoles(
       CatalogObj catalogObj,
       String celRetainExpr,
-      Function<CatalogRolesObj, IndexContainer<ObjRef>> indexContainerFunction,
       RetainedCollector collector,
       Consumer<CatalogRolesObj> objConsumer) {
     LOGGER.info(
@@ -364,7 +361,11 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
               new CelReferenceContinuePredicate<CatalogRolesObj>(
                   refName, persistence, celRetainExpr);
           collector.refRetainIndexToSingleObj(
-              refName, CatalogRolesObj.class, historyContinue, indexContainerFunction, objConsumer);
+              refName,
+              CatalogRolesObj.class,
+              historyContinue,
+              CatalogRolesObj::nameToObjRef,
+              objConsumer);
         });
   }
 
@@ -430,7 +431,7 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
 
       var anchor = GrantTriplet.fromRoleName(aclKey.toString());
       if (!entityLookup.entityExists(anchor.catalogId(), anchor.id(), anchor.typeCode())) {
-        candidates.add(new GrantCleanupCandidate(aclKey, List.of(), true));
+        candidates.add(new GrantCleanupCandidate(aclKey, List.of()));
       } else {
         var aclObj = persistence.fetch(elem.value(), AclObj.class);
         if (aclObj == null) {
@@ -448,7 +449,7 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
                   }
                 });
         if (!staleRoleIds.isEmpty()) {
-          candidates.add(new GrantCleanupCandidate(aclKey, staleRoleIds, false));
+          candidates.add(new GrantCleanupCandidate(aclKey, staleRoleIds));
         }
       }
 
@@ -473,12 +474,10 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
 
               var aclIndex =
                   refObj.get().acls().asUpdatableIndex(state.persistence(), OBJ_REF_SERIALIZER);
-              var changed = false;
               var cleaned = 0;
               for (var candidate : grantCleanupCandidates) {
                 if (candidate.removeAcl()) {
                   if (aclIndex.remove(candidate.aclKey())) {
-                    changed = true;
                     cleaned++;
                   }
                   continue;
@@ -501,9 +500,8 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
                   continue;
                 }
 
-                if (aclIsEmpty(updatedAcl)) {
+                if (updatedAcl.isEmpty()) {
                   if (aclIndex.remove(candidate.aclKey())) {
-                    changed = true;
                     cleaned++;
                   }
                   continue;
@@ -519,11 +517,10 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
                     state.writeOrReplace(
                         "acl-" + currentAclObj.securableId(), updatedAclObj, AclObj.class);
                 aclIndex.put(candidate.aclKey(), objRef(updatedAclObj));
-                changed = true;
                 cleaned++;
               }
 
-              if (!changed) {
+              if (cleaned == 0) {
                 return state.noCommit(0);
               }
 
@@ -586,18 +583,27 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
       skipContinuation = false;
 
       var mappingKey = PolicyMappingsObj.PolicyMappingKey.fromIndexKey(key);
-      if (!(mappingKey instanceof PolicyMappingsObj.KeyByEntity entityKey)) {
+
+      if (mappingKey instanceof PolicyMappingsObj.KeyByEntity entityKey) {
+        lastScannedKey = key;
+        if (!entityLookup.policyExists(entityKey.policyCatalogId(), entityKey.policyId())
+            || !entityLookup.policyTargetExists(
+                entityKey.entityCatalogId(), entityKey.entityId())) {
+          candidates.add(entityKey);
+        }
+
+        if (candidates.size() >= STALE_CLEANUP_BATCH_SIZE) {
+          return new PolicyMappingsCleanupBatch(candidates, lastScannedKey, false);
+        }
+      } else if (mappingKey instanceof PolicyMappingsObj.KeyByPolicy) {
+        // The serialized key representations for KeyByEntity and KeyByPolicy start with a 'type'
+        // character: `E` for KeyByEntity and `P` for KeyByPolicy.
+        // Indexes and the order of returned elements are always sorted.
+        // So we can safely stop on the first KeyByPolicy.
         break;
-      }
-
-      lastScannedKey = key;
-      if (!entityLookup.policyExists(entityKey.policyCatalogId(), entityKey.policyId())
-          || !entityLookup.policyTargetExists(entityKey.entityCatalogId(), entityKey.entityId())) {
-        candidates.add(entityKey);
-      }
-
-      if (candidates.size() >= STALE_CLEANUP_BATCH_SIZE) {
-        return new PolicyMappingsCleanupBatch(candidates, lastScannedKey, false);
+      } else {
+        // Paranoid check: we should never get here.
+        throw new IllegalStateException("Unexpected mapping key type: " + mappingKey.getClass());
       }
     }
     return new PolicyMappingsCleanupBatch(candidates, lastScannedKey, true);
@@ -642,20 +648,17 @@ class CatalogRetainedIdentifier implements PerRealmRetainedIdentifier {
         .orElse(0);
   }
 
-  private static boolean aclIsEmpty(Acl acl) {
-    var hasEntries = new boolean[1];
-    acl.forEach((roleId, entry) -> hasEntries[0] = true);
-    return !hasEntries[0];
-  }
-
   private record PolicyMappingsCleanupBatch(
       List<PolicyMappingsObj.KeyByEntity> candidates, IndexKey lastScannedKey, boolean exhausted) {}
 
   private record GrantCleanupBatch(
       List<GrantCleanupCandidate> candidates, IndexKey lastScannedKey, boolean exhausted) {}
 
-  private record GrantCleanupCandidate(
-      IndexKey aclKey, List<String> staleRoleIds, boolean removeAcl) {}
+  private record GrantCleanupCandidate(IndexKey aclKey, List<String> staleRoleIds) {
+    boolean removeAcl() {
+      return staleRoleIds.isEmpty();
+    }
+  }
 
   private static final class EntityLookupCache {
     private final Persistence persistence;

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
@@ -23,6 +23,7 @@ import static java.util.function.Function.identity;
 import static org.apache.polaris.core.entity.PolarisEntitySubType.ICEBERG_TABLE;
 import static org.apache.polaris.core.entity.PolarisEntityType.CATALOG_ROLE;
 import static org.apache.polaris.core.entity.PolarisEntityType.NAMESPACE;
+import static org.apache.polaris.core.entity.PolarisEntityType.POLICY;
 import static org.apache.polaris.core.entity.PolarisEntityType.PRINCIPAL;
 import static org.apache.polaris.core.entity.PolarisEntityType.PRINCIPAL_ROLE;
 import static org.apache.polaris.core.entity.PolarisEntityType.TABLE_LIKE;
@@ -37,6 +38,7 @@ import static org.apache.polaris.persistence.nosql.coretypes.changes.Change.CHAN
 import static org.apache.polaris.persistence.nosql.coretypes.realm.ImmediateTasksObj.IMMEDIATE_TASKS_REF_NAME;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping.POLICY_MAPPING_SERIALIZER;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj.POLICY_MAPPINGS_REF_NAME;
+import static org.apache.polaris.persistence.nosql.coretypes.realm.RealmGrantsObj.REALM_GRANTS_REF_NAME;
 import static org.apache.polaris.persistence.nosql.coretypes.refs.References.realmReferenceNames;
 import static org.apache.polaris.persistence.nosql.maintenance.impl.MutableMaintenanceConfig.GRACE_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,8 +46,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -59,19 +63,29 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.policy.PolicyEntity;
+import org.apache.polaris.core.policy.PolicyType;
+import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.ids.mocks.MutableMonotonicClock;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
 import org.apache.polaris.persistence.nosql.api.cache.CacheBackend;
+import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.api.ref.Reference;
+import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.GrantTriplet;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogStateObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.ImmediateTasksObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj;
+import org.apache.polaris.persistence.nosql.coretypes.realm.RealmGrantsObj;
 import org.apache.polaris.persistence.nosql.coretypes.refs.References;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceConfig;
 import org.apache.polaris.persistence.nosql.maintenance.api.MaintenanceRunInformation;
@@ -94,7 +108,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class TestCatalogMaintenance {
   @InjectSoftAssertions protected SoftAssertions soft;
 
-  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+  @SuppressWarnings("unused")
+  @WeldSetup
+  WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
 
   String realmId;
   RealmContext realmContext;
@@ -135,19 +151,10 @@ public class TestCatalogMaintenance {
 
   @Test
   public void catalogMaintenance() {
-
-    metaStoreManagerFactory.bootstrapRealms(List.of(realmId), RootCredentialsSet.fromEnvironment());
-
-    var manager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
-    var session = metaStoreManagerFactory.getOrCreateSession(realmContext);
-    var callCtx = new PolarisCallContext(realmContext, session, configurationSource);
-
-    var persistence =
-        realmPersistenceFactory.newBuilder().realmId(realmId).skipDecorators().build();
-
-    // Some references are "empty", need to populate those to be able to bump the references "back"
-    // to the "real" state below.
-    mandatoryRealmObjsForTestImpl(persistence);
+    var testSetup = bootstrapRealm();
+    var manager = testSetup.manager();
+    var callCtx = testSetup.callCtx();
+    var persistence = testSetup.persistence();
 
     var initialReferenceHeads = new HashMap<String, Reference>();
     realmReferenceNames().forEach(n -> initialReferenceHeads.put(n, persistence.fetchReference(n)));
@@ -261,12 +268,392 @@ public class TestCatalogMaintenance {
     checkEntities("real state after grace", entities);
   }
 
+  @Test
+  public void maintenanceRemovesStalePolicyMappings() {
+    var testSetup = bootstrapRealm();
+    var manager = testSetup.manager();
+    var callCtx = testSetup.callCtx();
+    var persistence = testSetup.persistence();
+
+    var catalog = createCatalog(manager, callCtx, persistence);
+    mandatoryCatalogObjsForTestImpl(persistence, catalog.getId());
+    var namespace = createNamespace(manager, callCtx, catalog, persistence, "policy-ns");
+    var policy =
+        createPolicy(
+            manager,
+            callCtx,
+            catalog,
+            namespace,
+            persistence,
+            "cleanup-policy",
+            PredefinedPolicyTypes.DATA_COMPACTION);
+    var tables =
+        createTables(
+            manager,
+            callCtx,
+            catalog,
+            namespace,
+            persistence,
+            CatalogRetainedIdentifier.STALE_CLEANUP_BATCH_SIZE + 1,
+            "policy-table-");
+
+    for (var table : tables) {
+      assertThat(
+              manager.attachPolicyToEntity(
+                  callCtx,
+                  List.of(catalog, namespace),
+                  table,
+                  List.of(catalog, namespace),
+                  policy,
+                  Map.of()))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+
+    assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
+        .isEqualTo(2L * tables.size());
+
+    assertThat(manager.dropEntityIfExists(callCtx, List.of(catalog, namespace), policy, null, true))
+        .extracting(BaseResult::isSuccess)
+        .isEqualTo(true);
+
+    LoadPolicyMappingsResult staleMappings =
+        manager.loadPoliciesOnEntity(callCtx, tables.getFirst());
+    assertThat(staleMappings.isSuccess()).isTrue();
+    assertThat(staleMappings.getPolicyMappingRecords()).hasSize(1);
+    assertThat(staleMappings.getEntities()).isEmpty();
+
+    assertThat(runMaintenance().success()).isTrue();
+
+    assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
+        .isZero();
+  }
+
+  @Test
+  public void maintenanceRemovesStalePolicyMappingsForDeletedTargets() {
+    var testSetup = bootstrapRealm();
+    var manager = testSetup.manager();
+    var callCtx = testSetup.callCtx();
+    var persistence = testSetup.persistence();
+
+    var catalog = createCatalog(manager, callCtx, persistence);
+    mandatoryCatalogObjsForTestImpl(persistence, catalog.getId());
+    var namespace = createNamespace(manager, callCtx, catalog, persistence, "policy-target-ns");
+    var policy =
+        createPolicy(
+            manager,
+            callCtx,
+            catalog,
+            namespace,
+            persistence,
+            "cleanup-target-policy",
+            PredefinedPolicyTypes.DATA_COMPACTION);
+    var staleTables =
+        createTables(
+            manager,
+            callCtx,
+            catalog,
+            namespace,
+            persistence,
+            CatalogRetainedIdentifier.STALE_CLEANUP_BATCH_SIZE + 1,
+            "stale-policy-table-");
+    var liveTable =
+        createTable(manager, callCtx, catalog, namespace, persistence, "live-policy-table");
+
+    for (var table : staleTables) {
+      assertThat(
+              manager.attachPolicyToEntity(
+                  callCtx,
+                  List.of(catalog, namespace),
+                  table,
+                  List.of(catalog, namespace),
+                  policy,
+                  Map.of()))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+    assertThat(
+            manager.attachPolicyToEntity(
+                callCtx,
+                List.of(catalog, namespace),
+                liveTable,
+                List.of(catalog, namespace),
+                policy,
+                Map.of()))
+        .extracting(BaseResult::isSuccess)
+        .isEqualTo(true);
+
+    assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
+        .isEqualTo(2L * (staleTables.size() + 1L));
+
+    for (var table : staleTables) {
+      assertThat(
+              manager.dropEntityIfExists(callCtx, List.of(catalog, namespace), table, null, false))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+
+    assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
+        .isEqualTo(2L * (staleTables.size() + 1L));
+    assertThat(manager.loadPoliciesOnEntity(callCtx, liveTable).getPolicyMappingRecords())
+        .hasSize(1);
+
+    assertThat(runMaintenance().success()).isTrue();
+
+    assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
+        .isEqualTo(2L);
+    assertThat(manager.loadPoliciesOnEntity(callCtx, liveTable).getPolicyMappingRecords())
+        .hasSize(1);
+  }
+
+  @Test
+  public void maintenanceRemovesStaleGrantRecords() {
+    var testSetup = bootstrapRealm();
+    var manager = testSetup.manager();
+    var callCtx = testSetup.callCtx();
+    var persistence = testSetup.persistence();
+
+    var catalog = createCatalog(manager, callCtx, persistence);
+    mandatoryCatalogObjsForTestImpl(persistence, catalog.getId());
+    var namespace = createNamespace(manager, callCtx, catalog, persistence, "grant-ns");
+    var catalogRole = createCatalogRole(manager, callCtx, catalog, persistence);
+    var tables =
+        createTables(
+            manager,
+            callCtx,
+            catalog,
+            namespace,
+            persistence,
+            CatalogRetainedIdentifier.STALE_CLEANUP_BATCH_SIZE + 1,
+            "grant-table-");
+
+    for (var table : tables) {
+      assertThat(
+              manager.grantPrivilegeOnSecurableToRole(
+                  callCtx,
+                  catalogRole,
+                  List.of(catalog, namespace),
+                  table,
+                  PolarisPrivilege.TABLE_READ_DATA))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+
+    var staleAclNames = new ArrayList<String>();
+    staleAclNames.add(grantAclName(catalogRole));
+    tables.forEach(table -> staleAclNames.add(grantAclName(table)));
+    assertThat(countGrantAclHeads(persistence, staleAclNames)).isEqualTo(tables.size() + 1L);
+
+    assertThat(manager.dropEntityIfExists(callCtx, List.of(catalog), catalogRole, null, false))
+        .extracting(BaseResult::isSuccess)
+        .isEqualTo(true);
+
+    var staleGrants = manager.loadGrantsOnSecurable(callCtx, tables.getFirst());
+    assertThat(staleGrants.isSuccess()).isTrue();
+    assertThat(staleGrants.getGrantRecords()).isEmpty();
+    assertThat(staleGrants.getEntities()).isEmpty();
+
+    assertThat(runMaintenance().success()).isTrue();
+
+    assertThat(countGrantAclHeads(persistence, staleAclNames)).isZero();
+
+    var cleanedGrants = manager.loadGrantsOnSecurable(callCtx, tables.getFirst());
+    assertThat(cleanedGrants.isSuccess()).isTrue();
+    assertThat(cleanedGrants.getGrantRecords()).isEmpty();
+    assertThat(cleanedGrants.getEntities()).isEmpty();
+  }
+
+  @Test
+  public void maintenanceRewritesGrantAclWhenOnlySomeEntriesAreStale() {
+    var testSetup = bootstrapRealm();
+    var manager = testSetup.manager();
+    var callCtx = testSetup.callCtx();
+    var persistence = testSetup.persistence();
+
+    var catalog = createCatalog(manager, callCtx, persistence);
+    mandatoryCatalogObjsForTestImpl(persistence, catalog.getId());
+    var namespace = createNamespace(manager, callCtx, catalog, persistence, "partial-grant-ns");
+    var table =
+        createTable(manager, callCtx, catalog, namespace, persistence, "partial-grant-table");
+    var liveRole = createCatalogRole(manager, callCtx, catalog, persistence, "live-role");
+    var staleRoles =
+        createCatalogRoles(
+            manager,
+            callCtx,
+            catalog,
+            persistence,
+            CatalogRetainedIdentifier.STALE_CLEANUP_BATCH_SIZE + 1,
+            "stale-role-");
+
+    assertThat(
+            manager.grantPrivilegeOnSecurableToRole(
+                callCtx,
+                liveRole,
+                List.of(catalog, namespace),
+                table,
+                PolarisPrivilege.TABLE_READ_DATA))
+        .extracting(BaseResult::isSuccess)
+        .isEqualTo(true);
+    for (var staleRole : staleRoles) {
+      assertThat(
+              manager.grantPrivilegeOnSecurableToRole(
+                  callCtx,
+                  staleRole,
+                  List.of(catalog, namespace),
+                  table,
+                  PolarisPrivilege.TABLE_READ_DATA))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+
+    var aclNames = new ArrayList<String>();
+    aclNames.add(grantAclName(table));
+    aclNames.add(grantAclName(liveRole));
+    staleRoles.forEach(role -> aclNames.add(grantAclName(role)));
+    assertThat(countGrantAclHeads(persistence, aclNames)).isEqualTo(staleRoles.size() + 2L);
+    assertThat(grantAclRoleIds(persistence, grantAclName(table))).hasSize(staleRoles.size() + 1);
+
+    for (var staleRole : staleRoles) {
+      assertThat(manager.dropEntityIfExists(callCtx, List.of(catalog), staleRole, null, false))
+          .extracting(BaseResult::isSuccess)
+          .isEqualTo(true);
+    }
+
+    var staleGrants = manager.loadGrantsOnSecurable(callCtx, table);
+    assertThat(staleGrants.isSuccess()).isTrue();
+    assertThat(staleGrants.getGrantRecords()).hasSize(1);
+    assertThat(staleGrants.getEntities()).hasSize(1);
+
+    assertThat(runMaintenance().success()).isTrue();
+
+    assertThat(countGrantAclHeads(persistence, aclNames)).isEqualTo(2L);
+    assertThat(grantAclRoleIds(persistence, grantAclName(table)))
+        .containsExactly(grantEntryName(liveRole));
+
+    var cleanedGrants = manager.loadGrantsOnSecurable(callCtx, table);
+    assertThat(cleanedGrants.isSuccess()).isTrue();
+    assertThat(cleanedGrants.getGrantRecords()).hasSize(1);
+    assertThat(cleanedGrants.getEntities()).hasSize(1);
+  }
+
+  private TestSetup bootstrapRealm() {
+    metaStoreManagerFactory.bootstrapRealms(List.of(realmId), RootCredentialsSet.fromEnvironment());
+
+    var manager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+    var session = metaStoreManagerFactory.getOrCreateSession(realmContext);
+    var callCtx = new PolarisCallContext(realmContext, session, configurationSource);
+    var persistence =
+        realmPersistenceFactory.newBuilder().realmId(realmId).skipDecorators().build();
+
+    mandatoryRealmObjsForTestImpl(persistence);
+    return new TestSetup(manager, callCtx, persistence);
+  }
+
+  private MaintenanceRunInformation runMaintenance() {
+    return maintenance.performMaintenance(
+        MaintenanceRunSpec.builder()
+            .includeSystemRealm(false)
+            .realmsToProcess(Set.of(realmId))
+            .build(),
+        OptionalLong.empty());
+  }
+
+  private static long countPolicyMappingsForPolicy(
+      Persistence persistence, long policyCatalogId, long policyId) {
+    return persistence
+        .fetchReferenceHead(POLICY_MAPPINGS_REF_NAME, PolicyMappingsObj.class)
+        .map(
+            policyMappingsObj -> {
+              var count = 0L;
+              for (var elem :
+                  policyMappingsObj
+                      .policyMappings()
+                      .indexForRead(persistence, POLICY_MAPPING_SERIALIZER)) {
+                var key = PolicyMappingsObj.PolicyMappingKey.fromIndexKey(elem.key());
+                if (key.policyCatalogId() == policyCatalogId && key.policyId() == policyId) {
+                  count++;
+                }
+              }
+              return count;
+            })
+        .orElse(0L);
+  }
+
+  private static long countGrantAclHeads(Persistence persistence, List<String> aclNames) {
+    return persistence
+        .fetchReferenceHead(REALM_GRANTS_REF_NAME, RealmGrantsObj.class)
+        .map(
+            grantsObj -> {
+              var index = grantsObj.acls().indexForRead(persistence, OBJ_REF_SERIALIZER);
+              return aclNames.stream()
+                  .filter(aclName -> index.contains(IndexKey.key(aclName)))
+                  .count();
+            })
+        .orElse(0L);
+  }
+
+  private static String grantAclName(PolarisBaseEntity entity) {
+    return GrantTriplet.forEntity(entity).toRoleName();
+  }
+
+  private static String grantEntryName(PolarisBaseEntity entity) {
+    return GrantTriplet.forEntity(entity).asDirected().toRoleName();
+  }
+
+  private static List<String> grantAclRoleIds(Persistence persistence, String aclName) {
+    return persistence
+        .fetchReferenceHead(REALM_GRANTS_REF_NAME, RealmGrantsObj.class)
+        .map(
+            grantsObj -> {
+              var index = grantsObj.acls().indexForRead(persistence, OBJ_REF_SERIALIZER);
+              var aclRef = index.get(IndexKey.key(aclName));
+              if (aclRef == null) {
+                return List.<String>of();
+              }
+
+              var aclObj = persistence.fetch(aclRef, AclObj.class);
+              if (aclObj == null) {
+                return List.<String>of();
+              }
+
+              var roleIds = new ArrayList<String>();
+              aclObj.acl().forEach((roleId, entry) -> roleIds.add(roleId));
+              return roleIds;
+            })
+        .orElseGet(List::of);
+  }
+
+  private static List<PolarisBaseEntity> createTables(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      PolarisBaseEntity namespace,
+      Persistence persistence,
+      int count,
+      String namePrefix) {
+    var tables = new ArrayList<PolarisBaseEntity>(count);
+    for (var i = 0; i < count; i++) {
+      tables.add(createTable(manager, callCtx, catalog, namespace, persistence, namePrefix + i));
+    }
+    return tables;
+  }
+
   private static PolarisBaseEntity createTable(
       PolarisMetaStoreManager manager,
       PolarisCallContext callCtx,
       PolarisBaseEntity catalog,
       PolarisBaseEntity namespace,
       Persistence persistence) {
+    return createTable(manager, callCtx, catalog, namespace, persistence, "table1");
+  }
+
+  private static PolarisBaseEntity createTable(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      PolarisBaseEntity namespace,
+      Persistence persistence,
+      String name) {
     var tableResult =
         manager.createEntityIfNotExists(
             callCtx,
@@ -274,7 +661,7 @@ public class TestCatalogMaintenance {
             new PolarisEntity.Builder()
                 .setType(TABLE_LIKE)
                 .setSubType(ICEBERG_TABLE)
-                .setName("table1")
+                .setName(name)
                 .setId(persistence.generateId())
                 .setCatalogId(catalog.getId())
                 .setCreateTimestamp(System.currentTimeMillis())
@@ -287,13 +674,22 @@ public class TestCatalogMaintenance {
       PolarisCallContext callCtx,
       PolarisBaseEntity catalog,
       Persistence persistence) {
+    return createNamespace(manager, callCtx, catalog, persistence, "ns");
+  }
+
+  private static PolarisBaseEntity createNamespace(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      Persistence persistence,
+      String name) {
     var namespaceResult =
         manager.createEntityIfNotExists(
             callCtx,
             List.of(catalog),
             new PolarisEntity.Builder()
                 .setType(NAMESPACE)
-                .setName("ns")
+                .setName(name)
                 .setId(persistence.generateId())
                 .setCatalogId(catalog.getId())
                 .setCreateTimestamp(System.currentTimeMillis())
@@ -301,23 +697,70 @@ public class TestCatalogMaintenance {
     return namespaceResult.getEntity();
   }
 
+  @SuppressWarnings("SameParameterValue")
+  private static PolicyEntity createPolicy(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      PolarisBaseEntity namespace,
+      Persistence persistence,
+      String name,
+      PolicyType policyType) {
+    var policyResult =
+        manager.createEntityIfNotExists(
+            callCtx,
+            List.of(catalog, namespace),
+            new PolarisEntity.Builder()
+                .setType(POLICY)
+                .setName(name)
+                .setId(persistence.generateId())
+                .setCatalogId(catalog.getId())
+                .setCreateTimestamp(System.currentTimeMillis())
+                .setProperties(Map.of("policy-type-code", Integer.toString(policyType.getCode())))
+                .build());
+    return PolicyEntity.of(policyResult.getEntity());
+  }
+
   private static PolarisBaseEntity createCatalogRole(
       PolarisMetaStoreManager manager,
       PolarisCallContext callCtx,
       PolarisBaseEntity catalog,
       Persistence persistence) {
+    return createCatalogRole(manager, callCtx, catalog, persistence, "catalog-role");
+  }
+
+  private static PolarisBaseEntity createCatalogRole(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      Persistence persistence,
+      String name) {
     var catalogRoleResult =
         manager.createEntityIfNotExists(
             callCtx,
             List.of(catalog),
             new PolarisEntity.Builder()
                 .setType(CATALOG_ROLE)
-                .setName("catalog-role")
+                .setName(name)
                 .setId(persistence.generateId())
                 .setCatalogId(catalog.getId())
                 .setCreateTimestamp(System.currentTimeMillis())
                 .build());
     return catalogRoleResult.getEntity();
+  }
+
+  private static List<PolarisBaseEntity> createCatalogRoles(
+      PolarisMetaStoreManager manager,
+      PolarisCallContext callCtx,
+      PolarisBaseEntity catalog,
+      Persistence persistence,
+      int count,
+      String namePrefix) {
+    var catalogRoles = new ArrayList<PolarisBaseEntity>(count);
+    for (var i = 0; i < count; i++) {
+      catalogRoles.add(createCatalogRole(manager, callCtx, catalog, persistence, namePrefix + i));
+    }
+    return catalogRoles;
   }
 
   private static PolarisBaseEntity createCatalog(
@@ -479,4 +922,7 @@ public class TestCatalogMaintenance {
           .isEqualTo(e);
     }
   }
+
+  private record TestSetup(
+      PolarisMetaStoreManager manager, PolarisCallContext callCtx, Persistence persistence) {}
 }

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
@@ -325,6 +325,8 @@ public class TestCatalogMaintenance {
 
     assertThat(runMaintenance().success()).isTrue();
 
+    purgeBackendCache("");
+
     assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
         .isZero();
     var cleanedMappings = manager.loadPoliciesOnEntity(callCtx, tables.getFirst());
@@ -411,6 +413,8 @@ public class TestCatalogMaintenance {
 
     assertThat(runMaintenance().success()).isTrue();
 
+    purgeBackendCache("");
+
     assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
         .isEqualTo(2L);
     var liveMappingsAfterCleanup = manager.loadPoliciesOnEntity(callCtx, liveTable);
@@ -474,6 +478,8 @@ public class TestCatalogMaintenance {
     assertThat(staleGrants.getEntities()).isEmpty();
 
     assertThat(runMaintenance().success()).isTrue();
+
+    purgeBackendCache("");
 
     assertThat(countGrantAclHeads(persistence, staleAclNames)).isZero();
 
@@ -545,6 +551,8 @@ public class TestCatalogMaintenance {
     assertThat(staleGrants.getEntities()).hasSize(1);
 
     assertThat(runMaintenance().success()).isTrue();
+
+    purgeBackendCache("");
 
     assertThat(countGrantAclHeads(persistence, aclNames)).isEqualTo(2L);
     assertThat(grantAclRoleIds(persistence, grantAclName(table)))
@@ -914,10 +922,7 @@ public class TestCatalogMaintenance {
   }
 
   private void checkEntities(String step, List<PolarisBaseEntity> entities) {
-    // Purge the whole cache in case maintenance purged objects/references that should not have
-    // been purged to make the assertions catch those cases.
-    cacheBackend.purge();
-    soft.assertThat(cacheBackend.estimatedSize()).describedAs(step).isEqualTo(0L);
+    purgeBackendCache(step);
 
     var manager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     var session = metaStoreManagerFactory.getOrCreateSession(realmContext);
@@ -941,6 +946,13 @@ public class TestCatalogMaintenance {
           .describedAs("%s: %s", step, result.getReturnStatus())
           .isEqualTo(e);
     }
+  }
+
+  private void purgeBackendCache(String step) {
+    // Purge the whole cache in case maintenance purged objects/references that should not have
+    // been purged to make the assertions catch those cases.
+    cacheBackend.purge();
+    soft.assertThat(cacheBackend.estimatedSize()).describedAs(step).isEqualTo(0L);
   }
 
   private record TestSetup(

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/java/org/apache/polaris/persistence/nosql/metastore/maintenance/TestCatalogMaintenance.java
@@ -327,6 +327,10 @@ public class TestCatalogMaintenance {
 
     assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
         .isZero();
+    var cleanedMappings = manager.loadPoliciesOnEntity(callCtx, tables.getFirst());
+    assertThat(cleanedMappings.isSuccess()).isTrue();
+    assertThat(cleanedMappings.getPolicyMappingRecords()).isEmpty();
+    assertThat(cleanedMappings.getEntities()).isEmpty();
   }
 
   @Test
@@ -395,15 +399,29 @@ public class TestCatalogMaintenance {
 
     assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
         .isEqualTo(2L * (staleTables.size() + 1L));
-    assertThat(manager.loadPoliciesOnEntity(callCtx, liveTable).getPolicyMappingRecords())
-        .hasSize(1);
+    var liveMappingsBeforeCleanup = manager.loadPoliciesOnEntity(callCtx, liveTable);
+    assertThat(liveMappingsBeforeCleanup.isSuccess()).isTrue();
+    assertThat(liveMappingsBeforeCleanup.getPolicyMappingRecords())
+        .singleElement()
+        .satisfies(
+            mapping -> {
+              assertThat(mapping.getTargetCatalogId()).isEqualTo(liveTable.getCatalogId());
+              assertThat(mapping.getTargetId()).isEqualTo(liveTable.getId());
+            });
 
     assertThat(runMaintenance().success()).isTrue();
 
     assertThat(countPolicyMappingsForPolicy(persistence, policy.getCatalogId(), policy.getId()))
         .isEqualTo(2L);
-    assertThat(manager.loadPoliciesOnEntity(callCtx, liveTable).getPolicyMappingRecords())
-        .hasSize(1);
+    var liveMappingsAfterCleanup = manager.loadPoliciesOnEntity(callCtx, liveTable);
+    assertThat(liveMappingsAfterCleanup.isSuccess()).isTrue();
+    assertThat(liveMappingsAfterCleanup.getPolicyMappingRecords())
+        .singleElement()
+        .satisfies(
+            mapping -> {
+              assertThat(mapping.getTargetCatalogId()).isEqualTo(liveTable.getCatalogId());
+              assertThat(mapping.getTargetId()).isEqualTo(liveTable.getId());
+            });
   }
 
   @Test
@@ -447,6 +465,8 @@ public class TestCatalogMaintenance {
     assertThat(manager.dropEntityIfExists(callCtx, List.of(catalog), catalogRole, null, false))
         .extracting(BaseResult::isSuccess)
         .isEqualTo(true);
+
+    assertThat(countGrantAclHeads(persistence, staleAclNames)).isEqualTo(tables.size() + 1L);
 
     var staleGrants = manager.loadGrantsOnSecurable(callCtx, tables.getFirst());
     assertThat(staleGrants.isSuccess()).isTrue();

--- a/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/acl/GrantTriplet.java
+++ b/persistence/nosql/persistence/metastore-types/src/main/java/org/apache/polaris/persistence/nosql/coretypes/acl/GrantTriplet.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.persistence.nosql.metastore.privs;
+package org.apache.polaris.persistence.nosql.coretypes.acl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -24,7 +24,6 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.coretypes.ObjBase;
-import org.apache.polaris.persistence.nosql.coretypes.acl.GrantsObj;
 
 /**
  * Represents the triplet of catalog-ID, entity-ID and type-code plus a reverse-or-key marker.

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -107,6 +107,7 @@ import org.apache.polaris.persistence.nosql.authz.api.Privileges;
 import org.apache.polaris.persistence.nosql.coretypes.ContainerObj;
 import org.apache.polaris.persistence.nosql.coretypes.ObjBase;
 import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.GrantTriplet;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogRoleObj;
 import org.apache.polaris.persistence.nosql.coretypes.catalog.CatalogRolesObj;
@@ -134,7 +135,6 @@ import org.apache.polaris.persistence.nosql.metastore.mutation.PolicyMutation;
 import org.apache.polaris.persistence.nosql.metastore.mutation.PrincipalMutations;
 import org.apache.polaris.persistence.nosql.metastore.mutation.PrincipalMutations.UpdateSecrets.SecretsUpdater;
 import org.apache.polaris.persistence.nosql.metastore.mutation.UpdateKeyForCatalogAndEntityType;
-import org.apache.polaris.persistence.nosql.metastore.privs.GrantTriplet;
 import org.apache.polaris.persistence.nosql.metastore.privs.SecurableAndGrantee;
 import org.apache.polaris.persistence.nosql.metastore.privs.SecurableGranteePrivilegeTuple;
 import org.jspecify.annotations.NonNull;
@@ -524,6 +524,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                       index.remove(fromIndexKey(key).reverse().toIndexKey());
                     }
 
+                    // Replacing this inline index leaves older mapping objects and stripes stale
+                    // until a later maintenance purge.
                     builder.policyMappings(index.toIndexed("mappings", state::writeOrReplace));
                     return state.commitResult("", builder, refObj);
                   })
@@ -627,11 +629,9 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                       .apply()));
     }
 
-    // TODO populate MutationResults.aclsToRemove and handle those, also need a maintenance
-    //  operation to garbage-collect ACL entries for no longer existing entities.
-
-    // TODO handle MutationResults.policyIndexKeysToRemove(), also need a maintenance
-    //  operation to garbage-collect stale policy entries.
+    // Cross-reference cleanup for grants and policy mappings cannot be atomic with the entity drop
+    // commit, because those structures live on separate refs. Stale entries are tolerated on the
+    // read path and are removed later by maintenance.
 
     return mutationResults;
   }
@@ -991,7 +991,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
         .apply();
   }
 
-  // TODO remove entirely?
+  // Dormant reverse-lookup helper kept for possible future policy-to-entity lookups.
   @SuppressWarnings("SameParameterValue")
   LoadPolicyMappingsResult loadEntitiesOnPolicy(
       @Nullable PolarisEntityType entityType,
@@ -1092,6 +1092,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               .byId(key.policyId())
               .flatMap(objBase -> filterIsEntityType(objBase, PolarisEntityType.POLICY))
               .map(obj -> mapToEntity(obj, key.policyCatalogId()))
+              // Missing policy entities indicate tolerated stale mappings that maintenance will
+              // eventually prune.
               .ifPresent(policyEntities::add);
         }
         mappingRecords.add(key.toMappingRecord(elem.value()));
@@ -1214,6 +1216,8 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               entities.add(entity);
             }
           } else {
+            // Missing targets indicate tolerated stale grant references that maintenance will
+            // eventually prune.
             LOGGER.trace("    Not returning stale entity reference");
           }
         },
@@ -1245,6 +1249,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                   securableAndGrantee.securableId(),
                   securableAndGrantee.securableTypeCode());
           if (!securableExists) {
+            // Stale grant entries are tolerated on reads and removed later by maintenance.
             LOGGER.trace("Skipping stale grant record due to missing securable reference");
             return;
           }
@@ -1255,6 +1260,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                   securableAndGrantee.granteeId(),
                   securableAndGrantee.granteeTypeCode());
           if (!granteeExists) {
+            // Stale grant entries are tolerated on reads and removed later by maintenance.
             LOGGER.trace("Skipping stale grant record due to missing grantee reference");
             return;
           }

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/GrantsMutation.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/GrantsMutation.java
@@ -39,10 +39,10 @@ import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 import org.apache.polaris.persistence.nosql.authz.api.Privilege;
 import org.apache.polaris.persistence.nosql.authz.api.Privileges;
 import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.GrantTriplet;
 import org.apache.polaris.persistence.nosql.coretypes.acl.GrantsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.RealmGrantsObj;
 import org.apache.polaris.persistence.nosql.metastore.indexaccess.MemoizedIndexedAccess;
-import org.apache.polaris.persistence.nosql.metastore.privs.GrantTriplet;
 import org.apache.polaris.persistence.nosql.metastore.privs.SecurableGranteePrivilegeTuple;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -181,6 +181,8 @@ public record GrantsMutation(
 
                   var aclObj = aclObjBuilder.build();
 
+                  // Replacing the ACL object or the grants index entry leaves older ACL objects and
+                  // index stripes stale until a later maintenance purge.
                   state.writeOrReplace("acl-" + aclTriplet.id(), aclObj);
 
                   securablesIndex.put(aclKey, objRef(aclObj));

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationAttempt.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationAttempt.java
@@ -280,14 +280,9 @@ public record MutationAttempt(
                           return false;
                         }
 
-                        while (iter.hasNext()) {
-                          var elem = iter.next();
-                          var key = PolicyMappingsObj.PolicyMappingKey.fromIndexKey(elem.key());
-                          var reversed = key.reverse();
-
-                          mutationResults.addPolicyIndexKeyToRemove(elem.key());
-                          mutationResults.addPolicyIndexKeyToRemove(reversed.toIndexKey());
-                        }
+                        // Policy-mapping cleanup happens as a separate maintenance workflow,
+                        // because entity drops and policy-mappings updates cannot be made atomic
+                        // across multiple refs in the NoSQL model.
 
                         return true;
                       })

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationResults.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationResults.java
@@ -28,30 +28,21 @@ import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.DropEntityResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
-import org.apache.polaris.persistence.nosql.api.index.IndexKey;
-import org.apache.polaris.persistence.nosql.metastore.privs.GrantTriplet;
 
 public final class MutationResults {
   private final List<BaseResult> results;
-  // TODO populate and process 'aclsToRemove'
-  private final List<GrantTriplet> aclsToRemove;
   private final List<PolarisBaseEntity> droppedEntities;
-  private final List<IndexKey> policyIndexKeysToRemove = new ArrayList<>();
 
   boolean anyChange;
   boolean hardFailure;
 
-  private MutationResults(
-      List<BaseResult> results,
-      List<GrantTriplet> aclsToRemove,
-      List<PolarisBaseEntity> droppedEntities) {
+  private MutationResults(List<BaseResult> results, List<PolarisBaseEntity> droppedEntities) {
     this.results = results;
-    this.aclsToRemove = aclsToRemove;
     this.droppedEntities = droppedEntities;
   }
 
   MutationResults(BaseResult single) {
-    this(List.of(single), List.of(), List.of());
+    this(List.of(single), List.of());
   }
 
   static MutationResults singleEntityResult(BaseResult.ReturnStatus returnStatus) {
@@ -63,27 +54,15 @@ public final class MutationResults {
   }
 
   static MutationResults newMutableMutationResults() {
-    return new MutationResults(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
-  }
-
-  public List<BaseResult> results() {
-    return results;
-  }
-
-  public List<GrantTriplet> aclsToRemove() {
-    return aclsToRemove;
+    return new MutationResults(new ArrayList<>(), new ArrayList<>());
   }
 
   public List<PolarisBaseEntity> droppedEntities() {
     return droppedEntities;
   }
 
-  public List<IndexKey> policyIndexKeysToRemove() {
-    return policyIndexKeysToRemove;
-  }
-
-  void addPolicyIndexKeyToRemove(IndexKey indexKey) {
-    policyIndexKeysToRemove.add(indexKey);
+  public List<BaseResult> results() {
+    return results;
   }
 
   void entityResult(PolarisBaseEntity entity) {

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
@@ -143,6 +143,8 @@ public record PolicyMutation(
                 }
 
                 if (changed) {
+                  // Replacing this inline index leaves older mapping objects and stripes stale
+                  // until a later maintenance purge.
                   builder.policyMappings(index.toIndexed("mappings", state::writeOrReplace));
                   return state.commitResult(result, builder, refObj);
                 }

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/privs/SecurableAndGrantee.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/privs/SecurableAndGrantee.java
@@ -20,6 +20,7 @@ package org.apache.polaris.persistence.nosql.metastore.privs;
 
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.persistence.nosql.coretypes.acl.AclObj;
+import org.apache.polaris.persistence.nosql.coretypes.acl.GrantTriplet;
 
 /**
  * Holds IDs needed during ACL/grants loading, before those are exploded into many {@link


### PR DESCRIPTION
Move stale grant and policy cross-reference cleanup into maintenance and do it before the retain scan.

NoSQL cannot make those cross-reference updates atomically with the entity drop itself. Runtime reads already tolerate stale entries, so maintenance is the right place to converge them and to drop the dead entries that never actually wired into the live path.