### PR TITLE
Makefile target for build-spark-plugin-4.0-2.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,14 @@ build-spark-plugin-3.5-2.13: check-dependencies ## Build Spark plugin v3.5 with 
 		:polaris-spark-3.5_2.13:assemble
 	@echo "--- Spark plugin v3.5 with Scala v2.13 build complete ---"
 
+build-spark-plugin-4.0-2.13: DEPENDENCIES := java21
+.PHONY: build-spark-plugin-4.0-2.13
+build-spark-plugin-4.0-2.13: check-dependencies ## Build Spark plugin v4.0 with Scala v2.13
+	@echo "--- Building Spark plugin v4.0 with Scala v2.13 ---"
+	@./gradlew \
+		:polaris-spark-4.0_2.13:assemble
+	@echo "--- Spark plugin v4.0 with Scala v2.13 build complete ---"
+
 spotless-apply: DEPENDENCIES := java21
 .PHONY: spotless-apply
 spotless-apply: check-dependencies ## Apply code formatting using Spotless Gradle plugin.


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

We have following currently:
```
  build-spark-plugin-3.5-2.12               Build Spark plugin v3.5 with Scala v2.12
  build-spark-plugin-3.5-2.13               Build Spark plugin v3.5 with Scala v2.13
```

Adding
```
  build-spark-plugin-4.0-2.13               Build Spark plugin v4.0 with Scala v2.13
```

Full output for `Polaris Build`:
```
Polaris Build
  build                                     Build Polaris server, admin, and container images
  build-admin                               Build Polaris admin and container image
  build-cleanup                             Clean build artifacts
  build-server                              Build Polaris server and container image
  build-spark-plugin-3.5-2.12               Build Spark plugin v3.5 with Scala v2.12
  build-spark-plugin-3.5-2.13               Build Spark plugin v3.5 with Scala v2.13
  build-spark-plugin-4.0-2.13               Build Spark plugin v4.0 with Scala v2.13
  spotless-apply                            Apply code formatting using Spotless Gradle plugin.
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
