### PR TITLE
NoSQL: Fix local commit synchronization timeout handling

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitSynchronizer.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitSynchronizer.java
@@ -19,14 +19,16 @@
 package org.apache.polaris.persistence.nosql.impl.commits;
 
 interface CommitSynchronizer {
-  void before(long nanosRemaining);
+  boolean before(long nanosRemaining);
 
   void after();
 
   CommitSynchronizer NON_SYNCHRONIZING =
       new CommitSynchronizer() {
         @Override
-        public void before(long nanosRemaining) {}
+        public boolean before(long nanosRemaining) {
+          return true;
+        }
 
         @Override
         public void after() {}

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitterImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/CommitterImpl.java
@@ -117,11 +117,17 @@ class CommitterImpl<REF_OBJ extends BaseCommitObj, RESULT>
       var result =
           loop.retryLoop(
               nanosRemaining -> {
+                var acquired = false;
                 try {
-                  sync.before(nanosRemaining);
+                  acquired = sync.before(nanosRemaining);
+                  if (!acquired) {
+                    return Optional.empty();
+                  }
                   return commitAttempt(committerState, commitRetryable);
                 } finally {
-                  sync.after();
+                  if (acquired) {
+                    sync.after();
+                  }
                 }
               });
       if (result == noResultSentinel()) {

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/ExclusiveCommitSynchronizer.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/commits/ExclusiveCommitSynchronizer.java
@@ -41,12 +41,12 @@ final class ExclusiveCommitSynchronizer implements CommitSynchronizer {
     semaphore.release();
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored") // fine in this case, it'll time out
   @Override
-  public void before(long nanosRemaining) {
+  public boolean before(long nanosRemaining) {
     try {
-      semaphore.tryAcquire(nanosRemaining, TimeUnit.NANOSECONDS);
+      return semaphore.tryAcquire(nanosRemaining, TimeUnit.NANOSECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitterImpl.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitterImpl.java
@@ -55,13 +55,14 @@ public abstract class BaseTestCommitterImpl {
   protected Persistence persistence;
 
   @Test
-  public void exclusiveSynchronizerDoesNotReleaseUnacquiredPermit() {
+  public void exclusiveSynchronizerDoesNotAcquirePermitOnTimeout() {
     var sync =
         ExclusiveCommitSynchronizer.forKey(
             persistence.realmId(), "exclusiveSynchronizer-" + persistence.generateId());
 
     soft.assertThat(sync.before(0L)).isTrue();
     soft.assertThat(sync.before(1L)).isFalse();
+    soft.assertThat(sync.before(0L)).isFalse();
     sync.after();
     soft.assertThat(sync.before(0L)).isTrue();
     sync.after();
@@ -309,6 +310,7 @@ public abstract class BaseTestCommitterImpl {
     var firstEntered = new CountDownLatch(1);
     var releaseFirst = new CountDownLatch(1);
     var secondEntered = new CountDownLatch(1);
+    var thirdEntered = new CountDownLatch(1);
     var firstReleased = new AtomicBoolean();
     var executor = Executors.newFixedThreadPool(2);
     try {
@@ -326,9 +328,13 @@ public abstract class BaseTestCommitterImpl {
                           Thread.currentThread().interrupt();
                           throw new RuntimeException(e);
                         }
+                        var result =
+                            state.commitResult(
+                                "first",
+                                CommitTestObj.builder().text("first"),
+                                refObjSupplier.get());
                         firstReleased.set(true);
-                        return state.commitResult(
-                            "first", CommitTestObj.builder().text("first"), refObjSupplier.get());
+                        return result;
                       }));
       soft.assertThat(firstEntered.await(5, TimeUnit.SECONDS)).isTrue();
 
@@ -347,9 +353,17 @@ public abstract class BaseTestCommitterImpl {
                       }));
 
       soft.assertThat(secondEntered.await(200, TimeUnit.MILLISECONDS)).isFalse();
+      var third =
+          executor.submit(
+              () -> {
+                thirdEntered.countDown();
+                return "third";
+              });
+      soft.assertThat(thirdEntered.await(200, TimeUnit.MILLISECONDS)).isFalse();
       releaseFirst.countDown();
       soft.assertThat(first.get(5, TimeUnit.SECONDS)).contains("first");
       soft.assertThat(second.get(5, TimeUnit.SECONDS)).contains("second");
+      soft.assertThat(third.get(5, TimeUnit.SECONDS)).isEqualTo("third");
     } finally {
       executor.shutdownNow();
     }

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitterImpl.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitterImpl.java
@@ -25,6 +25,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.commit.CommitException;
@@ -49,6 +53,19 @@ public abstract class BaseTestCommitterImpl {
 
   @PolarisPersistence(fastRetries = true)
   protected Persistence persistence;
+
+  @Test
+  public void exclusiveSynchronizerDoesNotReleaseUnacquiredPermit() {
+    var sync =
+        ExclusiveCommitSynchronizer.forKey(
+            persistence.realmId(), "exclusiveSynchronizer-" + persistence.generateId());
+
+    soft.assertThat(sync.before(0L)).isTrue();
+    soft.assertThat(sync.before(1L)).isFalse();
+    sync.after();
+    soft.assertThat(sync.before(0L)).isTrue();
+    sync.after();
+  }
 
   @Test
   public void committerStateImpl() {
@@ -267,6 +284,75 @@ public abstract class BaseTestCommitterImpl {
                 objRef(anotherObj1.withNumParts(1)),
                 objRef(anotherObj2.withNumParts(1))))
         .containsExactly(anotherObj1.withNumParts(1), anotherObj2.withNumParts(1));
+  }
+
+  @Test
+  public void synchronizingLocallySerializesConcurrentCommits(TestInfo testInfo) throws Exception {
+    var initialObj =
+        persistence.write(
+            CommitTestObj.builder()
+                .id(persistence.generateId())
+                .text("initial")
+                .seq(1)
+                .tail(new long[0])
+                .build(),
+            CommitTestObj.class);
+    var referenceName = testInfo.getTestMethod().orElseThrow().getName();
+
+    persistence.write(initialObj, CommitTestObj.class);
+    persistence.createReference(referenceName, Optional.of(objRef(initialObj)));
+
+    var committer =
+        persistence
+            .createCommitter(referenceName, CommitTestObj.class, String.class)
+            .synchronizingLocally();
+    var firstEntered = new CountDownLatch(1);
+    var releaseFirst = new CountDownLatch(1);
+    var secondEntered = new CountDownLatch(1);
+    var firstReleased = new AtomicBoolean();
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var first =
+          executor.submit(
+              () ->
+                  committer.commit(
+                      (state, refObjSupplier) -> {
+                        firstEntered.countDown();
+                        try {
+                          if (!releaseFirst.await(5, TimeUnit.SECONDS)) {
+                            throw new AssertionError("Timed out waiting to release first commit");
+                          }
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new RuntimeException(e);
+                        }
+                        firstReleased.set(true);
+                        return state.commitResult(
+                            "first", CommitTestObj.builder().text("first"), refObjSupplier.get());
+                      }));
+      soft.assertThat(firstEntered.await(5, TimeUnit.SECONDS)).isTrue();
+
+      var second =
+          executor.submit(
+              () ->
+                  committer.commit(
+                      (state, refObjSupplier) -> {
+                        secondEntered.countDown();
+                        if (!firstReleased.get()) {
+                          throw new AssertionError(
+                              "Second synchronized commit started before first commit finished");
+                        }
+                        return state.commitResult(
+                            "second", CommitTestObj.builder().text("second"), refObjSupplier.get());
+                      }));
+
+      soft.assertThat(secondEntered.await(200, TimeUnit.MILLISECONDS)).isFalse();
+      releaseFirst.countDown();
+      soft.assertThat(first.get(5, TimeUnit.SECONDS)).contains("first");
+      soft.assertThat(second.get(5, TimeUnit.SECONDS)).contains("second");
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   @Test


### PR DESCRIPTION
The reference commit synchronizer, used to serialize commits against references from a single instance, might run into a situation when the semaphore is more often released than acquired. This change fixes this rare edge case.