### PR TITLE
NoSQL: Limit inline policy mapping value size

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
@@ -21,6 +21,7 @@ package org.apache.polaris.persistence.nosql.metastore.mutation;
 
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.ENTITY_NOT_FOUND;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS;
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping.POLICY_MAPPING_SERIALIZER;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj.POLICY_MAPPINGS_REF_NAME;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj.PolicyMappingKey.fromIndexKey;
@@ -47,6 +48,8 @@ public record PolicyMutation(
     long targetId,
     boolean doAttach,
     @NonNull Map<String, String> parameters) {
+  private static final int MAX_POLICY_MAPPING_INDEX_VALUE_SIZE = 384;
+
   public PolicyAttachmentResult apply() {
     try {
       var committer =
@@ -131,11 +134,22 @@ public record PolicyMutation(
                     }
                   }
 
+                  var policyMapping = PolicyMapping.builder().parameters(parameters).build();
+                  var serializedPolicyMappingSize =
+                      POLICY_MAPPING_SERIALIZER.serializedSize(policyMapping);
+                  if (serializedPolicyMappingSize > MAX_POLICY_MAPPING_INDEX_VALUE_SIZE) {
+                    return state.noCommit(
+                        new PolicyAttachmentResult(
+                            UNEXPECTED_ERROR_SIGNALED,
+                            "Serialized policy-mapping index value size "
+                                + serializedPolicyMappingSize
+                                + " exceeds maximum allowed size "
+                                + MAX_POLICY_MAPPING_INDEX_VALUE_SIZE));
+                  }
+
                   // note: parameters are only added to the "by entity" entry
                   index.put(keyByPolicy.toIndexKey(), PolicyMapping.EMPTY);
-                  index.put(
-                      keyByEntity.toIndexKey(),
-                      PolicyMapping.builder().parameters(parameters).build());
+                  index.put(keyByEntity.toIndexKey(), policyMapping);
                   changed = true;
                 } else {
                   changed |= index.remove(keyByPolicy.toIndexKey());

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/PolicyMutation.java
@@ -33,6 +33,7 @@ import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.index.IndexContainer;
+import org.apache.polaris.persistence.nosql.api.obj.Obj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMappingsObj;
 import org.apache.polaris.persistence.nosql.metastore.indexaccess.MemoizedIndexedAccess;
@@ -48,7 +49,19 @@ public record PolicyMutation(
     long targetId,
     boolean doAttach,
     @NonNull Map<String, String> parameters) {
-  private static final int MAX_POLICY_MAPPING_INDEX_VALUE_SIZE = 384;
+  /**
+   * Conservative limit for serialized policy-mapping index value size to ensure that the serialized
+   * index-entry value sizes don't grow too large.
+   *
+   * <p>If this limit is ever exceeded, there are two options:
+   *
+   * <ul>
+   *   <li>If it's a marginal increase, it's possible to increase this value.
+   *   <li>If the property bag is becoming too big, the policy mapping should be stored in a
+   *       separate new {@link Obj}ect.
+   * </ul>
+   */
+  public static final int MAX_POLICY_MAPPING_INDEX_VALUE_SIZE = 384;
 
   public PolicyAttachmentResult apply() {
     try {

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.persistence.nosql.metastore;
 
 import static org.apache.polaris.core.entity.PolarisEntityConstants.ENTITY_BASE_LOCATION;
+import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping.POLICY_MAPPING_SERIALIZER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.tuple;
@@ -26,10 +27,12 @@ import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.RealmConfigurationSource;
@@ -50,7 +53,12 @@ import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
+import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
+import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
+import org.apache.polaris.core.policy.PolicyEntity;
+import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -66,7 +74,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @EnableWeld
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
-  @WeldSetup WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
+  @SuppressWarnings("unused")
+  @WeldSetup
+  WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
 
   @InjectSoftAssertions SoftAssertions soft;
 
@@ -242,6 +252,154 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
         .contains(Optional.empty());
   }
 
+  @Test
+  void attachPolicyAcceptsParametersWithinSerializedSizeLimit() {
+    var catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStore.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "policyMappingLimitCatalog");
+    var catalogCreated = metaStore.createCatalog(callContext, catalog, List.of());
+    assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    var namespaceResult =
+        createEntity(
+            List.of(catalog),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            "ns",
+            Map.of());
+    assertThat(namespaceResult.isSuccess()).isTrue();
+    var namespace = namespaceResult.getEntity();
+
+    var tableResult =
+        createEntity(
+            List.of(catalog, namespace),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            "tbl",
+            Map.of());
+    assertThat(tableResult.isSuccess()).isTrue();
+    var table = tableResult.getEntity();
+
+    var policyResult =
+        createEntity(
+            List.of(catalog, namespace),
+            PolarisEntityType.POLICY,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            "policy",
+            Map.of(
+                "policy-type-code",
+                Integer.toString(PredefinedPolicyTypes.DATA_COMPACTION.getCode())));
+    assertThat(policyResult.isSuccess()).isTrue();
+    var policy = PolicyEntity.of(policyResult.getEntity());
+
+    var parameters = policyMappingParameters(50);
+    assertThat(serializedPolicyMappingSize(parameters)).isLessThanOrEqualTo(384);
+
+    var attachResult =
+        metaStore.attachPolicyToEntity(
+            callContext,
+            List.of(catalog, namespace),
+            table,
+            List.of(catalog, namespace),
+            policy,
+            parameters);
+
+    assertThat(attachResult.isSuccess()).isTrue();
+    assertThat(attachResult.getPolicyMappingRecord()).isNotNull();
+    assertThat(attachResult.getPolicyMappingRecord().getParametersAsMap())
+        .containsExactlyEntriesOf(parameters);
+
+    var loadResult =
+        metaStore.loadPoliciesOnEntityByType(
+            callContext, table, PredefinedPolicyTypes.DATA_COMPACTION);
+    assertThat(loadResult.isSuccess()).isTrue();
+    assertThat(loadResult.getEntities()).hasSize(1);
+    assertThat(loadResult.getPolicyMappingRecords())
+        .singleElement()
+        .satisfies(
+            record -> assertThat(record.getParametersAsMap()).containsExactlyEntriesOf(parameters));
+  }
+
+  @Test
+  void attachPolicyRejectsParametersExceedingSerializedSizeLimit() {
+    var catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStore.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "policyMappingTooLargeCatalog");
+    var catalogCreated = metaStore.createCatalog(callContext, catalog, List.of());
+    assertThat(catalogCreated).isNotNull();
+    catalog = catalogCreated.getCatalog();
+
+    var namespaceResult =
+        createEntity(
+            List.of(catalog),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            "ns",
+            Map.of());
+    assertThat(namespaceResult.isSuccess()).isTrue();
+    var namespace = namespaceResult.getEntity();
+
+    var tableResult =
+        createEntity(
+            List.of(catalog, namespace),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            "tbl",
+            Map.of());
+    assertThat(tableResult.isSuccess()).isTrue();
+    var table = tableResult.getEntity();
+
+    var policyResult =
+        createEntity(
+            List.of(catalog, namespace),
+            PolarisEntityType.POLICY,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            "policy",
+            Map.of(
+                "policy-type-code",
+                Integer.toString(PredefinedPolicyTypes.DATA_COMPACTION.getCode())));
+    assertThat(policyResult.isSuccess()).isTrue();
+    var policy = PolicyEntity.of(policyResult.getEntity());
+
+    var parameters = policyMappingParameters(51);
+    assertThat(serializedPolicyMappingSize(parameters)).isGreaterThan(384);
+
+    var attachResult =
+        metaStore.attachPolicyToEntity(
+            callContext,
+            List.of(catalog, namespace),
+            table,
+            List.of(catalog, namespace),
+            policy,
+            parameters);
+
+    assertThat(attachResult)
+        .extracting(PolicyAttachmentResult::isSuccess, PolicyAttachmentResult::getReturnStatus)
+        .containsExactly(false, BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED);
+    assertThat(attachResult.getExtraInformation())
+        .contains("Serialized policy-mapping index value size")
+        .contains("384");
+
+    var loadResult = metaStore.loadPoliciesOnEntity(callContext, table);
+    assertThat(loadResult)
+        .extracting(
+            LoadPolicyMappingsResult::isSuccess,
+            LoadPolicyMappingsResult::getPolicyMappingRecords,
+            LoadPolicyMappingsResult::getEntities)
+        .containsExactly(true, List.of(), List.of());
+  }
+
   @SuppressWarnings("SameParameterValue")
   EntityResult createEntity(
       List<PolarisBaseEntity> catalogPath,
@@ -263,6 +421,17 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     var path = (List<PolarisEntityCore>) (List) catalogPath;
     return metaStore.createEntityIfNotExists(callContext, path, newEntity);
+  }
+
+  private static Map<String, String> policyMappingParameters(int entries) {
+    var parameters = new LinkedHashMap<String, String>();
+    IntStream.range(0, entries).forEach(i -> parameters.put("k" + i, "v" + i));
+    return parameters;
+  }
+
+  private static int serializedPolicyMappingSize(Map<String, String> parameters) {
+    return POLICY_MAPPING_SERIALIZER.serializedSize(
+        PolicyMapping.builder().parameters(parameters).build());
   }
 
   @Test

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -20,6 +20,7 @@ package org.apache.polaris.persistence.nosql.metastore;
 
 import static org.apache.polaris.core.entity.PolarisEntityConstants.ENTITY_BASE_LOCATION;
 import static org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping.POLICY_MAPPING_SERIALIZER;
+import static org.apache.polaris.persistence.nosql.metastore.mutation.PolicyMutation.MAX_POLICY_MAPPING_INDEX_VALUE_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.tuple;
@@ -299,7 +300,8 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
     var policy = PolicyEntity.of(policyResult.getEntity());
 
     var parameters = policyMappingParameters(50);
-    assertThat(serializedPolicyMappingSize(parameters)).isLessThanOrEqualTo(384);
+    assertThat(serializedPolicyMappingSize(parameters))
+        .isLessThanOrEqualTo(MAX_POLICY_MAPPING_INDEX_VALUE_SIZE);
 
     var attachResult =
         metaStore.attachPolicyToEntity(
@@ -373,7 +375,8 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
     var policy = PolicyEntity.of(policyResult.getEntity());
 
     var parameters = policyMappingParameters(51);
-    assertThat(serializedPolicyMappingSize(parameters)).isGreaterThan(384);
+    assertThat(serializedPolicyMappingSize(parameters))
+        .isGreaterThan(MAX_POLICY_MAPPING_INDEX_VALUE_SIZE);
 
     var attachResult =
         metaStore.attachPolicyToEntity(
@@ -389,7 +392,7 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
         .containsExactly(false, BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED);
     assertThat(attachResult.getExtraInformation())
         .contains("Serialized policy-mapping index value size")
-        .contains("384");
+        .contains(String.valueOf(MAX_POLICY_MAPPING_INDEX_VALUE_SIZE));
 
     var loadResult = metaStore.loadPoliciesOnEntity(callContext, table);
     assertThat(loadResult)


### PR DESCRIPTION
Put a hard cap on the inline NoSQL policy-mapping value size.

That value sits directly in the shared policy-mappings index, so leaving it unbounded lets one attachment bloat commit size and maintenance work for no real gain.

Polaris still accepts client-supplied policy-mapping parameters on the attach-policy request and persists them inline in the NoSQL policy-mappings index. I could not find any in-tree first-party caller that intentionally sets up a non-empty parameter bag itself, but the field is still live API surface, so the cap belongs in the NoSQL write path as a defensive bound on that inline index value.