### PR TITLE
Set entrypoint for admin tool image

### DIFF
--- a/runtime/admin/src/main/docker/Dockerfile.jvm
+++ b/runtime/admin/src/main/docker/Dockerfile.jvm
@@ -47,3 +47,5 @@ COPY --chown=polaris:polaris build/quarkus-app/app/ /deployments/app/
 COPY --chown=polaris:polaris build/quarkus-app/quarkus/ /deployments/quarkus/
 COPY --chown=polaris:polaris distribution/LICENSE /deployments/
 COPY --chown=polaris:polaris distribution/NOTICE /deployments/
+
+ENTRYPOINT ["/opt/jboss/container/java/run/run-java.sh"]


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Recently I worked on https://github.com/apache/polaris/pull/4760/changes to match admin image to server image, there is one thing which I missed to test: unlike server image there is no sub-command, the admin image has sub-command. 

This means, with current main, if we do `docker run --rm -it apache/polaris-admin-tool:latest` it will show the helper message without error (which is what I tested) but it would failed if we try to provide a sub-command such as `docker run --rm -it apache/polaris-admin-tool:latest bootstrap xxx`.

This due to with the change in 4760, only cmd would be set and there won't be any entrypoint and the sub-command would overwrite the cmd:
```
➜  ~ docker inspect apache/polaris-admin-tool:latest --format '{{.Config.Entrypoint}} {{.Config.Cmd}}'
[] [/opt/jboss/container/java/run/run-java.sh]
```

This would cause issues such as following:
```
➜  polaris git:(helm_maintenance_jobs) ✗ docker run -it apache/polaris-admin-tool:latest nosql

What's next:
    Debug this container error with Gordon → docker ai "help me fix this container error"
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "nosql": executable file not found in $PATH
```

Now to fix this problem, I am implicitly setting the built-in run script used by ubi jdk image as entrypoint:
```
➜  polaris git:(fix_admin_tool_image_entrypoint) docker run -it apache/polaris-admin-tool:latest nosql
INFO exec -a "java" java -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar /deployments/polaris-admin-tool.jar nosql
INFO running in /deployments
Polaris NoSql persistence has multiple subcommands,
use the 'help nosql' command.
...
``` 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
