### PR TITLE
Include ZIP artifacts in GitHub Release uploads

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -453,7 +453,16 @@ jobs:
           # ********************************************************************************
 
           # Collect all artifacts to attach from the artifacts directory
-          readarray -t artifacts_to_attach < <(find "${artifacts_dir}" -type f -name "*.tar.gz" -o -name "*.tgz" -o -name "*.asc" -o -name "*.sha512" -o -name "*.prov")
+          readarray -t artifacts_to_attach < <(
+            find "${artifacts_dir}" -type f \( \
+              -name "*.tar.gz" -o \
+              -name "*.tgz" -o \
+              -name "*.zip" -o \
+              -name "*.asc" -o \
+              -name "*.sha512" -o \
+              -name "*.prov" \
+            \)
+          )
 
           # Create GitHub release and immediately publish it
           exec_process gh release create \


### PR DESCRIPTION

## Summary

Fix the GitHub Release publishing workflow to include ZIP artifacts when attaching release assets.

## Root Cause

The workflow collects release artifacts using a `find` expression that matches:

* `*.tar.gz`
* `*.tgz`
* `*.asc`
* `*.sha512`
* `*.prov`

but does not match `*.zip`.

As a result, ZIP binary packages are excluded by the selector while their corresponding checksum and signature files are still attached.

## Changes

* Add `*.zip` to the artifact attachment filter.
* Parenthesize the `find` predicates so the file-type filter is applied consistently across all artifact patterns.

## Validation

Verified the release artifact flow:

* `runtime/distribution/build.gradle.kts` defines a `distZip` distribution artifact.
* `release-3-build-and-publish-artifacts.yml` stages files from `runtime/distribution/build/distributions/`.
* Reproduced the artifact-selection logic locally:
  * The previous selector included `*.zip.asc` and `*.zip.sha512` but excluded `*.zip`.
  * The updated selector includes the ZIP artifact together with its signature and checksum files.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
