### PR TITLE
Add tests for ResultSetIterator and EntityNameLookupRecordConverter

### DIFF
--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/ResultSetIteratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/ResultSetIteratorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.apache.polaris.persistence.relational.jdbc.models.Converter;
+import org.junit.jupiter.api.Test;
+
+public class ResultSetIteratorTest {
+
+  @Test
+  public void testIteration() throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    Converter<String> converter = mock(Converter.class);
+
+    when(resultSet.next()).thenReturn(true, true, false);
+    when(converter.fromResultSet(resultSet)).thenReturn("first").thenReturn("second");
+
+    ResultSetIterator<String> iterator = new ResultSetIterator<>(resultSet, converter);
+
+    assertTrue(iterator.hasNext());
+    assertEquals("first", iterator.next());
+
+    assertTrue(iterator.hasNext());
+    assertEquals("second", iterator.next());
+
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testNextThrowsWhenExhausted() throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    Converter<String> converter = mock(Converter.class);
+
+    when(resultSet.next()).thenReturn(false);
+
+    ResultSetIterator<String> iterator = new ResultSetIterator<>(resultSet, converter);
+
+    assertFalse(iterator.hasNext());
+    assertThrows(NoSuchElementException.class, iterator::next);
+  }
+
+  @Test
+  public void testToStream() throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    Converter<String> converter = mock(Converter.class);
+
+    when(resultSet.next()).thenReturn(true, true, false);
+    when(converter.fromResultSet(resultSet)).thenReturn("first").thenReturn("second");
+
+    ResultSetIterator<String> iterator = new ResultSetIterator<>(resultSet, converter);
+
+    List<String> results = iterator.toStream().toList();
+
+    assertEquals(List.of("first", "second"), results);
+  }
+}

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/EntityNameLookupRecordConverterTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/EntityNameLookupRecordConverterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.relational.jdbc.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.polaris.core.entity.EntityNameLookupRecord;
+import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
+import org.junit.jupiter.api.Test;
+
+public class EntityNameLookupRecordConverterTest {
+
+  @Test
+  public void testFromResultSet() throws SQLException {
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    when(mockResultSet.getLong("catalog_id")).thenReturn(1L);
+    when(mockResultSet.getLong("id")).thenReturn(2L);
+    when(mockResultSet.getLong("parent_id")).thenReturn(3L);
+    when(mockResultSet.getString("name")).thenReturn("test-entity");
+    when(mockResultSet.getInt("type_code")).thenReturn(4);
+    when(mockResultSet.getInt("sub_type_code")).thenReturn(5);
+
+    EntityNameLookupRecordConverter converter = new EntityNameLookupRecordConverter();
+
+    EntityNameLookupRecord result = converter.fromResultSet(mockResultSet);
+
+    assertEquals(1L, result.getCatalogId());
+    assertEquals(2L, result.getId());
+    assertEquals(3L, result.getParentId());
+    assertEquals("test-entity", result.getName());
+    assertEquals(4, result.getTypeCode());
+    assertEquals(5, result.getSubTypeCode());
+  }
+
+  @Test
+  public void testToMapThrowsUnsupportedOperationException() {
+    EntityNameLookupRecordConverter converter = new EntityNameLookupRecordConverter();
+
+    UnsupportedOperationException exception =
+        assertThrows(UnsupportedOperationException.class, () -> converter.toMap(DatabaseType.H2));
+
+    assertEquals(
+        "EntityNameLookupRecordConverter is read-only and does not support toMap operation",
+        exception.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary

Add unit tests for JDBC utility classes:

* `ResultSetIterator`

  * verifies iteration over result sets
  * verifies `toStream()` behavior
  * verifies exhaustion handling

* `EntityNameLookupRecordConverter`

  * verifies conversion from `ResultSet`
  * verifies unsupported `toMap()` behavior

## Testing

* `./gradlew spotlessCheck`
* `./gradlew :polaris-relational-jdbc:test`

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
