### PR TITLE
runtime-service/ITs: Unify some test profiles

### DIFF
--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
@@ -18,9 +18,11 @@
  */
 package org.apache.polaris.service.it;
 
+import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
+import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
+
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.net.URI;
 import java.util.List;
@@ -31,6 +33,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.service.it.env.RestCatalogConfig;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationBase;
+import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.minio.Minio;
 import org.apache.polaris.test.minio.MinioAccess;
 import org.apache.polaris.test.minio.MinioExtension;
@@ -38,27 +41,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @QuarkusIntegrationTest
-@TestProfile(PolarisRestCatalogMinIOIT.Profile.class)
+@TestProfile(MinioRustProfile.class)
 @ExtendWith(MinioExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 @RestCatalogConfig({"header.X-Iceberg-Access-Delegation", "vended-credentials"})
 public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase {
 
   protected static final String BUCKET_URI_PREFIX = "/minio-test-polaris";
-  protected static final String MINIO_ACCESS_KEY = "test-ak-123-polaris";
-  protected static final String MINIO_SECRET_KEY = "test-sk-123-polaris";
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .put("polaris.storage.aws.access-key", MINIO_ACCESS_KEY)
-          .put("polaris.storage.aws.secret-key", MINIO_SECRET_KEY)
-          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
-          .build();
-    }
-  }
 
   private static URI storageBase;
   private static String endpoint;
@@ -67,15 +56,15 @@ public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase
 
   @BeforeAll
   static void setup(
-      @Minio(accessKey = MINIO_ACCESS_KEY, secretKey = MINIO_SECRET_KEY) MinioAccess minioAccess) {
+      @Minio(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) MinioAccess minioAccess) {
     storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
     endpoint = minioAccess.s3endpoint();
     s3Properties =
         Map.of(
             S3FileIOProperties.ENDPOINT, endpoint,
             S3FileIOProperties.PATH_STYLE_ACCESS, "true",
-            S3FileIOProperties.ACCESS_KEY_ID, MINIO_ACCESS_KEY,
-            S3FileIOProperties.SECRET_ACCESS_KEY, MINIO_SECRET_KEY);
+            S3FileIOProperties.ACCESS_KEY_ID, ACCESS_KEY,
+            S3FileIOProperties.SECRET_ACCESS_KEY, SECRET_KEY);
   }
 
   @Override

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
@@ -18,9 +18,11 @@
  */
 package org.apache.polaris.service.it;
 
+import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
+import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
+
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.net.URI;
 import java.util.List;
@@ -30,6 +32,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationBase;
+import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.rustfs.Rustfs;
 import org.apache.polaris.test.rustfs.RustfsAccess;
 import org.apache.polaris.test.rustfs.RustfsExtension;
@@ -38,34 +41,19 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @QuarkusIntegrationTest
-@TestProfile(PolarisRestCatalogRustFSIT.Profile.class)
+@TestProfile(MinioRustProfile.class)
 @ExtendWith(RustfsExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBase {
 
   protected static final String BUCKET_URI_PREFIX = "/rustfs-test-polaris";
-  protected static final String RUSTFS_ACCESS_KEY = "test-ak-123-polaris";
-  protected static final String RUSTFS_SECRET_KEY = "test-sk-123-polaris";
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .put("polaris.storage.aws.access-key", RUSTFS_ACCESS_KEY)
-          .put("polaris.storage.aws.secret-key", RUSTFS_SECRET_KEY)
-          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
-          .build();
-    }
-  }
 
   private static URI storageBase;
   private static String endpoint;
 
   @BeforeAll
   static void setup(
-      @Rustfs(accessKey = RUSTFS_ACCESS_KEY, secretKey = RUSTFS_SECRET_KEY)
-          RustfsAccess rustfsAccess) {
+      @Rustfs(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) RustfsAccess rustfsAccess) {
     storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
     endpoint = rustfsAccess.s3endpoint();
   }
@@ -75,8 +63,8 @@ public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBas
     return super.clientFileIOProperties()
         .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
         .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
-        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), RUSTFS_ACCESS_KEY)
-        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), RUSTFS_SECRET_KEY);
+        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), ACCESS_KEY)
+        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), SECRET_KEY);
   }
 
   @Override
@@ -96,8 +84,8 @@ public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBas
     return ImmutableMap.<String, String>builder()
         .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
         .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
-        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), RUSTFS_ACCESS_KEY)
-        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), RUSTFS_SECRET_KEY)
+        .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), ACCESS_KEY)
+        .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), SECRET_KEY)
         .build();
   }
 }

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -30,12 +30,13 @@ import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_KEY_ID;
 import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_SECRET_KEY;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
+import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
+import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +73,7 @@ import org.apache.polaris.service.it.env.ManagementApi;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.polaris.service.it.env.PolarisClient;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
+import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.minio.Minio;
 import org.apache.polaris.test.minio.MinioAccess;
 import org.apache.polaris.test.minio.MinioExtension;
@@ -95,29 +97,15 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
  * some S3-specific options.
  */
 @QuarkusIntegrationTest
