### PR TITLE
polaris-admin/tests: consolidate to 1 test profile per backend

### DIFF
--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTestBase.java
@@ -29,13 +29,16 @@ import java.util.List;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.assertj.core.api.SoftAssertions;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusMainTest
 public abstract class PurgeCommandTestBase {
+  private static final String REALM1 = "purge-test-realm1";
+  private static final String REALM2 = "purge-test-realm2";
+  private static final String MISSING_REALM = "purge-test-missing-realm";
+
   protected SoftAssertions soft;
 
   @BeforeEach
@@ -48,30 +51,26 @@ public abstract class PurgeCommandTestBase {
     soft.assertAll();
   }
 
-  void preBootstrap(
-      @Observes StartupEvent event,
-      @ConfigProperty(name = "pre-bootstrap", defaultValue = "false") boolean preBootstrap,
-      MetaStoreManagerFactory metaStoreManagerFactory) {
-    if (preBootstrap) {
-      metaStoreManagerFactory.bootstrapRealms(
-          List.of("realm1", "realm2"), RootCredentialsSet.EMPTY);
-    }
+  void preBootstrap(@Observes StartupEvent event, MetaStoreManagerFactory metaStoreManagerFactory) {
+    metaStoreManagerFactory.bootstrapRealms(List.of(REALM1, REALM2), RootCredentialsSet.EMPTY);
   }
 
   @Test
-  @Launch(value = {"purge", "-r", "realm1", "-r", "realm2"})
+  @Launch(value = {"purge", "-r", REALM1, "-r", REALM2})
   public void testPurge(LaunchResult result) {
     assertThat(result.getOutput()).contains("Purge completed successfully.");
   }
 
   @Test
   @Launch(
-      value = {"purge", "-r", "realm3"},
+      value = {"purge", "-r", MISSING_REALM},
       exitCode = BaseCommand.EXIT_CODE_PURGE_ERROR)
   public void testPurgeFailure(LaunchResult result) {
     soft.assertThat(result.getOutput())
         .contains(
-            "Realm realm3 is not bootstrapped, could not load root principal. Please run Bootstrap command.");
+            "Realm "
+                + MISSING_REALM
+                + " is not bootstrapped, could not load root principal. Please run Bootstrap command.");
     soft.assertThat(result.getErrorOutput()).contains("Purge encountered errors during operation.");
   }
 }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/NoSqlInMemoryPurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/NoSqlInMemoryPurgeCommandTest.java
@@ -22,5 +22,5 @@ import io.quarkus.test.junit.TestProfile;
 import org.apache.polaris.admintool.AdminProfiles;
 import org.apache.polaris.admintool.PurgeCommandTestBase;
 
-@TestProfile(AdminProfiles.PreBootstrappedNoSqlInMemory.class)
+@TestProfile(AdminProfiles.NoSqlInMemory.class)
 class NoSqlInMemoryPurgeCommandTest extends PurgeCommandTestBase {}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/NoSqlMongoPurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/nosql/NoSqlMongoPurgeCommandTest.java
@@ -22,5 +22,5 @@ import io.quarkus.test.junit.TestProfile;
 import org.apache.polaris.admintool.AdminProfiles;
 import org.apache.polaris.admintool.PurgeCommandTestBase;
 
-@TestProfile(AdminProfiles.PreBootstrappedNoSqlMongo.class)
+@TestProfile(AdminProfiles.NoSqlMongo.class)
 class NoSqlMongoPurgeCommandTest extends PurgeCommandTestBase {}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/CockroachJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/CockroachJdbcBootstrapCommandTest.java
@@ -18,26 +18,8 @@
  */
 package org.apache.polaris.admintool.relational.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
 import org.apache.polaris.admintool.AdminProfiles;
-import org.junit.jupiter.api.Test;
 
 @TestProfile(AdminProfiles.CockroachJdbc.class)
-public class CockroachJdbcBootstrapCommandTest extends RelationalJdbcBootstrapCommandTest {
-
-  @Override
-  @Test
-  public void testBootstrapFailsWhenAddingRealmWithDifferentSchemaVersion(
-      QuarkusMainLauncher launcher) {
-    // CockroachDB only has schema v4 (no v1, v2 or v3 schemas exist).
-    // Override to bootstrap with v4, which is the only version available for CockroachDB.
-    LaunchResult result1 =
-        launcher.launch("bootstrap", "-v", "4", "-r", "realm1", "-c", "realm1,root,s3cr3t");
-    assertThat(result1.exitCode()).isEqualTo(0);
-    assertThat(result1.getOutput()).contains("Bootstrap completed successfully.");
-  }
-}
+public class CockroachJdbcBootstrapCommandTest extends RelationalJdbcBootstrapCommandTest {}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/CockroachJdbcPurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/CockroachJdbcPurgeCommandTest.java
@@ -22,5 +22,5 @@ import io.quarkus.test.junit.TestProfile;
 import org.apache.polaris.admintool.AdminProfiles;
 import org.apache.polaris.admintool.PurgeCommandTestBase;
 
