### PR TITLE
fix: validate JWT issuer claim during token verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
 - The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).
+- JWT verification now validates the issuer claim (`"polaris"`) in addition to the active claim. Tokens signed with the same key but carrying a different issuer are now rejected.
 
 ## [1.5.0]
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
@@ -69,7 +69,11 @@ public abstract class JWTBroker implements TokenBroker {
   }
 
   private InternalPolarisToken verifyInternal(String token) {
-    JWTVerifier verifier = JWT.require(getAlgorithm()).withClaim(CLAIM_KEY_ACTIVE, true).build();
+    JWTVerifier verifier =
+        JWT.require(getAlgorithm())
+            .withIssuer(ISSUER_KEY)
+            .withClaim(CLAIM_KEY_ACTIVE, true)
+            .build();
 
     try {
       DecodedJWT decodedJWT = verifier.verify(token);

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.auth.internal.broker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
@@ -82,5 +83,29 @@ public class RSAKeyPairJWTBrokerTest {
     assertThat(decodedJWT).isNotNull();
     assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo("PRINCIPAL_ROLE:TEST");
     assertThat(decodedJWT.getClaim("client_id").asString()).isEqualTo("test-client-id");
+  }
+
+  @Test
+  public void testVerifyRejectsTokenWithWrongIssuer() throws Exception {
+    var keyPair = PemUtils.generateKeyPair();
+
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
+    PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
+    KeyProvider provider = new LocalRSAKeyProvider(keyPair);
+    TokenBroker tokenBroker =
+        new RSAKeyPairJWTBroker(metastoreManager, polarisCallContext, 420, provider);
+
+    String tokenWithWrongIssuer =
+        JWT.create()
+            .withIssuer("not-polaris")
+            .withSubject("principal")
+            .withClaim("active", true)
+            .sign(
+                Algorithm.RSA256(
+                    (RSAPublicKey) provider.publicKey(), (RSAPrivateKey) provider.privateKey()));
+
+    assertThatThrownBy(() -> tokenBroker.verify(tokenWithWrongIssuer))
+        .isInstanceOf(org.apache.iceberg.exceptions.NotAuthorizedException.class)
+        .hasMessageContaining("Failed to verify the token");
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
@@ -108,4 +108,27 @@ public class RSAKeyPairJWTBrokerTest {
         .isInstanceOf(org.apache.iceberg.exceptions.NotAuthorizedException.class)
         .hasMessageContaining("Failed to verify the token");
   }
+
+  @Test
+  public void testVerifyRejectsTokenWithMissingIssuer() throws Exception {
+    var keyPair = PemUtils.generateKeyPair();
+
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
+    PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
+    KeyProvider provider = new LocalRSAKeyProvider(keyPair);
+    TokenBroker tokenBroker =
+        new RSAKeyPairJWTBroker(metastoreManager, polarisCallContext, 420, provider);
+
+    String tokenWithoutIssuer =
+        JWT.create()
+            .withSubject("principal")
+            .withClaim("active", true)
+            .sign(
+                Algorithm.RSA256(
+                    (RSAPublicKey) provider.publicKey(), (RSAPrivateKey) provider.privateKey()));
+
+    assertThatThrownBy(() -> tokenBroker.verify(tokenWithoutIssuer))
+        .isInstanceOf(org.apache.iceberg.exceptions.NotAuthorizedException.class)
+        .hasMessageContaining("Failed to verify the token");
+  }
 }


### PR DESCRIPTION
## Problem

`JWTBroker` sets the issuer claim to `"polaris"` when generating access tokens, but the verification path did not check the issuer claim. A JWT signed with the same realm key but carrying any other issuer would be accepted as a valid Polaris access token.

## Change

Add `.withIssuer(ISSUER_KEY)` to the `JWTVerifier` in `JWTBroker.verifyInternal()`, so the issuer claim is validated on every token verification.

## Tests

Added `RSAKeyPairJWTBrokerTest.testVerifyRejectsTokenWithWrongIssuer()` to verify that a token signed with the same RSA key but with issuer `"not-polaris"` is rejected with `NotAuthorizedException`.

## Checklist
- [x] Clearly explained why the changes are needed
- [x] Added/updated tests with good coverage
- [x] Updated `CHANGELOG.md`
- [ ] Updated documentation in `site/content/in-dev/unreleased` (not needed — no user-facing behavior change)