-@TestProfile(RestCatalogMinIOSpecialIT.Profile.class)
+@TestProfile(MinioRustProfile.class)
 @ExtendWith(MinioExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class RestCatalogMinIOSpecialIT {
 
   private static final String BUCKET_URI_PREFIX = "/minio-test";
-  private static final String MINIO_ACCESS_KEY = "test-ak-123";
-  private static final String MINIO_SECRET_KEY = "test-sk-123";
   private static final String TEST_REGION = "us-west-2";
   private static final String TEST_ROLE_ARN = "arn:aws:iam::000000000000:role/polaris-access-role";
   private static String adminToken;
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .put("polaris.storage.aws.access-key", MINIO_ACCESS_KEY)
-          .put("polaris.storage.aws.secret-key", MINIO_SECRET_KEY)
-          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
-          .build();
-    }
-  }
 
   private static final Schema SCHEMA =
       new Schema(
@@ -139,7 +127,7 @@ public class RestCatalogMinIOSpecialIT {
   @BeforeAll
   static void setup(
       PolarisApiEndpoints apiEndpoints,
-      @Minio(accessKey = MINIO_ACCESS_KEY, secretKey = MINIO_SECRET_KEY) MinioAccess minioAccess,
+      @Minio(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) MinioAccess minioAccess,
       ClientCredentials credentials) {
     s3Client = minioAccess.s3Client();
     endpoints = apiEndpoints;
@@ -231,10 +219,8 @@ public class RestCatalogMinIOSpecialIT {
     CatalogProperties.Builder catalogProps =
         CatalogProperties.builder(storageBase.toASCIIString() + "/" + catalogName);
     if (!stsEnabled) {
-      catalogProps.addProperty(
-          TABLE_DEFAULT_PREFIX + AWS_KEY_ID.getPropertyName(), MINIO_ACCESS_KEY);
-      catalogProps.addProperty(
-          TABLE_DEFAULT_PREFIX + AWS_SECRET_KEY.getPropertyName(), MINIO_SECRET_KEY);
+      catalogProps.addProperty(TABLE_DEFAULT_PREFIX + AWS_KEY_ID.getPropertyName(), ACCESS_KEY);
+      catalogProps.addProperty(TABLE_DEFAULT_PREFIX + AWS_SECRET_KEY.getPropertyName(), SECRET_KEY);
     }
     Catalog catalog =
         PolarisCatalog.builder()
@@ -262,8 +248,8 @@ public class RestCatalogMinIOSpecialIT {
 
     if (delegationMode.isEmpty()) {
       // Use local credentials on the client side
-      propertiesBuilder.put("s3.access-key-id", MINIO_ACCESS_KEY);
-      propertiesBuilder.put("s3.secret-access-key", MINIO_SECRET_KEY);
+      propertiesBuilder.put("s3.access-key-id", ACCESS_KEY);
+      propertiesBuilder.put("s3.secret-access-key", SECRET_KEY);
     }
 
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
@@ -30,12 +30,13 @@ import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_KEY_ID;
 import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_SECRET_KEY;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
+import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
+import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +73,7 @@ import org.apache.polaris.service.it.env.ManagementApi;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.polaris.service.it.env.PolarisClient;
 import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
+import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.rustfs.Rustfs;
 import org.apache.polaris.test.rustfs.RustfsAccess;
 import org.apache.polaris.test.rustfs.RustfsExtension;
@@ -95,29 +97,15 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
  * with some S3-specific options.
  */
 @QuarkusIntegrationTest
-@TestProfile(RestCatalogRustFSSpecialIT.Profile.class)
+@TestProfile(MinioRustProfile.class)
 @ExtendWith(RustfsExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class RestCatalogRustFSSpecialIT {
 
   private static final String BUCKET_URI_PREFIX = "/rustfs-test";
-  private static final String RUSTFS_ACCESS_KEY = "test-ak-123";
-  private static final String RUSTFS_SECRET_KEY = "test-sk-123";
   private static final String TEST_REGION = "us-west-2";
   private static final String TEST_ROLE_ARN = "arn:aws:iam::000000000000:role/polaris-access-role";
   private static String adminToken;
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .put("polaris.storage.aws.access-key", RUSTFS_ACCESS_KEY)
-          .put("polaris.storage.aws.secret-key", RUSTFS_SECRET_KEY)
-          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
-          .build();
-    }
-  }
 
   private static final Schema SCHEMA =
       new Schema(
@@ -139,8 +127,7 @@ public class RestCatalogRustFSSpecialIT {
   @BeforeAll
   static void setup(
       PolarisApiEndpoints apiEndpoints,
-      @Rustfs(accessKey = RUSTFS_ACCESS_KEY, secretKey = RUSTFS_SECRET_KEY)
-          RustfsAccess rustfsAccess,
+      @Rustfs(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) RustfsAccess rustfsAccess,
       ClientCredentials credentials) {
     s3Client = rustfsAccess.s3Client();
     endpoints = apiEndpoints;
@@ -232,10 +219,8 @@ public class RestCatalogRustFSSpecialIT {
     CatalogProperties.Builder catalogProps =
         CatalogProperties.builder(storageBase.toASCIIString() + "/" + catalogName);
     if (!stsEnabled) {
-      catalogProps.addProperty(
-          TABLE_DEFAULT_PREFIX + AWS_KEY_ID.getPropertyName(), RUSTFS_ACCESS_KEY);
-      catalogProps.addProperty(
-          TABLE_DEFAULT_PREFIX + AWS_SECRET_KEY.getPropertyName(), RUSTFS_SECRET_KEY);
+      catalogProps.addProperty(TABLE_DEFAULT_PREFIX + AWS_KEY_ID.getPropertyName(), ACCESS_KEY);
+      catalogProps.addProperty(TABLE_DEFAULT_PREFIX + AWS_SECRET_KEY.getPropertyName(), SECRET_KEY);
     }
     Catalog catalog =
         PolarisCatalog.builder()
@@ -263,8 +248,8 @@ public class RestCatalogRustFSSpecialIT {
 
     if (delegationMode.isEmpty()) {
       // Use local credentials on the client side
-      propertiesBuilder.put("s3.access-key-id", RUSTFS_ACCESS_KEY);
-      propertiesBuilder.put("s3.secret-access-key", RUSTFS_SECRET_KEY);
+      propertiesBuilder.put("s3.access-key-id", ACCESS_KEY);
+      propertiesBuilder.put("s3.secret-access-key", SECRET_KEY);
     }
 
     restCatalog.initialize("polaris", propertiesBuilder.buildKeepingLast());

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/nosql/NoSqlApplicationIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/nosql/NoSqlApplicationIT.java
@@ -21,7 +21,8 @@ package org.apache.polaris.service.it.nosql;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 import org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest;
+import org.apache.polaris.test.commons.NoSqlInMemoryProfile;
 
 @QuarkusIntegrationTest
-@TestProfile(value = NoSqlTesting.PersistenceInMemoryProfile.class)
+@TestProfile(value = NoSqlInMemoryProfile.class)
 public class NoSqlApplicationIT extends PolarisApplicationIntegrationTest {}

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/nosql/NoSqlCatalogIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/nosql/NoSqlCatalogIT.java
@@ -18,24 +18,11 @@
  */
 package org.apache.polaris.service.it.nosql;
 
-import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import java.util.Map;
 import org.apache.polaris.service.it.PolarisRestCatalogRustFSIT;
+import org.apache.polaris.test.commons.NoSqlInMemoryProfile;
 
 @QuarkusIntegrationTest
-@TestProfile(value = NoSqlCatalogIT.Profile.class)
-public class NoSqlCatalogIT extends PolarisRestCatalogRustFSIT {
-  public static class Profile extends NoSqlTesting.PersistenceInMemoryProfile {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(super.getConfigOverrides())
-          .put("polaris.storage.aws.access-key", RUSTFS_ACCESS_KEY)
-          .put("polaris.storage.aws.secret-key", RUSTFS_SECRET_KEY)
-          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
-          .build();
-    }
-  }
-}
+@TestProfile(value = NoSqlInMemoryProfile.class)
+public class NoSqlCatalogIT extends PolarisRestCatalogRustFSIT {}

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/MinioRustProfile.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/MinioRustProfile.java
@@ -16,13 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.it.nosql;
 
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
-import org.apache.polaris.test.commons.NoSqlInMemoryProfile;
+package org.apache.polaris.test.commons;
 
-@QuarkusIntegrationTest
-@TestProfile(value = NoSqlInMemoryProfile.class)
-public class NoSqlManagementServiceIT extends PolarisManagementServiceIntegrationTest {}
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class MinioRustProfile implements QuarkusTestProfile {
+  public static final String SECRET_KEY = "test-sk-123";
+  public static final String ACCESS_KEY = "test-ak-123";
+  public static final Map<String, String> CONFIG_OVERRIDES =
+      ImmutableMap.<String, String>builder()
+          .put("polaris.storage.aws.access-key", ACCESS_KEY)
+          .put("polaris.storage.aws.secret-key", SECRET_KEY)
+          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "false")
+          .build();
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return CONFIG_OVERRIDES;
+  }
+}

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/NoSqlInMemoryProfile.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/NoSqlInMemoryProfile.java
@@ -16,24 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.it.nosql;
 
+package org.apache.polaris.test.commons;
+
+import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.Map;
 
-public final class NoSqlTesting {
-  private NoSqlTesting() {}
-
-  public static class PersistenceInMemoryProfile implements QuarkusTestProfile {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
+public class NoSqlInMemoryProfile implements QuarkusTestProfile {
+  public static final Map<String, String> NOSQL_PERSISTENCE =
+      Map.of(
           "polaris.persistence.type",
           "nosql",
           "polaris.persistence.nosql.backend",
           "InMemory",
           "polaris.persistence.auto-bootstrap-types",
           "nosql");
-    }
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return ImmutableMap.<String, String>builder()
+        .putAll(NOSQL_PERSISTENCE)
+        .putAll(MinioRustProfile.CONFIG_OVERRIDES)
+        .build();
   }
 }


### PR DESCRIPTION
Consolidates various quarkus test profiles into unique `QuarkusTestProfile` implementations.