### PR TITLE
Replace safe Collectors.toList() usages with Stream.toList()

### DIFF
--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.ArrayList;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.polaris.persistence.nosql.authz.api.Privilege;
@@ -201,8 +200,7 @@ public class TestPrivilegeSetImpl {
     }
 
     soft.assertThat(values)
-        .containsExactlyInAnyOrderElementsOf(
-            inJson.stream().map(Privilege::name).collect(Collectors.toList()));
+        .containsExactlyInAnyOrderElementsOf(inJson.stream().map(Privilege::name).toList());
   }
 
   static Stream<Arguments> compositeByNameSerialization() {

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestStripedIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestStripedIndexImpl.java
@@ -60,19 +60,15 @@ public class TestStripedIndexImpl {
         () ->
             originalStripesList.stream()
                 .map(s -> deserializeStoreIndex(s.serialize(), OBJ_REF_SERIALIZER))
-                .collect(Collectors.toList());
+                .toList();
     var firstLastKeys =
-        stripesSupplier.get().stream()
-            .flatMap(s -> Stream.of(s.first(), s.last()))
-            .collect(Collectors.toList());
+        stripesSupplier.get().stream().flatMap(s -> Stream.of(s.first(), s.last())).toList();
 
     Supplier<IndexSpi<ObjRef>> stripedSupplier =
         () -> {
           var originalStripes = stripesSupplier.get();
           var stripes =
-              originalStripes.stream()
-                  .map(s -> lazyStoreIndex(() -> s, null, null))
-                  .collect(Collectors.toList());
+              originalStripes.stream().map(s -> lazyStoreIndex(() -> s, null, null)).toList();
           return IndexesInternal.indexFromStripes(
               stripes,
               firstLastKeys,
@@ -122,9 +118,7 @@ public class TestStripedIndexImpl {
 
     var originalStripes = splitIntoStripeCountForTest(reference, 5);
     var firstLastKeys =
-        originalStripes.stream()
-            .flatMap(s -> Stream.of(s.first(), s.last()))
-            .collect(Collectors.toList());
+        originalStripes.stream().flatMap(s -> Stream.of(s.first(), s.last())).toList();
 
     Supplier<IndexSpi<ObjRef>> stripedSupplier;
 
@@ -145,11 +139,9 @@ public class TestStripedIndexImpl {
         () ->
             originalStripesList.stream()
                 .map(s -> deserializeStoreIndex(s.serialize(), OBJ_REF_SERIALIZER))
-                .collect(Collectors.toList());
+                .toList();
     var firstLastKeys =
-        stripesSupplier.get().stream()
-            .flatMap(s -> Stream.of(s.first(), s.last()))
-            .collect(Collectors.toList());
+        stripesSupplier.get().stream().flatMap(s -> Stream.of(s.first(), s.last())).toList();
 
     Supplier<IndexSpi<ObjRef>> stripedSupplier =
         createStoreIndexSupplier(lazyStripes, stripesSupplier, firstLastKeys);
@@ -183,9 +175,7 @@ public class TestStripedIndexImpl {
           () -> {
             var originalStripes = stripesSupplier.get();
             var stripes =
-                originalStripes.stream()
-                    .map(s -> lazyStoreIndex(() -> s, null, null))
-                    .collect(Collectors.toList());
+                originalStripes.stream().map(s -> lazyStoreIndex(() -> s, null, null)).toList();
             return IndexesInternal.indexFromStripes(
                 stripes,
                 firstLastKeys,
@@ -228,8 +218,7 @@ public class TestStripedIndexImpl {
     var individualLoads = new boolean[numStripes];
     var bulkLoads = new boolean[numStripes];
 
-    var firstLastKeys =
-        stripes.stream().flatMap(s -> Stream.of(s.first(), s.last())).collect(Collectors.toList());
+    var firstLastKeys = stripes.stream().flatMap(s -> Stream.of(s.first(), s.last())).toList();
 
     // This supplier provides a striped-over-lazy-segments index. Individually loaded stripes
     // are marked in 'individualLoads' and bulk-loaded stripes in 'bulkLoads'.
@@ -476,9 +465,7 @@ public class TestStripedIndexImpl {
     var striped = indexFromStripes(splitIntoStripeCountForTest(indexTestSet.keyIndex(), 3));
     if (lazy) {
       var lazyStripes =
-          striped.stripes().stream()
-              .map(i -> lazyStoreIndex(() -> i, null, null))
-              .collect(Collectors.toList());
+          striped.stripes().stream().map(i -> lazyStoreIndex(() -> i, null, null)).toList();
       striped = indexFromStripes(lazyStripes);
     }
 
@@ -519,9 +506,7 @@ public class TestStripedIndexImpl {
     var striped = indexFromStripes(splitIntoStripeCountForTest(indexEven, 4));
     if (lazy) {
       var lazyStripes =
-          striped.stripes().stream()
-              .map(i -> lazyStoreIndex(() -> i, null, null))
-              .collect(Collectors.toList());
+          striped.stripes().stream().map(i -> lazyStoreIndex(() -> i, null, null)).toList();
       striped = indexFromStripes(lazyStripes);
     }
 

--- a/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitLogImpl.java
+++ b/persistence/nosql/persistence/impl/src/testFixtures/java/org/apache/polaris/persistence/nosql/impl/commits/BaseTestCommitLogImpl.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.testextension.PersistenceTestExtension;
@@ -62,8 +61,7 @@ public abstract class BaseTestCommitLogImpl {
 
     // Commit log in "reversed" (most recent commit last)
     var commits = persistence.commits();
-    var expectedPayloads =
-        IntStream.range(0, numCommits).mapToObj(i -> "commit #" + i).collect(Collectors.toList());
+    var expectedPayloads = IntStream.range(0, numCommits).mapToObj(i -> "commit #" + i).toList();
     soft.assertThatIterator(commits.commitLogReversed(refName, 0L, SimpleCommitTestObj.class))
         .toIterable()
         .extracting(SimpleCommitTestObj::payload)

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -406,7 +406,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               results.results().stream()
                   .map(EntityResult.class::cast)
                   .map(EntityResult::getEntity)
-                  .collect(Collectors.toList())));
+                  .toList()));
     }
 
     return new EntitiesResult(Page.fromItems(List.of()));

--- a/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkIntegrationBase.java
+++ b/plugins/spark/common/src/intTest/java/org/apache/polaris/spark/quarkus/it/SparkIntegrationBase.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
@@ -169,7 +168,7 @@ public abstract class SparkIntegrationBase {
   }
 
   protected List<Object[]> rowsToJava(List<Row> rows) {
-    return rows.stream().map(this::toJava).collect(Collectors.toList());
+    return rows.stream().map(this::toJava).toList();
   }
 
   private Object[] toJava(Row row) {

--- a/plugins/spark/common/src/test/java/org/apache/polaris/spark/PolarisInMemoryCatalog.java
+++ b/plugins/spark/common/src/test/java/org/apache/polaris/spark/PolarisInMemoryCatalog.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -45,7 +44,7 @@ public class PolarisInMemoryCatalog extends InMemoryCatalog implements PolarisCa
     return this.genericTables.keySet().stream()
         .filter(t -> t.namespace().equals(ns))
         .sorted(Comparator.comparing(TableIdentifier::toString))
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/catalog/PolarisCatalogHelpers.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/catalog/PolarisCatalogHelpers.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.catalog;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -99,6 +98,6 @@ public class PolarisCatalogHelpers {
     Namespace sharedNamespace = Namespace.of(parentNamespaces);
     return entities.stream()
         .map(entity -> TableIdentifier.of(sharedNamespace, entity.name()))
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntity.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -140,7 +139,7 @@ public class PolarisEntity extends PolarisBaseEntity {
   public static List<PolarisEntityCore> toCoreList(List<PolarisEntity> path) {
     return Optional.ofNullable(path)
         .filter(Predicate.not(List::isEmpty))
-        .map(list -> list.stream().map(PolarisEntity::toCore).collect(Collectors.toList()))
+        .map(list -> list.stream().map(PolarisEntity::toCore).toList())
         .orElse(null);
   }
 
@@ -150,7 +149,7 @@ public class PolarisEntity extends PolarisBaseEntity {
             list ->
                 list.stream()
                     .map(record -> new NameAndId(record.getName(), record.getId()))
-                    .collect(Collectors.toList()))
+                    .toList())
         .orElse(null);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -1364,14 +1363,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                     new PolarisEntityId(
                         grantRecord.getGranteeCatalogId(), grantRecord.getGranteeId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     List<PolarisBaseEntity> entities = ms.lookupEntities(callCtx, entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
-        grantsVersion,
-        returnGrantRecords,
-        entities.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        grantsVersion, returnGrantRecords, entities.stream().filter(Objects::nonNull).toList());
   }
 
   /** {@inheritDoc} */
@@ -1409,14 +1406,12 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                     new PolarisEntityId(
                         grantRecord.getSecurableCatalogId(), grantRecord.getSecurableId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     List<PolarisBaseEntity> entities = ms.lookupEntities(callCtx, entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
-        grantsVersion,
-        returnGrantRecords,
-        entities.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        grantsVersion, returnGrantRecords, entities.stream().filter(Objects::nonNull).toList());
   }
 
   /** {@inheritDoc} */
@@ -1504,7 +1499,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                   }
                 })
             .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+            .toList();
 
     // Since the contract of this method is to only return an empty list once no available tasks
     // are found anymore, if we happen to fail to lease any tasks at all due to all of them
@@ -1664,7 +1659,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                   }
                 })
             .map(e -> toResolvedPolarisEntity(callCtx, e, ms))
-            .collect(Collectors.toList());
+            .toList();
     return new ResolvedEntitiesResult(ret);
   }
 
@@ -1904,7 +1899,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyCatalogId(),
                         policyMappingRecord.getPolicyId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     return ms.lookupEntities(callCtx, policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisResolvedPathWrapper.java
@@ -20,7 +20,6 @@ package org.apache.polaris.core.persistence;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -62,7 +61,7 @@ public class PolarisResolvedPathWrapper {
     if (resolvedPath == null) {
       return null;
     }
-    return resolvedPath.stream().map(ResolvedPolarisEntity::getEntity).collect(Collectors.toList());
+    return resolvedPath.stream().map(ResolvedPolarisEntity::getEntity).toList();
   }
 
   public List<ResolvedPolarisEntity> getResolvedParentPath() {
@@ -76,9 +75,7 @@ public class PolarisResolvedPathWrapper {
     if (resolvedPath == null) {
       return null;
     }
-    return getResolvedParentPath().stream()
-        .map(ResolvedPolarisEntity::getEntity)
-        .collect(Collectors.toList());
+    return getResolvedParentPath().stream().map(ResolvedPolarisEntity::getEntity).toList();
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/ResolvedPolarisEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/ResolvedPolarisEntity.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.core.persistence;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -79,13 +78,9 @@ public class ResolvedPolarisEntity {
     // Split the combined list of grant records into grantee vs securable grants since the main
     // usage pattern is to get the two lists separately.
     this.grantRecordsAsGrantee =
-        grantRecords.stream()
-            .filter(record -> record.getGranteeId() == entity.getId())
-            .collect(Collectors.toList());
+        grantRecords.stream().filter(record -> record.getGranteeId() == entity.getId()).toList();
     this.grantRecordsAsSecurable =
-        grantRecords.stream()
-            .filter(record -> record.getSecurableId() == entity.getId())
-            .collect(Collectors.toList());
+        grantRecords.stream().filter(record -> record.getSecurableId() == entity.getId()).toList();
   }
 
   public ResolvedPolarisEntity(
@@ -104,8 +99,7 @@ public class ResolvedPolarisEntity {
   }
 
   public @NonNull List<PolarisGrantRecord> getAllGrantRecords() {
-    return Stream.concat(grantRecordsAsGrantee.stream(), grantRecordsAsSecurable.stream())
-        .collect(Collectors.toList());
+    return Stream.concat(grantRecordsAsGrantee.stream(), grantRecordsAsSecurable.stream()).toList();
   }
 
   /** The grant records associated with this entity being the grantee of the record. */

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -575,7 +575,7 @@ public class Resolver {
                       new PolarisEntityId(
                           resolvedEntity.getEntity().getCatalogId(),
                           resolvedEntity.getEntity().getId()))
-              .collect(Collectors.toList());
+              .toList();
 
       // now get the current backend versions of all these entities
       ChangeTrackingResult changeTrackingResult =

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.persistence.transactional;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.EntityNameLookupRecord;
@@ -281,7 +280,7 @@ public class PolarisEntityResolver {
                         entityCore.getParentId(),
                         entityCore.getTypeCode(),
                         entityCore.getName()))
-            .collect(Collectors.toList());
+            .toList();
 
     // now lookup all these entities by name
     Iterator<EntityNameLookupRecord> activeRecordIt =

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -1800,14 +1799,12 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                     new PolarisEntityId(
                         grantRecord.getGranteeCatalogId(), grantRecord.getGranteeId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(callCtx, entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
-        grantsVersion,
-        returnGrantRecords,
-        entities.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        grantsVersion, returnGrantRecords, entities.stream().filter(Objects::nonNull).toList());
   }
 
   /** {@inheritDoc} */
@@ -1855,14 +1852,12 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                     new PolarisEntityId(
                         grantRecord.getSecurableCatalogId(), grantRecord.getSecurableId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     List<PolarisBaseEntity> entities = ms.lookupEntitiesInCurrentTxn(callCtx, entityIds);
 
     // done, return the list of grants and their version
     return new LoadGrantsResult(
-        grantsVersion,
-        returnGrantRecords,
-        entities.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        grantsVersion, returnGrantRecords, entities.stream().filter(Objects::nonNull).toList());
   }
 
   /** {@inheritDoc} */
@@ -1996,7 +1991,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         result.getReturnStatus(), result.getExtraInformation());
                   }
                 })
-            .collect(Collectors.toList());
+            .toList();
     return EntitiesResult.fromPage(Page.fromItems(loadedTasks));
   }
 
@@ -2180,7 +2175,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                   }
                 })
             .map(e -> toResolvedPolarisEntity(callCtx, e, ms))
