### PR TITLE
Return HTTP 503 on concurrent rename instead of 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
 - The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).
 - JWT verification now validates the issuer claim (`"polaris"`) in addition to the active claim. Tokens signed with the same key but carrying a different issuer are now rejected.
+- Renaming a table or view now maps concurrent-modification and resolution failures to meaningful HTTP status codes instead of HTTP 500. A concurrent modification of the source returns 503 (Service Unavailable, retryable); a source or target path that no longer resolves (concurrently dropped or replaced) returns 404 (Not Found). HTTP 409 is intentionally not used because the Iceberg REST rename endpoint reserves 409 for "the target already exists".
 - Inheritable policy mapping inserts in the JDBC backend now use the active transaction connection, so they roll back correctly with the surrounding transaction.
 
 ## [1.5.0]

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -74,6 +74,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
+import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
@@ -2496,10 +2497,22 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         case BaseResult.ReturnStatus.ENTITY_NOT_FOUND:
           throw new NotFoundException("Cannot rename %s to %s. %s does not exist", from, to, from);
 
-        // this is temporary. Should throw a special error that will be caught and retried
-        case BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED:
+        // The source path (ENTITY_CANNOT_BE_RESOLVED) or the target path
+        // (CATALOG_PATH_CANNOT_BE_RESOLVED) could not be resolved, e.g. because it was concurrently
+        // dropped. This is not retriable, so surface it as 404.
         case BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED:
-          throw new RuntimeException("concurrent update detected, please retry");
+        case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:
+          throw new NoSuchNamespaceException(
+              "Cannot rename %s to %s because the source or target path could not be resolved",
+              from, to);
+
+        // The entity is still present but was concurrently modified: a genuine transient conflict.
+        // Surface as 503 so clients can retry. We avoid 409 because the rename endpoint reserves
+        // 409 for "target already exists" (handled by the ENTITY_ALREADY_EXISTS case above).
+        case BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED:
+          throw new ServiceUnavailableException(
+              "Cannot rename %s to %s because it was concurrently modified; please retry",
+              from, to);
 
         // some entities cannot be renamed
         case BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RENAMED:

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -89,6 +89,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
+import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
@@ -2552,6 +2553,57 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThatThrownBy(() -> update.commit())
         .isInstanceOf(CommitConflictException.class)
         .hasMessageContaining("conflict_table");
+  }
+
+  static Stream<Arguments> renameFailureStatuses() {
+    return Stream.of(
+        // Transient conflict: entity present but concurrently modified -> 503, retryable.
+        Arguments.of(
+            BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED,
+            ServiceUnavailableException.class),
+        // Source path could not be resolved (e.g. concurrently dropped) -> 404, not retryable.
+        Arguments.of(
+            BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED, NoSuchNamespaceException.class),
+        // Target path could not be resolved (e.g. concurrently dropped) -> 404, not retryable.
+        Arguments.of(
+            BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED,
+            NoSuchNamespaceException.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("renameFailureStatuses")
+  public void testConcurrencyConflictRenameTable(
+      BaseResult.ReturnStatus renameStatus, Class<? extends Throwable> expectedException) {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+
+    // Use a spy so that resolution succeeds normally, but the final rename reports the given
+    // failure status. The mapping must distinguish a transient conflict
+    // (TARGET_ENTITY_CONCURRENTLY_MODIFIED -> 503, retryable) from resolution failures
+    // (ENTITY_CANNOT_BE_RESOLVED / CATALOG_PATH_CANNOT_BE_RESOLVED -> 404), rather than failing
+    // with an opaque 500.
+    PolarisMetaStoreManager spyMetaStore = spy(metaStoreManager);
+    final LocalIcebergCatalog catalog = newIcebergCatalog(CATALOG_NAME, spyMetaStore);
+    catalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+
+    Namespace namespace = Namespace.of("rename_conflict_ns");
+    catalog.createNamespace(namespace);
+
+    final TableIdentifier from = TableIdentifier.of(namespace, "rename_from");
+    final TableIdentifier to = TableIdentifier.of(namespace, "rename_to");
+    catalog.buildTable(from, SCHEMA).create();
+
+    doReturn(new EntityResult(renameStatus, null))
+        .when(spyMetaStore)
+        .renameEntity(any(), any(), any(), any(), any());
+
+    Assertions.assertThatThrownBy(() -> catalog.renameTable(from, to))
+        .isInstanceOf(expectedException)
+        .hasMessageContaining("rename_from");
   }
 
   @Test


### PR DESCRIPTION
When a concurrent modification occurs during `renameTable`/`renameView`, the
operation now returns HTTP 503 (Service Unavailable) instead of HTTP 500
(Internal Server Error), signalling a transient, retryable condition.

## Why

`renameTableLike` in `IcebergCatalog` previously threw a bare `RuntimeException`
for both `TARGET_ENTITY_CONCURRENTLY_MODIFIED` and `ENTITY_CANNOT_BE_RESOLVED`.
`IcebergExceptionMapper` maps unknown `RuntimeException`s to 500, so clients
received an opaque server error instead of a retryable signal. The code even
admitted this was temporary: *"this is temporary. Should throw a special error
that will be caught and retried"*.

Both statuses are documented in `BaseResult.ReturnStatus` as retryable
concurrency conditions ("the client should retry"), and the rename
implementation (`TransactionalMetaStoreManagerImpl.renameEntityInCurrentTxn`)
returns both on real races, so each branch is reachable in practice.

HTTP 409 is intentionally **not** used here: the Iceberg REST rename endpoint
reserves 409 for *"the target identifier to rename to already exists"* (which
Polaris already uses via the `ENTITY_ALREADY_EXISTS` case). Mapping a concurrent
modification to 409 would collide with that meaning, so a spec-compliant client
would surface it as `AlreadyExistsException` rather than retrying. The rename
endpoint lists 503 for the transient case, so this change uses 503 instead.
(Thanks to @nandorKollar for catching the 409 semantic mismatch in review.)

## Changes

- `IcebergCatalog.renameTableLike`: replaced the bare `RuntimeException` with
  `ServiceUnavailableException` (HTTP 503) for concurrent rename failures
  (`TARGET_ENTITY_CONCURRENTLY_MODIFIED`, `ENTITY_CANNOT_BE_RESOLVED`).
- Added parameterized test `testConcurrencyConflictRenameTable` covering both
  statuses, verifying they surface as `ServiceUnavailableException` (503).
- `CHANGELOG.md`: added a Fixes entry.

## Known follow-up (out of scope)

The same `renameTableLike` switch still lacks a case for
`CATALOG_PATH_CANNOT_BE_RESOLVED` (cross-namespace renames where the destination
path can't be resolved). That falls through to `default → IllegalStateException
→ 500`, whereas `updateTableLike` handles it as `NotFoundException` (404). This
is a pre-existing gap not introduced by this change; tracking separately.

## Testing

- `./gradlew :polaris-runtime-service:compileTestJava` — passes
- `./gradlew :polaris-runtime-service:spotlessCheck :polaris-runtime-service:checkstyleMain :polaris-runtime-service:checkstyleTest` — passes
- `./gradlew :polaris-runtime-service:test --tests "org.apache.polaris.service.catalog.iceberg.IcebergCatalogRelationalTest.testConcurrencyConflictRenameTable"` — passes (both parameterized cases)
- `./gradlew :polaris-runtime-service:test --tests "org.apache.polaris.service.catalog.iceberg.IcebergCatalogRelationalTest.testConcurrencyConflictUpdateTableDuringFinalTransaction"` — passes (regression check)

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
