### PR TITLE
fix(catalog): Fix authorize generic table drop against the table over namespace

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -131,7 +131,7 @@ public abstract class GenericTableCatalogHandler extends CatalogHandler {
 
   public boolean dropGenericTable(TableIdentifier identifier) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.DROP_TABLE_WITHOUT_PURGE;
-    authorizeCreateTableLikeUnderNamespaceOperationOrThrow(op, identifier);
+    authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.GENERIC_TABLE, identifier);
 
     return this.genericTableCatalog.dropGenericTable(identifier);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
@@ -29,6 +29,7 @@ import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.service.admin.PolarisAuthzTestBase;
 import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 @QuarkusTest
@@ -125,5 +126,14 @@ public class PolarisGenericTableCatalogHandlerAuthzTest extends PolarisAuthzTest
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_CONTENT)
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_METADATA)
         .createTests();
+  }
+
+  @Test
+  void dropGenericTableHonorsTableScopedGrant() {
+    assertSuccess(
+        adminService.grantPrivilegeOnTableToRole(
+            CATALOG_NAME, CATALOG_ROLE1, TABLE_NS1_1_GENERIC, PolarisPrivilege.TABLE_DROP));
+
+    newWrapper(Set.of(PRINCIPAL_ROLE1)).dropGenericTable(TABLE_NS1_1_GENERIC);
   }
 }


### PR DESCRIPTION
- DropGenericTable authorizes via the create under namespace, so the authz target is the parent namespace, not the table.
- Table drop grant on generic table is ignored and the drop is wrongly denied.
- Use the correct table level check instead of the namespace. 
- Add ut

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [X] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [X] 💡 Added comments for complex logic
- [X] 🧾 Updated `CHANGELOG.md` (if needed)
- [X] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
