### PR TITLE
Print exception stack trace when admin purge command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
+- The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
 
 ## [1.5.0]
 

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/PurgeCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/PurgeCommand.java
@@ -59,6 +59,7 @@ public class PurgeCommand extends BaseMetaStoreCommand {
       spec.commandLine().getErr().printf("Purge encountered errors during operation.");
       return EXIT_CODE_PURGE_ERROR;
     } catch (Exception e) {
+      e.printStackTrace(spec.commandLine().getErr());
       spec.commandLine().getErr().println("Purge encountered errors during operation.");
       return EXIT_CODE_PURGE_ERROR;
     }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.admintool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import org.apache.polaris.core.config.RealmConfig;
+import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.persistence.BasePersistence;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
+import org.apache.polaris.core.persistence.cache.EntityCache;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class PurgeCommandTest {
+
+  /**
+   * When {@code purgeRealms} fails (e.g. database connection failure, permission denied), the
+   * command must surface the underlying exception to stderr so operators can diagnose it, in
+   * addition to the generic error message and the purge error exit code.
+   */
+  @Test
+  void testPurgeFailurePrintsStackTrace() {
+    String failureMessage = "simulated database connection failure";
+    PurgeCommand command = new PurgeCommand();
+    command.metaStoreManagerFactory =
+        new ThrowingMetaStoreManagerFactory(new RuntimeException(failureMessage));
+
+    CommandLine commandLine = new CommandLine(command);
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", "realm1");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_PURGE_ERROR);
+    assertThat(err.toString())
+        .contains("java.lang.RuntimeException: " + failureMessage)
+        .contains("\tat ")
+        .contains("Purge encountered errors during operation.");
+  }
+
+  /** Minimal {@link MetaStoreManagerFactory} whose {@code purgeRealms} always throws. */
+  private static final class ThrowingMetaStoreManagerFactory implements MetaStoreManagerFactory {
+    private final RuntimeException failure;
+
+    private ThrowingMetaStoreManagerFactory(RuntimeException failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
+      throw failure;
+    }
+
+    @Override
+    public PolarisMetaStoreManager getOrCreateMetaStoreManager(RealmContext realmContext) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BasePersistence getOrCreateSession(RealmContext realmContext) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EntityCache getOrCreateEntityCache(RealmContext realmContext, RealmConfig realmConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, PrincipalSecretsResult> bootstrapRealms(
+        Iterable<String> realms, RootCredentialsSet rootCredentialsSet) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION

When the admin tool `purge` command fails with an unexpected exception, it now
prints the exception stack trace to stderr before the generic error message,
matching the existing behavior of the `bootstrap` command.

### Why
Previously the `catch (Exception e)` block in `PurgeCommand` printed only a
generic line - "Purge encountered errors during operation." - and discarded the
exception entirely. A failed purge (e.g. database connection failure, realm not
found, permission denied) gave operators zero diagnostic information, making
production issues hard to triage. `BootstrapCommand` already prints the stack
trace via `e.printStackTrace(spec.commandLine().getErr())`; this change brings
`purge` in line with that convention.

### Changes
- `PurgeCommand`: print the caught exception's stack trace to stderr in the
  failure path.
- Added `PurgeCommandTest` covering the failure path: a stub
  `MetaStoreManagerFactory` whose `purgeRealms` throws, asserting stderr contains
  the exception details and that the command returns `EXIT_CODE_PURGE_ERROR`.
- `CHANGELOG.md`: added a Fixes entry.

### Testing
- `./gradlew :polaris-admin:test --tests "org.apache.polaris.admintool.PurgeCommandTest"` - pass
- `./gradlew :polaris-admin:spotlessCheck :polaris-admin:checkstyleMain :polaris-admin:checkstyleTest` - pass
- `./gradlew :polaris-admin:compileTestJava` - pass


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
