### PR TITLE
Refactor repeated PRINCIPAL_ROLE string literals into shared constants

### DIFF
--- a/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaIntegrationTestBase.java
+++ b/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaIntegrationTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.extension.auth.opa.test;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.polaris.core.auth.PolarisAuthConstants.PRINCIPAL_ROLE_ALL;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -60,7 +61,7 @@ public abstract class OpaIntegrationTestBase {
             .formParam("grant_type", "client_credentials")
             .formParam("client_id", "test-admin")
             .formParam("client_secret", "test-secret")
-            .formParam("scope", "PRINCIPAL_ROLE:ALL")
+            .formParam("scope", PRINCIPAL_ROLE_ALL)
             .when()
             .post("/api/catalog/v1/oauth/tokens")
             .then()
@@ -117,7 +118,7 @@ public abstract class OpaIntegrationTestBase {
             .formParam("grant_type", "client_credentials")
             .formParam("client_id", clientId)
             .formParam("client_secret", clientSecret)
-            .formParam("scope", "PRINCIPAL_ROLE:ALL")
+            .formParam("scope", PRINCIPAL_ROLE_ALL)
             .when()
             .post("/api/catalog/v1/oauth/tokens")
             .then()

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.extension.auth.ranger.test;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.polaris.core.auth.PolarisAuthConstants.PRINCIPAL_ROLE_ALL;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -58,7 +59,7 @@ public abstract class RangerIntegrationTestBase {
             .formParam("grant_type", "client_credentials")
             .formParam("client_id", "test-admin")
             .formParam("client_secret", "test-secret")
-            .formParam("scope", "PRINCIPAL_ROLE:ALL")
+            .formParam("scope", PRINCIPAL_ROLE_ALL)
             .when()
             .post("/api/catalog/v1/oauth/tokens")
             .then()
@@ -114,7 +115,7 @@ public abstract class RangerIntegrationTestBase {
             .formParam("grant_type", "client_credentials")
             .formParam("client_id", clientId)
             .formParam("client_secret", clientSecret)
-            .formParam("scope", "PRINCIPAL_ROLE:ALL")
+            .formParam("scope", PRINCIPAL_ROLE_ALL)
             .when()
             .post("/api/catalog/v1/oauth/tokens")
             .then()

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergTokenAccessManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/IcebergTokenAccessManager.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.it.env;
 
 import jakarta.ws.rs.client.Client;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.it.ext.PolarisAccessManager;
 
 /**
@@ -38,6 +39,6 @@ public class IcebergTokenAccessManager implements PolarisAccessManager {
   @Override
   public String obtainAccessToken(PolarisApiEndpoints endpoints, ClientCredentials credentials) {
     OAuth2Api api = new OAuth2Api(client, endpoints.catalogApiEndpoint(), "v1/oauth/tokens");
-    return api.obtainAccessToken(credentials, "PRINCIPAL_ROLE:ALL");
+    return api.obtainAccessToken(credentials, PolarisAuthConstants.PRINCIPAL_ROLE_ALL);
   }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/SparkSessionBuilder.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/SparkSessionBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.spark.sql.SparkSession;
 
@@ -160,7 +161,8 @@ public class SparkSessionBuilder {
             String.format("spark.sql.catalog.%s.warehouse", catalog.catalogName),
             catalog.catalogName)
         .config(
-            String.format("spark.sql.catalog.%s.scope", catalog.catalogName), "PRINCIPAL_ROLE:ALL");
+            String.format("spark.sql.catalog.%s.scope", catalog.catalogName),
+            PolarisAuthConstants.PRINCIPAL_ROLE_ALL);
 
     // Add endpoint configuration
     Preconditions.checkNotNull(catalog.endpoints, "endpoints is required");

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/CatalogFederationIntegrationTest.java
@@ -46,6 +46,7 @@ import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.admin.model.TableGrant;
 import org.apache.polaris.core.admin.model.TablePrivilege;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.it.env.CatalogApi;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.ManagementApi;
@@ -194,7 +195,7 @@ public class CatalogFederationIntegrationTest {
             .setTokenUri(endpoints.catalogApiEndpoint().toString() + "/v1/oauth/tokens")
             .setClientId(newUserCredentials.getCredentials().getClientId())
             .setClientSecret(newUserCredentials.getCredentials().getClientSecret())
-            .setScopes(List.of("PRINCIPAL_ROLE:ALL"))
+            .setScopes(List.of(PolarisAuthConstants.PRINCIPAL_ROLE_ALL))
             .build();
     ConnectionConfigInfo connectionConfig =
         IcebergRestConnectionConfigInfo.builder()

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisApplicationIntegrationTest.java
@@ -69,6 +69,7 @@ import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.PrincipalRole;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.service.it.env.ClientPrincipal;
@@ -108,7 +109,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisApplicationIntegrationTest {
 
-  public static final String PRINCIPAL_ROLE_ALL = "PRINCIPAL_ROLE:ALL";
+  public static final String PRINCIPAL_ROLE_ALL = PolarisAuthConstants.PRINCIPAL_ROLE_ALL;
 
   private static String realm;
 

--- a/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/PolarisManagementClient.java
+++ b/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/PolarisManagementClient.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.ManagementApi;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
@@ -88,7 +89,7 @@ public final class PolarisManagementClient implements AutoCloseable {
             restClient.withAuthSession(AuthSession.EMPTY),
             Map.of(),
             String.format("%s:%s", credentials.clientId(), credentials.clientSecret()),
-            "PRINCIPAL_ROLE:ALL",
+            PolarisAuthConstants.PRINCIPAL_ROLE_ALL,
             endpoints.catalogApiEndpoint() + "/v1/oauth/tokens",
             Map.of("grant_type", "client_credentials"));
     return response.token();

--- a/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkHudiIT.java
+++ b/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkHudiIT.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.it.env.IntegrationTestsHelper;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterEach;
@@ -54,7 +55,7 @@ public class SparkHudiIT extends SparkIntegrationBase {
             String.format("spark.sql.catalog.%s.uri", catalogName),
             endpoints.catalogApiEndpoint().toString())
         .config(String.format("spark.sql.catalog.%s.warehouse", catalogName), catalogName)
-        .config(String.format("spark.sql.catalog.%s.scope", catalogName), "PRINCIPAL_ROLE:ALL")
+        .config(String.format("spark.sql.catalog.%s.scope", catalogName), PolarisAuthConstants.PRINCIPAL_ROLE_ALL)
         .config(
             String.format("spark.sql.catalog.%s.header.realm", catalogName), endpoints.realmId())
         .config(String.format("spark.sql.catalog.%s.token", catalogName), sparkToken)

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthConstants.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+/** Shared constants for Polaris authentication and authorization. */
+public final class PolarisAuthConstants {
+
+  /**
+   * The prefix for role names in OAuth scopes and security identities that request activation of
+   * specific principal roles upon authentication.
+   */
+  public static final String PRINCIPAL_ROLE_PREFIX = "PRINCIPAL_ROLE:";
+
+  /**
+   * The pseudo-role that resolves to all roles the principal has been granted in the system.
+   *
+   * <p>This role is not stored in the database; it may be used in incoming credentials to request
+   * that all granted roles be activated without specifying each role individually.
+   */
+  public static final String PRINCIPAL_ROLE_ALL = PRINCIPAL_ROLE_PREFIX + "ALL";
+
+  private PolarisAuthConstants() {}
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.apache.polaris.core.admin.model.AwsIamServiceIdentityInfo;
 import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
 import org.apache.polaris.core.admin.model.ServiceIdentityInfo;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.identity.credential.AwsIamServiceIdentityCredential;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.junit.jupiter.api.Assertions;
@@ -79,7 +80,9 @@ public class ConnectionConfigInfoDpoTest {
             + "        \"encryption-key\": \"z0y9x8\""
             + "      }"
             + "    },"
-            + "    \"scopes\": [\"PRINCIPAL_ROLE:ALL\"]"
+            + "    \"scopes\": [\""
+            + PolarisAuthConstants.PRINCIPAL_ROLE_ALL
+            + "\"]"
             + "  }"
             + "}";
     ConnectionConfigInfoDpo connectionConfigInfoDpo = ConnectionConfigInfoDpo.deserialize(json);
@@ -101,7 +104,9 @@ public class ConnectionConfigInfoDpoTest {
             + "    \"authenticationType\": \"OAUTH\","
             + "    \"tokenUri\": \"https://myorg-my_account.snowflakecomputing.com/polaris/api/catalog/v1/oauth/tokens\","
             + "    \"clientId\": \"client-id\","
-            + "    \"scopes\": [\"PRINCIPAL_ROLE:ALL\"]"
+            + "    \"scopes\": [\""
+            + PolarisAuthConstants.PRINCIPAL_ROLE_ALL
+            + "\"]"
             + "  }"
             + "}";
     Assertions.assertEquals(

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -65,7 +66,7 @@ public class DefaultAuthenticator implements Authenticator {
    * credentials to explicitly indicate that the principal is requesting that all its roles be
    * activated upon authentication, without needing to specify each role individually.
    */
-  public static final String PRINCIPAL_ROLE_ALL = "PRINCIPAL_ROLE:ALL";
+  public static final String PRINCIPAL_ROLE_ALL = PolarisAuthConstants.PRINCIPAL_ROLE_ALL;
 
   /**
    * The prefix for the roles in incoming credentials that are used to indicate that the principal
@@ -78,7 +79,7 @@ public class DefaultAuthenticator implements Authenticator {
    * ignored during the authentication process. If necessary, use {@code PrincipalRolesMapper} to
    * convert roles from the identity to Polaris-specific roles.
    */
-  public static final String PRINCIPAL_ROLE_PREFIX = "PRINCIPAL_ROLE:";
+  public static final String PRINCIPAL_ROLE_PREFIX = PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticator.class);
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.auth.internal.broker;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.auth.internal.service.OAuthError;
 
 final class TokenRequestValidator {
@@ -30,7 +31,6 @@ final class TokenRequestValidator {
   static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
   static final String CLIENT_CREDENTIALS = "client_credentials";
   static final Set<String> ALLOWED_GRANT_TYPES = Set.of(CLIENT_CREDENTIALS, TOKEN_EXCHANGE);
-  static final String POLARIS_ROLE_PREFIX = "PRINCIPAL_ROLE:";
 
   /** Default constructor */
   TokenRequestValidator() {}
@@ -66,11 +66,11 @@ final class TokenRequestValidator {
     }
     String[] scopes = scope.split(" ");
     for (String s : scopes) {
-      if (!s.startsWith(POLARIS_ROLE_PREFIX)) {
+      if (!s.startsWith(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX)) {
         LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
         return Optional.of(OAuthError.invalid_scope);
       }
-      if (s.replaceFirst(POLARIS_ROLE_PREFIX, "").isEmpty()) {
+      if (s.replaceFirst(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX, "").isEmpty()) {
         LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
         return Optional.of(OAuthError.invalid_scope);
       }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -57,6 +57,7 @@ import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.secrets.UnsafeInMemorySecretsManager;
 import org.apache.polaris.service.TestServices;
+import org.apache.polaris.service.auth.DefaultAuthenticator;
 import org.apache.polaris.service.config.ReservedProperties;
 import org.apache.polaris.service.identity.provider.DefaultServiceIdentityProvider;
 import org.assertj.core.api.Assertions;
@@ -265,7 +266,7 @@ public class ManagementServiceTest {
                         AuthenticationParameters.AuthenticationTypeEnum.OAUTH)
                     .setClientId("my-client-id")
                     .setClientSecret("my-client-secret")
-                    .setScopes(List.of("PRINCIPAL_ROLE:ALL"))
+                    .setScopes(List.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL))
                     .build())
             .build();
     String catalogName = "mycatalog";
@@ -315,7 +316,7 @@ public class ManagementServiceTest {
                         AuthenticationParameters.AuthenticationTypeEnum.OAUTH)
                     .setClientId("my-client-id")
                     .setClientSecret("my-client-secret")
-                    .setScopes(List.of("PRINCIPAL_ROLE:ALL"))
+                    .setScopes(List.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL))
                     .build())
             .build();
     String catalogName = "mycatalog";

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -73,6 +73,7 @@ import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.auth.DefaultAuthenticator;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.Profiles;
 import org.apache.polaris.service.catalog.generic.PolarisGenericTableCatalog;
@@ -279,7 +280,7 @@ public abstract class PolarisAuthzTestBase {
                         AuthenticationParameters.AuthenticationTypeEnum.OAUTH)
                     .setClientId("my-client-id")
                     .setClientSecret("my-client-secret")
-                    .setScopes(List.of("PRINCIPAL_ROLE:ALL"))
+                    .setScopes(List.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL))
                     .build())
             .build();
     CatalogEntity externalCatalogEntity =

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/external/OidcTenantResolvingAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/external/OidcTenantResolvingAugmentorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.auth.external;
 
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.apache.polaris.service.auth.external.tenant.OidcTenantResolvingAugmentor.getOidcTenantConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -79,7 +80,7 @@ class OidcTenantResolvingAugmentorTest {
     SecurityIdentity identity =
         QuarkusSecurityIdentity.builder()
             .setPrincipal(oidcPrincipal)
-            .addRole("PRINCIPAL_ROLE:ALL")
+            .addRole(PRINCIPAL_ROLE_ALL)
             .build();
 
     OidcTenantConfiguration config = mock(OidcTenantConfiguration.class);
@@ -92,7 +93,7 @@ class OidcTenantResolvingAugmentorTest {
     // Then
     assertThat(result).isNotNull();
     assertThat(result.getPrincipal()).isSameAs(oidcPrincipal);
-    assertThat(result.getRoles()).containsExactlyInAnyOrder("PRINCIPAL_ROLE:ALL");
+    assertThat(result.getRoles()).containsExactlyInAnyOrder(PRINCIPAL_ROLE_ALL);
     assertThat(getOidcTenantConfig(result)).isSameAs(config);
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/external/mapping/DefaultPrincipalRolesMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/external/mapping/DefaultPrincipalRolesMapperTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.service.auth.external.tenant.OidcTenantConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +50,7 @@ class DefaultPrincipalRolesMapperTest {
     OidcTenantConfiguration.PrincipalRolesMapper.RegexMapping mapping =
         mock(OidcTenantConfiguration.PrincipalRolesMapper.RegexMapping.class);
     when(mapping.regex()).thenReturn("POLARIS_ROLE:(.*)");
-    when(mapping.replacement()).thenReturn("PRINCIPAL_ROLE:$1");
+    when(mapping.replacement()).thenReturn(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "$1");
     when(mapping.replace(any())).thenCallRealMethod();
     when(rolesMapper.mappings()).thenReturn(List.of(mapping));
     when(rolesMapper.filterPredicate()).thenCallRealMethod();
@@ -71,11 +72,16 @@ class DefaultPrincipalRolesMapperTest {
   static Stream<Arguments> mapPrincipalRoles() {
     return Stream.of(
         Arguments.of(Set.of(), Set.of()),
-        Arguments.of(Set.of("POLARIS_ROLE:role1"), Set.of("PRINCIPAL_ROLE:role1")),
+        Arguments.of(
+            Set.of("POLARIS_ROLE:role1"),
+            Set.of(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "role1")),
         Arguments.of(
             Set.of("POLARIS_ROLE:role1", "POLARIS_ROLE:role2"),
-            Set.of("PRINCIPAL_ROLE:role1", "PRINCIPAL_ROLE:role2")),
+            Set.of(
+                PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "role1",
+                PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "role2")),
         Arguments.of(
-            Set.of("POLARIS_ROLE:role1", "OTHER_ROLE:role2"), Set.of("PRINCIPAL_ROLE:role1")));
+            Set.of("POLARIS_ROLE:role1", "OTHER_ROLE:role2"),
+            Set.of(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "role1")));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
@@ -26,6 +26,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -54,12 +55,13 @@ public class JWTSymmetricKeyGeneratorTest {
         .thenReturn(Optional.of(principal));
     TokenBroker generator =
         new SymmetricKeyJWTBroker(metastoreManager, polarisCallContext, 666, () -> "polaris");
+    String scope = PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "TEST";
     TokenResponse token =
         generator.generateFromClientSecrets(
             clientId,
             mainSecret,
             TokenRequestValidator.CLIENT_CREDENTIALS,
-            "PRINCIPAL_ROLE:TEST",
+            scope,
             TokenType.ACCESS_TOKEN);
     assertThat(token).isNotNull();
 
@@ -67,7 +69,7 @@ public class JWTSymmetricKeyGeneratorTest {
     DecodedJWT decodedJWT = verifier.verify(token.getAccessToken());
     assertThat(decodedJWT).isNotNull();
     assertThat(token.getExpiresIn()).isEqualTo(666);
-    assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo("PRINCIPAL_ROLE:TEST");
+    assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo(scope);
     assertThat(decodedJWT.getClaim("client_id").asString()).isEqualTo(clientId);
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
@@ -28,6 +28,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -44,7 +45,7 @@ public class RSAKeyPairJWTBrokerTest {
 
     final long principalId = 123L;
     final String clientId = "test-client-id";
-    final String scope = "PRINCIPAL_ROLE:TEST";
+    final String scope = PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + "TEST";
 
     PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
     PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
@@ -80,7 +81,7 @@ public class RSAKeyPairJWTBrokerTest {
             .build();
     DecodedJWT decodedJWT = verifier.verify(token.getAccessToken());
     assertThat(decodedJWT).isNotNull();
-    assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo("PRINCIPAL_ROLE:TEST");
+    assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo(scope);
     assertThat(decodedJWT.getClaim("client_id").asString()).isEqualTo("test-client-id");
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidatorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.service.auth.internal.broker;
 
+import org.apache.polaris.core.auth.PolarisAuthConstants;
+import org.apache.polaris.service.auth.DefaultAuthenticator;
 import org.apache.polaris.service.auth.internal.service.OAuthError;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -69,7 +71,15 @@ public class TokenRequestValidatorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"null", "", ",", "ALL", "PRINCIPAL_ROLE:", "PRINCIPAL_ROLE"})
+  @ValueSource(
+      strings = {
+        "null",
+        "",
+        ",",
+        "ALL",
+        PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX,
+        "PRINCIPAL_ROLE"
+      })
   public void testValidateForClientCredentialsFlowInvalidScope(String scope) {
     Assertions.assertThat(
             new TokenRequestValidator()
@@ -84,7 +94,10 @@ public class TokenRequestValidatorTest {
     Assertions.assertThat(
             new TokenRequestValidator()
                 .validateForClientCredentialsFlow(
-                    "client-id", "client-secret", "client_credentials", "PRINCIPAL_ROLE:ALL"))
+                    "client-id",
+                    "client-secret",
+                    "client_credentials",
+                    DefaultAuthenticator.PRINCIPAL_ROLE_ALL))
         .isEmpty();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/context/RealmContextFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/context/RealmContextFilterTest.java
@@ -20,6 +20,7 @@
 package org.apache.polaris.service.context;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.hamcrest.CoreMatchers.is;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -104,7 +105,7 @@ class RealmContextFilterTest {
     return given()
         .contentType(ContentType.URLENC)
         .formParam("grant_type", "client_credentials")
-        .formParam("scope", "PRINCIPAL_ROLE:ALL")
+        .formParam("scope", PRINCIPAL_ROLE_ALL)
         .formParam("client_id", clientId)
         .formParam("client_secret", clientSecret);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.it;
 
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -86,7 +87,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
       var authConfig =
           AuthConfig.builder()
               .credential(credentialString)
-              .scope("PRINCIPAL_ROLE:ALL")
+              .scope(PRINCIPAL_ROLE_ALL)
               .oauth2ServerUri(path)
               .token(expiredToken)
               .build();
@@ -117,7 +118,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
                   "grant_type",
                   "client_credentials",
                   "scope",
-                  "PRINCIPAL_ROLE:ALL",
+                  PRINCIPAL_ROLE_ALL,
                   "client_id",
                   clientCredentials.clientId(),
                   "client_secret",
@@ -129,7 +130,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
       var authConfig =
           AuthConfig.builder()
               .credential(clientCredentials.clientId() + ":" + clientCredentials.clientSecret())
-              .scope("PRINCIPAL_ROLE:ALL")
+              .scope(PRINCIPAL_ROLE_ALL)
               .oauth2ServerUri(path)
               .token(token)
               .build();
@@ -158,7 +159,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
                   "grant_type",
                   "client_credentials",
                   "scope",
-                  "PRINCIPAL_ROLE:ALL",
+                  PRINCIPAL_ROLE_ALL,
                   "client_id",
                   clientCredentials.clientId(),
                   "client_secret",
@@ -176,7 +177,7 @@ public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTes
                           "grant_type",
                           "urn:ietf:params:oauth:grant-type:token-exchange",
                           "scope",
-                          "PRINCIPAL_ROLE:ALL",
+                          PRINCIPAL_ROLE_ALL,
                           "subject_token",
                           "invalid",
                           "subject_token_type",

--- a/runtime/service/src/test/java/org/apache/polaris/service/tracing/RequestIdFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/tracing/RequestIdFilterTest.java
@@ -20,6 +20,7 @@
 package org.apache.polaris.service.tracing;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -97,7 +98,7 @@ public class RequestIdFilterTest {
     return given()
         .contentType(ContentType.URLENC)
         .formParam("grant_type", "client_credentials")
-        .formParam("scope", "PRINCIPAL_ROLE:ALL")
+        .formParam("scope", PRINCIPAL_ROLE_ALL)
         .formParam("client_id", "test-admin")
         .formParam("client_secret", "test-secret");
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/tracing/RequestIdHeaderTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/tracing/RequestIdHeaderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.tracing;
 
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -75,7 +76,7 @@ public class RequestIdHeaderTest {
                           "grant_type",
                           "client_credentials",
                           "scope",
-                          "PRINCIPAL_ROLE:ALL",
+                          PRINCIPAL_ROLE_ALL,
                           "client_id",
                           CLIENT_ID,
                           "client_secret",

--- a/runtime/service/src/test/java/org/apache/polaris/service/tracing/TracingFilterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/tracing/TracingFilterTest.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.tracing;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.restassured.RestAssured.given;
+import static org.apache.polaris.service.auth.DefaultAuthenticator.PRINCIPAL_ROLE_ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -79,7 +80,7 @@ public class TracingFilterTest {
     given()
         .contentType(ContentType.URLENC)
         .formParam("grant_type", "client_credentials")
-        .formParam("scope", "PRINCIPAL_ROLE:ALL")
+        .formParam("scope", PRINCIPAL_ROLE_ALL)
         .formParam("client_id", "test-admin")
         .formParam("client_secret", "test-secret")
         // W3C headers

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakAccess.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakAccess.java
@@ -52,7 +52,7 @@ public interface KeycloakAccess {
 
   /**
    * Creates a new role in Keycloak with the specified name. The role should not have the {@code
-   * PRINCIPAL_ROLE:} prefix.
+   * PolarisAuthConstants#PRINCIPAL_ROLE_PREFIX} prefix.
    */
   void createRole(String name);
 
@@ -60,8 +60,8 @@ public interface KeycloakAccess {
   void createUser(String name);
 
   /**
-   * Assigns a role to a user in Keycloak. The role should not have the {@code PRINCIPAL_ROLE:}
-   * prefix. Both the role and the user must exist.
+   * Assigns a role to a user in Keycloak. The role should not have the {@code
+   * PolarisAuthConstants#PRINCIPAL_ROLE_PREFIX} prefix. Both the role and the user must exist.
    */
   void assignRoleToUser(String role, String user);
 
@@ -70,7 +70,7 @@ public interface KeycloakAccess {
 
   /**
    * Deletes a role in Keycloak with the specified name. The role should not have the {@code
-   * PRINCIPAL_ROLE:} prefix.
+   * PolarisAuthConstants#PRINCIPAL_ROLE_PREFIX} prefix.
    */
   void deleteRole(String name);
 

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakContainer.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakContainer.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
 import org.apache.polaris.containerspec.ContainerSpecHelper;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -96,7 +97,7 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   public void createRole(String roleName) {
     RealmResource master = keycloakAdminClient.realms().realm("master");
     RoleRepresentation role = new RoleRepresentation();
-    role.setName("PRINCIPAL_ROLE:" + roleName);
+    role.setName(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + roleName);
     master.roles().create(role);
   }
 
@@ -128,7 +129,7 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
     List<UserRepresentation> users = master.users().search(user);
     UserResource userResource = master.users().get(users.getFirst().getId());
     RoleRepresentation roleRepresentation =
-        master.roles().get("PRINCIPAL_ROLE:" + role).toRepresentation();
+        master.roles().get(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + role).toRepresentation();
     userResource.roles().realmLevel().add(List.of(roleRepresentation));
   }
 
@@ -150,7 +151,7 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   @Override
   public void deleteRole(String name) {
     RealmResource master = keycloakAdminClient.realms().realm("master");
-    master.roles().deleteRole("PRINCIPAL_ROLE:" + name);
+    master.roles().deleteRole(PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + name);
   }
 
   @Override

--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakProfile.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakProfile.java
@@ -21,6 +21,7 @@ package org.apache.polaris.test.commons.keycloak;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.List;
 import java.util.Map;
+import org.apache.polaris.core.auth.PolarisAuthConstants;
 
 public class KeycloakProfile implements QuarkusTestProfile {
 
@@ -36,7 +37,7 @@ public class KeycloakProfile implements QuarkusTestProfile {
         "polaris.oidc.principal-mapper.name-claim-path",
         KeycloakAccess.PRINCIPAL_NAME_CLAIM,
         "polaris.oidc.principal-roles-mapper.filter",
-        "PRINCIPAL_ROLE:.*");
+        PolarisAuthConstants.PRINCIPAL_ROLE_PREFIX + ".*");
   }
 
   @Override


### PR DESCRIPTION
FIxes#4738
## Summary

Introduce a shared `PolarisAuthConstants` class to centralize authentication-related role constants and remove duplicated `PRINCIPAL_ROLE:` string literals across the codebase.

## Changes

* Add `PolarisAuthConstants` in `polaris-core`
* Define:

  * `PRINCIPAL_ROLE_PREFIX`
  * `PRINCIPAL_ROLE_ALL`
* Update `DefaultAuthenticator` to reference the shared constants
* Remove the duplicate `POLARIS_ROLE_PREFIX` constant from `TokenRequestValidator`
* Replace repeated usages of `PRINCIPAL_ROLE:` and `PRINCIPAL_ROLE:ALL` with shared constants in tests and supporting utilities

## Testing

Executed:

```bash
./gradlew spotlessApply
./gradlew compileJava
```

Both completed successfully.

## Impact

This is a refactoring-only change with no intended behavioral changes. It improves maintainability by providing a single source of truth for principal role scope constants.

Fixes #4738


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
