### PR TITLE
Remove deprecated task timeout constants

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisTaskConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisTaskConstants.java
@@ -18,22 +18,8 @@
  */
 package org.apache.polaris.core.entity;
 
-import org.apache.polaris.core.config.FeatureConfiguration;
-
 /** Constants used to store task properties and configuration parameters */
 public class PolarisTaskConstants {
-  /**
-   * @deprecated Use {@link FeatureConfiguration#POLARIS_TASK_TIMEOUT_MILLIS}
-   */
-  @Deprecated(forRemoval = true)
-  public static final long TASK_TIMEOUT_MILLIS = 300000;
-
-  /**
-   * @deprecated Use {@link FeatureConfiguration#POLARIS_TASK_TIMEOUT_MILLIS}
-   */
-  @Deprecated(forRemoval = true)
-  public static final String TASK_TIMEOUT_MILLIS_CONFIG = "POLARIS_TASK_TIMEOUT_MILLIS";
-
   public static final String LAST_ATTEMPT_EXECUTOR_ID = "lastAttemptExecutorId";
   public static final String LAST_ATTEMPT_START_TIME = "lastAttemptStartTime";
   public static final String ATTEMPT_COUNT = "attemptCount";


### PR DESCRIPTION
## What is changed

Removes deprecated and unused task timeout constants from `PolarisTaskConstants`.

### Removed

* `TASK_TIMEOUT_MILLIS`
* `TASK_TIMEOUT_MILLIS_CONFIG`

Also removes the unused `FeatureConfiguration` import.

## Why

These constants are marked `@Deprecated(forRemoval = true)` and active code already uses `FeatureConfiguration.POLARIS_TASK_TIMEOUT_MILLIS`.

Verified there are no remaining usages and project compilation succeeds after removal.

Manual verification:
- Ran `./gradlew compileJava` successfully

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
