### PR TITLE
Fix optimized sibling check for JDBC persistence

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -811,9 +811,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       if (!results.isEmpty()) {
         StorageLocation entityLocation = StorageLocation.of(entity.getBaseLocation());
         for (PolarisBaseEntity result : results) {
-          // JDBC materializes persisted rows as PolarisBaseEntity; resolve location via entity
-          // utils
-          // instead of casting to LocationBasedEntity.
+          // JDBC materializes persisted rows as PolarisBaseEntity. Resolve the sibling location
+          // via PolarisEntityUtils instead of casting to LocationBasedEntity.
           Optional<String> overlappingSiblingLocation =
               PolarisEntityUtils.asLocationBasedEntity(PolarisEntity.of(result))
                   .map(LocationBasedEntity::getBaseLocation)

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -42,6 +42,7 @@ import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
@@ -810,8 +811,14 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       if (!results.isEmpty()) {
         StorageLocation entityLocation = StorageLocation.of(entity.getBaseLocation());
         for (PolarisBaseEntity result : results) {
-          StorageLocation potentialSiblingLocation =
-              StorageLocation.of(((LocationBasedEntity) result).getBaseLocation());
+          // JDBC materializes persisted rows as PolarisBaseEntity, so use the stored location
+          // property instead of casting to LocationBasedEntity.
+          String siblingBaseLocation =
+              result.getPropertiesAsMap().get(PolarisEntityConstants.ENTITY_BASE_LOCATION);
+          if (siblingBaseLocation == null || siblingBaseLocation.isBlank()) {
+            continue;
+          }
+          StorageLocation potentialSiblingLocation = StorageLocation.of(siblingBaseLocation);
           if (entityLocation.isChildOf(potentialSiblingLocation)
               || potentialSiblingLocation.isChildOf(entityLocation)) {
             return Optional.of(Optional.of(potentialSiblingLocation.toString()));

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -42,11 +42,11 @@ import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisEntityUtils;
 import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
@@ -811,17 +811,21 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       if (!results.isEmpty()) {
         StorageLocation entityLocation = StorageLocation.of(entity.getBaseLocation());
         for (PolarisBaseEntity result : results) {
-          // JDBC materializes persisted rows as PolarisBaseEntity, so use the stored location
-          // property instead of casting to LocationBasedEntity.
-          String siblingBaseLocation =
-              result.getPropertiesAsMap().get(PolarisEntityConstants.ENTITY_BASE_LOCATION);
-          if (siblingBaseLocation == null || siblingBaseLocation.isBlank()) {
-            continue;
-          }
-          StorageLocation potentialSiblingLocation = StorageLocation.of(siblingBaseLocation);
-          if (entityLocation.isChildOf(potentialSiblingLocation)
-              || potentialSiblingLocation.isChildOf(entityLocation)) {
-            return Optional.of(Optional.of(potentialSiblingLocation.toString()));
+          // JDBC materializes persisted rows as PolarisBaseEntity; resolve location via entity
+          // utils
+          // instead of casting to LocationBasedEntity.
+          Optional<String> overlappingSiblingLocation =
+              PolarisEntityUtils.asLocationBasedEntity(PolarisEntity.of(result))
+                  .map(LocationBasedEntity::getBaseLocation)
+                  .filter(location -> location != null && !location.isBlank())
+                  .map(StorageLocation::of)
+                  .filter(
+                      potentialSiblingLocation ->
+                          entityLocation.isChildOf(potentialSiblingLocation)
+                              || potentialSiblingLocation.isChildOf(entityLocation))
+                  .map(StorageLocation::toString);
+          if (overlappingSiblingLocation.isPresent()) {
+            return Optional.of(overlappingSiblingLocation);
           }
         }
       }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -22,16 +22,26 @@ import static org.apache.polaris.core.persistence.PrincipalSecretsGenerator.RAND
 
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.LocationBasedEntity;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
+import org.assertj.core.api.Assertions;
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public abstract class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
@@ -77,6 +87,85 @@ public abstract class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
         new AtomicOperationMetaStoreManager(clock, diagServices);
     PolarisCallContext callCtx = new PolarisCallContext(realmContext, basePersistence);
     return new PolarisTestMetaStoreManager(metaStoreManager, callCtx);
+  }
+
+  @Test
+  void testHasOverlappingSiblingsUsesStoredBaseLocation() {
+    // The optimized check relies on the location_without_scheme column added in schema v2.
+    if (schemaVersion() < 2) {
+      return;
+    }
+
+    var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
+    var callContext = polarisTestMetaStoreManager.polarisCallContext();
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "overlap_test_catalog");
+    catalog = metaStoreManager.createCatalog(callContext, catalog, List.of()).getCatalog();
+
+    PolarisBaseEntity existingNamespace =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "existing",
+            "s3://bucket/warehouse/existing/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), existingNamespace);
+
+    TestLocationBasedEntity candidateNamespace =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "candidate",
+                "s3://bucket/warehouse/existing/child"));
+
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, candidateNamespace))
+        .contains(Optional.of("s3://bucket/warehouse/existing/"));
+
+    TestLocationBasedEntity nonOverlappingNamespace =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "non_overlapping",
+                "s3://bucket/warehouse/non-overlapping"));
+
+    Assertions.assertThat(
+            metaStoreManager.hasOverlappingSiblings(callContext, nonOverlappingNamespace))
+        .contains(Optional.empty());
+  }
+
+  private static PolarisBaseEntity buildLocationBasedNamespace(
+      PolarisBaseEntity catalog, long entityId, String name, String baseLocation) {
+    return new PolarisBaseEntity.Builder()
+        .catalogId(catalog.getId())
+        .parentId(catalog.getId())
+        .id(entityId)
+        .typeCode(PolarisEntityType.NAMESPACE.getCode())
+        .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+        .name(name)
+        .propertiesAsMap(
+            Map.of(PolarisEntityConstants.ENTITY_BASE_LOCATION, baseLocation))
+        .internalPropertiesAsMap(Map.of())
+        .build();
+  }
+
+  private static class TestLocationBasedEntity extends PolarisEntity
+      implements LocationBasedEntity {
+    TestLocationBasedEntity(PolarisBaseEntity sourceEntity) {
+      super(sourceEntity);
+    }
+
+    @Override
+    public String getBaseLocation() {
+      return getPropertiesAsMap().get(PolarisEntityConstants.ENTITY_BASE_LOCATION);
+    }
   }
 
   private static class H2JdbcConfiguration implements RelationalJdbcConfiguration {

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -40,6 +40,7 @@ import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -92,9 +93,7 @@ public abstract class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
   @Test
   void testHasOverlappingSiblingsUsesStoredBaseLocation() {
     // The optimized check relies on the location_without_scheme column added in schema v2.
-    if (schemaVersion() < 2) {
-      return;
-    }
+    Assumptions.assumeThat(schemaVersion()).isGreaterThanOrEqualTo(2);
 
     var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
     var callContext = polarisTestMetaStoreManager.polarisCallContext();

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -150,8 +150,7 @@ public abstract class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
         .typeCode(PolarisEntityType.NAMESPACE.getCode())
         .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
         .name(name)
-        .propertiesAsMap(
-            Map.of(PolarisEntityConstants.ENTITY_BASE_LOCATION, baseLocation))
+        .propertiesAsMap(Map.of(PolarisEntityConstants.ENTITY_BASE_LOCATION, baseLocation))
         .internalPropertiesAsMap(Map.of())
         .build();
   }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Fixes #3378

This fixes a `ClassCastException` in the JDBC optimized sibling location check when `OPTIMIZED_SIBLING_CHECK=true`.

JDBC persistence materializes queried entities as `PolarisBaseEntity`, but the optimized sibling check assumed results could be cast to `LocationBasedEntity`. This caused table creation to fail when optimized sibling checking was enabled.

The fix uses the persisted base location property stored on the entity instead of relying on a runtime type cast. Existing overlap detection behavior is preserved.

Added regression coverage for JDBC schema versions that support `location_without_scheme`, including both overlapping and non-overlapping sibling location scenarios.



## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
