### PR TITLE
CI: restrict docker-image-scan job to Polaris repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
 
   docker-image-scan:
     name: Polaris Docker Image Scan
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-latest
     needs:
       - docker-image-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
 
   docker-image-scan:
     name: Polaris Docker Image Scan
-    if: github.repository_owner == 'apache'
+    if: github.repository == 'apache/polaris'
     runs-on: ubuntu-latest
     needs:
       - docker-image-build


### PR DESCRIPTION
This job publishes security reports, it doesn't make sense to enable it in forks.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
