### PR TITLE
Fix binary distribution URLs by removing incubator path segment

### DIFF
--- a/1.5.0/getting-started/binary-distribution.md
+++ b/1.5.0/getting-started/binary-distribution.md
@@ -32,7 +32,7 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.5.0/polaris-bin-1.5.0.tgz | tar xz
+curl -L https://downloads.apache.org/polaris/1.5.0/polaris-bin-1.5.0.tgz | tar xz
 cd polaris-bin-1.5.0
 ```
 


### PR DESCRIPTION
@adutra already fixed the template in #4478, but we still made the 1.4.1 and 1.5.0 release versions with the wrong URLs. A quick fix for this for the immediate-term.