### PR TITLE
Rename the PolarisEvent entity class to EventEntity

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -42,7 +43,6 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PolarisPrivilege;
@@ -687,7 +687,7 @@ record NoSqlMetaStoreManager(
 
   @Override
   public void writeEvents(
-      @NonNull PolarisCallContext callCtx, @NonNull List<PolarisEvent> polarisEvents) {
+      @NonNull PolarisCallContext callCtx, @NonNull List<EventEntity> polarisEvents) {
     throw new UnsupportedOperationException("Events not supported in NoSQL persistence");
   }
 }

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NonFunctionalBasePersistence.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NonFunctionalBasePersistence.java
@@ -24,13 +24,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.BasePersistence;
@@ -329,7 +329,7 @@ abstract class NonFunctionalBasePersistence implements BasePersistence, Integrat
   }
 
   @Override
-  public void writeEvents(@NonNull List<PolarisEvent> events) {
+  public void writeEvents(@NonNull List<EventEntity> events) {
     throw unimplemented();
   }
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
@@ -47,7 +48,6 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisEntityUtils;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.exceptions.AlreadyExistsException;
@@ -277,7 +277,7 @@ public class JdbcBasePersistenceImpl
   }
 
   @Override
-  public void writeEvents(@NonNull List<PolarisEvent> events) {
+  public void writeEvents(@NonNull List<EventEntity> events) {
     if (events.isEmpty()) {
       return; // or throw if empty list is invalid
     }
@@ -301,7 +301,7 @@ public class JdbcBasePersistenceImpl
 
       // Process remaining events and verify SQL consistency
       for (int i = 1; i < events.size(); i++) {
-        PolarisEvent event = events.get(i);
+        EventEntity event = events.get(i);
         PreparedQuery pq =
             QueryGenerator.generateInsertQuery(
                 ModelEvent.ALL_COLUMNS,

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEvent.java
@@ -24,13 +24,13 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 import org.jspecify.annotations.Nullable;
 
 @PolarisImmutable
-public interface ModelEvent extends Converter<PolarisEvent> {
+public interface ModelEvent extends Converter<EventEntity> {
   String TABLE_NAME = "EVENTS";
 
   String CATALOG_ID = "catalog_id";
@@ -68,7 +68,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
           .eventType("")
           .timestampMs(0L)
           .principalName("")
-          .resourceType(PolarisEvent.ResourceType.CATALOG)
+          .resourceType(EventEntity.ResourceType.CATALOG)
           .resourceIdentifier("")
           .additionalProperties("")
           .build();
@@ -92,7 +92,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   @Nullable String getPrincipalName();
 
   // Enum that states the type of resource was being operated on
-  PolarisEvent.ResourceType getResourceType();
+  EventEntity.ResourceType getResourceType();
 
   // Which resource was operated on
   String getResourceIdentifier();
@@ -101,7 +101,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
   String getAdditionalProperties();
 
   @Override
-  default PolarisEvent fromResultSet(ResultSet rs) throws SQLException {
+  default EventEntity fromResultSet(ResultSet rs) throws SQLException {
     var modelEvent =
         ImmutableModelEvent.builder()
             .catalogId(rs.getString(CATALOG_ID))
@@ -110,7 +110,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
             .eventType(rs.getString(EVENT_TYPE))
             .timestampMs(rs.getLong(TIMESTAMP_MS))
             .principalName(rs.getString(PRINCIPAL_NAME))
-            .resourceType(PolarisEvent.ResourceType.valueOf(rs.getString(RESOURCE_TYPE)))
+            .resourceType(EventEntity.ResourceType.valueOf(rs.getString(RESOURCE_TYPE)))
             .resourceIdentifier(rs.getString(RESOURCE_IDENTIFIER))
             .additionalProperties(rs.getString(ADDITIONAL_PROPERTIES))
             .build();
@@ -136,7 +136,7 @@ public interface ModelEvent extends Converter<PolarisEvent> {
     return map;
   }
 
-  static ModelEvent fromEvent(PolarisEvent event) {
+  static ModelEvent fromEvent(EventEntity event) {
     if (event == null) return null;
 
     return ImmutableModelEvent.builder()
@@ -152,11 +152,11 @@ public interface ModelEvent extends Converter<PolarisEvent> {
         .build();
   }
 
-  static PolarisEvent toEvent(ModelEvent model) {
+  static EventEntity toEvent(ModelEvent model) {
     if (model == null) return null;
 
-    PolarisEvent polarisEvent =
-        new PolarisEvent(
+    EventEntity polarisEvent =
+        new EventEntity(
             model.getCatalogId(),
             model.getEventId(),
             model.getRequestId(),

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.Operation;
 import org.apache.polaris.persistence.relational.jdbc.models.ImmutableModelEvent;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
@@ -108,7 +108,7 @@ public class DatasourceOperationsTest {
     for (int i = 0; i < 1000; i++) {
       ModelEvent modelEvent =
           ImmutableModelEvent.builder()
-              .resourceType(PolarisEvent.ResourceType.CATALOG)
+              .resourceType(EventEntity.ResourceType.CATALOG)
               .resourceIdentifier("catalog_" + i)
               .catalogId("catalog_" + i)
               .eventId("event_" + i)

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEventTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/models/ModelEventTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 import org.junit.jupiter.api.Test;
 import org.postgresql.util.PGobject;
@@ -49,8 +49,7 @@ public class ModelEventTest {
   private static final String TEST_EVENT_TYPE = "CREATE";
   private static final long TEST_TIMESTAMP_MS = 1234567890L;
   private static final String TEST_USER = "test-user";
-  private static final PolarisEvent.ResourceType TEST_RESOURCE_TYPE =
-      PolarisEvent.ResourceType.TABLE;
+  private static final EventEntity.ResourceType TEST_RESOURCE_TYPE = EventEntity.ResourceType.TABLE;
   private static final String TEST_RESOURCE_TYPE_STRING = "TABLE";
   private static final String TEST_RESOURCE_IDENTIFIER = "test-table";
   private static final String EMPTY_JSON = "{}";
@@ -71,7 +70,7 @@ public class ModelEventTest {
     when(mockResultSet.getString(ADDITIONAL_PROPERTIES)).thenReturn(EMPTY_JSON);
 
     // Act
-    PolarisEvent result = ModelEvent.CONVERTER.fromResultSet(mockResultSet);
+    EventEntity result = ModelEvent.CONVERTER.fromResultSet(mockResultSet);
 
     // Assert
     assertEquals(TEST_CATALOG_ID, result.getCatalogId());
@@ -163,8 +162,8 @@ public class ModelEventTest {
   @Test
   public void testFromEvent() {
     // Arrange
-    PolarisEvent polarisEvent =
-        new PolarisEvent(
+    EventEntity polarisEvent =
+        new EventEntity(
             TEST_CATALOG_ID,
             TEST_EVENT_ID,
             TEST_REQUEST_ID,
@@ -207,7 +206,7 @@ public class ModelEventTest {
             .build();
 
     // Act
-    PolarisEvent result = ModelEvent.toEvent(modelEvent);
+    EventEntity result = ModelEvent.toEvent(modelEvent);
 
     // Assert
     assertEquals(TEST_CATALOG_ID, result.getCatalogId());

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/EventEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/EventEntity.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
-public class PolarisEvent {
+public class EventEntity {
   public static final String EMPTY_MAP_STRING = "{}";
 
   /**
@@ -118,7 +118,7 @@ public class PolarisEvent {
     return additionalProperties != null ? additionalProperties : EMPTY_MAP_STRING;
   }
 
-  public PolarisEvent(
+  public EventEntity(
       String catalogId,
       String id,
       @Nullable String requestId,

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEventManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEventManager.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NonNull;
 
 public interface PolarisEventManager {
   default void writeEvents(
-      @NonNull PolarisCallContext callCtx, @NonNull List<PolarisEvent> polarisEvents) {
+      @NonNull PolarisCallContext callCtx, @NonNull List<EventEntity> polarisEvents) {
     BasePersistence ms = callCtx.getMetaStore();
     ms.writeEvents(polarisEvents);
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
@@ -32,7 +33,6 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.persistence.pagination.Page;
 import org.apache.polaris.core.persistence.pagination.PageToken;
@@ -148,7 +148,7 @@ public interface BasePersistence extends PolicyMappingPersistence {
    *
    * @param events events to persist
    */
-  void writeEvents(@NonNull List<PolarisEvent> events);
+  void writeEvents(@NonNull List<EventEntity> events);
 
   /**
    * Delete this entity from the meta store.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.LocationBasedEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -32,7 +33,6 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
@@ -396,7 +396,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
 
   @Override
   public void writeEvents(
-      @NonNull PolarisCallContext callCtx, @NonNull List<PolarisEvent> polarisEvents) {
+      @NonNull PolarisCallContext callCtx, @NonNull List<EventEntity> polarisEvents) {
     throw illegalMethodError("writeEvents");
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/AbstractTransactionalPersistence.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntitiesActiveKey;
@@ -32,7 +33,6 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PolarisEvent;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
@@ -275,7 +275,7 @@ public abstract class AbstractTransactionalPersistence implements TransactionalP
   }
 
   @Override
-  public void writeEvents(@NonNull List<PolarisEvent> events) {
+  public void writeEvents(@NonNull List<EventEntity> events) {
     throw new UnsupportedOperationException("Not implemented for transactional persistence.");
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
@@ -30,7 +30,8 @@ import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.entity.PolarisEvent.ResourceType;
+import org.apache.polaris.core.entity.EventEntity;
+import org.apache.polaris.core.entity.EventEntity.ResourceType;
 import org.apache.polaris.service.events.AttributeKey;
 import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.events.EventAttributes;
@@ -47,8 +48,8 @@ public abstract class PolarisPersistenceEventListener implements PolarisEventLis
     ResourceType resourceType = resolveResourceType(event.type());
     String resourceIdentifier = resolveResourceIdentifier(event, resourceType, catalogName);
 
-    org.apache.polaris.core.entity.PolarisEvent polarisEvent =
-        new org.apache.polaris.core.entity.PolarisEvent(
+    EventEntity polarisEvent =
+        new EventEntity(
             catalogName,
             event.metadata().eventId().toString(),
             event.metadata().requestId().orElse(null),
@@ -67,10 +68,7 @@ public abstract class PolarisPersistenceEventListener implements PolarisEventLis
   }
 
   private static String resolveCatalogName(PolarisEvent event) {
-    return event
-        .attributes()
-        .get(EventAttributes.CATALOG_NAME)
-        .orElse(org.apache.polaris.core.entity.PolarisEvent.REALM_SCOPED);
+    return event.attributes().get(EventAttributes.CATALOG_NAME).orElse(EventEntity.REALM_SCOPED);
   }
 
   /**
@@ -236,7 +234,7 @@ public abstract class PolarisPersistenceEventListener implements PolarisEventLis
   }
 
   private static String fallbackResourceIdentifier(PolarisEvent event, String catalogName) {
-    if (!org.apache.polaris.core.entity.PolarisEvent.REALM_SCOPED.equals(catalogName)) {
+    if (!EventEntity.REALM_SCOPED.equals(catalogName)) {
       return catalogName;
     }
     return event.type().name();
@@ -307,6 +305,5 @@ public abstract class PolarisPersistenceEventListener implements PolarisEventLis
     return summary;
   }
 
-  protected abstract void processEvent(
-      String realmId, org.apache.polaris.core.entity.PolarisEvent event);
+  protected abstract void processEvent(String realmId, EventEntity event);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListener.java
@@ -36,7 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.RealmContext;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.service.events.listeners.PolarisPersistenceEventListener;
 import org.eclipse.microprofile.faulttolerance.Fallback;
@@ -68,7 +68,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
    */
   protected final class EventProcessor {
 
-    @VisibleForTesting final UnicastProcessor<PolarisEvent> processor;
+    @VisibleForTesting final UnicastProcessor<EventEntity> processor;
     private final ReentrantLock lock = new ReentrantLock();
     private boolean completed = false; // guarded by lock
 
@@ -83,7 +83,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
           .with(events -> flush(realmId, events), error -> onProcessorError(realmId, error));
     }
 
-    void onNext(PolarisEvent event) {
+    void onNext(EventEntity event) {
       lock.lock();
       try {
         if (completed) {
@@ -131,7 +131,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
   private boolean shutdown = false; // guarded by shutdownLock
 
   @Override
-  protected void processEvent(String realmId, PolarisEvent event) {
+  protected void processEvent(String realmId, EventEntity event) {
     shutdownLock.readLock().lock();
     try {
       if (shutdown) {
@@ -164,7 +164,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
 
   @Retry(maxRetries = 5, delay = 1000, jitter = 100)
   @Fallback(fallbackMethod = "onFlushError")
-  protected void flush(String realmId, List<PolarisEvent> events) {
+  protected void flush(String realmId, List<EventEntity> events) {
     RealmContext realmContext = () -> realmId;
     var metaStoreManager = metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
     var basePersistence = metaStoreManagerFactory.getOrCreateSession(realmContext);
@@ -174,7 +174,7 @@ public class InMemoryBufferEventListener extends PolarisPersistenceEventListener
   }
 
   @SuppressWarnings("unused")
-  protected void onFlushError(String realmId, List<PolarisEvent> events, Throwable error) {
+  protected void onFlushError(String realmId, List<EventEntity> events, Throwable error) {
     LOGGER.error("Failed to persist {} events for realm '{}'", events.size(), realmId, error);
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListenerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListenerTest.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.service.events.DefaultEventSanitizer;
 import org.apache.polaris.service.events.EventAttributeMap;
 import org.apache.polaris.service.events.EventAttributes;
@@ -102,12 +103,11 @@ class PolarisPersistenceEventListenerTest {
     assertThat(listener.persistedEventsByType()).hasSize(TABLE_EVENT_TYPES.size());
 
     for (PolarisEventType eventType : TABLE_EVENT_TYPES) {
-      org.apache.polaris.core.entity.PolarisEvent persisted = listener.persistedEvent(eventType);
+      EventEntity persisted = listener.persistedEvent(eventType);
       assertThat(listener.persistedRealm(eventType)).isEqualTo(REALM_ID);
       assertThat(persisted.getCatalogId()).isEqualTo(CATALOG_NAME);
       assertThat(persisted.getEventType()).isEqualTo(eventType.name());
-      assertThat(persisted.getResourceType())
-          .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.TABLE);
+      assertThat(persisted.getResourceType()).isEqualTo(EventEntity.ResourceType.TABLE);
       assertThat(persisted.getResourceIdentifier())
           .isEqualTo(expectedResourceIdentifier(eventType));
     }
@@ -173,12 +173,10 @@ class PolarisPersistenceEventListenerTest {
             metadata(),
             new EventAttributeMap().put(EventAttributes.CATALOG_NAME, CATALOG_NAME)));
 
-    org.apache.polaris.core.entity.PolarisEvent persisted =
-        listener.persistedEvent(PolarisEventType.AFTER_CREATE_CATALOG);
+    EventEntity persisted = listener.persistedEvent(PolarisEventType.AFTER_CREATE_CATALOG);
     assertThat(listener.persistedRealm(PolarisEventType.AFTER_CREATE_CATALOG)).isEqualTo(REALM_ID);
     assertThat(persisted.getCatalogId()).isEqualTo(CATALOG_NAME);
-    assertThat(persisted.getResourceType())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.CATALOG);
+    assertThat(persisted.getResourceType()).isEqualTo(EventEntity.ResourceType.CATALOG);
     assertThat(persisted.getResourceIdentifier()).isEqualTo(CATALOG_NAME);
     assertThat(additionalProperties(persisted))
         .containsEntry(EventAttributes.CATALOG_NAME.name(), CATALOG_NAME);
@@ -192,12 +190,9 @@ class PolarisPersistenceEventListenerTest {
         new PolarisEvent(
             PolarisEventType.BEFORE_LIMIT_REQUEST_RATE, metadata(), new EventAttributeMap()));
 
-    org.apache.polaris.core.entity.PolarisEvent persisted =
-        listener.persistedEvent(PolarisEventType.BEFORE_LIMIT_REQUEST_RATE);
-    assertThat(persisted.getCatalogId())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.REALM_SCOPED);
-    assertThat(persisted.getResourceType())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.REALM);
+    EventEntity persisted = listener.persistedEvent(PolarisEventType.BEFORE_LIMIT_REQUEST_RATE);
+    assertThat(persisted.getCatalogId()).isEqualTo(EventEntity.REALM_SCOPED);
+    assertThat(persisted.getResourceType()).isEqualTo(EventEntity.ResourceType.REALM);
     assertThat(persisted.getResourceIdentifier())
         .isEqualTo(PolarisEventType.BEFORE_LIMIT_REQUEST_RATE.name());
     assertThat(additionalProperties(persisted)).isEmpty();
@@ -207,7 +202,7 @@ class PolarisPersistenceEventListenerTest {
   void shouldPersistRequestUserAndTimestampMetadataFields() {
     CapturingPersistenceListener listener = new CapturingPersistenceListener();
     Instant timestamp = Instant.parse("2024-01-02T03:04:05Z");
-    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), java.util.Set.of("role1"));
+    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("role1"));
     PolarisEventMetadata metadata =
         PolarisEventMetadata.builder()
             .realmId(REALM_ID)
@@ -218,8 +213,7 @@ class PolarisPersistenceEventListenerTest {
 
     listener.onEvent(beforeListTablesEvent(metadata));
 
-    org.apache.polaris.core.entity.PolarisEvent persisted =
-        listener.persistedEvent(PolarisEventType.BEFORE_LIST_TABLES);
+    EventEntity persisted = listener.persistedEvent(PolarisEventType.BEFORE_LIST_TABLES);
     assertThat(persisted.getRequestId()).isEqualTo("request-123");
     assertThat(persisted.getPrincipalName()).isEqualTo("alice");
     assertThat(persisted.getTimestampMs()).isEqualTo(timestamp.toEpochMilli());
@@ -230,8 +224,7 @@ class PolarisPersistenceEventListenerTest {
     PolarisPersistenceEventListener listener =
         new PolarisPersistenceEventListener() {
           @Override
-          protected void processEvent(
-              String realmId, org.apache.polaris.core.entity.PolarisEvent event) {
+          protected void processEvent(String realmId, EventEntity event) {
             throw new IllegalStateException("persist failure");
           }
         };
@@ -303,16 +296,12 @@ class PolarisPersistenceEventListenerTest {
                         .withDestination(viewDest)
                         .build())));
 
-    org.apache.polaris.core.entity.PolarisEvent beforeEvent =
-        listener.persistedEvent(PolarisEventType.BEFORE_RENAME_VIEW);
-    assertThat(beforeEvent.getResourceType())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.VIEW);
+    EventEntity beforeEvent = listener.persistedEvent(PolarisEventType.BEFORE_RENAME_VIEW);
+    assertThat(beforeEvent.getResourceType()).isEqualTo(EventEntity.ResourceType.VIEW);
     assertThat(beforeEvent.getResourceIdentifier()).isEqualTo(viewSource.toString());
 
-    org.apache.polaris.core.entity.PolarisEvent afterEvent =
-        listener.persistedEvent(PolarisEventType.AFTER_RENAME_VIEW);
-    assertThat(afterEvent.getResourceType())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.VIEW);
+    EventEntity afterEvent = listener.persistedEvent(PolarisEventType.AFTER_RENAME_VIEW);
+    assertThat(afterEvent.getResourceType()).isEqualTo(EventEntity.ResourceType.VIEW);
     assertThat(afterEvent.getResourceIdentifier()).isEqualTo(viewDest.toString());
   }
 
@@ -329,10 +318,8 @@ class PolarisPersistenceEventListenerTest {
                 .put(EventAttributes.NAMESPACE, NAMESPACE)
                 .put(EventAttributes.TABLE_NAME, "generic_tbl")));
 
-    org.apache.polaris.core.entity.PolarisEvent persisted =
-        listener.persistedEvent(PolarisEventType.AFTER_CREATE_GENERIC_TABLE);
-    assertThat(persisted.getResourceType())
-        .isEqualTo(org.apache.polaris.core.entity.PolarisEvent.ResourceType.TABLE);
+    EventEntity persisted = listener.persistedEvent(PolarisEventType.AFTER_CREATE_GENERIC_TABLE);
+    assertThat(persisted.getResourceType()).isEqualTo(EventEntity.ResourceType.TABLE);
     assertThat(persisted.getResourceIdentifier())
         .isEqualTo(TableIdentifier.of(NAMESPACE, "generic_tbl").toString());
   }
@@ -449,14 +436,12 @@ class PolarisPersistenceEventListenerTest {
     };
   }
 
-  private static Map<String, String> additionalProperties(
-      org.apache.polaris.core.entity.PolarisEvent event) {
+  private static Map<String, String> additionalProperties(EventEntity event) {
     return event.getAdditionalPropertiesAsMap();
   }
 
   private static final class CapturingPersistenceListener extends PolarisPersistenceEventListener {
-    private final Map<PolarisEventType, org.apache.polaris.core.entity.PolarisEvent>
-        persistedEventsByType = new LinkedHashMap<>();
+    private final Map<PolarisEventType, EventEntity> persistedEventsByType = new LinkedHashMap<>();
     private final Map<PolarisEventType, String> persistedRealmsByType = new LinkedHashMap<>();
 
     private CapturingPersistenceListener() {
@@ -464,17 +449,17 @@ class PolarisPersistenceEventListenerTest {
     }
 
     @Override
-    protected void processEvent(String realmId, org.apache.polaris.core.entity.PolarisEvent event) {
+    protected void processEvent(String realmId, EventEntity event) {
       PolarisEventType eventType = PolarisEventType.valueOf(event.getEventType());
       persistedEventsByType.put(eventType, event);
       persistedRealmsByType.put(eventType, realmId);
     }
 
-    Map<PolarisEventType, org.apache.polaris.core.entity.PolarisEvent> persistedEventsByType() {
+    Map<PolarisEventType, EventEntity> persistedEventsByType() {
       return persistedEventsByType;
     }
 
-    org.apache.polaris.core.entity.PolarisEvent persistedEvent(PolarisEventType eventType) {
+    EventEntity persistedEvent(PolarisEventType eventType) {
       return persistedEventsByType.get(eventType);
     }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerIntegrationTest.java
@@ -57,7 +57,7 @@ import org.apache.polaris.core.admin.model.CatalogProperties;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.service.it.env.ClientPrincipal;
 import org.apache.polaris.service.it.env.IntegrationTestsHelper;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
@@ -174,17 +174,17 @@ class InMemoryBufferEventListenerIntegrationTest {
             + realm
             + "' ORDER BY timestamp_ms";
 
-    List<PolarisEvent> events =
+    List<EventEntity> events =
         await()
             .atMost(Duration.ofSeconds(10))
             .until(
                 () -> {
-                  ImmutableList.Builder<PolarisEvent> e = ImmutableList.builder();
+                  ImmutableList.Builder<EventEntity> e = ImmutableList.builder();
                   try (Connection connection = dataSource.get().getConnection();
                       Statement statement = connection.createStatement();
                       ResultSet rs = statement.executeQuery(query)) {
                     while (rs.next()) {
-                      PolarisEvent event = CONVERTER.fromResultSet(rs);
+                      EventEntity event = CONVERTER.fromResultSet(rs);
                       e.add(event);
                     }
                   }
@@ -192,13 +192,13 @@ class InMemoryBufferEventListenerIntegrationTest {
                 },
                 e -> e.size() >= 2);
 
-    PolarisEvent e1 =
+    EventEntity e1 =
         events.stream()
             .filter(e -> e.getEventType().equals("AFTER_CREATE_CATALOG"))
             .findFirst()
             .orElseThrow();
     assertThat(e1.getCatalogId()).isEqualTo(catalogName);
-    assertThat(e1.getResourceType()).isEqualTo(PolarisEvent.ResourceType.CATALOG);
+    assertThat(e1.getResourceType()).isEqualTo(EventEntity.ResourceType.CATALOG);
     assertThat(e1.getResourceIdentifier()).isEqualTo(catalogName);
     assertThat(e1.getEventType()).isEqualTo("AFTER_CREATE_CATALOG");
     assertThat(e1.getPrincipalName()).isEqualTo("root");
@@ -209,13 +209,13 @@ class InMemoryBufferEventListenerIntegrationTest {
         .hasEntrySatisfying("otel.trace_id", value -> assertThat(value).matches("[0-9a-f]{32}"))
         .hasEntrySatisfying("otel.span_id", value -> assertThat(value).matches("[0-9a-f]{16}"));
 
-    PolarisEvent e2 =
+    EventEntity e2 =
         events.stream()
             .filter(e -> e.getEventType().equals("AFTER_CREATE_TABLE"))
             .findFirst()
             .orElseThrow();
     assertThat(e2.getCatalogId()).isEqualTo(catalogName);
-    assertThat(e2.getResourceType()).isEqualTo(PolarisEvent.ResourceType.TABLE);
+    assertThat(e2.getResourceType()).isEqualTo(EventEntity.ResourceType.TABLE);
     assertThat(e2.getResourceIdentifier()).isEqualTo("db1.t1");
     assertThat(e2.getEventType()).isEqualTo("AFTER_CREATE_TABLE");
     assertThat(e2.getPrincipalName()).isEqualTo("root");

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerTestBase.java
@@ -19,7 +19,7 @@
 
 package org.apache.polaris.service.events.listeners.inmemory;
 
-import static org.apache.polaris.core.entity.PolarisEvent.ResourceType.CATALOG;
+import static org.apache.polaris.core.entity.EventEntity.ResourceType.CATALOG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.reset;
@@ -38,7 +38,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import javax.sql.DataSource;
-import org.apache.polaris.core.entity.PolarisEvent;
+import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,8 +118,8 @@ abstract class InMemoryBufferEventListenerTestBase {
             });
   }
 
-  static PolarisEvent event() {
+  static EventEntity event() {
     String id = UUID.randomUUID().toString();
-    return new PolarisEvent("test", id, null, "test", 0, null, CATALOG, "test");
+    return new EventEntity("test", id, null, "test", 0, null, CATALOG, "test");
   }
 }


### PR DESCRIPTION
The `org.apache.polaris.core.entity.PolarisEvent` class has a confusing name since it clashes with `org.apache.polaris.service.events.PolarisEvent` and does not bear the `Entity` suffix that other entity classes sport. This change fixes that.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
