### PR TITLE
Remove createTableDirectWithWriteDelegation method

### DIFF
--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/NoSqlCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/NoSqlCommand.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.admintool.nosql;
 
-import jakarta.inject.Inject;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceInfoCommand;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceLogCommand;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceRunCommand;
-import org.apache.polaris.persistence.nosql.api.backend.Backend;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -35,8 +33,6 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     description = "Sub-commands specific to NoSQL persistence.")
 public class NoSqlCommand extends BaseNoSqlCommand {
-  @Inject protected Backend backend;
-
   @Override
   public Integer call() {
     printNoSqlInfo();

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -427,21 +427,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
         namespace, request, EnumSet.noneOf(AccessDelegationMode.class), Optional.empty());
   }
 
-  /**
-   * Create a table.
-   *
-   * @param namespace the namespace to create the table in
-   * @param request the table creation request
-   * @return ETagged {@link LoadTableResponse} to uniquely identify the table metadata
-   */
-  public LoadTableResponse createTableDirectWithWriteDelegation(
-      Namespace namespace,
-      CreateTableRequest request,
-      Optional<String> refreshCredentialsEndpoint) {
-    return createTableDirect(
-        namespace, request, EnumSet.of(VENDED_CREDENTIALS), refreshCredentialsEndpoint);
-  }
-
   public void authorizeCreateTableDirect(
       Namespace namespace, CreateTableRequest request, boolean delegationRequested) {
     if (delegationRequested) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
+
 import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;
 import java.time.Instant;
@@ -469,8 +471,11 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         .action(
             () ->
                 newHandler(Set.of(PRINCIPAL_ROLE1))
-                    .createTableDirectWithWriteDelegation(
-                        NS2, createDirectWithWriteDelegationRequest, Optional.empty()))
+                    .createTableDirect(
+                        NS2,
+                        createDirectWithWriteDelegationRequest,
+                        EnumSet.of(VENDED_CREDENTIALS),
+                        Optional.empty()))
         .cleanupAction(() -> newHandler(Set.of(PRINCIPAL_ROLE2)).dropTableWithPurge(newtable))
         .shouldPassWith(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_DATA)
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_CONTENT)


### PR DESCRIPTION
Remove `createTableDirectWithWriteDelegation` method as it it is used only from test code. Also, cleanup redundant `@Inject protected Backend backend` from `NoSqlCommand` (`BaseNoSqlCommand` already has this protected field)

Fixes #4709

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
