### PR TITLE
CI/Build: Make `jcstress` cachable

### DIFF
--- a/persistence/nosql/idgen/impl/build.gradle.kts
+++ b/persistence/nosql/idgen/impl/build.gradle.kts
@@ -85,22 +85,20 @@ jcstress {
 }
 
 tasks.named<JcstressTask>("jcstress") {
-  inputs.properties(
-    System.getProperties()
-      .mapKeys { it.key.toString() }
-      .filterKeys {
-        setOf("os.name", "os.arch", "os.version", "java.runtime.name", "java.runtime.version")
-          .contains(it)
-      }
-  )
+  listOf("os.name", "os.arch", "os.version", "java.runtime.name", "java.runtime.version").forEach {
+    inputs.property(it, providers.systemProperty(it).orElse(""))
+  }
   inputs.property("availableProcessors", Runtime.getRuntime().availableProcessors())
   inputs.property("jcstressMode", jcstressMode.get())
   inputs.property("jcstressSplitPerActor", jcstressSplitPerActor.get())
   inputs.files(jcstressRuntime)
   inputs.files(configurations.runtimeClasspath)
   outputs.dir(layout.buildDirectory.dir("reports/jcstress"))
+  outputs.cacheIf { true }
 
-  if (!System.getProperty("jcstress-no-capture").toBoolean()) {
+  val noCapture = providers.systemProperty("jcstress-no-capture").orElse("false").get().toBoolean()
+  inputs.property("jcstress-no-capture", noCapture)
+  if (!noCapture) {
     // Capture jcstress output in a log file, dump that in case of a failure.
 
     val logDir = project.layout.buildDirectory.dir("reports/jcstress").get().asFile

--- a/persistence/nosql/persistence/impl/build.gradle.kts
+++ b/persistence/nosql/persistence/impl/build.gradle.kts
@@ -119,22 +119,20 @@ jcstress {
 }
 
 tasks.named<JcstressTask>("jcstress") {
-  inputs.properties(
-    System.getProperties()
-      .mapKeys { it.key.toString() }
-      .filterKeys {
-        setOf("os.name", "os.arch", "os.version", "java.runtime.name", "java.runtime.version")
-          .contains(it)
-      }
-  )
+  listOf("os.name", "os.arch", "os.version", "java.runtime.name", "java.runtime.version").forEach {
+    inputs.property(it, providers.systemProperty(it).orElse(""))
+  }
   inputs.property("availableProcessors", Runtime.getRuntime().availableProcessors())
   inputs.property("jcstressMode", jcstressMode.get())
   inputs.property("jcstressSplitPerActor", jcstressSplitPerActor.get())
   inputs.files(jcstressRuntime)
   inputs.files(configurations.runtimeClasspath)
   outputs.dir(layout.buildDirectory.dir("reports/jcstress"))
+  outputs.cacheIf { true }
 
-  if (!System.getProperty("jcstress-no-capture").toBoolean()) {
+  val noCapture = providers.systemProperty("jcstress-no-capture").orElse("false").get().toBoolean()
+  inputs.property("jcstress-no-capture", noCapture)
+  if (!noCapture) {
     // Capture jcstress output in a log file, dump that in case of a failure.
 
     val logDir = project.layout.buildDirectory.dir("reports/jcstress").get().asFile


### PR DESCRIPTION
This change caches the result of the jcstress tasks, which saves a couple of minutes during each CI run.

Also use the now preferred capturing of Java system properties via `providers.systemProperty(...)`.