### PR TITLE
Build: allow setting environment variables for the Gradle invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ venv
 # And then use `./gradlew run -Dquarkus.profile=local` to run Polaris with dev profile.
 application-local.properties
 
+/.env
+
 # AI / Agentic Development Tools
 .agents/
 .aider/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("ide-name.txt")
   excludes.add("version.txt")
 
+  excludes.add(".env")
+
   excludes.add("**/LICENSE*")
   excludes.add("**/NOTICE*")
 
@@ -269,6 +271,7 @@ tasks.named<Wrapper>("wrapper") {
     val insertAtLine =
       scriptLines.indexOf("# Use the maximum available, or set MAX_FD != -1 to use that value.")
     scriptLines.add(insertAtLine, "")
+    scriptLines.add(insertAtLine, $$"[ -f \"${APP_HOME}/.env\" ] && . \"${APP_HOME}/.env\"")
     scriptLines.add(insertAtLine, $$". \"${APP_HOME}/gradle/gradlew-include.sh\"")
 
     scriptFile.writeText(scriptLines.joinToString("\n"))

--- a/gradlew
+++ b/gradlew
@@ -88,6 +88,7 @@ APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
 APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
+[ -f "${APP_HOME}/.env" ] && . "${APP_HOME}/.env"
 . "${APP_HOME}/gradle/gradlew-include.sh"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
This allows creating a `.env` file and for example enable the Gradle configuration cache via
```
GRADLE_OPTS='-Dorg.gradle.configuration-cache=true'
```
