### PR TITLE
Remove duplicated backend field from NoSqlCommand

### DIFF
--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/NoSqlCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/nosql/NoSqlCommand.java
@@ -18,11 +18,9 @@
  */
 package org.apache.polaris.admintool.nosql;
 
-import jakarta.inject.Inject;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceInfoCommand;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceLogCommand;
 import org.apache.polaris.admintool.nosql.maintenance.NoSqlMaintenanceRunCommand;
-import org.apache.polaris.persistence.nosql.api.backend.Backend;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -35,8 +33,6 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     description = "Sub-commands specific to NoSQL persistence.")
 public class NoSqlCommand extends BaseNoSqlCommand {
-  @Inject protected Backend backend;
-
   @Override
   public Integer call() {
     printNoSqlInfo();


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The dependency `@Inject protected Backend backend` is already inherited from base class.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
