### PR TITLE
Allow only Table level drop permissions to drop Generic Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).
 - JWT verification now validates the issuer claim (`"polaris"`) in addition to the active claim. Tokens signed with the same key but carrying a different issuer are now rejected.
 - Inheritable policy mapping inserts in the JDBC backend now use the active transaction connection, so they roll back correctly with the surrounding transaction.
+- Generic table drop now accepts table-scoped `TABLE_DROP` privilege.
 
 ## [1.5.0]
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/GenericTableCatalogHandler.java
@@ -131,7 +131,7 @@ public abstract class GenericTableCatalogHandler extends CatalogHandler {
 
   public boolean dropGenericTable(TableIdentifier identifier) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.DROP_TABLE_WITHOUT_PURGE;
-    authorizeCreateTableLikeUnderNamespaceOperationOrThrow(op, identifier);
+    authorizeBasicTableLikeOperationOrThrow(op, PolarisEntitySubType.GENERIC_TABLE, identifier);
 
     return this.genericTableCatalog.dropGenericTable(identifier);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.admin.PolarisAuthzTestBase;
@@ -144,8 +145,16 @@ public class PolarisGenericTableCatalogHandlerAuthzTest extends PolarisAuthzTest
                   adminService.revokePrivilegeOnTableFromRole(
                       CATALOG_NAME, CATALOG_ROLE1, tableId, priv);
               // After table drop + recreate, grants on the old entity no longer exist on the
-              // new entity. This is expected and equivalent to a successful revoke.
-              return res.isSuccess() ? res : new PrivilegeResult(new PolarisGrantRecord());
+              // new entity. Only treat GRANT_NOT_FOUND or ENTITY_NOT_FOUND as acceptable —
+              // any other failure should propagate to avoid masking real errors.
+              if (!res.isSuccess()) {
+                BaseResult.ReturnStatus status = res.getReturnStatus();
+                if (status == BaseResult.ReturnStatus.GRANT_NOT_FOUND
+                    || status == BaseResult.ReturnStatus.ENTITY_NOT_FOUND) {
+                  return new PrivilegeResult(new PolarisGrantRecord());
+                }
+              }
+              return res;
             });
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
@@ -26,9 +26,12 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
 import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.admin.PolarisAuthzTestBase;
+import org.apache.polaris.service.admin.PolarisAuthzTestsFactory;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
@@ -115,6 +118,49 @@ public class PolarisGenericTableCatalogHandlerAuthzTest extends PolarisAuthzTest
             CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_CREATE));
 
     return authzTestsBuilder("dropGenericTable")
+        .action(() -> newWrapper(Set.of(PRINCIPAL_ROLE1)).dropGenericTable(TABLE_NS1_1_GENERIC))
+        .cleanupAction(
+            () ->
+                newWrapper(Set.of(PRINCIPAL_ROLE2))
+                    .createGenericTable(
+                        TABLE_NS1_1_GENERIC, "format", "file:///temp/", "doc", Map.of()))
+        .shouldPassWith(PolarisPrivilege.TABLE_DROP)
+        .shouldPassWith(PolarisPrivilege.TABLE_FULL_METADATA)
+        .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_CONTENT)
+        .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_METADATA)
+        .createTests();
+  }
+
+  private PolarisAuthzTestsFactory.Builder tableLevelAuthzTestsBuilder(
+      String operationName, TableIdentifier tableId) {
+    return authzTestsBuilder(operationName)
+        .grantAction(
+            priv ->
+                adminService.grantPrivilegeOnTableToRole(
+                    CATALOG_NAME, CATALOG_ROLE1, tableId, priv))
+        .revokeAction(
+            priv -> {
+              PrivilegeResult res =
+                  adminService.revokePrivilegeOnTableFromRole(
+                      CATALOG_NAME, CATALOG_ROLE1, tableId, priv);
+              // After table drop + recreate, grants on the old entity no longer exist on the
+              // new entity. This is expected and equivalent to a successful revoke.
+              return res.isSuccess() ? res : new PrivilegeResult(new PolarisGrantRecord());
+            });
+  }
+
+  /**
+   * Tests that dropGenericTable works with table-level privilege grants. This verifies that the
+   * authorization resolves the table entity (not just the namespace), which is required for
+   * table-level grants to take effect.
+   */
+  @TestFactory
+  Stream<DynamicNode> testDropGenericTableWithTableLevelPrivileges() {
+    assertSuccess(
+        adminService.grantPrivilegeOnCatalogToRole(
+            CATALOG_NAME, CATALOG_ROLE2, PolarisPrivilege.TABLE_CREATE));
+
+    return tableLevelAuthzTestsBuilder("dropGenericTableWithTableLevelGrant", TABLE_NS1_1_GENERIC)
         .action(() -> newWrapper(Set.of(PRINCIPAL_ROLE1)).dropGenericTable(TABLE_NS1_1_GENERIC))
         .cleanupAction(
             () ->


### PR DESCRIPTION
Fixes: https://github.com/apache/polaris/issues/4778

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
