### PR TITLE
Refactor static map initializations to use Map.ofEntries

### DIFF
--- a/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestProfiles.java
+++ b/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestProfiles.java
@@ -22,7 +22,6 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,16 +34,15 @@ public final class OpaTestProfiles {
   public static class StaticToken implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      Map<String, String> config = new HashMap<>();
-      config.put("polaris.authorization.type", "opa");
-      config.put("polaris.authorization.opa.auth.type", "bearer");
-      config.put(
-          "polaris.authorization.opa.auth.bearer.static-token.value",
-          "test-opa-bearer-token-12345");
-      config.put("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
-      config.put("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
-      config.put("polaris.readiness.ignore-severe-issues", "true");
-      return config;
+      return Map.ofEntries(
+          Map.entry("polaris.authorization.type", "opa"),
+          Map.entry("polaris.authorization.opa.auth.type", "bearer"),
+          Map.entry(
+              "polaris.authorization.opa.auth.bearer.static-token.value",
+              "test-opa-bearer-token-12345"),
+          Map.entry("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]"),
+          Map.entry("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true"),
+          Map.entry("polaris.readiness.ignore-severe-issues", "true"));
     }
 
     @Override
@@ -64,16 +62,15 @@ public final class OpaTestProfiles {
         tokenFilePath = Files.createTempFile("opa-test-token", ".txt");
         Files.writeString(tokenFilePath, "test-opa-bearer-token-from-file");
 
-        Map<String, String> config = new HashMap<>();
-        config.put("polaris.authorization.type", "opa");
-        config.put("polaris.authorization.opa.auth.type", "bearer");
-        config.put(
-            "polaris.authorization.opa.auth.bearer.file-based.path", tokenFilePath.toString());
-        config.put("polaris.authorization.opa.auth.bearer.file-based.refresh-interval", "PT1S");
-        config.put("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
-        config.put("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
-        config.put("polaris.readiness.ignore-severe-issues", "true");
-        return config;
+        return Map.ofEntries(
+            Map.entry("polaris.authorization.type", "opa"),
+            Map.entry("polaris.authorization.opa.auth.type", "bearer"),
+            Map.entry(
+                "polaris.authorization.opa.auth.bearer.file-based.path", tokenFilePath.toString()),
+            Map.entry("polaris.authorization.opa.auth.bearer.file-based.refresh-interval", "PT1S"),
+            Map.entry("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]"),
+            Map.entry("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true"),
+            Map.entry("polaris.readiness.ignore-severe-issues", "true"));
       } catch (IOException e) {
         throw new RuntimeException("Failed to create test token file", e);
       }

--- a/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestResource.java
+++ b/extensions/auth/opa/tests/src/intTest/java/org/apache/polaris/extension/auth/opa/test/OpaTestResource.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.polaris.containerspec.ContainerSpecHelper;
 import org.testcontainers.containers.GenericContainer;
@@ -80,10 +79,8 @@ public class OpaTestResource implements QuarkusTestResourceLifecycleManager {
         """;
       loadRegoPolicy(baseUrl, polarisPolicyName, polarisRegoPolicy);
 
-      Map<String, String> config = new HashMap<>();
-      config.put("polaris.authorization.opa.policy-uri", baseUrl + "/v1/data/polaris/authz");
-
-      return config;
+      return Map.ofEntries(
+          Map.entry("polaris.authorization.opa.policy-uri", baseUrl + "/v1/data/polaris/authz"));
 
     } catch (Exception e) {
       throw new RuntimeException("Failed to start OPA test resource", e);

--- a/extensions/auth/ranger/impl/src/test/java/org/apache/polaris/extension/auth/ranger/RangerTestUtils.java
+++ b/extensions/auth/ranger/impl/src/test/java/org/apache/polaris/extension/auth/ranger/RangerTestUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.polaris.extension.auth.ranger;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.polaris.core.config.PolarisConfiguration;
@@ -32,14 +31,13 @@ public class RangerTestUtils {
   private static final String REALM_CONTEXT_NAME = "POLARIS";
 
   public static RangerPolarisAuthorizerConfig createConfig() {
-    Map<String, String> properties = new HashMap<>();
-
-    properties.put(
-        "authz.default.policy.source.impl",
-        "org.apache.ranger.admin.client.EmbeddedResourcePolicySource");
-    properties.put("authz.default.policy.source.embedded_resource.path", "/authz_tests");
-
-    return createConfig("dev_polaris", properties);
+    return createConfig(
+        "dev_polaris",
+        Map.ofEntries(
+            Map.entry(
+                "authz.default.policy.source.impl",
+                "org.apache.ranger.admin.client.EmbeddedResourcePolicySource"),
+            Map.entry("authz.default.policy.source.embedded_resource.path", "/authz_tests")));
   }
 
   public static RangerPolarisAuthorizerConfig createConfig(

--- a/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
+++ b/extensions/auth/ranger/tests/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerTestProfiles.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.extension.auth.ranger.test;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
-import java.util.HashMap;
 import java.util.Map;
 
 /** Quarkus test profiles for Ranger integration tests using embedded policy fixtures. */
@@ -31,21 +30,21 @@ public final class RangerTestProfiles {
   public static class EmbeddedPolicy implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      Map<String, String> config = new HashMap<>();
-      config.put("polaris.authorization.type", "ranger");
-      config.put("polaris.authorization.ranger.service-name", "dev_polaris");
-      config.put(
-          "polaris.authorization.ranger.authz.default.policy.source.impl",
-          "org.apache.ranger.admin.client.EmbeddedResourcePolicySource");
-      config.put(
-          "polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher", "true");
-      config.put(
-          "polaris.authorization.ranger.authz.default.policy.source.embedded_resource.path",
-          "/authz_it_tests");
-      config.put("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
-      config.put("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
-      config.put("polaris.readiness.ignore-severe-issues", "true");
-      return config;
+      return Map.ofEntries(
+          Map.entry("polaris.authorization.type", "ranger"),
+          Map.entry("polaris.authorization.ranger.service-name", "dev_polaris"),
+          Map.entry(
+              "polaris.authorization.ranger.authz.default.policy.source.impl",
+              "org.apache.ranger.admin.client.EmbeddedResourcePolicySource"),
+          Map.entry(
+              "polaris.authorization.ranger.authz.default.enable.implicit.userstore.enricher",
+              "true"),
+          Map.entry(
+              "polaris.authorization.ranger.authz.default.policy.source.embedded_resource.path",
+              "/authz_it_tests"),
+          Map.entry("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]"),
+          Map.entry("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true"),
+          Map.entry("polaris.readiness.ignore-severe-issues", "true"));
     }
   }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/CatalogApi.java
@@ -142,11 +142,11 @@ public class CatalogApi extends PolarisRestApi {
   public ListTablesResponse listTables(
       String catalog, Namespace namespace, String pageToken, String pageSize) {
     String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
-    Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("pageToken", pageToken);
-    queryParams.put("pageSize", pageSize);
     try (Response res =
-        request("v1/{cat}/namespaces/{ns}/tables", Map.of("cat", catalog, "ns", ns), queryParams)
+        request(
+                "v1/{cat}/namespaces/{ns}/tables",
+                Map.of("cat", catalog, "ns", ns),
+                Map.ofEntries(Map.entry("pageToken", pageToken), Map.entry("pageSize", pageSize)))
             .get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class);
@@ -297,11 +297,11 @@ public class CatalogApi extends PolarisRestApi {
   public ListTablesResponse listViews(
       String catalog, Namespace namespace, String pageToken, String pageSize) {
     String ns = NamespaceUtils.joinNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
-    Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("pageToken", pageToken);
-    queryParams.put("pageSize", pageSize);
     try (Response res =
-        request("v1/{cat}/namespaces/{ns}/views", Map.of("cat", catalog, "ns", ns), queryParams)
+        request(
+                "v1/{cat}/namespaces/{ns}/views",
+                Map.of("cat", catalog, "ns", ns),
+                Map.ofEntries(Map.entry("pageToken", pageToken), Map.entry("pageSize", pageSize)))
             .get()) {
       assertThat(res.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
       return res.readEntity(ListTablesResponse.class);

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -52,7 +52,6 @@ import static org.apache.polaris.persistence.nosql.metastore.mutation.UpdateKeyF
 import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -444,11 +443,12 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               .setSubType(PolarisEntitySubType.NULL_SUBTYPE)
               .setCreateTimestamp(persistence.currentTimeMillis());
 
-      Map<String, String> properties = new HashMap<>();
-      properties.put(
-          PolarisTaskConstants.TASK_TYPE,
-          String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode()));
-      properties.put("data", PolarisObjectMapperUtil.serialize(dropped));
+      Map<String, String> properties =
+          Map.ofEntries(
+              Map.entry(
+                  PolarisTaskConstants.TASK_TYPE,
+                  String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode())),
+              Map.entry("data", PolarisObjectMapperUtil.serialize(dropped)));
       taskEntityBuilder.setProperties(properties);
       if (cleanupProperties != null) {
         taskEntityBuilder.setInternalProperties(cleanupProperties);

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/idempotency/RelationalJdbcIdempotencyStore.java
@@ -20,7 +20,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,9 +207,10 @@ public class RelationalJdbcIdempotencyStore implements IdempotencyStore {
     setClause.put(ModelIdempotencyRecord.FINALIZED_AT, Timestamp.from(finalizedAt));
     setClause.put(ModelIdempotencyRecord.UPDATED_AT, Timestamp.from(finalizedAt));
 
-    Map<String, Object> whereEquals = new HashMap<>();
-    whereEquals.put(ModelIdempotencyRecord.REALM_ID, realmId);
-    whereEquals.put(ModelIdempotencyRecord.IDEMPOTENCY_KEY, idempotencyKey);
+    Map<String, Object> whereEquals =
+        Map.ofEntries(
+            Map.entry(ModelIdempotencyRecord.REALM_ID, realmId),
+            Map.entry(ModelIdempotencyRecord.IDEMPOTENCY_KEY, idempotencyKey));
 
     QueryGenerator.PreparedQuery update =
         QueryGenerator.generateUpdateQuery(

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
@@ -43,9 +43,9 @@ public class QueryGeneratorTest {
 
   @Test
   void testGenerateSelectQuery_withMaQueryGeneratorpWhereClause() {
-    Map<String, Object> whereClause = new HashMap<>();
-    whereClause.put("name", "testEntity");
+    Map<String, Object> whereClause = new LinkedHashMap<>();
     whereClause.put("entity_version", 1);
+    whereClause.put("name", "testEntity");
     String expectedQuery =
         "SELECT id, catalog_id, parent_id, type_code, name, entity_version, sub_type_code, create_timestamp, drop_timestamp, purge_timestamp, to_purge_timestamp, last_update_timestamp, properties, internal_properties, grant_records_version, location_without_scheme FROM POLARIS_SCHEMA.ENTITIES WHERE entity_version = ? AND name = ?";
     assertEquals(

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/GcpAuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/GcpAuthenticationParametersDpo.java
@@ -19,7 +19,6 @@
 
 package org.apache.polaris.core.connection;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.rest.auth.AuthProperties;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
@@ -41,9 +40,7 @@ public class GcpAuthenticationParametersDpo extends AuthenticationParametersDpo 
   @Override
   public Map<String, String> asIcebergCatalogProperties(
       PolarisCredentialManager credentialManager) {
-    HashMap<String, String> properties = new HashMap<>();
-    properties.put(AuthProperties.AUTH_TYPE, AuthProperties.AUTH_TYPE_GOOGLE);
-    return properties;
+    return Map.ofEntries(Map.entry(AuthProperties.AUTH_TYPE, AuthProperties.AUTH_TYPE_GOOGLE));
   }
 
   @NonNull

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -22,7 +22,6 @@ import static org.apache.polaris.core.admin.model.StorageConfigInfo.StorageTypeE
 
 import com.google.common.base.Preconditions;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -86,9 +85,8 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setName(catalog.getName())
             .setProperties(catalog.getProperties().toMap())
             .setCatalogType(catalog.getType().name());
-    Map<String, String> internalProperties = new HashMap<>();
-    internalProperties.put(CATALOG_TYPE_PROPERTY, catalog.getType().name());
-    builder.setInternalProperties(internalProperties);
+    builder.setInternalProperties(
+        Map.ofEntries(Map.entry(CATALOG_TYPE_PROPERTY, catalog.getType().name())));
     builder.setStorageConfigurationInfo(
         realmConfig, catalog.getStorageConfigInfo(), getBaseLocation(catalog));
     return builder.build();

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.persistence;
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1187,12 +1186,14 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // the cleanup task is transactional. Otherwise, we'll be unable to schedule the cleanup task
     // later
     if (cleanup && refreshEntityToDrop.getType() != PolarisEntityType.POLICY) {
-      Map<String, String> properties = new HashMap<>();
-      properties.put(
-          PolarisTaskConstants.TASK_TYPE,
-          String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode()));
-      properties.put(
-          PolarisTaskConstants.TASK_DATA, PolarisObjectMapperUtil.serialize(refreshEntityToDrop));
+      Map<String, String> properties =
+          Map.ofEntries(
+              Map.entry(
+                  PolarisTaskConstants.TASK_TYPE,
+                  String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode())),
+              Map.entry(
+                  PolarisTaskConstants.TASK_DATA,
+                  PolarisObjectMapperUtil.serialize(refreshEntityToDrop)));
       PolarisBaseEntity.Builder taskEntityBuilder =
           new PolarisBaseEntity.Builder()
               .propertiesAsMap(properties)

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.persistence.transactional;
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1421,12 +1420,14 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     // the cleanup task is transactional. Otherwise, we'll be unable to schedule the cleanup task
     // later
     if (cleanup && refreshEntityToDrop.getType() != PolarisEntityType.POLICY) {
-      Map<String, String> properties = new HashMap<>();
-      properties.put(
-          PolarisTaskConstants.TASK_TYPE,
-          String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode()));
-      properties.put(
-          PolarisTaskConstants.TASK_DATA, PolarisObjectMapperUtil.serialize(refreshEntityToDrop));
+      Map<String, String> properties =
+          Map.ofEntries(
+              Map.entry(
+                  PolarisTaskConstants.TASK_TYPE,
+                  String.valueOf(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER.typeCode())),
+              Map.entry(
+                  PolarisTaskConstants.TASK_DATA,
+                  PolarisObjectMapperUtil.serialize(refreshEntityToDrop)));
       PolarisBaseEntity.Builder taskEntityBuilder =
           new PolarisBaseEntity.Builder()
               .id(ms.generateNewIdInCurrentTxn(callCtx))

--- a/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/credentials/connection/ConnectionCredentialsTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -33,10 +32,12 @@ public class ConnectionCredentialsTest {
 
   @Test
   public void testMultipleExpirationTsThrows() {
-    Map<CatalogAccessProperty, String> properties = new HashMap<>();
-    properties.put(
-        AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli()));
-    properties.put(EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli()));
+    Map<CatalogAccessProperty, String> properties =
+        Map.ofEntries(
+            Map.entry(
+                AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                String.valueOf(Instant.ofEpochMilli(1).toEpochMilli())),
+            Map.entry(EXPIRES_AT_MS, String.valueOf(Instant.ofEpochMilli(1).toEpochMilli())));
 
     assertThatThrownBy(() -> ConnectionCredentials.of(properties))
         .isInstanceOf(IllegalArgumentException.class)

--- a/polaris-core/src/test/java/org/apache/polaris/core/rest/PolarisResourcePathsTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/rest/PolarisResourcePathsTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.core.rest;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -33,9 +32,9 @@ public class PolarisResourcePathsTest {
 
   @BeforeEach
   public void setUp() {
-    Map<String, String> properties = new HashMap<>();
-    properties.put(PolarisResourcePaths.PREFIX, testPrefix);
-    paths = PolarisResourcePaths.forCatalogProperties(properties);
+    paths =
+        PolarisResourcePaths.forCatalogProperties(
+            Map.ofEntries(Map.entry(PolarisResourcePaths.PREFIX, testPrefix)));
   }
 
   @Test

--- a/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/listeners/PolarisPersistenceEventListener.java
@@ -279,10 +279,9 @@ public abstract class PolarisPersistenceEventListener implements PolarisEventLis
 
     if (key.equals(EventAttributes.RENAME_TABLE_REQUEST)
         && value instanceof RenameTableRequest request) {
-      Map<String, String> result = new LinkedHashMap<>();
-      result.put("rename_source", request.source().toString());
-      result.put("rename_destination", request.destination().toString());
-      return result;
+      return Map.ofEntries(
+          Map.entry("rename_source", request.source().toString()),
+          Map.entry("rename_destination", request.destination().toString()));
     }
 
     return Map.of(key.name(), value.toString());

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -326,8 +326,9 @@ public class IcebergAllowedLocationTest {
     // update the view with allowed locations
     String customAllowedLocation3 = Paths.get(namespaceLocation, "custom-location3").toString();
 
-    Map<String, String> updatedProperties = new HashMap<>();
-    updatedProperties.put(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, customAllowedLocation3);
+    Map<String, String> updatedProperties =
+        Map.ofEntries(
+            Map.entry(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, customAllowedLocation3));
 
     UpdateTableRequest updateRequest =
         UpdateTableRequest.create(
@@ -381,8 +382,8 @@ public class IcebergAllowedLocationTest {
                 services.securityContext());
     assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
 
-    Map<String, String> updatedProperties = new HashMap<>();
-    updatedProperties.put(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, locationNotAllowed);
+    Map<String, String> updatedProperties =
+        Map.ofEntries(Map.entry(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, locationNotAllowed));
 
     var updateRequest =
         UpdateTableRequest.create(
@@ -434,14 +435,13 @@ public class IcebergAllowedLocationTest {
 
   private static @NotNull CreateViewRequest getCreateViewRequest(
       String writeMetadataPath, String viewName, String location) {
-    var properties = new HashMap<String, String>();
-    properties.put(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, writeMetadataPath);
     return ImmutableCreateViewRequest.builder()
         .name(viewName)
         .schema(SCHEMA)
         .viewVersion(VIEW_VERSION)
         .location(location)
-        .properties(properties)
+        .properties(
+            Map.ofEntries(Map.entry(USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, writeMetadataPath)))
         .build();
   }
 
@@ -476,8 +476,8 @@ public class IcebergAllowedLocationTest {
 
     // Update the table to set write.data.path to a subdirectory under the table's location
     String writeDataPath = tableLocation + "/alternative_data";
-    Map<String, String> updatedProperties = new HashMap<>();
-    updatedProperties.put("write.data.path", writeDataPath);
+    Map<String, String> updatedProperties =
+        Map.ofEntries(Map.entry("write.data.path", writeDataPath));
 
     var updateRequest =
         UpdateTableRequest.create(

--- a/tools/azurite-testcontainer/src/main/java/org/projectnessie/testing/azurite/AzuriteContainer.java
+++ b/tools/azurite-testcontainer/src/main/java/org/projectnessie/testing/azurite/AzuriteContainer.java
@@ -21,7 +21,6 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.polaris.containerspec.ContainerSpecHelper;
@@ -157,30 +156,24 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer>
 
   @Override
   public Map<String, String> icebergProperties() {
-    Map<String, String> r = new HashMap<>();
-    r.put("io-impl", "org.apache.iceberg.azure.adlsv2.ADLSFileIO");
-    r.put("adls.connection-string." + accountFq, endpoint());
-    r.put("adls.auth.shared-key.account.name", account);
-    r.put("adls.auth.shared-key.account.key", secretBase64);
-    return r;
+    return Map.ofEntries(
+        Map.entry("io-impl", "org.apache.iceberg.azure.adlsv2.ADLSFileIO"),
+        Map.entry("adls.connection-string." + accountFq, endpoint()),
+        Map.entry("adls.auth.shared-key.account.name", account),
+        Map.entry("adls.auth.shared-key.account.key", secretBase64));
   }
 
   @Override
   public Map<String, String> hadoopConfig() {
-    Map<String, String> r = new HashMap<>();
-
-    r.put("fs.azure.impl", "org.apache.hadoop.fs.azure.AzureNativeFileSystemStore");
-    r.put("fs.AbstractFileSystem.azure.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
-
-    r.put("fs.azure.always.use.https", "false");
-    r.put("fs.azure.abfs.endpoint", endpointHostPort());
-
-    r.put("fs.azure.test.emulator", "true");
-    r.put("fs.azure.storage.emulator.account.name", account);
-    r.put("fs.azure.account.auth.type", "SharedKey");
-    r.put("fs.azure.account.key." + accountFq, secretBase64);
-
-    return r;
+    return Map.ofEntries(
+        Map.entry("fs.azure.impl", "org.apache.hadoop.fs.azure.AzureNativeFileSystemStore"),
+        Map.entry("fs.AbstractFileSystem.azure.impl", "org.apache.hadoop.fs.azurebfs.Abfs"),
+        Map.entry("fs.azure.always.use.https", "false"),
+        Map.entry("fs.azure.abfs.endpoint", endpointHostPort()),
+        Map.entry("fs.azure.test.emulator", "true"),
+        Map.entry("fs.azure.storage.emulator.account.name", account),
+        Map.entry("fs.azure.account.auth.type", "SharedKey"),
+        Map.entry("fs.azure.account.key." + accountFq, secretBase64));
   }
 
   private static String randomString(String prefix) {

--- a/tools/gcs-testcontainer/src/main/java/org/projectnessie/testing/gcs/GcsContainer.java
+++ b/tools/gcs-testcontainer/src/main/java/org/projectnessie/testing/gcs/GcsContainer.java
@@ -24,7 +24,6 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -179,28 +178,25 @@ public class GcsContainer extends GenericContainer<GcsContainer>
 
   @Override
   public Map<String, String> hadoopConfig() {
-    Map<String, String> r = new HashMap<>();
-    // See https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md
-    r.put("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
-    r.put("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-    r.put("fs.gs.storage.root.url", baseUri());
-    r.put("fs.gs.project.id", projectId);
-    // TODO the docs don't mention anything about using an OAuth2 token :(
-    r.put("fs.gs.auth.type", "USER_CREDENTIALS");
-    r.put("fs.gs.auth.client.id", "foo");
-    r.put("fs.gs.auth.client.secret", "bar");
-    r.put("fs.gs.auth.refresh.token", "baz");
-    return r;
+    return Map.ofEntries(
+        Map.entry("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem"),
+        Map.entry("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS"),
+        Map.entry("fs.gs.storage.root.url", baseUri()),
+        Map.entry("fs.gs.project.id", projectId),
+        // TODO the docs don't mention anything about using an OAuth2 token :(
+        Map.entry("fs.gs.auth.type", "USER_CREDENTIALS"),
+        Map.entry("fs.gs.auth.client.id", "foo"),
+        Map.entry("fs.gs.auth.client.secret", "bar"),
+        Map.entry("fs.gs.auth.refresh.token", "baz"));
   }
 
   @Override
   public Map<String, String> icebergProperties() {
-    Map<String, String> r = new HashMap<>();
-    r.put("io-impl", "org.apache.iceberg.gcp.gcs.GCSFileIO");
-    r.put("gcs.project-id", projectId);
-    r.put("gcs.service.host", baseUri());
-    r.put("gcs.oauth2.token", oauth2token);
-    return r;
+    return Map.ofEntries(
+        Map.entry("io-impl", "org.apache.iceberg.gcp.gcs.GCSFileIO"),
+        Map.entry("gcs.project-id", projectId),
+        Map.entry("gcs.service.host", baseUri()),
+        Map.entry("gcs.oauth2.token", oauth2token));
   }
 
   @Override

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioContainer.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioContainer.java
@@ -218,12 +218,11 @@ public final class MinioContainer extends GenericContainer<MinioContainer>
 
   @Override
   public Map<String, String> hadoopConfig() {
-    Map<String, String> r = new HashMap<>();
-    r.put("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-    r.put("fs.s3a.access.key", accessKey());
-    r.put("fs.s3a.secret.key", secretKey());
-    r.put("fs.s3a.endpoint", s3endpoint());
-    return r;
+    return Map.ofEntries(
+        Map.entry("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"),
+        Map.entry("fs.s3a.access.key", accessKey()),
+        Map.entry("fs.s3a.secret.key", secretKey()),
+        Map.entry("fs.s3a.endpoint", s3endpoint()));
   }
 
   @Override

--- a/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
+++ b/tools/misc-types/src/main/java/org/apache/polaris/misc/types/memorysize/MemorySize.java
@@ -25,7 +25,6 @@ import static java.util.Locale.ROOT;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigInteger;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.spi.Converter;
@@ -57,20 +56,17 @@ public abstract class MemorySize {
   private static final Pattern MEMORY_SIZE_PATTERN =
       Pattern.compile("^(\\d+)([BbKkMmGgTtPpEeZzYy]?)$");
   private static final BigInteger KILO_BYTES = BigInteger.valueOf(1024);
-  private static final Map<String, BigInteger> MEMORY_SIZE_MULTIPLIERS;
+  private static final Map<String, BigInteger> MEMORY_SIZE_MULTIPLIERS =
+      Map.ofEntries(
+          Map.entry("K", KILO_BYTES),
+          Map.entry("M", KILO_BYTES.pow(2)),
+          Map.entry("G", KILO_BYTES.pow(3)),
+          Map.entry("T", KILO_BYTES.pow(4)),
+          Map.entry("P", KILO_BYTES.pow(5)),
+          Map.entry("E", KILO_BYTES.pow(6)),
+          Map.entry("Z", KILO_BYTES.pow(7)),
+          Map.entry("Y", KILO_BYTES.pow(8)));
   private static final char[] SUFFIXES = new char[] {'B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'};
-
-  static {
-    MEMORY_SIZE_MULTIPLIERS = new HashMap<>();
-    MEMORY_SIZE_MULTIPLIERS.put("K", KILO_BYTES);
-    MEMORY_SIZE_MULTIPLIERS.put("M", KILO_BYTES.pow(2));
-    MEMORY_SIZE_MULTIPLIERS.put("G", KILO_BYTES.pow(3));
-    MEMORY_SIZE_MULTIPLIERS.put("T", KILO_BYTES.pow(4));
-    MEMORY_SIZE_MULTIPLIERS.put("P", KILO_BYTES.pow(5));
-    MEMORY_SIZE_MULTIPLIERS.put("E", KILO_BYTES.pow(6));
-    MEMORY_SIZE_MULTIPLIERS.put("Z", KILO_BYTES.pow(7));
-    MEMORY_SIZE_MULTIPLIERS.put("Y", KILO_BYTES.pow(8));
-  }
 
   static final class MemorySizeLong extends MemorySize {
     private final long bytes;

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsContainer.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsContainer.java
@@ -226,12 +226,11 @@ public final class RustfsContainer extends GenericContainer<RustfsContainer>
 
   @Override
   public Map<String, String> hadoopConfig() {
-    Map<String, String> r = new HashMap<>();
-    r.put("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-    r.put("fs.s3a.access.key", accessKey());
-    r.put("fs.s3a.secret.key", secretKey());
-    r.put("fs.s3a.endpoint", s3endpoint());
-    return r;
+    return Map.ofEntries(
+        Map.entry("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"),
+        Map.entry("fs.s3a.access.key", accessKey()),
+        Map.entry("fs.s3a.secret.key", secretKey()),
+        Map.entry("fs.s3a.endpoint", s3endpoint()));
   }
 
   @Override


### PR DESCRIPTION
Fixes #4744

## What changes were proposed?

Refactor eligible static map initializations from mutable `HashMap` and `LinkedHashMap` constructions with immediate `put()` calls to `Map.ofEntries()`.

Only locations where maps are created locally, populated immediately, and never modified afterward were updated.

## Why are the changes needed?

`Map.ofEntries()` provides a more concise and readable way to define immutable maps and better communicates intent by avoiding unnecessary mutable map construction.

## Does this change introduce any user-facing behavior?

No. This is a refactoring-only change with no intended functional impact.

## Additional Notes

During verification, several unsafe conversions were identified and reverted:

* Maps requiring downstream mutation
* Order-sensitive test fixtures
* Iceberg namespace property maps that rely on mutable map behavior

Only safe immutable-map conversions remain.

## How was this tested?

* `./gradlew format compileAll`
* Reviewed all converted locations for mutability requirements
* Verified ordering-sensitive tests remain correct
* Ran targeted validation on affected modules


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
