### PR TITLE
fix(spec): Bug fix for system reserved name pattern

### DIFF
--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -84,7 +84,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: getCatalog
       description: Get the details of a catalog
@@ -187,7 +187,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: getPrincipal
       description: Get the principal details
@@ -248,7 +248,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     post:
       operationId: rotateCredentials
       description: Rotate a principal's credentials. The new credentials will be returned in the response. This is the only
@@ -275,7 +275,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     post:
       operationId: resetCredentials
       description: >-
@@ -310,7 +310,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listPrincipalRolesAssigned
       description: List the roles assigned to the principal
@@ -354,7 +354,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: principalRoleName
         in: path
         description: The name of the role
@@ -363,7 +363,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     delete:
       operationId: revokePrincipalRole
       description: Remove a role from a catalog principal
@@ -421,7 +421,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: getPrincipalRole
       description: Get the principal role details
@@ -482,7 +482,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listAssigneePrincipalsForPrincipalRole
       description: List the Principals to whom the target principal role has been assigned
@@ -508,7 +508,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogName
         in: path
         required: true
@@ -517,7 +517,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listCatalogRolesForPrincipalRole
       description: Get the catalog roles mapped to the principal role
@@ -559,7 +559,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogName
         in: path
         description: The name of the catalog that contains the role to revoke
@@ -568,7 +568,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogRoleName
         in: path
         description: The name of the catalog role that should be revoked
@@ -577,7 +577,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     delete:
       operationId: revokeCatalogRoleFromPrincipalRole
       description: Remove a catalog role from a principal role
@@ -599,7 +599,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listCatalogRoles
       description: List existing roles in the catalog
@@ -640,7 +640,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogRoleName
         in: path
         description: The name of the role
@@ -649,7 +649,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: getCatalogRole
       description: Get the details of an existing role
@@ -708,7 +708,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogRoleName
         in: path
         required: true
@@ -717,7 +717,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listAssigneePrincipalRolesForCatalogRole
       description: List the PrincipalRoles to which the target catalog role has been assigned
@@ -743,7 +743,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
       - name: catalogRoleName
         in: path
         required: true
@@ -752,7 +752,7 @@ paths:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
     get:
       operationId: listGrantsForCatalogRole
       description: List the grants the catalog role holds
@@ -854,7 +854,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
           description: The name of the catalog
         properties:
           type: object
@@ -1317,7 +1317,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
         clientId:
           type: string
           description: The output-only OAuth clientId associated with this principal if applicable
@@ -1395,7 +1395,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
           description: The name of the role
         federated:
           type: boolean
@@ -1462,7 +1462,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^(?!\s*[s|S][y|Y][s|S][t|T][e|E][m|M]\$).*$'
+          pattern: '^(?!\s*[sS][yY][sS][tT][eE][mM]\$).*$'
           description: The name of the role
         properties:
           type: object


### PR DESCRIPTION
 - The system regex checker is incorrectly allowing `system` identifier to go through
 - `\$` is an escaped literal dollar character, not the end anchor.
 - Further `[s|S]` is a character class containing `s`, `|`, `S`.
 - Corrected the regex, and added unit tests to verify the behaviour. 


## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
