### PR TITLE
Add test coverage for DigestUtils and IdGenerator

### DIFF
--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/IdGeneratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/IdGeneratorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class IdGeneratorTest {
+
+  @Test
+  void generatedIdsArePositive() {
+    IdGenerator generator = IdGenerator.getIdGenerator();
+
+    for (int i = 0; i < 1000; i++) {
+      assertThat(generator.nextId()).isGreaterThanOrEqualTo(0L);
+    }
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/DigestUtilsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/DigestUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class DigestUtilsTest {
+
+  @Test
+  void sha256HexEmptyString() {
+    assertThat(DigestUtils.sha256Hex(""))
+        .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  }
+
+  @Test
+  void sha256HexAbc() {
+    assertThat(DigestUtils.sha256Hex("abc"))
+        .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  }
+}


### PR DESCRIPTION
## Summary

Add test coverage for two utility classes that currently have no direct unit tests.

* Add SHA-256 golden vector tests for `DigestUtils.sha256Hex()`.
* Add a test verifying the documented contract that `IdGenerator.nextId()` returns non-negative IDs.

## Testing

* Ran `DigestUtilsTest`
* Ran `IdGeneratorTest`
* Ran `spotlessCheck`



## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
