### PR TITLE
Add support for unique-table-location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
     - Names containing any of these characters: <code>/\:*?"<>|#+`</code>
 
 ### New Features
+- Added support for Iceberg's `unique-table-location` catalog property when creating tables without an explicit location.
 - Added `SESSION_NAME_FIELDS_IN_SUBSCOPED_CREDENTIAL` feature flag for AWS credential vending. Operators can now configure an ordered list of fields (`realm`, `catalog`, `namespace`, `table`, `principal`) to compose structured STS role session names (e.g. `p-acme-hr_catalog-employee-etl_writer`). Session names are sanitized and proportionally truncated to the AWS 64-character limit. When unset, existing `INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL` behaviour is preserved.
 - Added `hostUsers` support in Helm chart.
 - Added documentation for BigQuery Metastore Catalog federation. Build with `-PNonRESTCatalogs=BIGQUERY` to include the BigQueryMetastoreCatalog federation extension. See `site/content/in-dev/unreleased/federation/bigquery-metastore-federation.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
     - Names containing any of these characters: <code>/\:*?"<>|#+`</code>
 
 ### New Features
-- Added support for Iceberg's `unique-table-location` catalog property when creating tables without an explicit location.
+- Added support for Iceberg's `unique-table-location` catalog property for default table locations (direct and staged create, including prefixed warehouse layouts). View default locations are unchanged.
 - Added `SESSION_NAME_FIELDS_IN_SUBSCOPED_CREDENTIAL` feature flag for AWS credential vending. Operators can now configure an ordered list of fields (`realm`, `catalog`, `namespace`, `table`, `principal`) to compose structured STS role session names (e.g. `p-acme-hr_catalog-employee-etl_writer`). Session names are sanitized and proportionally truncated to the AWS 64-character limit. When unset, existing `INCLUDE_PRINCIPAL_NAME_IN_SUBSCOPED_CREDENTIAL` behaviour is preserved.
 - Added `hostUsers` support in Helm chart.
 - Added documentation for BigQuery Metastore Catalog federation. Build with `-PNonRESTCatalogs=BIGQUERY` to include the BigQueryMetastoreCatalog federation extension. See `site/content/in-dev/unreleased/federation/bigquery-metastore-federation.md`.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -364,9 +364,9 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+    String tableLocation = defaultTableLocation(tableIdentifier);
     if (tableIdentifier.namespace().isEmpty()) {
-      return SLASH.join(
-          defaultNamespaceLocation(tableIdentifier.namespace()), tableIdentifier.name());
+      return SLASH.join(defaultNamespaceLocation(tableIdentifier.namespace()), tableLocation);
     } else {
       PolarisResolvedPathWrapper resolvedNamespace =
           resolvedEntityView.getResolvedPath(
@@ -376,8 +376,17 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       }
       List<PolarisEntity> namespacePath = resolvedNamespace.getRawFullPath();
       String namespaceLocation = resolveLocationForPath(diagnostics, namespacePath);
-      return SLASH.join(namespaceLocation, tableIdentifier.name());
+      return SLASH.join(namespaceLocation, tableLocation);
     }
+  }
+
+  private String defaultTableLocation(TableIdentifier tableIdentifier) {
+    boolean useUniqueTableLocation =
+        PropertyUtil.propertyAsBoolean(
+            properties(),
+            CatalogProperties.UNIQUE_TABLE_LOCATION,
+            CatalogProperties.UNIQUE_TABLE_LOCATION_DEFAULT);
+    return LocationUtil.tableLocation(tableIdentifier, useUniqueTableLocation);
   }
 
   private String defaultNamespaceLocation(Namespace namespace) {
@@ -1000,7 +1009,7 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
     locationBuilder
         .append("/")
-        .append(URLEncoder.encode(tableIdentifier.name(), Charset.defaultCharset()))
+        .append(URLEncoder.encode(defaultTableLocation(tableIdentifier), Charset.defaultCharset()))
         .append("/");
     return locationBuilder.toString();
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalog.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
@@ -60,6 +61,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -182,6 +184,14 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
   private final PolarisEventDispatcher polarisEventDispatcher;
   private final PolarisEventMetadataFactory eventMetadataFactory;
   private final AtomicBoolean loggedPrefixOverlapWarning = new AtomicBoolean(false);
+
+  /**
+   * Set while a {@link TableBuilder} is deriving a default table location so {@link
+   * #defaultWarehouseLocation} can honor {@link CatalogProperties#UNIQUE_TABLE_LOCATION} without
+   * applying unique suffixes to view default locations (views use the same Iceberg hook).
+   */
+  private final ThreadLocal<Boolean> deriveTableDefaultLocationWithUniqueSuffix =
+      ThreadLocal.withInitial(() -> false);
 
   private String ioImplClassName;
   private FileIO catalogFileIO;
@@ -364,7 +374,21 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
 
   @Override
   protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
-    String tableLocation = defaultTableLocation(tableIdentifier);
+    boolean useUniqueTableLocation =
+        useUniqueTableLocation() && deriveTableDefaultLocationWithUniqueSuffix.get();
+    return resolveDefaultWarehouseLocation(tableIdentifier, useUniqueTableLocation);
+  }
+
+  private boolean useUniqueTableLocation() {
+    return PropertyUtil.propertyAsBoolean(
+        properties(),
+        CatalogProperties.UNIQUE_TABLE_LOCATION,
+        CatalogProperties.UNIQUE_TABLE_LOCATION_DEFAULT);
+  }
+
+  private String resolveDefaultWarehouseLocation(
+      TableIdentifier tableIdentifier, boolean useUniqueTableLocation) {
+    String tableLocation = LocationUtil.tableLocation(tableIdentifier, useUniqueTableLocation);
     if (tableIdentifier.namespace().isEmpty()) {
       return SLASH.join(defaultNamespaceLocation(tableIdentifier.namespace()), tableLocation);
     } else {
@@ -378,15 +402,6 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
       String namespaceLocation = resolveLocationForPath(diagnostics, namespacePath);
       return SLASH.join(namespaceLocation, tableLocation);
     }
-  }
-
-  private String defaultTableLocation(TableIdentifier tableIdentifier) {
-    boolean useUniqueTableLocation =
-        PropertyUtil.propertyAsBoolean(
-            properties(),
-            CatalogProperties.UNIQUE_TABLE_LOCATION,
-            CatalogProperties.UNIQUE_TABLE_LOCATION_DEFAULT);
-    return LocationUtil.tableLocation(tableIdentifier, useUniqueTableLocation);
   }
 
   private String defaultNamespaceLocation(Namespace namespace) {
@@ -1009,7 +1024,10 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     }
     locationBuilder
         .append("/")
