### PR TITLE
Disable merge commit action on GitHub PR merge button

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,7 +35,7 @@ github:
     - catalog
 
   enabled_merge_buttons:
-    merge: true
+    merge: false
     squash: true
     rebase: true
 


### PR DESCRIPTION
Following the discussion from the dev mailing list, I propose to disable the merge commit action on the GitHub PR merge button.
