### PR TITLE
Add test coverage for invalid feature configuration handling

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
@@ -199,4 +199,14 @@ public class DefaultConfigurationStoreTest {
     Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, safeConfig))
         .isTrue();
   }
+  @Test
+  public void testInvalidFeatureConfigurationIsHandled() {
+    // invalid feature key format (simulates malformed configuration input)
+    String invalidKey = "polaris.features.invalid..json";
+
+    Object value = configurationStore.getConfiguration(realmContext, invalidKey);
+
+    // should not crash and should safely return null
+    assertThat(value).isNull();
+}
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/DefaultConfigurationStoreTest.java
@@ -199,6 +199,7 @@ public class DefaultConfigurationStoreTest {
     Assertions.assertThat(configurationStore.getConfiguration(realmContext, catalog, safeConfig))
         .isTrue();
   }
+
   @Test
   public void testInvalidFeatureConfigurationIsHandled() {
     // invalid feature key format (simulates malformed configuration input)
@@ -208,5 +209,5 @@ public class DefaultConfigurationStoreTest {
 
     // should not crash and should safely return null
     assertThat(value).isNull();
-}
+  }
 }


### PR DESCRIPTION
Adds a negative test in DefaultConfigurationStoreTest to verify that invalid feature configuration keys are safely handled by the configuration store.

This ensures the configuration system remains stable when encountering malformed or unexpected feature keys and does not throw exceptions.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4639
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
