### PR TITLE
Fix GcpCredentialsStorageIntegrationTest

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -206,7 +206,7 @@ public class GcpCredentialsStorageIntegration
     LinkedHashSet<String> writeBuckets = new LinkedHashSet<>();
     Stream.concat(allowedReadLocations.stream(), allowedWriteLocations.stream())
         .distinct()
-        .sorted()
+        .sorted() // to ensure this method's output is deterministic
         .forEach(
             location -> {
               StorageUri uri = StorageUri.parse(location);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -39,7 +39,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -202,10 +202,11 @@ public class GcpCredentialsStorageIntegration
     Map<String, List<String>> readConditionsMap = new HashMap<>();
     Map<String, List<String>> writeConditionsMap = new HashMap<>();
 
-    HashSet<String> readBuckets = new HashSet<>();
-    HashSet<String> writeBuckets = new HashSet<>();
+    LinkedHashSet<String> readBuckets = new LinkedHashSet<>();
+    LinkedHashSet<String> writeBuckets = new LinkedHashSet<>();
     Stream.concat(allowedReadLocations.stream(), allowedWriteLocations.stream())
         .distinct()
+        .sorted()
         .forEach(
             location -> {
               StorageUri uri = StorageUri.parse(location);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -39,7 +39,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -202,11 +202,10 @@ public class GcpCredentialsStorageIntegration
     Map<String, List<String>> readConditionsMap = new HashMap<>();
     Map<String, List<String>> writeConditionsMap = new HashMap<>();
 
-    LinkedHashSet<String> readBuckets = new LinkedHashSet<>();
-    LinkedHashSet<String> writeBuckets = new LinkedHashSet<>();
+    HashSet<String> readBuckets = new HashSet<>();
+    HashSet<String> writeBuckets = new HashSet<>();
     Stream.concat(allowedReadLocations.stream(), allowedWriteLocations.stream())
         .distinct()
-        .sorted() // to ensure this method's output is deterministic
         .forEach(
             location -> {
               StorageUri uri = StorageUri.parse(location);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
@@ -203,6 +204,22 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     }
   }
 
+  private Set<JsonNode> canonicalRules(JsonNode rules) {
+    Set<JsonNode> canonical = new HashSet<>();
+    for (JsonNode rule : rules.path("accessBoundaryRules")) {
+      ObjectNode copy = rule.deepCopy();
+      JsonNode condition = copy.path("availabilityCondition");
+      JsonNode expression = condition.path("expression");
+      if (expression.isTextual()) {
+        String[] clauses = expression.asText().split(" \\|\\| ");
+        Arrays.sort(clauses);
+        ((ObjectNode) condition).put("expression", String.join(" || ", clauses));
+      }
+      canonical.add(copy);
+    }
+    return canonical;
+  }
+
   @Test
   public void testGenerateAccessBoundary() throws IOException {
     CredentialAccessBoundary credentialAccessBoundary =
@@ -211,7 +228,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     assertThat(credentialAccessBoundary).isNotNull();
     JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource("gcp-testGenerateAccessBoundary.json");
-    assertThat(parsedRules).isEqualTo(refRules);
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
   }
 
   @Test
@@ -227,7 +244,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     assertThat(credentialAccessBoundary).isNotNull();
     JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithMultipleBuckets.json");
-    assertThat(parsedRules).isEqualTo(refRules);
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
   }
 
   @Test
@@ -240,7 +257,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     assertThat(credentialAccessBoundary).isNotNull();
     JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithoutList.json");
-    assertThat(parsedRules).isEqualTo(refRules);
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
   }
 
   @Test
@@ -253,7 +270,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
     assertThat(credentialAccessBoundary).isNotNull();
     JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithoutWrites.json");
-    assertThat(parsedRules).isEqualTo(refRules);
+    assertThat(canonicalRules(parsedRules)).isEqualTo(canonicalRules(refRules));
   }
 
   @Test

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -400,13 +400,23 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   /**
    * Custom comparator as ObjectNodes are compared by field indexes as opposed to field names. They
-   * also don't equate a field that is present and set to null with a field that is omitted
-   *
-   * @param on1
-   * @param on2
-   * @return
+   * also don't equate a field that is present and set to null with a field that is omitted. Array
+   * nodes are compared element-by-element in order — without this, {@code fieldNames()} returns
+   * empty for arrays and the loop below would short-circuit to {@code true}, hiding mismatches in
+   * array contents.
    */
   private boolean recursiveEquals(ContainerNode<?> on1, ContainerNode<?> on2) {
+    if (on1.isArray() || on2.isArray()) {
+      if (!on1.isArray() || !on2.isArray() || on1.size() != on2.size()) {
+        return false;
+      }
+      for (int i = 0; i < on1.size(); i++) {
+        if (!nodeEquals(on1.get(i), on2.get(i))) {
+          return false;
+        }
+      }
+      return true;
+    }
     Set<String> fieldNames = new HashSet<>();
     on1.fieldNames().forEachRemaining(fieldNames::add);
     on2.fieldNames().forEachRemaining(fieldNames::add);
@@ -415,20 +425,18 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         if (isNotNull(on1.get(fieldName)) || isNotNull(on2.get(fieldName))) {
           return false;
         }
-      } else {
-        JsonNode fieldValue = on1.get(fieldName);
-        JsonNode fieldValue2 = on2.get(fieldName);
-        if (fieldValue.isContainerNode()) {
-          if (!fieldValue2.isContainerNode()
-              || !recursiveEquals((ContainerNode<?>) fieldValue, (ContainerNode<?>) fieldValue2)) {
-            return false;
-          }
-        } else if (!fieldValue.equals(fieldValue2)) {
-          return false;
-        }
+      } else if (!nodeEquals(on1.get(fieldName), on2.get(fieldName))) {
+        return false;
       }
     }
     return true;
