### PR TITLE
Fix event listener detection for filtered event types

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventListeners.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventListeners.java
@@ -50,7 +50,8 @@ public class PolarisEventListeners {
   @Identifier("event-listener-executor")
   Executor executor;
 
-  private final EnumSet<PolarisEventType> enabledEventTypes = EnumSet.allOf(PolarisEventType.class);
+  private final EnumSet<PolarisEventType> eventTypesWithListeners =
+      EnumSet.noneOf(PolarisEventType.class);
 
   public void onStartup(@Observes StartupEvent event) {
     var listenerTypeSet = configuration.types().orElseGet(HashSet::new);
@@ -76,7 +77,7 @@ public class PolarisEventListeners {
       Handler<Message<PolarisEvent>> handler =
           message -> deliverEvent(message.body(), enabledEventListener, listener);
       for (var polarisEventType : supportedTypes) {
-        enabledEventTypes.add(polarisEventType);
+        eventTypesWithListeners.add(polarisEventType);
         eventBus.localConsumer(POLARIS_EVENT_CHANNEL + "." + polarisEventType, handler);
       }
     }
@@ -113,7 +114,7 @@ public class PolarisEventListeners {
     }
   }
 
-  public boolean hasListeners(PolarisEventType polarisEventType) {
-    return enabledEventTypes.contains(polarisEventType);
+  public boolean hasListeners(PolarisEventType eventType) {
+    return eventTypesWithListeners.contains(eventType);
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventListenersHasListenersTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/PolarisEventListenersHasListenersTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.service.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.common.annotation.Identifier;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Map;
+import org.apache.polaris.service.events.listeners.PolarisEventListener;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(PolarisEventListenersHasListenersTest.Profile.class)
+public class PolarisEventListenersHasListenersTest {
+  @Singleton
+  @Identifier("has-listeners-after-send-listener")
+  public static class AfterSendEventListener implements PolarisEventListener {
+    @Override
+    public void onEvent(PolarisEvent event) {}
+  }
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.event-listener.types",
+          "has-listeners-after-send-listener",
+          "polaris.event-listener.has-listeners-after-send-listener.enabled-event-types",
+          "AFTER_SEND_NOTIFICATION");
+    }
+  }
+
+  @Inject PolarisEventDispatcher eventDispatcher;
+
+  @Test
+  public void testHasListenersReturnsTrueOnlyForConfiguredEventTypes() {
+    assertThat(eventDispatcher.hasListeners(PolarisEventType.AFTER_SEND_NOTIFICATION)).isTrue();
+    assertThat(eventDispatcher.hasListeners(PolarisEventType.BEFORE_SEND_NOTIFICATION)).isFalse();
+  }
+}


### PR DESCRIPTION
`hasListeners(...)` was always returning true because the tracked event-type set was initialized with every event type. This made the listener guard ineffective for filtered listeners and caused Polaris to build and publish events even when no listener was registered for that type. The fix makes the set reflect only the event types actually registered at startup.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
