### PR TITLE
Doc: Remove note around using --devel for incubating chart version

### DIFF
--- a/site/content/in-dev/unreleased/helm-chart/_index.md
+++ b/site/content/in-dev/unreleased/helm-chart/_index.md
@@ -53,9 +53,4 @@ helm repo update
 helm upgrade --install polaris polaris/polaris --namespace polaris --create-namespace
 ```
 
-{{< alert note >}}
-For Apache Polaris releases up to 1.3.0-incubating, the `--devel` flag is required for `helm` invocations.
-Helm treats the -incubating suffix as a pre‑release by SemVer rules, and will skip charts that are not in a stable versioning scheme by default.
-{{< /alert >}}
-
 For production deployments, see the [Production Installation]({{% relref "production" %}}) guide.

--- a/site/content/in-dev/unreleased/helm-chart/dev.md
+++ b/site/content/in-dev/unreleased/helm-chart/dev.md
@@ -52,11 +52,6 @@ kubectl create namespace polaris
 helm install polaris polaris/polaris --namespace polaris
 ```
 
-{{< alert note >}}
-For Apache Polaris releases up to 1.3.0-incubating, the `--devel` flag is required for `helm` invocations.
-Helm treats the -incubating suffix as a pre‑release by SemVer rules, and will skip charts that are not in a stable versioning scheme by default.
-{{< /alert >}}
-
 Verify the installation:
 
 ```bash

--- a/site/content/in-dev/unreleased/helm-chart/production.md
+++ b/site/content/in-dev/unreleased/helm-chart/production.md
@@ -52,11 +52,6 @@ kubectl create namespace polaris
 helm install polaris polaris/polaris --namespace polaris --values your-production-values.yaml
 ```
 
-{{< alert note >}}
-For Apache Polaris releases up to 1.3.0-incubating, the `--devel` flag is required for `helm` invocations.
-Helm treats the -incubating suffix as a pre‑release by SemVer rules, and will skip charts that are not in a stable versioning scheme by default.
-{{< /alert >}}
-
 Verify the installation:
 
 ```bash


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

As we only have 1.5.0 chart version in https://downloads.apache.org/polaris/helm-chart/, this rule no longer apply. This only apply if we are using incubating repo (https://downloads.apache.org/incubator/polaris/helm-chart/).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