+  }
+
+  private boolean nodeEquals(JsonNode a, JsonNode b) {
+    if (a.isContainerNode()) {
+      return b.isContainerNode() && recursiveEquals((ContainerNode<?>) a, (ContainerNode<?>) b);
+    }
+    return a.equals(b);
   }
 
   @Test

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -21,11 +21,10 @@ package org.apache.polaris.core.storage.gcp;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ContainerNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
@@ -59,7 +58,6 @@ import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
-import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,6 +72,13 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
       System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
 
   private static final String REFRESH_ENDPOINT = "get/credentials";
+
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder()
+          .defaultPropertyInclusion(
+              JsonInclude.Value.construct(
+                  JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+          .build();
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -192,9 +197,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         CredentialVendingContext.empty());
   }
 
-  private JsonNode readResource(ObjectMapper mapper, String name) throws IOException {
+  private JsonNode readResource(String name) throws IOException {
     try (InputStream in = GcpCredentialsStorageIntegrationTest.class.getResourceAsStream(name)) {
-      return mapper.readTree(in);
+      return MAPPER.readTree(in);
     }
   }
 
@@ -204,15 +209,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true, Set.of("gs://bucket1/path/to/data"), Set.of("gs://bucket1/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
-    JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundary.json");
-    assertThat(parsedRules)
-        .usingRecursiveComparison(
-            RecursiveComparisonConfiguration.builder()
-                .withEqualsForType(this::recursiveEquals, ObjectNode.class)
-                .build())
-        .isEqualTo(refRules);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundary.json");
+    assertThat(parsedRules).isEqualTo(refRules);
   }
 
   @Test
@@ -226,16 +225,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 "gs://bucket2/a/super/path/to/data"),
             Set.of("gs://bucket1/normal/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
-    JsonNode refRules =
-        readResource(mapper, "gcp-testGenerateAccessBoundaryWithMultipleBuckets.json");
-    assertThat(parsedRules)
-        .usingRecursiveComparison(
-            RecursiveComparisonConfiguration.builder()
-                .withEqualsForType(this::recursiveEquals, ObjectNode.class)
-                .build())
-        .isEqualTo(refRules);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithMultipleBuckets.json");
+    assertThat(parsedRules).isEqualTo(refRules);
   }
 
   @Test
@@ -246,15 +238,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             Set.of("gs://bucket1/path/to/data", "gs://bucket1/another/path/to/data"),
             Set.of("gs://bucket1/path/to/data"));
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
-    JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundaryWithoutList.json");
-    assertThat(parsedRules)
-        .usingRecursiveComparison(
-            RecursiveComparisonConfiguration.builder()
-                .withEqualsForType(this::recursiveEquals, ObjectNode.class)
-                .build())
-        .isEqualTo(refRules);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithoutList.json");
+    assertThat(parsedRules).isEqualTo(refRules);
   }
 
   @Test
@@ -265,15 +251,9 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             Set.of("gs://bucket1/normal/path/to/data", "gs://bucket1/awesome/path/to/data"),
             Set.of());
     assertThat(credentialAccessBoundary).isNotNull();
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
-    JsonNode refRules = readResource(mapper, "gcp-testGenerateAccessBoundaryWithoutWrites.json");
-    assertThat(parsedRules)
-        .usingRecursiveComparison(
-            RecursiveComparisonConfiguration.builder()
-                .withEqualsForType(this::recursiveEquals, ObjectNode.class)
-                .build())
-        .isEqualTo(refRules);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode refRules = readResource("gcp-testGenerateAccessBoundaryWithoutWrites.json");
+    assertThat(parsedRules).isEqualTo(refRules);
   }
 
   @Test
