### PR TITLE
Redact access token from PolarisCredential toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Fixes
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
+- The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).
 
 ## [1.5.0]
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/PolarisCredential.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/PolarisCredential.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.auth;
 import io.quarkus.security.credential.Credential;
 import java.util.Set;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -57,6 +58,10 @@ public interface PolarisCredential extends Credential {
   /** The principal roles, or empty if the principal has no roles. */
   Set<String> getPrincipalRoles();
 
-  /** The access token of the current user, or null if not applicable. */
+  /**
+   * The access token of the current user, or null if not applicable. Redacted from {@code
+   * toString()} so it is not leaked into logs.
+   */
+  @Value.Redacted
   @Nullable String getToken();
 }


### PR DESCRIPTION
`DefaultAuthenticator` logs `PolarisCredential` at DEBUG and WARN (including on failed principal resolution). Immutables `toString()` previously included the raw bearer token.

Add `@Value.Redacted` on `getToken()`, matching the existing pattern on `PolarisPrincipal.getToken()`. Programmatic access is unchanged; only log output is affected.

## Checklist
- [ ] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] Added comments for complex logic
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)
