### PR TITLE
Fix javadoc warning in nosql-maintenance-api

### DIFF
--- a/persistence/nosql/persistence/maintenance/api/build.gradle.kts
+++ b/persistence/nosql/persistence/maintenance/api/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
+  compileOnly(libs.jakarta.enterprise.cdi.api)
 }


### PR DESCRIPTION
Add Jakarta cdi-api as a compile-only dependency to fix:

```
package-info.java:71: warning: reference not found: jakarta.enterprise.context.ApplicationScoped
 * <p>Implementations of {@link jakarta.enterprise.context.ApplicationScoped @ApplicationScoped}
                         ^
```

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
