### PR TITLE
Build: eliminate cross-project dependencies in license-report and checks

### DIFF
--- a/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
@@ -29,29 +29,27 @@ import licenses.QuarkusAppDependencyFilter
 
 plugins { id("com.github.jk1.dependency-license-report") }
 
-afterEvaluate {
-  licenseReport {
-    filters =
-      arrayOf(
-        QuarkusAppDependencyFilter(),
-        LicenseBundleNormalizer(
-          "${rootProject.projectDir}/gradle/license/normalizer-bundle.json",
-          false,
-        ),
-        NoticeFileLicenseFilter(),
-        LicenseFileValidation(),
-      )
-    allowedLicensesFile = rootProject.projectDir.resolve("gradle/license/allowed-licenses.json")
-    renderers =
-      arrayOf<ReportRenderer>(
-        InventoryHtmlReportRenderer("index.html"),
-        JsonReportRenderer(),
-        XmlReportRenderer(),
-      )
-    excludeBoms = true
-    outputDir = "${project.layout.buildDirectory.get()}/reports/dependency-license"
-    configurations = arrayOf("quarkusProdRuntimeClasspathConfiguration")
-  }
+val normalizerBundle = layout.settingsDirectory.file("gradle/license/normalizer-bundle.json")
+val allowedLicenses = layout.settingsDirectory.file("gradle/license/allowed-licenses.json")
+
+licenseReport {
+  filters =
+    arrayOf(
+      QuarkusAppDependencyFilter(),
+      LicenseBundleNormalizer(normalizerBundle.asFile.absolutePath, false),
+      NoticeFileLicenseFilter(),
+      LicenseFileValidation(),
+    )
+  allowedLicensesFile = allowedLicenses.asFile
+  renderers =
+    arrayOf<ReportRenderer>(
+      InventoryHtmlReportRenderer("index.html"),
+      JsonReportRenderer(),
+      XmlReportRenderer(),
+    )
+  excludeBoms = true
+  outputDir = layout.buildDirectory.dir("reports/dependency-license").get().asFile.absolutePath
+  configurations = arrayOf("quarkusProdRuntimeClasspathConfiguration")
 }
 
 val generateLicenseReport =
@@ -59,8 +57,8 @@ val generateLicenseReport =
     dependsOn("quarkusBuild")
     inputs
       .files(
-        rootProject.projectDir.resolve("gradle/license/normalizer-bundle.json"),
-        rootProject.projectDir.resolve("gradle/license/allowed-licenses.json"),
+        normalizerBundle,
+        allowedLicenses,
         project.layout.buildDirectory.file("quarkus-app/quarkus-app-dependencies.txt"),
       )
       .withPathSensitivity(PathSensitivity.RELATIVE)


### PR DESCRIPTION
This change eliminates cross-project dependencies, which can introduce configuration coordination issues. This is cleaner than relying on `afterEvaluate` and prevents eager subprojects resolution.