### PR TITLE
Ranger: map REGISTER_VIEW to view-create privilege

### DIFF
--- a/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisOperationSemantics.java
+++ b/extensions/auth/ranger/impl/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisOperationSemantics.java
@@ -209,6 +209,9 @@ public record RangerPolarisOperationSemantics(
         PolarisAuthorizableOperation.CREATE_VIEW,
         new RangerPolarisOperationSemantics(toSet(VIEW_CREATE), null, ResolvedPathRooting.ROOT));
     RBAC_SEMANTICS_BY_OPERATION.put(
+        PolarisAuthorizableOperation.REGISTER_VIEW,
+        new RangerPolarisOperationSemantics(toSet(VIEW_CREATE), null, ResolvedPathRooting.ROOT));
+    RBAC_SEMANTICS_BY_OPERATION.put(
         PolarisAuthorizableOperation.LOAD_VIEW,
         new RangerPolarisOperationSemantics(
             toSet(VIEW_READ_PROPERTIES), null, ResolvedPathRooting.ROOT));

--- a/extensions/auth/ranger/impl/src/test/resources/authz_tests/tests_authz_namespace.json
+++ b/extensions/auth/ranger/impl/src/test/resources/authz_tests/tests_authz_namespace.json
@@ -69,6 +69,10 @@
       "result":  { "isAllowed": true }
     },
     {
+      "request": { "authzOp": "REGISTER_VIEW", "principal": { "name": "admin1" }, "target": "NAMESPACE:POLARIS/catalog1/namespace1" },
+      "result":  { "isAllowed": true }
+    },
+    {
       "request": { "authzOp": "LIST_VIEWS", "principal": { "name": "admin1" }, "target": "NAMESPACE:POLARIS/catalog1/namespace1" },
       "result":  { "isAllowed": true }
     },


### PR DESCRIPTION
`REGISTER_VIEW` was missing from `RangerPolarisOperationSemantics`, causing `RangerPolarisAuthorizer` to deny the operation even when the principal had the `view-create` privilege.

Follow-up to #4507.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