-@TestProfile(AdminProfiles.PreBootstrappedCockroachJdbc.class)
+@TestProfile(AdminProfiles.CockroachJdbc.class)
 public class CockroachJdbcPurgeCommandTest extends PurgeCommandTestBase {}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
@@ -31,19 +31,11 @@ import org.junit.jupiter.api.Test;
 public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase {
 
   @Test
-  public void testBootstrapFailsWhenAddingRealmWithDifferentSchemaVersion(
-      QuarkusMainLauncher launcher) {
-    // First, bootstrap the schema to version 1
+  public void testBootstrapWithExplicitSchemaVersion(QuarkusMainLauncher launcher) {
     LaunchResult result1 =
-        launcher.launch("bootstrap", "-v", "1", "-r", "realm1", "-c", "realm1,root,s3cr3t");
+        launcher.launch("bootstrap", "-v", "4", "-r", "realm1", "-c", "realm1,root,s3cr3t");
     assertThat(result1.exitCode()).isEqualTo(0);
     assertThat(result1.getOutput()).contains("Bootstrap completed successfully.");
-
-    // TODO: enable this once we enable postgres container reuse in the same test.
-    // LaunchResult result2 = launcher.launch("bootstrap", "-v", "2", "-r", "realm2", "-c",
-    // "realm2,root,s3cr3t");
-    // assertThat(result2.exitCode()).isEqualTo(EXIT_CODE_BOOTSTRAP_ERROR);
-    // assertThat(result2.getOutput()).contains("Cannot bootstrap due to schema version mismatch.");
   }
 
   @Test

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcPurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcPurgeCommandTest.java
@@ -22,5 +22,5 @@ import io.quarkus.test.junit.TestProfile;
 import org.apache.polaris.admintool.AdminProfiles;
 import org.apache.polaris.admintool.PurgeCommandTestBase;
 
-@TestProfile(AdminProfiles.PreBootstrappedRelationalJdbc.class)
+@TestProfile(AdminProfiles.RelationalJdbc.class)
 public class RelationalJdbcPurgeCommandTest extends PurgeCommandTestBase {}

--- a/runtime/admin/src/testFixtures/java/org/apache/polaris/admintool/AdminProfiles.java
+++ b/runtime/admin/src/testFixtures/java/org/apache/polaris/admintool/AdminProfiles.java
@@ -18,7 +18,6 @@
  */
 package org.apache.polaris.admintool;
 
-import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +26,6 @@ import org.apache.polaris.test.commons.PostgresRelationalJdbcLifeCycleManagement
 
 public final class AdminProfiles {
 
-  private static final Map<String, String> PRE_BOOTSTRAP_CONFIG = Map.of("pre-bootstrap", "true");
-
   private AdminProfiles() {}
 
   public static class NoSqlInMemory implements QuarkusTestProfile {
@@ -36,16 +33,6 @@ public final class AdminProfiles {
     public Map<String, String> getConfigOverrides() {
       return Map.of(
           "polaris.persistence.type", "nosql", "polaris.persistence.nosql.backend", "InMemory");
-    }
-  }
-
-  public static class PreBootstrappedNoSqlInMemory extends NoSqlInMemory {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(super.getConfigOverrides())
-          .putAll(PRE_BOOTSTRAP_CONFIG)
-          .build();
     }
   }
 
@@ -59,16 +46,6 @@ public final class AdminProfiles {
     @Override
     public List<TestResourceEntry> testResources() {
       return List.of(new TestResourceEntry(MongoTestResourceLifecycleManager.class));
-    }
-  }
-
-  public static class PreBootstrappedNoSqlMongo extends NoSqlMongo {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(super.getConfigOverrides())
-          .putAll(PRE_BOOTSTRAP_CONFIG)
-          .build();
     }
   }
 
@@ -93,16 +70,6 @@ public final class AdminProfiles {
     }
   }
 
-  public static class PreBootstrappedRelationalJdbc extends RelationalJdbc {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(super.getConfigOverrides())
-          .putAll(PRE_BOOTSTRAP_CONFIG)
-          .build();
-    }
-  }
-
   public static class CockroachJdbc implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
@@ -123,16 +90,6 @@ public final class AdminProfiles {
     public List<TestResourceEntry> testResources() {
       return List.of(
           new TestResourceEntry(CockroachRelationalJdbcLifeCycleManagement.class, Map.of()));
-    }
-  }
-
-  public static class PreBootstrappedCockroachJdbc extends CockroachJdbc {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(super.getConfigOverrides())
-          .putAll(PRE_BOOTSTRAP_CONFIG)
-          .build();
     }
   }
 }


### PR DESCRIPTION
Removed the four PreBootstrapped* admin profiles and the pre-bootstrap config flag from AdminProfiles.
* Switched purge tests to the regular backend profiles.
* Kept purge setup inside PurgeCommandTestBase with an unconditional test startup observer, using purge-specific realms: `purge-test-realm1`, `purge-test-realm2`, `purge-test-missing-realm`.