### PR TITLE
Add unit tests for PolicyMappingUtil target entity validation

### DIFF
--- a/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
@@ -20,49 +20,41 @@ package org.apache.polaris.core.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Stream;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class PolicyMappingUtilTest {
 
-  @Test
-  public void testValidTargetEntityTypes() {
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.CATALOG, null))
-        .isTrue();
-
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.NAMESPACE, null))
-        .isTrue();
-
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.TABLE_LIKE,
-                PolarisEntitySubType.ICEBERG_TABLE))
-        .isTrue();
+  static Stream<Arguments> validTargetEntityTypes() {
+    return Stream.of(
+        Arguments.of(PolarisEntityType.CATALOG, null),
+        Arguments.of(PolarisEntityType.NAMESPACE, null),
+        Arguments.of(PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ICEBERG_TABLE));
   }
 
-  @Test
-  public void testInvalidTargetEntityTypes() {
-    assertThat(PolicyMappingUtil.isValidTargetEntityType(null, null)).isFalse();
+  static Stream<Arguments> invalidTargetEntityTypes() {
+    return Stream.of(
+        Arguments.of(null, null),
+        Arguments.of(PolarisEntityType.PRINCIPAL_ROLE, null),
+        Arguments.of(PolarisEntityType.TABLE_LIKE, null),
+        Arguments.of(PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ICEBERG_VIEW));
+  }
 
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.PRINCIPAL_ROLE, null))
-        .isFalse();
+  @ParameterizedTest
+  @MethodSource("validTargetEntityTypes")
+  public void testValidTargetEntityTypes(
+      PolarisEntityType entityType, PolarisEntitySubType entitySubType) {
+    assertThat(PolicyMappingUtil.isValidTargetEntityType(entityType, entitySubType)).isTrue();
+  }
 
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.TABLE_LIKE, null))
-        .isFalse();
-    
-    assertThat(
-            PolicyMappingUtil.isValidTargetEntityType(
-                PolarisEntityType.TABLE_LIKE,
-                PolarisEntitySubType.ICEBERG_VIEW))
-        .isFalse();
+  @ParameterizedTest
+  @MethodSource("invalidTargetEntityTypes")
+  public void testInvalidTargetEntityTypes(
+      PolarisEntityType entityType, PolarisEntitySubType entitySubType) {
+    assertThat(PolicyMappingUtil.isValidTargetEntityType(entityType, entitySubType)).isFalse();
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.junit.jupiter.api.Test;
+
+public class PolicyMappingUtilTest {
+
+  @Test
+  public void testValidTargetEntityTypes() {
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.CATALOG, null))
+        .isTrue();
+
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.NAMESPACE, null))
+        .isTrue();
+
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.TABLE_LIKE,
+                PolarisEntitySubType.ICEBERG_TABLE))
+        .isTrue();
+  }
+
+  @Test
+  public void testInvalidTargetEntityTypes() {
+    assertThat(PolicyMappingUtil.isValidTargetEntityType(null, null)).isFalse();
+
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.PRINCIPAL_ROLE, null))
+        .isFalse();
+
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.TABLE_LIKE, null))
+        .isFalse();
+
+    assertThat(
+            PolicyMappingUtil.isValidTargetEntityType(
+                PolarisEntityType.TABLE_LIKE,
+                PolarisEntitySubType.ICEBERG_VIEW))
+        .isFalse();
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/policy/PolicyMappingUtilTest.java
@@ -58,7 +58,7 @@ public class PolicyMappingUtilTest {
             PolicyMappingUtil.isValidTargetEntityType(
                 PolarisEntityType.TABLE_LIKE, null))
         .isFalse();
-
+    
     assertThat(
             PolicyMappingUtil.isValidTargetEntityType(
                 PolarisEntityType.TABLE_LIKE,


### PR DESCRIPTION
## Summary
Adds unit tests for PolicyMappingUtil.isValidTargetEntityType() to validate allowed and disallowed entity types.

## What is tested
- CATALOG and NAMESPACE are valid targets
- TABLE_LIKE only allows ICEBERG_TABLE
- Invalid cases like PRINCIPAL_ROLE and ICEBERG_VIEW are rejected

## Why
Ensures policy mapping rules are correctly enforced and prevents regressions in entity type validation logic.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
