### PR TITLE
NoSQL: Fix retry sleep elapsed time calculation

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/retry/RetryLoopImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/retry/RetryLoopImpl.java
@@ -119,7 +119,7 @@ final class RetryLoopImpl<RESULT> implements RetryLoop<RESULT> {
 
     var current = currentNanos();
     var totalElapsed = current - timeLoopStarted;
-    var attemptElapsed = timeAttemptStarted - current;
+    var attemptElapsed = current - timeAttemptStarted;
 
     if (maxTime < totalElapsed || maxRetries < retries) {
       return false;

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/retry/TestRetryLoopImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/commits/retry/TestRetryLoopImpl.java
@@ -160,17 +160,17 @@ public class TestRetryLoopImpl {
     var mockedConfig =
         mockedConfig(Integer.MAX_VALUE, Integer.MAX_VALUE, 100, 100, Integer.MAX_VALUE);
 
-    var clock = mockedClock(3);
+    var clock = mockedClock(MILLISECONDS.toNanos(30), MILLISECONDS.toNanos(50));
     var tryLoopState = new RetryLoopImpl<>(mockedConfig, clock);
-    var t0 = clock.nanoTime();
+    var t0 = 0L;
 
     soft.assertThat(tryLoopState.canRetry(t0, MILLISECONDS.toNanos(20))).isTrue();
-    verify(clock, times(1)).sleepMillis(80L);
+    verify(clock, times(1)).sleepMillis(90L);
 
     // bounds doubled
 
     soft.assertThat(tryLoopState.canRetry(t0, MILLISECONDS.toNanos(30))).isTrue();
-    verify(clock, times(1)).sleepMillis(170L);
+    verify(clock, times(1)).sleepMillis(180L);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The sleep-time calculation in `RetryLoopImpl` was slightly off due to a subtraction with accidentally swapped arguments, so the total timeout could be wrong. No practical problem, but a correctness issue that is fixed in this change.
