### PR TITLE
Doc: disable line nums for code block

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -264,7 +264,7 @@ markup:
     hl_inline: false
     lineAnchors: ''
     lineNoStart: 1
-    lineNos: true
+    lineNos: false
     lineNumbersInTable: false
     noClasses: true
     noHl: false


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently we are have `lineNos` on and `lineNumbersInTable` off which render the page to following:
<img width="846" height="255" alt="image" src="https://github.com/user-attachments/assets/6d875c73-2744-4fa4-bff4-9ce2352357aa" />

The problem here is the `Copy to clipboard` will copy the line number as well due to the following html:
```
<span style="display:flex"><span style="white-space:pre;-webkit-user-select:none;user-select:none;margin-right:.4em;padding:0 .4em;color:#7f7f7f">1</span><span>java -jar polaris-bin-&lt;version&gt;/admin/quarkus-run.jar --help
</span></span>
```

While I tried to fix it properly by setting `lineNumbersInTable` to `true`, however, there appears to be bug on docsy where when both lineNos and lineNumbersInTable are on, the `Copy to clickboard` option will be no longer available. Same report found in https://github.com/google/docsy/issues/2633.

This is bad UX IMO as as couple code blocks are 7-8 lines long and manually removing those numbers are cumbersome (or manually highlight within the block instead of using `Copy to clickboard`. Alternative solution is to manually patch this via JS.

Here is the new UI with line number off for the time being (unless we want to do the custom JS route):
<img width="1354" height="240" alt="image" src="https://github.com/user-attachments/assets/1e207b6e-2dc7-4078-b0b0-c0022dcc49d4" />

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
