### PR TITLE
Add unit tests for ReservedProperties

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/config/ReservedPropertiesTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/ReservedPropertiesTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReservedPropertiesTest {
+
+  @Test
+  void testReservedPropertyThrows() {
+    ReservedProperties reservedProperties = new ReservedProperties() {};
+
+    assertThatThrownBy(
+            () -> reservedProperties.removeReservedProperties(Map.of("polaris.test", "value")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("polaris.test");
+  }
+
+  @Test
+  void testNoneAllowsReservedProperties() {
+    Map<String, String> properties = Map.of("polaris.test", "value");
+
+    Map<String, String> result = ReservedProperties.NONE.removeReservedProperties(properties);
+
+    assertThat(result).containsEntry("polaris.test", "value");
+  }
+
+  @Test
+  void testReservedPropertyFilteredWhenThrowDisabled() {
+    ReservedProperties reservedProperties =
+        new ReservedProperties() {
+          @Override
+          public boolean shouldThrow() {
+            return false;
+          }
+        };
+
+    Map<String, String> result =
+        reservedProperties.removeReservedProperties(Map.of("polaris.test", "value"));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void testUpdateRestoresExistingReservedProperty() {
+    ReservedProperties reservedProperties =
+        new ReservedProperties() {
+          @Override
+          public boolean shouldThrow() {
+            return false;
+          }
+        };
+
+    Map<String, String> result =
+        reservedProperties.removeReservedPropertiesFromUpdate(
+            Map.of("polaris.test", "original"), Map.of("polaris.test", "new"));
+
+    assertThat(result).containsEntry("polaris.test", "original");
+  }
+
+  @Test
+  void testRemoveReservedPropertiesList() {
+    ReservedProperties reservedProperties =
+        new ReservedProperties() {
+          @Override
+          public boolean shouldThrow() {
+            return false;
+          }
+        };
+
+    assertThat(reservedProperties.removeReservedProperties(List.of("polaris.test", "user.test")))
+        .containsExactly("user.test");
+  }
+}


### PR DESCRIPTION
What changes are proposed in this pull request?

Add a new ReservedPropertiesTest covering:

Reserved property rejection when shouldThrow() is enabled
ReservedProperties.NONE behavior
Filtering when exceptions are disabled
Reserved property restoration during updates
List-based property filtering

Fixes #4641 

How was this patch tested?

Added unit tests and verified with:

./gradlew :polaris-runtime-service:test --tests "org.apache.polaris.service

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Fixes Add test coverage for ReservedProperties filtering and update handling #4641
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
