### PR TITLE
BOM: Add missing dependencies and add a verification

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -21,6 +21,8 @@ plugins { id("polaris-bom") }
 
 description = "Apache Polaris - Bill of Materials (BOM)"
 
+val ideaActive = System.getProperty("idea.active").toBoolean()
+
 dependencies {
   constraints {
     api(rootProject)
@@ -44,6 +46,7 @@ dependencies {
     api(project(":polaris-idgen-api"))
     api(project(":polaris-idgen-impl"))
     api(project(":polaris-idgen-spi"))
+    api(project(":polaris-idgen-mocks"))
 
     api(project(":polaris-nodes-api"))
     api(project(":polaris-nodes-impl"))
@@ -90,6 +93,20 @@ dependencies {
     api(project(":polaris-relational-jdbc"))
 
     api(project(":polaris-extensions-auth-opa"))
+    api(project(":polaris-extensions-auth-opa-tests"))
+    api(project(":polaris-extensions-auth-ranger"))
+    api(project(":polaris-extensions-auth-ranger-tests"))
+    api(project(":polaris-extensions-federation-bigquery"))
+    api(project(":polaris-extensions-federation-hadoop"))
+    api(project(":polaris-extensions-federation-hive"))
+    api(project(":polaris-hms-testcontainer"))
+
+    api(project(":polaris-spark-3.5_2.12"))
+    api(project(":polaris-spark-integration-3.5_2.12"))
+    if (!ideaActive) {
+      api(project(":polaris-spark-3.5_2.13"))
+      api(project(":polaris-spark-integration-3.5_2.13"))
+    }
 
     api(project(":polaris-admin"))
     api(project(":polaris-runtime-common"))
@@ -102,3 +119,46 @@ dependencies {
     api(project(":polaris-tests"))
   }
 }
+
+tasks.register("verifyBomDependencies") {
+  group = "verification"
+  description = "Checks if the BOM dependencies are complete"
+
+  actions.addLast {
+    // Projects that shall not be referenced from the BOM.
+    val nonBomProjects =
+      setOf(
+        ":polaris-bom",
+        ":aggregated-license-report",
+        ":polaris-config-docs-site",
+        ":polaris-distribution",
+      )
+
+    val apiConfig = configurations.api.get()
+    val declaredGroupName =
+      apiConfig.dependencyConstraints.filterIsInstance<DependencyConstraint>().map {
+        "${it.group}:${it.name}"
+      }
+
+    val missingProjectPaths =
+      rootProject.allprojects
+        .filter {
+          !declaredGroupName.contains("${it.group}:${it.name}") && !nonBomProjects.contains(it.path)
+        }
+        .map { it.path }
+        .sorted()
+
+    if (!missingProjectPaths.isEmpty()) {
+      logger.error(
+        "The dependencies declared in ${project.projectDir.relativeTo(rootProject.projectDir)} might be incomplete, the following delcarations might be missing:"
+      )
+      missingProjectPaths.forEach { logger.error("  api(project(\"$it\"))") }
+
+      throw GradleException(
+        "The dependencies declared in ${project.projectDir.relativeTo(rootProject.projectDir)} might be incomplete, see logged errors above."
+      )
+    }
+  }
+}
+
+tasks.named("check") { dependsOn("verifyBomDependencies") }


### PR DESCRIPTION
A couple of recently added Gradle projects were missing in the BOM. This change adds those.

To prevent in the future, this change also adds a check that projects are either declared as a dependency constraint or explicitly mentioned as excluded.