-        .append(URLEncoder.encode(defaultTableLocation(tableIdentifier), Charset.defaultCharset()))
+        .append(
+            URLEncoder.encode(
+                LocationUtil.tableLocation(tableIdentifier, useUniqueTableLocation()),
+                Charset.defaultCharset()))
         .append("/");
     return locationBuilder.toString();
   }
@@ -1415,6 +1433,35 @@ public class IcebergCatalog extends BaseMetastoreViewCatalog
     @Override
     public TableBuilder withLocation(String newLocation) {
       return super.withLocation(transformTableLikeLocation(identifier, newLocation));
+    }
+
+    @Override
+    public Table create() {
+      return withUniqueTableDefaultLocation(super::create);
+    }
+
+    @Override
+    public Transaction createTransaction() {
+      return withUniqueTableDefaultLocation(super::createTransaction);
+    }
+
+    @Override
+    public Transaction replaceTransaction() {
+      return withUniqueTableDefaultLocation(super::replaceTransaction);
+    }
+
+    @Override
+    public Transaction createOrReplaceTransaction() {
+      return withUniqueTableDefaultLocation(super::createOrReplaceTransaction);
+    }
+  }
+
+  private <T> T withUniqueTableDefaultLocation(Supplier<T> action) {
+    deriveTableDefaultLocationWithUniqueSuffix.set(true);
+    try {
+      return action.get();
+    } finally {
+      deriveTableDefaultLocationWithUniqueSuffix.remove();
     }
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -2804,11 +2804,6 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
   public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) {}
 
   @Test
-  @Disabled("Feature is not implemented yet")
-  @Override
-  public void createTableInUniqueLocation() {}
-
-  @Test
   @Disabled(
       "Test is not compatible with Polaris: rename-table op does not change the table location")
   @Override

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogTest.java
@@ -2799,6 +2799,48 @@ public abstract class AbstractIcebergCatalogTest extends CatalogTests<IcebergCat
   }
 
   @Test
+  public void stagedCreateUsesUniqueTableLocationWhenEnabled() {
+    IcebergCatalog uniqueCatalog =
+        initCatalog(
+            "staged_unique_catalog",
+            ImmutableMap.of(CatalogProperties.UNIQUE_TABLE_LOCATION, "true"));
+    if (requiresNamespaceCreate()) {
+      uniqueCatalog.createNamespace(NS);
+    }
+
+    String stagedLocation =
+        uniqueCatalog
+            .buildTable(TableIdentifier.of(NS, "staged_unique_table"), SCHEMA)
+            .createTransaction()
+            .table()
+            .location();
+
+    assertThat(stagedLocation).contains("staged_unique_table-");
+    assertThat(stagedLocation).doesNotEndWith("/staged_unique_table");
+  }
+
+  @Test
+  public void viewDefaultLocationIgnoresUniqueTableLocationProperty() {
+    IcebergCatalog uniqueCatalog =
+        initCatalog(
+            "view_unique_catalog",
+            ImmutableMap.of(CatalogProperties.UNIQUE_TABLE_LOCATION, "true"));
+    uniqueCatalog.createNamespace(NS);
+
+    TableIdentifier viewId = TableIdentifier.of(NS, "unique_loc_view");
+    uniqueCatalog
+        .buildView(viewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS)
+        .withQuery("spark", VIEW_QUERY)
+        .create();
+
+    assertThat(uniqueCatalog.loadView(viewId).location()).endsWith("/unique_loc_view");
+    assertThat(uniqueCatalog.loadView(viewId).location())
+        .doesNotMatch(".*\\/unique_loc_view-[0-9a-f]+");
+  }
+
+  @Test
   @Disabled("Test is not compatible with REST catalogs")
   @Override
   public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) {}


### PR DESCRIPTION
Fixes #4492

## Summary

Add support for Iceberg's `unique-table-location` catalog property when creating tables without an explicit location.

## Changes

* Honor `CatalogProperties.UNIQUE_TABLE_LOCATION` when computing default table locations.
* Use Iceberg's `LocationUtil.tableLocation(...)` helper to generate table directory names.
* Re-enable the previously disabled Iceberg compatibility test `createTableInUniqueLocation()`.
* Add a changelog entry.

## Validation

Verified Iceberg 1.11 uses the same `LocationUtil.tableLocation(...)` helper when `unique-table-location` is enabled.

Ran:

```bash
./gradlew :polaris-runtime-service:test \
  --tests "org.apache.polaris.service.catalog.iceberg.IcebergCatalogRelationalTest.createTableInUniqueLocation"
```

Result: passed.

Also ran:

```bash
./gradlew :polaris-runtime-service:spotlessJavaCheck
./gradlew compileAll
```

Both passed.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
