### PR TITLE
CI: Improve Python client job duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,10 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
       - name: Image build
         env: *gradle_env_vars
-        run: ./gradlew :polaris-server:assemble -Dquarkus.container-image.build=true
+        run: |
+          ./gradlew \
+            :polaris-server:assemble \
+            -Dquarkus.container-image.build=true
       - name: Save image to tar
         run: |
           docker save apache/polaris:latest | zstd -T0 > polaris-image.tar.zst
@@ -234,6 +237,12 @@ jobs:
         with:
           name: polaris-image
           path: polaris-image.tar.zst
+          retention-days: 1
+      - name: Upload server app artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: polaris-server-app
+          path: runtime/server/build/quarkus-app
           retention-days: 1
 
   docker-image-scan:
@@ -397,6 +406,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docker-image-build
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -405,13 +416,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with: *setup-java-vars
       - name: Setup test environment
         uses: ./.github/actions/setup-test-env
-      - name: Prepare Gradle build cache
-        uses: ./.github/actions/ci-incr-build-cache-prepare
+      - name: Download server-app artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: polaris-server-app
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -423,7 +433,7 @@ jobs:
       - name: Generated Client Tests
         run: make client-unit-test
       - name: Integration Tests
-        run: make client-integration-test
+        run: make _client-integration-test
       - name: Run Polaris Client help manual
         run: .venv/bin/polaris --help
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
       - name: Generated Client Tests
         run: make client-unit-test
       - name: Integration Tests
-        run: make _client-integration-test
+        run: make run-client-integration-test
       - name: Run Polaris Client help manual
         run: .venv/bin/polaris --help
 

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ client-setup-env: $(VENV_DIR) ## Set up Python client environment (venv + depend
 	@$(ACTIVATE_AND_CD) && uv lock && uv sync --active --all-extras
 	@echo "--- Python client environment setup complete ---"
 
-_client-integration-test: client-setup-env
+run-client-integration-test: client-setup-env
 	@echo "--- Starting client integration tests ---"
 	@echo "Ensuring Docker Compose services are stopped and removed..."
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml kill || true # `|| true` prevents make from failing if containers don't exist
@@ -176,7 +176,7 @@ _client-integration-test: client-setup-env
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml down || true # Ensure teardown even if tests fail
 
 .PHONY: client-integration-test
-client-integration-test: build-server _client-integration-test ## Run client integration tests
+client-integration-test: build-server run-client-integration-test ## Run client integration tests
 
 .PHONY: client-license-check
 client-license-check: client-setup-env ## Run license compliance check

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,7 @@ client-setup-env: $(VENV_DIR) ## Set up Python client environment (venv + depend
 	@$(ACTIVATE_AND_CD) && uv lock && uv sync --active --all-extras
 	@echo "--- Python client environment setup complete ---"
 
-.PHONY: client-integration-test
-client-integration-test: build-server client-setup-env ## Run client integration tests
+_client-integration-test: client-setup-env
 	@echo "--- Starting client integration tests ---"
 	@echo "Ensuring Docker Compose services are stopped and removed..."
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml kill || true # `|| true` prevents make from failing if containers don't exist
@@ -175,6 +174,9 @@ client-integration-test: build-server client-setup-env ## Run client integration
 	@echo "--- Client integration tests complete ---"
 	@echo "Tearing down Docker Compose services..."
 	@$(DOCKER) compose -f $(PYTHON_CLIENT_DIR)/docker-compose.yml down || true # Ensure teardown even if tests fail
+
+.PHONY: client-integration-test
+client-integration-test: build-server _client-integration-test ## Run client integration tests
 
 .PHONY: client-license-check
 client-license-check: client-setup-env ## Run license compliance check


### PR DESCRIPTION
Currently, the Python CI jobs all build a Polaris server Quarkus app, which is already built by the `Polaris Docker Image build` job.
This change exposes the built Polaris server app via a build artifact, so it can be reused in the Python CI jobs.
This saves about 3 minutes per Python CI jobs, so 5 times 3 minutes ~= 15 minutes in total.