### PR TITLE
Add unit tests for JDBC production readiness check

### DIFF
--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
 
   testImplementation(libs.mockito.junit.jupiter)
+  testImplementation(libs.jakarta.enterprise.cdi.api)
   testImplementation(libs.h2)
   testImplementation(testFixtures(project(":polaris-core")))
 

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcProductionReadinessChecksTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/RelationalJdbcProductionReadinessChecksTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.relational.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.enterprise.inject.Instance;
+import org.apache.polaris.core.config.ProductionReadinessCheck;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RelationalJdbcProductionReadinessChecksTest {
+
+  private RelationalJdbcProductionReadinessChecks checks;
+
+  @Mock private Instance<DatasourceOperations> datasourceOperations;
+
+  @BeforeEach
+  void setUp() {
+    checks = new RelationalJdbcProductionReadinessChecks();
+  }
+
+  @Test
+  void nonJdbcMetaStoreManagerFactoryReturnsOk() {
+    MetaStoreManagerFactory metaStoreManagerFactory = mock(MetaStoreManagerFactory.class);
+
+    ProductionReadinessCheck result =
+        checks.checkRelationalJdbc(metaStoreManagerFactory, datasourceOperations);
+
+    assertThat(result.ready()).isTrue();
+    assertThat(result.getErrors()).isEmpty();
+  }
+
+  @Test
+  void jdbcWithH2ReturnsWarning() {
+    JdbcMetaStoreManagerFactory metaStoreManagerFactory = mock(JdbcMetaStoreManagerFactory.class);
+    DatasourceOperations operations = mock(DatasourceOperations.class);
+    when(datasourceOperations.get()).thenReturn(operations);
+    when(operations.getDatabaseType()).thenReturn(DatabaseType.H2);
+
+    ProductionReadinessCheck result =
+        checks.checkRelationalJdbc(metaStoreManagerFactory, datasourceOperations);
+
+    assertThat(result.ready()).isFalse();
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error.message())
+                  .isEqualTo("The current persistence (jdbc:h2) is intended for tests only.");
+              assertThat(error.offendingProperty()).isEqualTo("quarkus.datasource.jdbc.url");
+              assertThat(error.severe()).isFalse();
+            });
+  }
+
+  @Test
+  void jdbcWithPostgresReturnsOk() {
+    JdbcMetaStoreManagerFactory metaStoreManagerFactory = mock(JdbcMetaStoreManagerFactory.class);
+    DatasourceOperations operations = mock(DatasourceOperations.class);
+    when(datasourceOperations.get()).thenReturn(operations);
+    when(operations.getDatabaseType()).thenReturn(DatabaseType.POSTGRES);
+
+    ProductionReadinessCheck result =
+        checks.checkRelationalJdbc(metaStoreManagerFactory, datasourceOperations);
+
+    assertThat(result.ready()).isTrue();
+    assertThat(result.getErrors()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

`RelationalJdbcProductionReadinessChecks` (added in #1707) warns at startup when JDBC persistence uses H2, but had no direct unit tests. This adds coverage for its three branches:

- Non-JDBC `MetaStoreManagerFactory` → no error (check skipped)
- JDBC + H2 → non-severe warning with message and `quarkus.datasource.jdbc.url` as the offending property
- JDBC + PostgreSQL → no error

Also adds `jakarta.enterprise.cdi-api` to the relational-jdbc **test** classpath so tests can mock the CDI `Instance<DatasourceOperations>` parameter (main uses it as `compileOnly`).

Related to #1707. No behavior change.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
