### PR TITLE
Build: eliminate cross-project dependencies in publishing related areas

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -98,8 +98,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
             val signingKey: String? by project
             val signingPassword: String? by project
             useInMemoryPgpKeys(signingKey, signingPassword)
-            val publishing = project.extensions.getByType(PublishingExtension::class.java)
-            afterEvaluate { sign(publishing.publications.getByName("maven")) }
 
             if (project.hasProperty("useGpgAgent")) {
               useGpgCmd()
@@ -120,32 +118,35 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
           publications {
             register<MavenPublication>("maven") {
               val mavenPublication = this
-              afterEvaluate {
-                // This MUST happen in an 'afterEvaluate' to ensure that the Shadow*Plugin has
-                // been applied.
-                if (project.plugins.hasPlugin(ShadowPlugin::class.java)) {
-                  configureShadowPublishing(project, mavenPublication, softwareComponentFactory)
-                } else {
-                  val component =
-                    components.firstOrNull { c -> c.name == "javaPlatform" || c.name == "java" }
-                  if (component is AdhocComponentWithVariants) {
-                    listOf("testFixturesApiElements", "testFixturesRuntimeElements").forEach { cfg
-                      ->
-                      configurations.findByName(cfg)?.apply {
-                        component.addVariantsFromConfiguration(this) { skip() }
-                      }
+              if (project.plugins.hasPlugin(ShadowPlugin::class.java)) {
+                configureShadowPublishing(project, mavenPublication, softwareComponentFactory)
+              } else {
+                val component =
+                  components.firstOrNull { c -> c.name == "javaPlatform" || c.name == "java" }
+                if (component is AdhocComponentWithVariants) {
+                  listOf("testFixturesApiElements", "testFixturesRuntimeElements").forEach { cfg ->
+                    configurations.findByName(cfg)?.apply {
+                      component.addVariantsFromConfiguration(this) { skip() }
                     }
                   }
+                }
+                if (component != null) {
                   from(component)
                 }
+              }
 
-                suppressPomMetadataWarningsFor("testFixturesApiElements")
-                suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
+              suppressPomMetadataWarningsFor("testFixturesApiElements")
+              suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
 
-                if (project.tasks.findByName("createPolarisSparkJar") != null) {
+              project.tasks
+                .matching { task -> task.name == "createPolarisSparkJar" }
+                .configureEach {
                   // if the project contains spark client jar, also publish the jar to maven
-                  artifact(project.tasks.named("createPolarisSparkJar").get())
+                  artifact(this)
                 }
+
+              if (project.isSigningEnabled()) {
+                configure<SigningExtension> { sign(mavenPublication) }
               }
 
               if (
@@ -170,7 +171,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
               }
 
               tasks.named("generatePomFileForMavenPublication").configure {
-                configurePom(project, mavenPublication, this)
+                configurePom(project, project.parentPomCoordinates(), mavenPublication, this)
               }
             }
           }
@@ -178,5 +179,12 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       }
 
       addAdditionalJarContent(this)
+    }
+
+  private fun Project.parentPomCoordinates(): ParentPomCoordinates? =
+    if (this == rootProject) {
+      null
+    } else {
+      ParentPomCoordinates(group.toString(), "polaris", version.toString())
     }
 }

--- a/build-logic/src/main/kotlin/publishing/configurePom.kt
+++ b/build-logic/src/main/kotlin/publishing/configurePom.kt
@@ -43,10 +43,23 @@ import org.gradle.api.publish.maven.MavenPublication
  * must be exactly the same when built by a release manager and by someone else to verify the built
  * artifact(s).
  */
-internal fun configurePom(project: Project, mavenPublication: MavenPublication, task: Task) =
+internal data class ParentPomCoordinates(
+  val groupId: String,
+  val artifactId: String,
+  val version: String,
+)
+
+internal fun configurePom(
+  project: Project,
+  parentPomCoordinates: ParentPomCoordinates?,
+  mavenPublication: MavenPublication,
+  task: Task,
+) =
   mavenPublication.run {
     pom {
-      if (project != project.rootProject) {
+      if (parentPomCoordinates != null) {
+        // Non-root Gradle projects.
+
         // Add the license to every pom to make it easier for downstream projects to retrieve the
         // license.
         licenses {
@@ -54,11 +67,6 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
             name.set("Apache-2.0") // SPDX identifier
           }
         }
-
-        val parent = project.parent!!
-        val parentGroup = parent.group
-        val parentName = parent.name
-        val parentVersion = parent.version
 
         withXml {
           val projectNode = asNode()
@@ -79,14 +87,17 @@ internal fun configurePom(project: Project, mavenPublication: MavenPublication, 
               }
             }
           }
+
           // Add GAV to <parent> element
-          parentNode.appendNode("groupId", parentGroup)
-          parentNode.appendNode("artifactId", parentName)
-          parentNode.appendNode("version", parentVersion)
+          parentNode.appendNode("groupId", parentPomCoordinates.groupId)
+          parentNode.appendNode("artifactId", parentPomCoordinates.artifactId)
+          parentNode.appendNode("version", parentPomCoordinates.version)
 
           verifyMandatoryDependencyVersions(projectNode)
         }
       } else {
+        // Root Gradle projects.
+
         val mavenPom = this
         val effectiveAsfProject = project.provider { EffectiveAsfProject.forProject(project) }
         val projectVersion = project.version.toString()

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -210,7 +210,7 @@ internal fun configureOnRootProject(project: Project) =
       sourceTarball.configure { finalizedBy(releaseEmailTemplate) }
     }
 
-    afterEvaluate {
-      tasks.named("closeApacheStagingRepository") { mustRunAfter(releaseEmailTemplate) }
-    }
+    tasks
+      .matching { task -> task.name == "closeApacheStagingRepository" }
+      .configureEach { mustRunAfter(releaseEmailTemplate) }
   }

--- a/build-logic/src/main/kotlin/publishing/shadowPub.kt
+++ b/build-logic/src/main/kotlin/publishing/shadowPub.kt
@@ -98,8 +98,9 @@ internal fun configureShadowPublishing(
     }
     // Sonatype requires the javadoc and sources jar to be present, but the
     // Shadow extension does not publish those.
-    component.addVariantsFromConfiguration(project.configurations.getByName("javadocElements")) {}
-    component.addVariantsFromConfiguration(project.configurations.getByName("sourcesElements")) {}
+    project.configurations
+      .matching { it.name == "javadocElements" || it.name == "sourcesElements" }
+      .configureEach { component.addVariantsFromConfiguration(this) {} }
     mavenPublication.from(component)
 
     // This a replacement to add dependencies to the pom, if necessary. Equivalent to

--- a/persistence/nosql/persistence/benchmark/build.gradle.kts
+++ b/persistence/nosql/persistence/benchmark/build.gradle.kts
@@ -20,8 +20,8 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id("polaris-server")
   id("com.gradleup.shadow")
+  id("polaris-server")
   alias(libs.plugins.jmh)
 }
 


### PR DESCRIPTION
This change eliminates cross-project dependencies, which can introduce configuration coordination issues. This is cleaner than relying on `afterEvaluate` and prevents eager subprojects resolution.