### PR TITLE
Fix admin tool dockerfile to match to server

### DIFF
--- a/runtime/admin/src/main/docker/Dockerfile.jvm
+++ b/runtime/admin/src/main/docker/Dockerfile.jvm
@@ -25,14 +25,16 @@ LABEL org.opencontainers.image.source=https://github.com/apache/polaris \
 ENV LANGUAGE='en_US:en' \
     USER=polaris \
     UID=10000 \
-    HOME=/home/polaris
+    HOME=/home/polaris \
+    AB_JOLOKIA_OFF="" \
+    JAVA_APP_JAR="/deployments/polaris-admin-tool.jar"
 
 USER root
 
 RUN groupadd --gid 10001 polaris && \
-    useradd --uid 10000 --gid polaris -m polaris && \
-    mkdir -p /deployments && \
-    chown -R polaris:polaris /deployments /opt/jboss/container
+    useradd --uid 10000 --gid polaris polaris && \
+    chown -R polaris:polaris /opt/jboss/container && \
+    chown -R polaris:polaris /deployments
 
 USER polaris
 
@@ -45,5 +47,3 @@ COPY --chown=polaris:polaris build/quarkus-app/app/ /deployments/app/
 COPY --chown=polaris:polaris build/quarkus-app/quarkus/ /deployments/quarkus/
 COPY --chown=polaris:polaris distribution/LICENSE /deployments/
 COPY --chown=polaris:polaris distribution/NOTICE /deployments/
-
-ENTRYPOINT [ "java", "-jar", "/deployments/polaris-admin-tool.jar" ]


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR matches dockerfile used by admin tool to polaris server (https://github.com/apache/polaris/blob/main/runtime/server/src/main/docker/Dockerfile.jvm):
1. Disable Jolokia
2. Use `JAVA_APP_JAR` instead of `ENTRYPOINT` so CWD will be set to `deployment` instead of `/home/polaris` via `/opt/jboss/container/java/run/run-java.sh`
3. Match `chown` command and remove unnecessary `mkdir` command as `/deployment` is created by default from ubi jdk image.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
