### PR TITLE
Enable merge and rebase action on the merge button

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,9 +35,9 @@ github:
     - catalog
 
   enabled_merge_buttons:
-    merge: false
+    merge: true
     squash: true
-    rebase: false
+    rebase: true
 
   del_branch_on_merge: true
 


### PR DESCRIPTION
With this PR, we have three possible actions on the GitHub Merge Button: merge (preserving the history/commits), squash and merge, rebase and merge (preserving the history/commits).