### PR TITLE
Fix AzuriteExtension annotation attribute mapping

### DIFF
--- a/tools/azurite-testcontainer/src/main/java/org/projectnessie/testing/azurite/AzuriteExtension.java
+++ b/tools/azurite-testcontainer/src/main/java/org/projectnessie/testing/azurite/AzuriteExtension.java
@@ -112,8 +112,8 @@ public class AzuriteExtension
 
   private AzuriteAccess createContainer(Azurite azurite) {
     String bucket = nonDefault(azurite.storageContainer());
-    String account = nonDefault(azurite.storageContainer());
-    String secret = nonDefault(azurite.storageContainer());
+    String account = nonDefault(azurite.account());
+    String secret = nonDefault(azurite.secret());
     AzuriteContainer container =
         new AzuriteContainer(null, bucket, account, secret).withStartupAttempts(5);
     container.start();


### PR DESCRIPTION
Summary

AzuriteExtension#createContainer() currently uses storageContainer() for bucket, account, and secret values, causing @Azurite.account() and @Azurite.secret() to be ignored.

This change updates the extension to use the correct annotation attributes:

storageContainer() → bucket
account() → account
secret() → secret
Testing

Ran:

./gradlew :polaris-azurite-testcontainer:intTest

Build passed successfully.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
