### PR TITLE
NoSQL: cover async retry and shutdown cases

### DIFF
--- a/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/main/java/org/apache/polaris/nosql/async/java/JavaPoolAsyncExec.java
@@ -243,6 +243,7 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
     try {
       executorService.submit(cancelable);
     } catch (RejectedExecutionException e) {
+      taskSubmissionRejectedHook(cancelable);
       // In case the pool is being shut-down, do not attempt to reschedule.
       if (!cancelable.cancelledOrShutdown()) {
         try {
@@ -272,6 +273,9 @@ public class JavaPoolAsyncExec implements AsyncExec, AutoCloseable {
 
   @VisibleForTesting
   void taskTrackedHook(Cancelable<?> cancelable) {}
+
+  @VisibleForTesting
+  void taskSubmissionRejectedHook(Cancelable<?> cancelable) {}
 
   private final class CancelableFuture<R> implements Cancelable<R>, Runnable {
     private final CompletableFuture<R> completable = new CompletableFuture<>();

--- a/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
+++ b/persistence/nosql/async/java/src/test/java/org/apache/polaris/nosql/async/java/TestJavaPoolAsyncExec.java
@@ -20,11 +20,14 @@ package org.apache.polaris.nosql.async.java;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.polaris.nosql.async.AsyncConfiguration;
@@ -148,5 +151,178 @@ public class TestJavaPoolAsyncExec extends AsyncExecTestBase {
       assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
       assertThat(delayed).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("delayed");
     }
+  }
+
+  @Test
+  public void delayedTaskRetriesWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var delayed =
+          executor
+              .schedule(() -> "delayed", Duration.ofMillis(1))
+              .completionStage()
+              .toCompletableFuture();
+
+      await(rejected);
+      assertThat(delayed).isNotDone();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(delayed).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("delayed");
+    }
+  }
+
+  @Test
+  public void periodicTaskRetriesWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new CountDownLatch(1);
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var periodic =
+          executor.schedulePeriodic(ran::countDown, Duration.ofMillis(1), Duration.ofSeconds(60));
+
+      await(rejected);
+      assertThat(ran.await(100, MILLISECONDS)).isFalse();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      await(ran);
+      periodic.cancel();
+    }
+  }
+
+  @Test
+  public void taskCanBeCanceledWhileSubmissionRetryIsPending() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new AtomicBoolean();
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var task =
+          executor.submit(
+              () -> {
+                ran.set(true);
+                return "unexpected";
+              });
+
+      await(rejected);
+      task.cancel();
+      assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+      assertThat(ran).isFalse();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(ran).isFalse();
+    }
+  }
+
+  @Test
+  public void taskRetriesAfterRepeatedRejections() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejectedTwice = new CountDownLatch(2);
+
+    try (var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejectedTwice.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var task = executor.submit(() -> "retried").completionStage().toCompletableFuture();
+
+      await(rejectedTwice);
+      assertThat(task).isNotDone();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(task).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("retried");
+    }
+  }
+
+  @Test
+  public void closeCancelsTrackedTasksAndRejectsLaterSchedules() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new AtomicBoolean();
+
+    var executor =
+        new JavaPoolAsyncExec(AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        };
+
+    var blocker = executor.submit(blockingTask(started, release));
+    await(started);
+    var task =
+        executor.submit(
+            () -> {
+              ran.set(true);
+              return "unexpected";
+            });
+    await(rejected);
+
+    executor.close();
+
+    assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+    assertThat(ran).isFalse();
+    assertThat(blocker.completionStage().toCompletableFuture()).isDone();
+    assertThatThrownBy(() -> executor.submit(() -> "after-close"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private static Callable<Void> blockingTask(CountDownLatch started, Semaphore release) {
+    return () -> {
+      started.countDown();
+      try {
+        release.acquire();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    };
+  }
+
+  private static void await(CountDownLatch latch) throws InterruptedException {
+    assertThat(latch.await(5_000, MILLISECONDS)).isTrue();
   }
 }

--- a/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/main/java/org/apache/polaris/nosql/async/vertx/VertxAsyncExec.java
@@ -144,6 +144,9 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
   @VisibleForTesting
   void taskTrackedHook(Cancelable<?> cancelable) {}
 
+  @VisibleForTesting
+  void taskSubmissionRejectedHook(Cancelable<?> cancelable) {}
+
   @PreDestroy
   @Override
   public void close() {
@@ -277,6 +280,7 @@ class VertxAsyncExec implements AsyncExec, AutoCloseable {
         runningFuture.set(f);
         VertxAsyncExec.this.taskSubmittedHook(f);
       } catch (Throwable e) {
+        VertxAsyncExec.this.taskSubmissionRejectedHook(this);
         if (cancelledOrShutdown()) {
           if (periodic) {
             running.set(false);

--- a/persistence/nosql/async/vertx/src/test/java/org/apache/polaris/nosql/async/vertx/TestVertxAsyncExec.java
+++ b/persistence/nosql/async/vertx/src/test/java/org/apache/polaris/nosql/async/vertx/TestVertxAsyncExec.java
@@ -21,13 +21,16 @@ package org.apache.polaris.nosql.async.vertx;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.vertx.core.Vertx;
 import jakarta.inject.Inject;
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.polaris.nosql.async.AsyncConfiguration;
@@ -152,5 +155,178 @@ public class TestVertxAsyncExec extends AsyncExecTestBase {
       assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
       assertThat(delayed).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("delayed");
     }
+  }
+
+  @Test
+  public void delayedTaskRetriesWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+
+    try (var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var delayed =
+          executor
+              .schedule(() -> "delayed", Duration.ofMillis(1))
+              .completionStage()
+              .toCompletableFuture();
+
+      await(rejected);
+      assertThat(delayed).isNotDone();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(delayed).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("delayed");
+    }
+  }
+
+  @Test
+  public void periodicTaskRetriesWhenThreadPoolIsSaturated() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new CountDownLatch(1);
+
+    try (var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var periodic =
+          executor.schedulePeriodic(ran::countDown, Duration.ofMillis(1), Duration.ofSeconds(60));
+
+      await(rejected);
+      assertThat(ran.await(100, MILLISECONDS)).isFalse();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      await(ran);
+      periodic.cancel();
+    }
+  }
+
+  @Test
+  public void taskCanBeCanceledWhileSubmissionRetryIsPending() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new AtomicBoolean();
+
+    try (var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var task =
+          executor.submit(
+              () -> {
+                ran.set(true);
+                return "unexpected";
+              });
+
+      await(rejected);
+      task.cancel();
+      assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+      assertThat(ran).isFalse();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(ran).isFalse();
+    }
+  }
+
+  @Test
+  public void taskRetriesAfterRepeatedRejections() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejectedTwice = new CountDownLatch(2);
+
+    try (var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejectedTwice.countDown();
+          }
+        }) {
+      var blocker = executor.submit(blockingTask(started, release));
+
+      await(started);
+      var task = executor.submit(() -> "retried").completionStage().toCompletableFuture();
+
+      await(rejectedTwice);
+      assertThat(task).isNotDone();
+
+      release.release();
+      assertThat(blocker.completionStage()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(task).succeedsWithin(Duration.ofSeconds(5)).isEqualTo("retried");
+    }
+  }
+
+  @Test
+  public void closeCancelsTrackedTasksAndRejectsLaterSchedules() throws Exception {
+    var started = new CountDownLatch(1);
+    var release = new Semaphore(0);
+    var rejected = new CountDownLatch(1);
+    var ran = new AtomicBoolean();
+
+    var executor =
+        new VertxAsyncExec(vertx, AsyncConfiguration.builder().maxThreads(1).build()) {
+          @Override
+          void taskSubmissionRejectedHook(Cancelable<?> cancelable) {
+            rejected.countDown();
+          }
+        };
+
+    var blocker = executor.submit(blockingTask(started, release));
+    await(started);
+    var task =
+        executor.submit(
+            () -> {
+              ran.set(true);
+              return "unexpected";
+            });
+    await(rejected);
+
+    executor.close();
+
+    assertThat(task.completionStage().toCompletableFuture()).isCancelled();
+    assertThat(ran).isFalse();
+    assertThat(blocker.completionStage().toCompletableFuture()).isDone();
+    assertThatThrownBy(() -> executor.submit(() -> "after-close"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private static Callable<Void> blockingTask(CountDownLatch started, Semaphore release) {
+    return () -> {
+      started.countDown();
+      try {
+        release.acquire();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    };
+  }
+
+  private static void await(CountDownLatch latch) throws InterruptedException {
+    assertThat(latch.await(5_000, MILLISECONDS)).isTrue();
   }
 }


### PR DESCRIPTION
Add the missing tests around async task submission retries for both async
executor implementations.

The tests cover immediate, delayed, and periodic tasks under pool saturation,
repeated rejections, cancellation while a retry is pending, and close-time
cleanup. These are the cases that are easy to break because the task, timer,
and executor state all move independently.

Depends on #4543