### PR TITLE
Remove deprecated StorageUtil.getBucket(URI)

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.storage;
 
-import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -60,18 +59,6 @@ public class StorageUtil {
       return null;
     }
     return StorageUri.parse(path).authority();
-  }
-
-  /**
-   * Given a URI, extract the bucket (authority).
-   *
-   * @param uri A path to parse
-   * @return The bucket/authority of the URI
-   * @deprecated Use {@link StorageUri#parse(String)} instead.
-   */
-  @Deprecated(forRemoval = true)
-  public static @NonNull String getBucket(URI uri) {
-    return uri.getAuthority();
   }
 
   /** Given a TableMetadata, extracts the locations where the table's [meta]data might be found. */


### PR DESCRIPTION
## Summary

Remove deprecated `StorageUtil.getBucket(URI)` from `polaris-core`.

## Changes

* Removed deprecated `StorageUtil.getBucket(URI)` method
* Removed unused `java.net.URI` import

## Validation

* Verified no internal usages via `git grep "getBucket("`
* Ran `./gradlew :polaris-core:test`
* Tests passed successfully



## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #N/A
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
