### PR TITLE
Helm CI: wait for fixture database readiness before ct install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,10 @@ jobs:
         run: |
           kubectl create namespace polaris-ns
           kubectl apply --namespace polaris-ns -f helm/polaris/ci/fixtures
+          kubectl wait --namespace polaris-ns --for=condition=ready pod \
+            --selector=app.kubernetes.io/name=postgres --timeout=120s
+          kubectl wait --namespace polaris-ns --for=condition=ready pod \
+            --selector=app.kubernetes.io/name=mongodb --timeout=120s
       - name: Run chart-testing (install)
         env:
           DEFAULT_BRANCH: ${{ github.base_ref || github.event.repository.default_branch }}


### PR DESCRIPTION
Fixes #4601.

Helm CI applied fixture databases and immediately ran ct install, while local workflows (make helm-fixtures) and developer docs wait for PostgreSQL and MongoDB pods to become Ready first.

This adds the same kubectl wait steps to CI before chart-testing install.

No production or chart behavior changes.

What changed
After kubectl apply for helm/polaris/ci/fixtures, CI now waits for:

app.kubernetes.io/name=postgres
app.kubernetes.io/name=mongodb
in namespace polaris-ns (120s timeout), matching the selectors already used in the Makefile and helm-chart/dev.md.

Notes
Fixture YAML confirms both Deployments use these labels, run at replicas: 1, and define readiness probes — so --for=condition=ready pod is appropriate.

This aligns CI with documented local practice. It may reduce Helm CI flakes when persistence scenarios start before databases are accepting connections, but I have not tied it to a specific past CI failure.

Test plan

 CI Helm chart-testing job passes
Verified fixture labels/selectors in:
helm/polaris/ci/fixtures/postgres.yaml
helm/polaris/ci/fixtures/mongodb.yaml

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
