### PR TITLE
Update renovate bot rules for ANTLR and Spark

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,6 +127,26 @@
       matchPackageNames: [ "org.scala-lang:*" ],
       matchCurrentVersion: "/^2\\.13\\./",
       allowedVersions: "/^2\\.13\\./"
+    },
+    // ANTLR runtime versions are pinned to match the version used by Delta
+    // https://github.com/delta-io/delta/blob/master/project/CrossSparkVersions.scala#L211
+    {
+      matchManagers: ["gradle"],
+      matchPackageNames: ["org.antlr:antlr4-runtime"],
+      enabled: false
+    },
+    // Apache Spark major/minor verisons are not comaptible with each other
+    {
+      matchManagers: ["dockerfile", "docker-compose"],
+      matchPackageNames: [ "apache/spark", "docker.io/apache/spark" ],
+      matchCurrentVersion: "/^3\\.5\\./",
+      allowedVersions: "/^3\\.5\\./"
+    },
+    {
+      matchManagers: ["dockerfile", "docker-compose"],
+      matchPackageNames: [ "apache/spark", "docker.io/apache/spark" ],
+      matchCurrentVersion: "/^4\\.0\\./",
+      allowedVersions: "/^4\\.0\\./"
     }
   ],
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR pinned the version for ANTLR (due to https://github.com/delta-io/delta/blob/master/project/CrossSparkVersions.scala#L211 from delta) and ensure spark doesn't perform cross version update for docker/docker-compose.

This PR will fix issues https://github.com/apache/polaris/pull/4660 and https://github.com/apache/polaris/pull/4662.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
