### PR TITLE
Add `jackson-annotations` to `nosql-testextension`

### DIFF
--- a/persistence/nosql/persistence/testextension/build.gradle.kts
+++ b/persistence/nosql/persistence/testextension/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  testCompileOnly(platform(libs.jackson.bom))
+  testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
   implementation(platform(libs.junit.bom))
   implementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
This is to fix compilation warnings:

```
> Task :polaris-persistence-nosql-testextension:compileTestJava
warning: unknown enum constant Include.NON_DEFAULT
  reason: class file for com.fasterxml.jackson.annotation.JsonInclude$Include not found
warning: unknown enum constant Include.NON_NULL
warning: unknown enum constant Include.NON_EMPTY
warning: unknown enum constant Include.NON_DEFAULT
```

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
