### PR TITLE
Build: use Gradle providers for system properties

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -21,8 +21,6 @@ plugins { id("polaris-bom") }
 
 description = "Apache Polaris - Bill of Materials (BOM)"
 
-val ideaActive = System.getProperty("idea.active").toBoolean()
-
 dependencies {
   constraints {
     api(rootProject)
@@ -105,6 +103,7 @@ dependencies {
 
     api(project(":polaris-spark-3.5_2.12"))
     api(project(":polaris-spark-integration-3.5_2.12"))
+    val ideaActive = providers.systemProperty("idea.active").getOrElse("false").toBoolean()
     if (!ideaActive) {
       api(project(":polaris-spark-3.5_2.13"))
       api(project(":polaris-spark-integration-3.5_2.13"))

--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -43,7 +43,7 @@ if (!project.extra.has("duplicated-project-sources")) {
   }
 }
 
-if (System.getProperty("idea.sync.active").toBoolean()) {
+if (providers.systemProperty("idea.sync.active").getOrElse("false").toBoolean()) {
   idea {
     module {
       isDownloadJavadoc = false // was 'true', but didn't work

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 val projectName = rootProject.file("ide-name.txt").readText().trim()
 val ideName = "$projectName ${rootProject.version.toString().replace("^([0-9.]+).*", "\\1")}"
 
-if (System.getProperty("idea.sync.active").toBoolean()) {
+if (providers.systemProperty("idea.sync.active").getOrElse("false").toBoolean()) {
   // There's no proper way to set the name of the IDEA project (when "just importing" or
   // syncing the Gradle project)
   val ideaDir = rootProject.layout.projectDirectory.dir(".idea")

--- a/persistence/nosql/persistence/correctness/build.gradle.kts
+++ b/persistence/nosql/persistence/correctness/build.gradle.kts
@@ -76,9 +76,9 @@ testing {
         // `o.a.p.persistence.api.BackendConfigurer.defaultBackendConfigurer` using smallrye-config.
         targets.all {
           testTask.configure {
-            System.getProperties()
-              .filter { p -> p.key.toString().startsWith("polaris.") }
-              .forEach { p -> systemProperty(p.key.toString(), p.value) }
+            providers.systemPropertiesPrefixedBy("polaris").get().forEach { (k, v) ->
+              systemProperty(k, v)
+            }
           }
         }
       }

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -245,7 +245,8 @@ listOf("intTest", "cloudTest")
           // Example: to attach a debugger to the spawned JVM running Quarkus, add
           // -Dquarkus.test.arg-line=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
           // to your test configuration.
-          val explicitQuarkusTestArgLine = System.getProperty("quarkus.test.arg-line")
+          val explicitQuarkusTestArgLine =
+            providers.systemProperty("quarkus.test.arg-line").getOrNull()
           var quarkusTestArgLine =
             if (explicitQuarkusTestArgLine != null)
               "$explicitQuarkusTestArgLine $securityManagerAllow"
@@ -257,13 +258,11 @@ listOf("intTest", "cloudTest")
           args.add("-Dquarkus.log.file.path=${logsDir.resolve("polaris.log").absolutePath}")
 
           // Add `quarkus.*` system properties, other than the ones explicitly set above
-          System.getProperties()
-            .filter {
-              it.key.toString().startsWith("quarkus.") &&
-                !"quarkus.test.arg-line".equals(it.key) &&
-                !"quarkus.log.file.path".equals(it.key)
-            }
-            .forEach { args.add("${it.key}=${it.value}") }
+          providers
+            .systemPropertiesPrefixedBy("quarkus.")
+            .get()
+            .filter { e -> "quarkus.test.arg-line" != e.key && "quarkus.log.file.path" != e.key }
+            .forEach { e -> args.add("${e.key}=${e.value}") }
 
           args
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,7 +57,7 @@ loadProperties(file("gradle/projects.main.properties")).forEach { name, director
   polarisProject(name as String, file(directory as String))
 }
 
-val ideaActive = System.getProperty("idea.active").toBoolean()
+val ideaActive = providers.systemProperty("idea.active").getOrElse("false").toBoolean()
 
 // load the polaris spark plugin projects
 val polarisSparkDir = "plugins/spark"


### PR DESCRIPTION
This is rather a premature optimization, but may prevent copying the deprecated habit of accessing system properties directly.