### PR TITLE
fix(codegen): Do not use unnecessary @Valid annotations in static builder factories

### DIFF
--- a/server-templates/pojo.mustache
+++ b/server-templates/pojo.mustache
@@ -90,7 +90,7 @@ It is updated to remove all swagger annotations and support builders and immutab
         return new Builder();
     }
     {{#hasRequired}}
-    public static Builder builder({{#requiredVars}}{{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}{{/requiredVars}}) {
+    public static Builder builder({{#requiredVars}}{{#isContainer}}{{#isMap}}{{{baseType}}}<String, {{{items.baseType}}}>{{/isMap}}{{^isMap}}{{{baseType}}}<{{{items.baseType}}}>{{/isMap}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}} {{name}}{{^-last}}, {{/-last}}{{/requiredVars}}) {
         return new Builder({{#requiredVars}}{{name}}{{^-last}}, {{/-last}}{{/requiredVars}});
     }
     {{/hasRequired}}


### PR DESCRIPTION
 - Generated POJOs decorate static builder lists with `### @Valid`.
 - Hibernate Validator silently ignores @Valid on static method parameters.
 - Add explicit validator call inside static builder body.
 - Fixes #3716
 - Added UT

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
