### PR TITLE
Forward catalog static FileIO properties to server-side FileIO

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2637,8 +2637,15 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     StorageAccessConfig storageAccessConfig =
         storageAccessConfigProvider.getStorageAccessConfig(
             identifier, readLocations, storageActions, Optional.empty(), resolvedStorageEntity);
-    // Reload fileIO based on table specific context
-    FileIO fileIO = fileIOFactory.loadFileIO(storageAccessConfig, ioImplClassName, tableProperties);
+    // Catalog-level FileIO properties (e.g. s3.access-key-id / s3.secret-access-key for
+    // S3-compatible storage with stsUnavailable=true) form the base; the caller's
+    // tableProperties overlay on top, and DefaultFileIOFactory further overlays
+    // storageAccessConfig so STS-vended subscoped credentials always take precedence
+    // over static catalog credentials when STS is available.
+    Map<String, String> mergedProperties = new HashMap<>(catalogProperties);
+    mergedProperties.putAll(tableProperties);
+    FileIO fileIO =
+        fileIOFactory.loadFileIO(storageAccessConfig, ioImplClassName, mergedProperties);
     // ensure the new fileIO is closed when the catalog is closed
     closeableGroup.addCloseable(fileIO);
     return fileIO;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -133,6 +133,7 @@ import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.apache.polaris.core.storage.StorageAccessConfig;
+import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.core.storage.StorageUtil;
 import org.apache.polaris.service.catalog.SupportsNotifications;
@@ -2637,12 +2638,20 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     StorageAccessConfig storageAccessConfig =
         storageAccessConfigProvider.getStorageAccessConfig(
             identifier, readLocations, storageActions, Optional.empty(), resolvedStorageEntity);
-    // Catalog-level FileIO properties (e.g. s3.access-key-id / s3.secret-access-key for
-    // S3-compatible storage with stsUnavailable=true) form the base; the caller's
-    // tableProperties overlay on top, and DefaultFileIOFactory further overlays
-    // storageAccessConfig so STS-vended subscoped credentials always take precedence
-    // over static catalog credentials when STS is available.
-    Map<String, String> mergedProperties = new HashMap<>(catalogProperties);
+    // For S3-compatible storage with stsUnavailable=true the admin sets static credentials
+    // (s3.access-key-id / s3.secret-access-key) as catalog properties. These form the base so
+    // that tableProperties can override them, and DefaultFileIOFactory then further overlays
+    // storageAccessConfig credentials so STS-vended credentials always win when STS is available.
+    // Only the two S3 credential keys are forwarded from catalogProperties to avoid leaking
+    // unrelated catalog configuration into the FileIO property map.
+    Map<String, String> mergedProperties = new HashMap<>();
+    for (StorageAccessProperty credProp :
+        List.of(StorageAccessProperty.AWS_KEY_ID, StorageAccessProperty.AWS_SECRET_KEY)) {
+      String val = catalogProperties.get(credProp.getPropertyName());
+      if (val != null) {
+        mergedProperties.put(credProp.getPropertyName(), val);
+      }
+    }
     mergedProperties.putAll(tableProperties);
     FileIO fileIO =
         fileIOFactory.loadFileIO(storageAccessConfig, ioImplClassName, mergedProperties);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -192,6 +192,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.NonRetryableException;
@@ -1068,6 +1069,59 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThatThrownBy(() -> catalog.sendNotification(table, request))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Fake failure applying downscoped credentials");
+  }
+
+  @Test
+  public void testCatalogStaticS3CredentialsAreForwardedToFileIO() {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+    Assumptions.assumeTrue(
+        supportsNestedNamespaces(), "Only applicable if nested namespaces are supported");
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    // Static S3 credentials set on the catalog (the stsUnavailable=true case for
+    // S3-compatible storage) must reach the server-side FileIO. Without this they
+    // would be dropped and S3FileIO would fall back to the AWS default credentials
+    // provider chain.
+    final String tableLocation = "s3://externally-owned-bucket/static_creds_table/";
+    final String tableMetadataLocation = tableLocation + "metadata/v1.metadata.json";
+    FileIOFactory spiedFileIOFactory = spy(this.fileIOFactory);
+    IcebergCatalog catalog =
+        newIcebergCatalog(catalog().name(), metaStoreManager, spiedFileIOFactory);
+    catalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            "s3.access-key-id",
+            "static-access-key",
+            "s3.secret-access-key",
+            "static-secret-key"));
+
+    Namespace namespace = Namespace.of("parent", "child1");
+    TableIdentifier table = TableIdentifier.of(namespace, "table");
+
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.VALIDATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(tableMetadataLocation);
+    update.setTableName(table.name());
+    update.setTableUuid(UUID.randomUUID().toString());
+    update.setTimestamp(230950845L);
+    request.setPayload(update);
+
+    Assertions.assertThat(catalog.sendNotification(table, request))
+        .as("VALIDATE notification should succeed")
+        .isTrue();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+    Mockito.verify(spiedFileIOFactory).loadFileIO(any(), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry("s3.access-key-id", "static-access-key")
+        .containsEntry("s3.secret-access-key", "static-secret-key");
   }
 
   @Test


### PR DESCRIPTION
`IcebergCatalog.loadFileIOForTableLike` only passed `tableDefaultProperties` (the `table-default.*`-prefixed subset of catalog properties) to the `FileIOFactory`. For S3-compatible storage configured with `stsUnavailable: true`, catalogs typically carry static credentials (`s3.access-key-id` / `s3.secret-access-key`) as catalog properties. These were dropped before reaching `S3FileIO`, which then fell back to the AWS default credentials provider chain and failed when no chain credential was available.

Merge `catalogProperties` as the base layer under `tableProperties`. `DefaultFileIOFactory` still overlays `StorageAccessConfig` last, so STS-vended subscoped credentials continue to take precedence over static catalog credentials when STS is available.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