@@ -283,8 +263,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true, Set.of("gs://bucket1/" + path), Set.of("gs://bucket1/" + path));
 
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
     assertThat(parsedRules.path("accessBoundaryRules")).hasSize(2);
 
     assertThat(expressionAt(parsedRules, 0))
@@ -384,8 +363,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         GcpCredentialsStorageIntegration.generateAccessBoundaryRules(
             true, Set.of("gs://bucket1/path/to/data?with?question"), Set.of());
 
-    ObjectMapper mapper = JsonMapper.builder().build();
-    JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
+    JsonNode parsedRules = MAPPER.convertValue(credentialAccessBoundary, JsonNode.class);
 
     assertThat(
             parsedRules
@@ -396,47 +374,6 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 .asText())
         .contains("projects/_/buckets/bucket1/objects/path/to/data?with?question")
         .contains("startsWith('path/to/data?with?question')");
-  }
-
-  /**
-   * Custom comparator as ObjectNodes are compared by field indexes as opposed to field names. They
-   * also don't equate a field that is present and set to null with a field that is omitted. Array
-   * nodes are compared element-by-element in order — without this, {@code fieldNames()} returns
-   * empty for arrays and the loop below would short-circuit to {@code true}, hiding mismatches in
-   * array contents.
-   */
-  private boolean recursiveEquals(ContainerNode<?> on1, ContainerNode<?> on2) {
-    if (on1.isArray() || on2.isArray()) {
-      if (!on1.isArray() || !on2.isArray() || on1.size() != on2.size()) {
-        return false;
-      }
-      for (int i = 0; i < on1.size(); i++) {
-        if (!nodeEquals(on1.get(i), on2.get(i))) {
-          return false;
-        }
-      }
-      return true;
-    }
-    Set<String> fieldNames = new HashSet<>();
-    on1.fieldNames().forEachRemaining(fieldNames::add);
-    on2.fieldNames().forEachRemaining(fieldNames::add);
-    for (String fieldName : fieldNames) {
-      if ((!on1.has(fieldName) || !on2.has(fieldName))) {
-        if (isNotNull(on1.get(fieldName)) || isNotNull(on2.get(fieldName))) {
-          return false;
-        }
-      } else if (!nodeEquals(on1.get(fieldName), on2.get(fieldName))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean nodeEquals(JsonNode a, JsonNode b) {
-    if (a.isContainerNode()) {
-      return b.isContainerNode() && recursiveEquals((ContainerNode<?>) a, (ContainerNode<?>) b);
-    }
-    return a.equals(b);
   }
 
   @Test
@@ -514,10 +451,6 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                         && request
                             .getScope(0)
                             .equals(GcpCredentialsStorageIntegration.IMPERSONATION_SCOPE)));
-  }
-
-  private boolean isNotNull(JsonNode node) {
-    return node != null && !node.isNull();
   }
 
   private static String expressionAt(JsonNode parsedRules, int ruleIndex) {

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundary.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundary.json
@@ -2,6 +2,7 @@
   "accessBoundaryRules": [
     {
       "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
         "inRole:roles/storage.objectViewer"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
@@ -11,7 +12,7 @@
     },
     {
       "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
+        "inRole:roles/storage.legacyBucketWriter"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithMultipleBuckets.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithMultipleBuckets.json
@@ -2,15 +2,17 @@
   "accessBoundaryRules": [
     {
       "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
         "inRole:roles/storage.objectViewer"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data')"
       }
     },
     {
       "availablePermissions": [
+        "inRole:roles/storage.legacyObjectReader",
         "inRole:roles/storage.objectViewer"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket2",
@@ -20,11 +22,11 @@
     },
     {
       "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
+        "inRole:roles/storage.legacyBucketWriter"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data')"
       }
     }
   ]

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithoutList.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithoutList.json
@@ -2,16 +2,16 @@
   "accessBoundaryRules": [
     {
       "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
+        "inRole:roles/storage.legacyObjectReader"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/another/path/to/data')"
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/another/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
       }
     },
     {
       "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
+        "inRole:roles/storage.legacyBucketWriter"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {

--- a/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithoutWrites.json
+++ b/polaris-core/src/test/resources/org/apache/polaris/core/storage/gcp/gcp-testGenerateAccessBoundaryWithoutWrites.json
@@ -2,11 +2,11 @@
   "accessBoundaryRules": [
     {
       "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
+        "inRole:roles/storage.legacyObjectReader"
       ],
       "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
       "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data')"
       }
     }
   ]


### PR DESCRIPTION
* Use plain `.equals()` for `JsonNode` comparison

* Use set logic for comparing rules (instead of ordered lists). This is in line with GCS rule enforcement behaviour.

* Make corresponding adjustments in sample JSON files.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
