### PR TITLE
NoSQL: Keep oversized NoSQL index entries out of the embedded index

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -104,6 +104,7 @@ import org.jspecify.annotations.Nullable;
  */
 final class IndexImpl<V> implements IndexSpi<V> {
 
+  static final int INDEX_SERIALIZATION_HEADER_SIZE = 2;
   static final int MAX_KEY_BYTES = 4096;
 
   /**
@@ -242,6 +243,13 @@ final class IndexImpl<V> implements IndexSpi<V> {
       return buf;
     }
     return newKeyBuffer();
+  }
+
+  static long singleEntrySerializedSizeUpperBound(IndexKey key, int valueSerializedSize) {
+    return (long) INDEX_SERIALIZATION_HEADER_SIZE
+        + key.serializedSize()
+        + ASSUMED_PER_ENTRY_OVERHEAD
+        + valueSerializedSize;
   }
 
   static void releaseScratchKeyBuffer(ByteBuffer buf) {

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
@@ -52,11 +52,13 @@ import org.slf4j.LoggerFactory;
 final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements UpdatableIndex<V> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UpdatableIndexImpl.class);
+  static final int FORCE_SPILL_MAX_EMBEDDED_ENTRY_DIVISOR = 4;
 
   private final IndexContainer<V> indexContainer;
   private final PersistenceParams params;
   private final LongSupplier idGenerator;
   private final IndexValueSerializer<V> serializer;
+  private boolean hasOversizedEmbeddedEntry;
   private boolean finalized;
 
   UpdatableIndexImpl(
@@ -81,7 +83,8 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
 
     var indexContainerBuilder = ImmutableIndexContainer.<V>builder();
 
-    if (embedded.estimatedSerializedSize() > params.maxEmbeddedIndexSize().asLong()) {
+    if (embedded.estimatedSerializedSize() > params.maxEmbeddedIndexSize().asLong()
+        || hasOversizedEmbeddedEntry) {
       // The serialized representation of the embedded index is probably bigger than the configured
       // limit. Spill out the embedded index.
       spillOutEmbedded(prefix, persistObj, indexContainerBuilder);
@@ -181,7 +184,11 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
       // Only use stripe if it (still) has elements.
       if (stripe.hasElements()) {
         var serSize = stripe.estimatedSerializedSize();
-        var desiredSplits = checkedCast(serSize / params.maxIndexStripeSize().asLong() + 1);
+        var maxStripeSize = params.maxIndexStripeSize().asLong();
+        var desiredSplits = checkedCast((serSize - 1L) / maxStripeSize + 1L);
+        if (desiredSplits > 1) {
+          desiredSplits = Math.min(desiredSplits, stripe.asKeyList().size());
+        }
         if (desiredSplits > 1) {
           // The stripe became too big, needs to be split further
           LOGGER.debug(
@@ -212,7 +219,8 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
       var last = stripe.last();
       ObjRef id;
       if (stripe.isModified()) {
-        var obj = indexStripeObj(idGenerator.getAsLong(), stripe.serialize());
+        var serialized = stripe.serialize();
+        var obj = indexStripeObj(idGenerator.getAsLong(), serialized);
         // Persist updated stripes
         persistObj.accept(first.toSafeString(prefix), obj);
         id = objRef(obj);
@@ -230,6 +238,16 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
   @Override
   public boolean add(@NonNull InternalIndexElement<V> element) {
     checkNotFinalized();
+
+    var maxEmbeddedIndexSize = params.maxEmbeddedIndexSize().asLong();
+    var maxEmbeddedEntrySizeBeforeForcedSpill =
+        Math.max(1L, maxEmbeddedIndexSize / FORCE_SPILL_MAX_EMBEDDED_ENTRY_DIVISOR);
+    var entrySerializedSizeUpperBound =
+        IndexImpl.singleEntrySerializedSizeUpperBound(
+            element.key(), element.contentSerializedSize(serializer));
+
+    hasOversizedEmbeddedEntry |=
+        entrySerializedSizeUpperBound > maxEmbeddedEntrySizeBeforeForcedSpill;
     var added = embedded.add(element);
     if (added) {
       return !reference.containsElement(element.key());

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestUpdatableIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestUpdatableIndexImpl.java
@@ -26,6 +26,8 @@ import static org.apache.polaris.persistence.nosql.impl.indexes.IndexesInternal.
 import static org.apache.polaris.persistence.nosql.impl.indexes.IndexesInternal.indexElement;
 import static org.apache.polaris.persistence.nosql.impl.indexes.IndexesInternal.newStoreIndex;
 import static org.apache.polaris.persistence.nosql.impl.indexes.ObjTestValue.OBJ_TEST_SERIALIZER;
+import static org.apache.polaris.persistence.nosql.impl.indexes.ObjTestValue.objTestValueFromString;
+import static org.apache.polaris.persistence.nosql.impl.indexes.ObjTestValue.objTestValueOfSize;
 import static org.apache.polaris.persistence.nosql.impl.indexes.Util.randomObjId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -52,6 +54,7 @@ import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 import org.apache.polaris.persistence.nosql.testextension.BackendSpec;
 import org.apache.polaris.persistence.nosql.testextension.PersistenceTestExtension;
 import org.apache.polaris.persistence.nosql.testextension.PolarisPersistence;
+import org.apache.polaris.persistence.varint.VarInt;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -387,6 +390,232 @@ public class TestUpdatableIndexImpl {
         // verify that the element, even the remove-sentinel, has been removed
         .allMatch(k -> !deserializedRemovedSpilled.containsElement(k), "containsElement(k)")
         .allMatch(k -> deserializedRemovedSpilled.getElement(k) == null, "getElement(k)");
+  }
+
+  @Test
+  public void keepLargeEntryEmbeddedBelowForcedSpillThreshold() {
+    var updatable = updatableIndexForTest(Map.of(), Map.of(), OBJ_TEST_SERIALIZER);
+    var key = key("stay-embedded");
+    var maxEmbeddedEntrySize =
+        persistence.params().maxEmbeddedIndexSize().asLong()
+            / UpdatableIndexImpl.FORCE_SPILL_MAX_EMBEDDED_ENTRY_DIVISOR;
+    var value = objTestValueOfSize(valueSizeAroundUpperBound(key, maxEmbeddedEntrySize, 0));
+
+    updatable.put(key, value);
+
+    var indexed = updatable.toIndexed("idx-", (n, o) -> soft.fail("Unexpected obj persist"));
+    soft.assertThat(indexed.stripes()).isEmpty();
+    soft.assertThat(indexed.embedded().remaining()).isPositive();
+    soft.assertThat(indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER).get(key))
+        .isEqualTo(value);
+  }
+
+  @Test
+  public void forceSpillLargeEntryBeforeEmbeddedIndexLimit() {
+    var updatable = updatableIndexForTest(Map.of(), Map.of(), OBJ_TEST_SERIALIZER);
+    var largeKey = key("force-spill-b");
+    var largeValue =
+        objTestValueOfSize(
+            valueSizeAroundUpperBound(
+                largeKey, persistence.params().maxIndexStripeSize().asLong(), 0));
+
+    updatable.put(largeKey, largeValue);
+
+    var toPersist = new ArrayList<Map.Entry<String, Obj>>();
+    var indexed = updatable.toIndexed("idx-", (n, o) -> toPersist.add(Map.entry(n, o)));
+
+    soft.assertThat(toPersist).hasSize(1);
+    soft.assertThat(indexed.embedded().remaining()).isEqualTo(2);
+    soft.assertThat(indexed.stripes()).hasSize(1);
+
+    toPersist.stream().map(Map.Entry::getValue).forEach(o -> persistence.write(o, Obj.class));
+
+    var readIndex = indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER);
+    soft.assertThat(readIndex.get(largeKey)).isEqualTo(largeValue);
+
+    var reserialized =
+        indexed
+            .asUpdatableIndex(persistence, OBJ_TEST_SERIALIZER)
+            .toIndexed("idx-", (n, o) -> soft.fail("Unexpected obj persist"));
+    soft.assertThat(reserialized.stripes()).containsExactlyElementsOf(indexed.stripes());
+  }
+
+  @Test
+  public void forceSpillMixedEntriesRoundTrip() {
+    var updatable = updatableIndexForTest(Map.of(), Map.of(), OBJ_TEST_SERIALIZER);
+    var firstKey = key("force-spill-a");
+    var largeKey = key("force-spill-b");
+    var lastKey = key("force-spill-c");
+    var largeValue =
+        objTestValueOfSize(
+            valueSizeAroundUpperBound(
+                largeKey, persistence.params().maxIndexStripeSize().asLong() / 2, 0));
+    var firstValue = objTestValueFromString("cafe");
+    var lastValue = objTestValueFromString("babe");
+
+    updatable.put(firstKey, firstValue);
+    updatable.put(largeKey, largeValue);
+    updatable.put(lastKey, lastValue);
+
+    var toPersist = new ArrayList<Map.Entry<String, Obj>>();
+    var indexed = updatable.toIndexed("idx-", (n, o) -> toPersist.add(Map.entry(n, o)));
+
+    soft.assertThat(toPersist).hasSize(1);
+    soft.assertThat(indexed.embedded().remaining()).isEqualTo(2);
+    soft.assertThat(indexed.stripes()).hasSize(1);
+
+    toPersist.stream().map(Map.Entry::getValue).forEach(o -> persistence.write(o, Obj.class));
+
+    var readIndex = indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER);
+    soft.assertThat(readIndex.get(firstKey)).isEqualTo(firstValue);
+    soft.assertThat(readIndex.get(largeKey)).isEqualTo(largeValue);
+    soft.assertThat(readIndex.get(lastKey)).isEqualTo(lastValue);
+  }
+
+  @Test
+  public void allowEntryThatExceedsStripeSizeIfItFitsPersistedObject() {
+    var updatable = updatableIndexForTest(Map.of(), Map.of(), OBJ_TEST_SERIALIZER);
+    var key = key("persist-too-large-for-stripe");
+    var value =
+        objTestValueOfSize(
+            smallestValueSizeAboveActualSingleEntrySerializedSize(
+                key, persistence.params().maxIndexStripeSize().asLong()));
+
+    soft.assertThat(updatable.put(key, value)).isTrue();
+
+    var toPersist = new ArrayList<Map.Entry<String, Obj>>();
+    var indexed = updatable.toIndexed("idx-", (n, o) -> toPersist.add(Map.entry(n, o)));
+
+    soft.assertThat(toPersist).hasSize(1);
+    soft.assertThat(indexed.stripes()).hasSize(1);
+
+    toPersist.stream().map(Map.Entry::getValue).forEach(o -> persistence.write(o, Obj.class));
+    soft.assertThat(indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER).get(key))
+        .isEqualTo(value);
+  }
+
+  @Test
+  public void legacyOversizedEmbeddedEntryRemainsReadableWithoutForcedSpill() {
+    var key = key("legacy-embedded");
+    var maxEmbeddedEntrySize =
+        persistence.params().maxEmbeddedIndexSize().asLong()
+            / UpdatableIndexImpl.FORCE_SPILL_MAX_EMBEDDED_ENTRY_DIVISOR;
+    var value = objTestValueOfSize(valueSizeAroundUpperBound(key, maxEmbeddedEntrySize, 1));
+    var legacyEmbedded = newStoreIndex(OBJ_TEST_SERIALIZER);
+    legacyEmbedded.add(indexElement(key, value));
+
+    var updatable =
+        (UpdatableIndexImpl<ObjTestValue>)
+            ImmutableIndexContainer.<ObjTestValue>builder()
+                .embedded(legacyEmbedded.serialize())
+                .build()
+                .asUpdatableIndex(persistence, OBJ_TEST_SERIALIZER);
+
+    var indexed = updatable.toIndexed("idx-", (n, o) -> soft.fail("Unexpected obj persist"));
+    soft.assertThat(indexed.stripes()).isEmpty();
+    soft.assertThat(indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER).get(key))
+        .isEqualTo(value);
+  }
+
+  @Test
+  public void legacyOversizedReferenceStripeCanBeRewritten() {
+    var key = key("legacy-reference");
+    var value =
+        objTestValueOfSize(
+            smallestValueSizeAboveActualSingleEntrySerializedSize(
+                key, persistence.params().maxIndexStripeSize().asLong()));
+    var legacyReference = newStoreIndex(OBJ_TEST_SERIALIZER);
+    legacyReference.add(indexElement(key, value));
+
+    soft.assertThat((long) legacyReference.serialize().remaining())
+        .isGreaterThan(persistence.params().maxIndexStripeSize().asLong());
+
+    var stripeObj =
+        persistence.write(
+            IndexStripeObj.indexStripeObj(persistence.generateId(), legacyReference.serialize()),
+            IndexStripeObj.class);
+    var legacyIndexContainer =
+        ImmutableIndexContainer.<ObjTestValue>builder()
+            .embedded(newStoreIndex(OBJ_TEST_SERIALIZER).serialize())
+            .addStripe(IndexStripe.indexStripe(key, key, objRef(stripeObj)))
+            .build();
+
+    var indexed =
+        legacyIndexContainer
+            .asUpdatableIndex(persistence, OBJ_TEST_SERIALIZER)
+            .toIndexed("idx-", (n, o) -> soft.fail("Unexpected obj persist"));
+    soft.assertThat(indexed.stripes()).containsExactlyElementsOf(legacyIndexContainer.stripes());
+    soft.assertThat(indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER).get(key))
+        .isEqualTo(value);
+
+    var updatable =
+        (UpdatableIndexImpl<ObjTestValue>)
+            indexed.asUpdatableIndex(persistence, OBJ_TEST_SERIALIZER);
+    var forceSpillKey = key("legacy-reference-spill");
+    var forceSpillValue =
+        objTestValueOfSize(
+            valueSizeAroundUpperBound(
+                forceSpillKey,
+                persistence.params().maxEmbeddedIndexSize().asLong()
+                    / UpdatableIndexImpl.FORCE_SPILL_MAX_EMBEDDED_ENTRY_DIVISOR,
+                1));
+    updatable.put(forceSpillKey, forceSpillValue);
+
+    var toPersist = new ArrayList<Map.Entry<String, Obj>>();
+    indexed = updatable.toIndexed("idx-", (n, o) -> toPersist.add(Map.entry(n, o)));
+
+    soft.assertThat(toPersist).isNotEmpty();
+    toPersist.stream().map(Map.Entry::getValue).forEach(o -> persistence.write(o, Obj.class));
+
+    var readIndex = indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER);
+    soft.assertThat(readIndex.get(key)).isEqualTo(value);
+    soft.assertThat(readIndex.get(forceSpillKey)).isEqualTo(forceSpillValue);
+  }
+
+  @Test
+  public void allowEntryThatExceedsPersistedObjectSizeViaMultipartPersistence() {
+    var updatable = updatableIndexForTest(Map.of(), Map.of(), OBJ_TEST_SERIALIZER);
+    var key = key("reject-too-large-for-persist");
+    var value =
+        objTestValueOfSize(
+            smallestValueSizeAboveActualSingleEntrySerializedSize(
+                key, persistence.params().maxSerializedValueSize().asLong()));
+
+    soft.assertThat(updatable.put(key, value)).isTrue();
+
+    var toPersist = new ArrayList<Map.Entry<String, Obj>>();
+    var indexed = updatable.toIndexed("idx-", (n, o) -> toPersist.add(Map.entry(n, o)));
+
+    soft.assertThat(toPersist).hasSize(1);
+    soft.assertThat(indexed.stripes()).hasSize(1);
+
+    toPersist.stream().map(Map.Entry::getValue).forEach(o -> persistence.write(o, Obj.class));
+    soft.assertThat(indexed.indexForRead(persistence, OBJ_TEST_SERIALIZER).get(key))
+        .isEqualTo(value);
+  }
+
+  private static int smallestValueSizeAboveActualSingleEntrySerializedSize(
+      IndexKey key, long maxEntrySerializedSize) {
+    var valueSize = (int) Math.min(maxEntrySerializedSize, Integer.MAX_VALUE);
+    while (((long) IndexImpl.INDEX_SERIALIZATION_HEADER_SIZE
+            + key.serializedSize()
+            + VarInt.varIntLen(valueSize)
+            + valueSize)
+        <= maxEntrySerializedSize) {
+      valueSize++;
+    }
+    return valueSize;
+  }
+
+  private static int valueSizeAroundUpperBound(
+      IndexKey key, long maxEntrySerializedSize, int delta) {
+    var valueSize = (int) Math.min(maxEntrySerializedSize, Integer.MAX_VALUE);
+    while (IndexImpl.singleEntrySerializedSizeUpperBound(
+            key, VarInt.varIntLen(valueSize) + valueSize)
+        > maxEntrySerializedSize) {
+      valueSize--;
+    }
+    return valueSize + delta;
   }
 
   <V> UpdatableIndexImpl<V> updatableIndexForTest(


### PR DESCRIPTION
Force large generic index entries out of the embedded representation once they take too much of the embedded budget.

This is a policy guard, not a hard correctness bound. Large-but-valid entries still work, but they stop monopolizing the inline container.