### PR TITLE
Build: use typed providers

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -22,9 +22,12 @@ import java.util.Properties
 import kotlin.jvm.java
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.named
+import org.gradle.process.CommandLineArgumentProvider
 import org.kordamp.gradle.plugin.jandex.JandexExtension
 import org.kordamp.gradle.plugin.jandex.JandexPlugin
 import publishing.PublishingHelperPlugin
@@ -188,14 +191,17 @@ dependencies {
   mockitoAgent(mockitoCoreLib) { isTransitive = false }
 }
 
+private class MockitoJavaAgentArgumentProvider(@get:Classpath val mockitoAgent: FileCollection) :
+  CommandLineArgumentProvider {
+  override fun asArguments(): Iterable<String> = listOf("-javaagent:${mockitoAgent.asPath}")
+}
+
 tasks.withType<Test>().configureEach {
   systemProperty("file.encoding", "UTF-8")
   systemProperty("user.language", "en")
   systemProperty("user.country", "US")
   systemProperty("user.variant", "")
-  jvmArgumentProviders.add(
-    CommandLineArgumentProvider { listOf("-javaagent:${mockitoAgent.asPath}") }
-  )
+  jvmArgumentProviders.add(MockitoJavaAgentArgumentProvider(mockitoAgent))
 }
 
 tasks.withType<Jar>().configureEach {

--- a/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
@@ -15,8 +15,18 @@
  */
 
 import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.api.tasks.Input
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import org.gradle.process.CommandLineArgumentProvider
+
+class QuarkusProfileArgumentProvider(private val profile: String) : CommandLineArgumentProvider {
+  @get:Input
+  val inputProfile: String
+    get() = profile
+
+  override fun asArguments(): Iterable<String> = listOf("-Dquarkus.profile=$profile")
+}
 
 plugins { id("polaris-server") }
 
@@ -44,7 +54,7 @@ testing {
             systemProperty("build.output.directory", layout.buildDirectory.asFile.get())
             dependsOn(tasks.named("quarkusBuild"))
             // Set the 'it' profile explicitly
-            jvmArgumentProviders.add(CommandLineArgumentProvider { listOf("-Dquarkus.profile=it") })
+            jvmArgumentProviders.add(QuarkusProfileArgumentProvider("it"))
           }
         }
         tasks.named(sources.compileJavaTaskName).configure {


### PR DESCRIPTION
This change removes some build-script lambdas that capture Gradle script state. It declares the Mockito agent as a proper `@Classpath` input to Test.

More things:
* makes task inputs more explicit and inspectable.
* reduces accidental coupling between task execution and configuration-time objects.
* aligns with Gradle’s lazy/configuration-safe task modeling.