### PR TITLE
Fix duplicate scopes log fragment in TokenRequestValidator

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
@@ -67,11 +67,11 @@ final class TokenRequestValidator {
     String[] scopes = scope.split(" ");
     for (String s : scopes) {
       if (!s.startsWith(POLARIS_ROLE_PREFIX)) {
-        LOGGER.info("Invalid scope provided. scopes=" + s + "scopes=" + scope);
+        LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
         return Optional.of(OAuthError.invalid_scope);
       }
       if (s.replaceFirst(POLARIS_ROLE_PREFIX, "").isEmpty()) {
-        LOGGER.info("Invalid scope provided. scopes=" + s + "scopes=" + scope);
+        LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
         return Optional.of(OAuthError.invalid_scope);
       }
     }


### PR DESCRIPTION
## What is changed

Removes a duplicated `scopes=` fragment in `TokenRequestValidator` logging for invalid scope validation.

## Validation

Ran:

`./gradlew compileAll`

## Impact

Logging-only cleanup with no behavior change.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
