### PR TITLE
CI/Build: More deterministric exclusion of int-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           ./gradlew check sourceTarball distTar distZip publishToMavenLocal \
             -x :polaris-runtime-service:test \
             -x :polaris-admin:test \
-            -x intTest \
+            -PnoIntegrationTests \
             --continue
       - name: Verify configuration reference is up to date
         run: |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Apache Polaris is built using Gradle with Java 21+ and Docker 27+.
 - `./gradlew build` - To build and run tests. Make sure Docker is running, as the integration tests depend on it.
 - `./gradlew assemble` - To skip tests.
 - `./gradlew check` - To run all checks, including unit tests and integration tests.
+  To run all checks except integration tests, use `./gradlew check -PnoIntegrationTests`.
 - `./gradlew run` - To run the Polaris server locally; the server is reachable at localhost:8181. This is also suitable for running regression tests, or for connecting with Spark. Set your own credentials by specifying system property `./gradlew run -Dpolaris.bootstrap.credentials=POLARIS,root,secret` where:
   - `POLARIS` is the realm
   - `root` is the CLIENT_ID

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -340,7 +340,11 @@ gradle.sharedServices.registerIfAbsent(
 abstract class TestingParallelismHelper : BuildService<BuildServiceParameters.None>
 
 tasks.withType<Test>().configureEach {
+  val isTestTask = name == "test"
   val constraintName =
-    if ("test" == name) "testParallelismConstraint" else "intTestParallelismConstraint"
+    if (isTestTask) "testParallelismConstraint" else "intTestParallelismConstraint"
   usesService(gradle.sharedServices.registrations.named(constraintName).get().service)
+  if (project.hasProperty("noIntegrationTests") && !isTestTask) {
+    enabled = false
+  }
 }

--- a/persistence/nosql/persistence/correctness/build.gradle.kts
+++ b/persistence/nosql/persistence/correctness/build.gradle.kts
@@ -49,13 +49,18 @@ dependencies {
 // test-backend names to be exercised.
 var dbs = mapOf("inmemory" to listOf("InMemory"), "mongodb" to listOf("MongoDb"))
 
+tasks.register<Test>("intTest") {
+  description = "Runs all integration tests."
+  group = LifecycleBasePlugin.VERIFICATION_GROUP
+}
+
 testing {
   suites {
     dbs.forEach { prjDbs ->
       val prj = prjDbs.key
       prjDbs.value.forEach { db ->
-        val dbTaskName = db.replace("-", "")
-        register<JvmTestSuite>("correctness${dbTaskName}Test") {
+        val dbTaskName = "correctness${db.replace("-", "")}Test"
+        register<JvmTestSuite>(dbTaskName) {
           dependencies {
             runtimeOnly(project(":polaris-persistence-nosql-$prj"))
             implementation(testFixtures(project(":polaris-persistence-nosql-$prj")))
@@ -63,6 +68,8 @@ testing {
 
           targets.all { testTask.configure { systemProperty("polaris.testBackend.name", db) } }
         }
+
+        tasks.named("intTest") { dependsOn(dbTaskName) }
       }
     }
 


### PR DESCRIPTION
Exclusion of integration-tests in ci.yml in the `build-checks` CI job is currently implemented by only exluding the task `intTest`. Other test tasks, like `cloudTest`, NoSQL correctness tests, and others that can be registered via Gradle test suites, will not be excluded.

This change adds a new project property `noIntegrationTests` that, if present, disables all test tasks with a name other than `test`. The `build-checks` job uses the new project property instead.

This change can also saves some duplicate integration test executions.