### PR TITLE
Build: eliminate cross-project dependencies in copied-code-checker

### DIFF
--- a/build-logic/src/main/kotlin/copiedcode/CopiedCodeCheckerPlugin.kt
+++ b/build-logic/src/main/kotlin/copiedcode/CopiedCodeCheckerPlugin.kt
@@ -18,13 +18,11 @@ package copiedcode
 
 import java.nio.file.Files
 import java.util.regex.Pattern
-import javax.inject.Inject
 import kotlin.collections.joinToString
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -69,18 +67,13 @@ import org.gradle.work.DisableCachingByDefault
  * space).
  */
 @Suppress("unused")
-class CopiedCodeCheckerPlugin
-@Inject
-constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Plugin<Project> {
+class CopiedCodeCheckerPlugin : Plugin<Project> {
   override fun apply(project: Project): Unit =
     project.run {
       val extension =
         extensions.create("copiedCodeChecks", CopiedCodeCheckerExtension::class.java, project)
 
       if (rootProject == this) {
-        // Apply this plugin to all projects
-        afterEvaluate { subprojects { plugins.apply(CopiedCodeCheckerPlugin::class.java) } }
-
         tasks.register(
           CHECK_COPIED_CODE_MENTIONS_EXIST_TASK_NAME,
           CheckCopiedCodeMentionsExistTask::class.java,
@@ -89,48 +82,15 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
           rootDirectory.convention(layout.projectDirectory)
         }
 
-        afterEvaluate {
-          tasks.named("check").configure { dependsOn(CHECK_COPIED_CODE_MENTIONS_EXIST_TASK_NAME) }
-        }
-      } else {
-        extension.excludedContentTypePatterns.convention(
-          provider {
-            rootProject.extensions
-              .getByType(CopiedCodeCheckerExtension::class.java)
-              .excludedContentTypePatterns
-              .get()
-          }
-        )
-        extension.includedContentTypePatterns.convention(
-          provider {
-            rootProject.extensions
-              .getByType(CopiedCodeCheckerExtension::class.java)
-              .includedContentTypePatterns
-              .get()
-          }
-        )
-        extension.includeUnrecognizedContentType.convention(
-          provider {
-            rootProject.extensions
-              .getByType(CopiedCodeCheckerExtension::class.java)
-              .includeUnrecognizedContentType
-              .get()
-          }
-        )
-        extension.licenseFile.convention(
-          provider {
-            rootProject.extensions
-              .getByType(CopiedCodeCheckerExtension::class.java)
-              .licenseFile
-              .get()
-          }
-        )
+        tasks
+          .matching { task -> task.name == "check" }
+          .configureEach { dependsOn(CHECK_COPIED_CODE_MENTIONS_EXIST_TASK_NAME) }
       }
 
       val checkForCopiedCode =
         tasks.register(CHECK_FOR_COPIED_CODE_TASK_NAME, CheckForCopiedCodeTask::class.java) {
           licenseFile.convention(extension.licenseFile)
-          rootDirectory.convention(rootProject.layout.projectDirectory)
+          rootDirectory.convention(layout.settingsDirectory)
           projectDirectory.convention(layout.projectDirectory)
           buildDirectory.convention(layout.buildDirectory)
           excludedContentTypePatterns.convention(extension.excludedContentTypePatterns)
@@ -153,9 +113,9 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
         }
       }
 
-      afterEvaluate {
-        tasks.named("check").configure { dependsOn(CHECK_FOR_COPIED_CODE_TASK_NAME) }
-      }
+      tasks
+        .matching { task -> task.name == "check" }
+        .configureEach { dependsOn(CHECK_FOR_COPIED_CODE_TASK_NAME) }
     }
 
   companion object {

--- a/build-logic/src/main/kotlin/polaris-base.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-base.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import copiedcode.CopiedCodeCheckerExtension
+import copiedcode.CopiedCodeCheckerPlugin
+
+apply<CopiedCodeCheckerPlugin>()
+
+extensions.getByType<CopiedCodeCheckerExtension>().apply {
+  addDefaultContentTypes()
+  licenseFile.convention(layout.settingsDirectory.file("LICENSE"))
+}

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -38,6 +38,7 @@ plugins {
   `java-test-fixtures`
   `jvm-test-suite`
   checkstyle
+  id("polaris-base")
   id("polaris-spotless")
   id("polaris-reproducible")
   id("jacoco-report-aggregation")

--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import copiedcode.CopiedCodeCheckerPlugin
 import org.jetbrains.gradle.ext.copyright
 import org.jetbrains.gradle.ext.encodings
 import org.jetbrains.gradle.ext.settings
@@ -25,13 +24,12 @@ import publishing.PublishingHelperExtension
 import publishing.PublishingHelperPlugin
 
 plugins {
+  id("polaris-base")
   id("com.diffplug.spotless")
   id("org.jetbrains.gradle.plugin.idea-ext")
 }
 
 apply<PublishingHelperPlugin>()
-
-apply<CopiedCodeCheckerPlugin>()
 
 if (!project.extra.has("duplicated-project-sources")) {
   spotless {

--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
   `java-library`
+  id("polaris-base")
   id("polaris-reproducible")
 }
 


### PR DESCRIPTION
This change eliminates cross-project dependencies, which can introduce configuration coordination issues. This is cleaner than relying on `afterEvaluate` and prevents eager subprojects resolution.