-            .collect(Collectors.toList());
+            .toList();
     return new ResolvedEntitiesResult(ret);
   }
 
@@ -2527,7 +2522,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
                         policyMappingRecord.getPolicyCatalogId(),
                         policyMappingRecord.getPolicyId()))
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     return ms.lookupEntitiesInCurrentTxn(callCtx, policyEntityIds);
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocationValidator.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageLocationValidator.java
@@ -71,7 +71,7 @@ public final class StorageLocationValidator {
             .map(str -> str.replace("file:///", "file:/"))
             .collect(Collectors.toSet());
     List<StorageLocation> allowedLocations =
-        allowedLocationStrings.stream().map(StorageLocation::of).collect(Collectors.toList());
+        allowedLocationStrings.stream().map(StorageLocation::of).toList();
 
     boolean allowWildcardLocation = realmConfig.getConfig(ALLOW_WILDCARD_LOCATION);
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -179,7 +179,7 @@ public class AwsCredentialsStorageIntegration
             .filter(t -> !t.startsWith(AwsSessionNameBuilder.PREFIX_CONFIG_TOKEN))
             .map(SessionNameField::fromConfigName)
             .flatMap(Optional::stream)
-            .collect(Collectors.toList());
+            .toList();
     if (!enabledSessionNameFields.isEmpty()) {
       return buildSessionName(principalName, context, enabledSessionNameFields, sessionNamePrefix);
     }
@@ -235,7 +235,7 @@ public class AwsCredentialsStorageIntegration
       if (!sessionTags.isEmpty()) {
         request.tags(sessionTags);
         // Mark all tags as transitive for role chaining support
-        request.transitiveTagKeys(sessionTags.stream().map(Tag::key).collect(Collectors.toList()));
+        request.transitiveTagKeys(sessionTags.stream().map(Tag::key).toList());
       }
 
       key.credentialsResolver()

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsSessionTagsBuilder.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsSessionTagsBuilder.java
@@ -21,7 +21,6 @@ package org.apache.polaris.core.storage.aws;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.storage.CredentialVendingContext;
 import software.amazon.awssdk.services.sts.model.Tag;
 
@@ -60,7 +59,7 @@ public final class AwsSessionTagsBuilder {
     return enabledFields.stream()
         .map(field -> field.buildTag(principalName, context))
         .flatMap(Optional::stream)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/InMemoryEntityCacheTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
@@ -229,7 +228,7 @@ public class InMemoryEntityCacheTest {
             .filter(
                 grantRecord ->
                     grantRecord.getPrivilegeCode() == PolarisPrivilege.TABLE_READ_DATA.getCode())
-            .collect(Collectors.toList());
+            .toList();
     assertThat(matchPriv).hasSize(1);
     gr = matchPriv.get(0);
     assertThat(gr.getGranteeId()).isEqualTo(cacheEntry_R1.getEntity().getId());

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -456,7 +456,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
                     throw new RuntimeException(e);
                   }
                 })
