### PR TITLE
Give the in-memory event buffer its own lock (#4572)

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -68,7 +68,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
    */
   protected final class EventProcessor {
 
-    private final UnicastProcessor<PolarisEvent> processor;
+    @VisibleForTesting final UnicastProcessor<PolarisEvent> processor;
     private final ReentrantLock lock = new ReentrantLock();
     private boolean completed = false; // guarded by lock
 
@@ -105,11 +105,6 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
       } finally {
         lock.unlock();
       }
-    }
-
-    @VisibleForTesting
-    UnicastProcessor<PolarisEvent> processor() {
-      return processor;
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -32,6 +32,8 @@ import jakarta.inject.Inject;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEvent;
@@ -51,56 +53,137 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
   @Inject MetaStoreManagerFactory metaStoreManagerFactory;
   @Inject InMemoryBufferEventListenerConfiguration configuration;
 
+  /**
+   * Thrown by {@link EventProcessor#onNext} when the wrapped processor has already completed (for
+   * example, it was evicted between the cache lookup and the {@code onNext} call). {@link
+   * #processEvent} catches it and retries with a freshly loaded processor.
+   */
+  private static final class EvictedException extends IllegalStateException {}
+
+  /**
+   * Wraps a {@link UnicastProcessor} together with its own lock, so that mutual exclusion between
+   * {@code onNext} (from {@link #processEvent}) and {@code onComplete} (from eviction or shutdown)
+   * does not depend on smallrye-mutiny's internal {@code synchronized} on {@code
+   * UnicastProcessor.onNext}.
+   */
+  final class EventProcessor {
+
+    private final UnicastProcessor<PolarisEvent> processor;
+    private final ReentrantLock lock = new ReentrantLock();
+    private boolean completed = false; // guarded by lock
+
+    EventProcessor(String realmId) {
+      processor = UnicastProcessor.create();
+      processor
+          .emitOn(Infrastructure.getDefaultWorkerPool())
+          .group()
+          .intoLists()
+          .of(configuration.maxBufferSize(), configuration.bufferTime())
+          .subscribe()
+          .with(events -> flush(realmId, events), error -> onProcessorError(realmId, error));
+    }
+
+    void onNext(PolarisEvent event) {
+      lock.lock();
+      try {
+        if (completed) {
+          throw new EvictedException();
+        }
+        processor.onNext(event);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    void onComplete() {
+      lock.lock();
+      try {
+        if (!completed) {
+          completed = true;
+          processor.onComplete();
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @VisibleForTesting
+    UnicastProcessor<PolarisEvent> processor() {
+      return processor;
+    }
+  }
+
   @VisibleForTesting
-  final LoadingCache<String, UnicastProcessor<PolarisEvent>> processors =
+  final LoadingCache<String, EventProcessor> processors =
       Caffeine.newBuilder()
           .expireAfterAccess(Duration.ofHours(1))
           .evictionListener(
-              (String realmId, UnicastProcessor<?> processor, RemovalCause cause) ->
-                  completeSynchronized(processor))
+              (String realmId, EventProcessor processor, RemovalCause cause) -> {
+                if (processor != null) {
+                  processor.onComplete();
+                }
+              })
           .build(this::createProcessor);
+
+  // Construct via a method (not EventProcessor::new) so that when the cache lives on a CDI client
+  // proxy, the call is delegated to the contextual bean instance, whose injected configuration is
+  // non-null. A direct inner-class instantiation would capture the proxy as the enclosing instance
+  // and read its uninjected (null) configuration.
+  protected EventProcessor createProcessor(String realmId) {
+    return new EventProcessor(realmId);
+  }
+
+  private final ReentrantReadWriteLock shutdownLock = new ReentrantReadWriteLock();
+  private boolean shutdown = false; // guarded by shutdownLock
 
   @Override
   protected void processEvent(String realmId, PolarisEvent event) {
-    var processor = Objects.requireNonNull(processors.get(realmId));
-    // UnicastProcessor.onNext() is internally synchronized (smallrye-mutiny
-    // UnicastProcessor declares onNext as `public synchronized void`), so concurrent
-    // processEvent() calls for the same realm serialize on the processor's intrinsic
-    // lock without an external guard.
-    processor.onNext(event);
+    shutdownLock.readLock().lock();
+    try {
+      if (shutdown) {
+        return;
+      }
+      while (true) {
+        var processor = Objects.requireNonNull(processors.get(realmId));
+        try {
+          processor.onNext(event);
+          return;
+        } catch (EvictedException ignored) {
+          // processor was evicted between the cache lookup and onNext; retry with a fresh one
+        }
+      }
+    } finally {
+      shutdownLock.readLock().unlock();
+    }
   }
 
   @PreDestroy
   public void shutdown() {
-    processors.asMap().values().forEach(InMemoryBufferEventListener::completeSynchronized);
-    processors.invalidateAll(); // doesn't call the eviction listener
-  }
-
-  /**
-   * Calls {@link UnicastProcessor#onComplete()} while holding the processor's intrinsic monitor.
-   *
-   * <p>smallrye-mutiny's {@code UnicastProcessor.onNext} is method-{@code synchronized} on the
-   * processor instance; {@code onComplete} is not. Acquiring the same intrinsic monitor here
-   * restores symmetric mutual exclusion between concurrent {@code onNext} (from {@code
-   * processEvent}) and {@code onComplete} (from eviction or shutdown). Wrapping the pattern as an
-   * invariant keeps the synchronization requirement structurally visible to future maintainers.
-   */
-  private static void completeSynchronized(UnicastProcessor<?> processor) {
-    synchronized (processor) {
-      processor.onComplete();
+    shutdownLock.writeLock().lock();
+    try {
+      shutdown = true;
+      processors.asMap().values().forEach(EventProcessor::onComplete);
+      processors.invalidateAll(); // doesn't call the eviction listener
+    } finally {
+      shutdownLock.writeLock().unlock();
     }
   }
 
-  protected UnicastProcessor<PolarisEvent> createProcessor(String realmId) {
-    UnicastProcessor<PolarisEvent> processor = UnicastProcessor.create();
-    processor
-        .emitOn(Infrastructure.getDefaultWorkerPool())
-        .group()
-        .intoLists()
-        .of(configuration.maxBufferSize(), configuration.bufferTime())
-        .subscribe()
-        .with(events -> flush(realmId, events), error -> onProcessorError(realmId, error));
-    return processor;
+  /**
+   * Re-enables the listener after a {@link #shutdown()}. {@code shutdown} is terminal in production
+   * (it runs on {@code @PreDestroy}), but tests reuse the same {@code @ApplicationScoped} bean
+   * across methods and call {@link #shutdown()} between them, so they need a way to clear the flag
+   * and start fresh.
+   */
+  @VisibleForTesting
+  void reset() {
+    shutdownLock.writeLock().lock();
+    try {
+      shutdown = false;
+      processors.invalidateAll();
+    } finally {
+      shutdownLock.writeLock().unlock();
+    }
   }
 
   @Retry(maxRetries = 5, delay = 1000, jitter = 100)

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -58,7 +58,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
    * example, it was evicted between the cache lookup and the {@code onNext} call). {@link
    * #processEvent} catches it and retries with a freshly loaded processor.
    */
-  private static final class EvictedException extends IllegalStateException {}
+  private static final class CompletedException extends IllegalStateException {}
 
   /**
    * Wraps a {@link UnicastProcessor} together with its own lock, so that mutual exclusion between
@@ -66,7 +66,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
    * does not depend on smallrye-mutiny's internal {@code synchronized} on {@code
    * UnicastProcessor.onNext}.
    */
-  final class EventProcessor {
+  protected final class EventProcessor {
 
     private final UnicastProcessor<PolarisEvent> processor;
     private final ReentrantLock lock = new ReentrantLock();
@@ -87,7 +87,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
       lock.lock();
       try {
         if (completed) {
-          throw new EvictedException();
+          throw new CompletedException();
         }
         processor.onNext(event);
       } finally {
@@ -148,7 +148,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
         try {
           processor.onNext(event);
           return;
-        } catch (EvictedException ignored) {
+        } catch (CompletedException ignored) {
           // processor was evicted between the cache lookup and onNext; retry with a fresh one
         }
       }
@@ -164,23 +164,6 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
       shutdown = true;
       processors.asMap().values().forEach(EventProcessor::onComplete);
       processors.invalidateAll(); // doesn't call the eviction listener
-    } finally {
-      shutdownLock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Re-enables the listener after a {@link #shutdown()}. {@code shutdown} is terminal in production
-   * (it runs on {@code @PreDestroy}), but tests reuse the same {@code @ApplicationScoped} bean
-   * across methods and call {@link #shutdown()} between them, so they need a way to clear the flag
-   * and start fresh.
-   */
-  @VisibleForTesting
-  void reset() {
-    shutdownLock.writeLock().lock();
-    try {
-      shutdown = false;
-      processors.invalidateAll();
     } finally {
       shutdownLock.writeLock().unlock();
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
@@ -90,7 +90,7 @@ class InMemoryBufferEventListenerBufferSizeTest extends InMemoryBufferEventListe
     var test1 = producer.processors.get("test1");
     assertThat(test1).isNotNull();
     // emulate backpressure error; will drop the event and invalidate the processor
-    test1.processor().onError(new BackPressureFailure("error"));
+    test1.processor.onError(new BackPressureFailure("error"));
     // will create a new processor and recover
     sendAsync("test1", 10);
     assertRows("test1", 10);

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
@@ -28,10 +28,8 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import java.util.Map;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -89,10 +87,10 @@ class InMemoryBufferEventListenerBufferSizeTest extends InMemoryBufferEventListe
   @Test
   void testProcessorFailureRecovery() {
     producer.processEvent("test1", event());
-    UnicastProcessor<PolarisEvent> test1 = producer.processors.get("test1");
+    var test1 = producer.processors.get("test1");
     assertThat(test1).isNotNull();
     // emulate backpressure error; will drop the event and invalidate the processor
-    test1.onError(new BackPressureFailure("error"));
+    test1.processor().onError(new BackPressureFailure("error"));
     // will create a new processor and recover
     sendAsync("test1", 10);
     assertRows("test1", 10);

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
@@ -82,6 +82,7 @@ abstract class InMemoryBufferEventListenerTestBase {
   void clearEvents() throws Exception {
     reset(metaStoreManagerFactory);
     producer.shutdown();
+    producer.reset();
     try (Connection connection = dataSource.get().getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("DELETE FROM polaris_schema.events");

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
@@ -41,6 +41,7 @@ import javax.sql.DataSource;
 import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 abstract class InMemoryBufferEventListenerTestBase {
 
@@ -64,6 +65,8 @@ abstract class InMemoryBufferEventListenerTestBase {
 
   @Inject
   @Identifier("persistence-in-memory-buffer")
+  Instance<InMemoryBufferEventListener> producerInstance;
+
   InMemoryBufferEventListener producer;
 
   @InjectSpy
@@ -78,11 +81,15 @@ abstract class InMemoryBufferEventListenerTestBase {
 
   @Inject Instance<DataSource> dataSource;
 
+  @BeforeEach
+  void resolveProducer() {
+    producer = producerInstance.get();
+  }
+
   @AfterEach
   void clearEvents() throws Exception {
     reset(metaStoreManagerFactory);
-    producer.shutdown();
-    producer.reset();
+    producerInstance.destroy(producer);
     try (Connection connection = dataSource.get().getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("DELETE FROM polaris_schema.events");


### PR DESCRIPTION
This is a follow-up to #4498. That change guarded onComplete() with synchronized (processor), which only holds because Mutiny's UnicastProcessor.onNext happens to be synchronized on the same monitor.

As @adutra pointed out, that leans on a Mutiny implementation detail - if a future version locked differently, the guard would quietly stop doing anything.

This gives InMemoryBufferEventListener its own lock instead: an EventProcessor wraps each UnicastProcessor with a ReentrantLock, and onNext/onComplete go through it - no more dependence on how Mutiny locks internally. It follows the shape he sketched on #4498.

Two small changes from that sketch, both commented inline:
- construction goes through a createProcessor method, not EventProcessor::new.
- added a reset() so the tests can reuse the bean after shutdown().

Existing InMemoryBufferEventListener tests pass.

Closes #4572

@adutra thank you for your detailed example / sample in other PR, it was super helpful. Please review and let me know your thoughts.