### PR TITLE
nit: Silence some noisy ranger loggers during integration tests

### DIFF
--- a/runtime/defaults/src/main/resources/application-it.properties
+++ b/runtime/defaults/src/main/resources/application-it.properties
@@ -20,13 +20,6 @@
 # Configuration common to ALL integration tests (executed with "it" profile – Gradle "intTest" tasks).
 # Note: Quarkus integration tests cannot use QuarkusTestProfile.
 
-# Note about logging during integration tests:
-# - Logging for test code is configured in the `application-test.properties` file (!!).
-#   By default, it is set to `ERROR` level.
-# - Logging for application code is configured in the main `application.properties` file.
-#   By default, it is set to `INFO` level.
-# Configuring logging levels or appenders in this file IS INEFFECTIVE!
-
 quarkus.http.limits.max-body-size=1000000
 quarkus.http.port=0
 
@@ -56,3 +49,5 @@ polaris.realm-context.realms=POLARIS,OTHER
 polaris.storage.gcp.token=token
 polaris.storage.gcp.lifespan=PT1H
 
+# Silence verbose Ranger audit lifecycle logs
+quarkus.log.category."org.apache.ranger.audit.provider.AuditProviderFactory".level=WARN


### PR DESCRIPTION
Incidentally, it seems that newer Quarkus versions actually allow logger levels to be configured in an application-it.properties.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
