### PR TITLE
Improve readability of Keycloak container cleanup

### DIFF
--- a/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakLifecycleManager.java
+++ b/runtime/test-common/src/main/java/org/apache/polaris/test/commons/keycloak/KeycloakLifecycleManager.java
@@ -48,10 +48,12 @@ public class KeycloakLifecycleManager
 
   @Override
   public void stop() {
-    KeycloakContainer k = keycloak;
-    try (k) {
-    } finally {
-      keycloak = null;
+    if (keycloak != null) {
+      try {
+        keycloak.stop();
+      } finally {
+        keycloak = null;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4742

Replace an empty try-with-resources block in `KeycloakLifecycleManager.stop()` with an explicit `keycloak.stop()` call.

The previous implementation relied on an empty try-with-resources block to trigger automatic cleanup through `AutoCloseable.close()`. While functionally correct, the intent was not immediately obvious because the resource was never referenced within the block.

This change preserves the existing behavior while making the resource cleanup logic clearer and more consistent with other lifecycle managers in the codebase.

## Changes

* Replace empty try-with-resources cleanup pattern with an explicit `keycloak.stop()` call.
* Retain the existing `finally` block to ensure the field is cleared.
* No functional behavior changes.

## Test Plan

* [x] `./gradlew :polaris-runtime-test-common:compileJava`

## Impact

* Readability improvement only.
* No behavioral changes.
* No API changes.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
