### PR TITLE
Fix binary distribution URL and directory for 1.4.1

### DIFF
--- a/1.4.1/getting-started/binary-distribution.md
+++ b/1.4.1/getting-started/binary-distribution.md
@@ -34,7 +34,7 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/polaris/1.4.1/polaris-bin-1.4.1.tgz | tar xz
+curl -L https://archive.apache.org/dist/polaris/1.4.1/polaris-bin-1.4.1.tgz | tar xz
 cd polaris-bin-1.4.1
 ```
 

--- a/1.4.1/getting-started/binary-distribution.md
+++ b/1.4.1/getting-started/binary-distribution.md
@@ -34,8 +34,8 @@ Use this guide to quickly start running Polaris using the pre-built binary distr
 Download and extract the binary distribution:
 
 ```bash
-curl -L https://downloads.apache.org/incubator/polaris/1.4.1/polaris-bin-1.4.1.tgz | tar xz
-cd polaris-bin-1.3.0-incubating
+curl -L https://downloads.apache.org/polaris/1.4.1/polaris-bin-1.4.1.tgz | tar xz
+cd polaris-bin-1.4.1
 ```
 
 Start the Polaris server:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Fix two bugs in the 1.4.1 binary distribution getting started guide:
- Download URL incorrectly included `incubator/` path segment
- `cd` command referenced wrong directory `polaris-bin-1.3.0-incubating` instead of `polaris-bin-1.4.1`

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)