### PR TITLE
nit: fix Gradle log noise during tests

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationSender.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationSender.java
@@ -462,7 +462,7 @@ public class TestCacheInvalidationSender {
                 body.set(new String(requestBody.readAllBytes(), UTF_8));
               }
               reqUri.set(exchange.getRequestURI());
-              exchange.sendResponseHeaders(204, 0);
+              exchange.sendResponseHeaders(204, -1);
               exchange.getResponseBody().close();
             })) {
 
@@ -524,7 +524,7 @@ public class TestCacheInvalidationSender {
                 body.set(new String(requestBody.readAllBytes(), UTF_8));
               }
               reqUri.set(exchange.getRequestURI());
-              exchange.sendResponseHeaders(204, 0);
+              exchange.sendResponseHeaders(204, -1);
               exchange.getResponseBody().close();
             })) {
 


### PR DESCRIPTION
The JDK's built-in HTTP server logs a warning when one calls `sendResponseHeaders(204, contentLen)` with a `contentLen` other than -1:

```
sendResponseHeaders: rCode = 204: forcing contentLen = -1
```

The JDK forces it to -1 (since 204 means "No Content") and emits that warning. This change fixes it by passing -1 instead.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