-            .collect(Collectors.toList());
+            .toList();
     Assertions.assertThat(responses)
         .hasSize(3)
         .satisfies(l -> Assertions.assertThat(l.stream().flatMap(Set::stream)).hasSize(100));
@@ -505,7 +505,7 @@ public abstract class BasePolarisMetaStoreManagerTest {
                       throw new RuntimeException(e);
                     }
                   })
-              .collect(Collectors.toList());
+              .toList();
 
       Assertions.assertThat(responses)
           .hasSize(10)

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.auth.PolarisPrincipal;
@@ -432,7 +431,7 @@ public abstract class BaseResolverTest {
                                 metaStoreManager().findPrincipalRoleByName(callCtx(), roleName))
                         .filter(Optional::isPresent)
                         .map(Optional::get)
-                        .collect(Collectors.toList()));
+                        .toList());
     PolarisPrincipal authenticatedPrincipal =
         PolarisPrincipal.of(
             PrincipalEntity.of(P1), Optional.ofNullable(principalRolesScope).orElse(Set.of()));

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogUtils.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.catalog.common;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -86,7 +85,7 @@ public class CatalogUtils {
                     locations.stream()
                         .filter(
                             location -> location.startsWith("file:") || location.startsWith("http"))
-                        .collect(Collectors.toList());
+                        .toList();
                 if (!invalidLocations.isEmpty()) {
                   throw new ForbiddenException(
                       "Invalid locations '%s' for identifier '%s': File locations are not allowed",

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -379,7 +379,7 @@ public class CatalogHandlerUtils {
       List<UpdateRequirement> invalidRequirements =
           request.requirements().stream()
               .filter(req -> !(req instanceof UpdateRequirement.AssertTableDoesNotExist))
-              .collect(Collectors.toList());
+              .toList();
       Preconditions.checkArgument(
           invalidRequirements.isEmpty(), "Invalid create requirements: %s", invalidRequirements);
     }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -1389,7 +1389,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                   }
                   return siblingTablesResult.getEntities().stream()
                       .map(tbl -> TableIdentifier.of(ns.asNamespace(), tbl.getName()))
-                      .collect(Collectors.toList());
+                      .toList();
                 })
             .orElse(List.of());
 

--- a/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
+++ b/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -34,9 +33,7 @@ public class TestDocGenTool {
   @Test
   public void docGenTool(@TempDir Path dir) throws Exception {
     var classpath =
-        Arrays.stream(System.getProperty("testing.libraries").split(":"))
-            .map(Paths::get)
-            .collect(Collectors.toList());
+        Arrays.stream(System.getProperty("testing.libraries").split(":")).map(Paths::get).toList();
 
     var tool =
         new ReferenceConfigDocsGenerator(List.of(Paths.get("src/test/java")), classpath, dir, true);


### PR DESCRIPTION
Fixes #4757

## Summary

Replace usages of Collectors.toList() with Stream.toList() where mutability is not required.

## Changes

- Replaced safe Collectors.toList() usages across core, runtime, persistence, plugins, and tests.
- Removed unused Collectors imports.
- Preserved mutable-list and nullable-list use cases.
- Reverted two conversions in AbstractLocalIcebergCatalogTest due to generic type inference differences between Collectors.toList() and Stream.toList().

## Validation

- ./gradlew format
- ./gradlew :polaris-runtime-service:compileTestJava
- ./gradlew compileAll

All passed successfully.
## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
