### PR TITLE
relational-jdbc: improve Javadoc for JdbcMetaStoreManagerFactory

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcMetaStoreManagerFactory.java
@@ -61,9 +61,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The implementation of Configuration interface for configuring the {@link PolarisMetaStoreManager}
- * using a JDBC backed by SQL metastore. TODO: refactor - <a
- * href="https://github.com/apache/polaris/pull/1287/files#r2047487588">...</a>
+ * JDBC-based implementation of {@link MetaStoreManagerFactory} that creates and manages {@link
+ * PolarisMetaStoreManager} instances backed by a relational SQL metastore.
+ *
+ * <p>This factory is responsible for: - Bootstrapping realms - Managing per-realm persistence
+ * sessions - Caching schema versions and bootstrap state - Providing entity caches for runtime
+ * operations
  */
 @ApplicationScoped
 @Identifier("relational-jdbc")


### PR DESCRIPTION
This PR improves the Javadoc for JdbcMetaStoreManagerFactory to make it clearer and more descriptive.

Changes:
- Clarifies that this is a JDBC-based implementation of MetaStoreManagerFactory
- Replaces outdated TODO/refactor comment
- Documents key responsibilities of the factory:
  - Bootstrapping realms
  - Managing per-realm persistence sessions
  - Caching schema versions and bootstrap state
  - Providing entity caches for runtime operations

No behavior or functional changes.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #NONE
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
