### PR TITLE
polaris-admin/test: migrate some tests to pure unit tests

### DIFF
--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.admintool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class BootstrapCommandTest {
+
+  @Test
+  void testBootstrapInvalidCredentials() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", "realm1", "-c", "invalid syntax");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_BOOTSTRAP_ERROR);
+    assertThat(err.toString())
+        .contains("Invalid credentials format: invalid syntax")
+        .contains("Bootstrap encountered errors during operation.");
+  }
+
+  @Test
+  void testBootstrapInvalidArguments() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", "realm1", "-f", "/irrelevant");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_USAGE);
+    assertThat(err.toString())
+        .contains(
+            "Error: [-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]] and [[-f=<file>]] are mutually exclusive (specify only one)");
+  }
+
+  @Test
+  void testBootstrapFromInvalidFile() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-f", "/non/existing/file");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_BOOTSTRAP_ERROR);
+    assertThat(err.toString())
+        .contains("Failed to read credentials from file:///non/existing/file")
+        .contains("Bootstrap encountered errors during operation.");
+  }
+
+  @Test
+  void testNoPrintCredentialsSystemGenerated() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", "realm1");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_BOOTSTRAP_ERROR);
+    assertThat(err.toString()).contains("--credentials").contains("--print-credentials");
+  }
+
+  @Test
+  void testBootstrapInvalidArg() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", "realm1", "--not-real-arg");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_USAGE);
+    assertThat(err.toString()).contains("Unknown option: '--not-real-arg'").contains("Usage:");
+  }
+}

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTestBase.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.admintool;
 
-import static org.apache.polaris.admintool.BaseCommand.EXIT_CODE_BOOTSTRAP_ERROR;
-import static org.apache.polaris.admintool.BaseCommand.EXIT_CODE_USAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.main.Launch;
@@ -69,32 +67,6 @@ public abstract class BootstrapCommandTestBase {
   }
 
   @Test
-  @Launch(
-      value = {
-        "bootstrap",
-        "-r",
-        "realm1",
-        "-c",
-        "invalid syntax",
-      },
-      exitCode = EXIT_CODE_BOOTSTRAP_ERROR)
-  public void testBootstrapInvalidCredentials(LaunchResult result) {
-    assertThat(result.getErrorOutput())
-        .contains("Invalid credentials format: invalid syntax")
-        .contains("Bootstrap encountered errors during operation.");
-  }
-
-  @Test
-  @Launch(
-      value = {"bootstrap", "-r", "realm1", "-f", "/irrelevant"},
-      exitCode = EXIT_CODE_USAGE)
-  public void testBootstrapInvalidArguments(LaunchResult result) {
-    assertThat(result.getErrorOutput())
-        .contains(
-            "Error: [-r=<realm> [-r=<realm>]... [-c=<realm,clientId,clientSecret>]... [-p]] and [[-f=<file>]] are mutually exclusive (specify only one)");
-  }
-
-  @Test
   public void testBootstrapFromValidJsonFile(QuarkusMainLauncher launcher) {
     LaunchResult result = launcher.launch("bootstrap", "-f", json.toString());
     assertThat(result.exitCode()).isEqualTo(0);
@@ -115,15 +87,6 @@ public abstract class BootstrapCommandTestBase {
   }
 
   @Test
-  public void testBootstrapFromInvalidFile(QuarkusMainLauncher launcher) {
-    LaunchResult result = launcher.launch("bootstrap", "-f", "/non/existing/file");
-    assertThat(result.exitCode()).isEqualTo(EXIT_CODE_BOOTSTRAP_ERROR);
-    assertThat(result.getErrorOutput())
-        .contains("Failed to read credentials from file:///non/existing/file")
-        .contains("Bootstrap encountered errors during operation.");
-  }
-
-  @Test
   @Launch(
       value = {"bootstrap", "-r", "realm1", "-c", "realm1,client1d,s3cr3t", "--print-credentials"})
   public void testPrintCredentials(LaunchResult result) {
@@ -136,30 +99,6 @@ public abstract class BootstrapCommandTestBase {
   public void testPrintCredentialsSystemGenerated(LaunchResult result) {
     assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
     assertThat(result.getOutput()).contains("realm: realm1 root principal credentials: ");
-  }
-
-  @Test
-  @Launch(
-      value = {"bootstrap", "-r", "realm1"},
-      exitCode = EXIT_CODE_BOOTSTRAP_ERROR)
-  public void testNoPrintCredentialsSystemGenerated(LaunchResult result) {
-    assertThat(result.getErrorOutput()).contains("--credentials");
-    assertThat(result.getErrorOutput()).contains("--print-credentials");
-  }
-
-  @Test
-  @Launch(
-      value = {
-        "bootstrap",
-        "-r",
-        "realm1",
-        "--not-real-arg",
-      },
-      exitCode = EXIT_CODE_USAGE)
-  public void testBootstrapInvalidArg(LaunchResult result) {
-    assertThat(result.getErrorOutput())
-        .contains("Unknown option: '--not-real-arg'")
-        .contains("Usage:");
   }
 
   private static Path copyResource(Path temp, String resource) throws IOException {

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTest.java
@@ -38,6 +38,33 @@ import picocli.CommandLine;
 
 class PurgeCommandTest {
 
+  @Test
+  void testPurgeFailure() {
+    String realm = "missing-realm";
+    PurgeCommand command = new PurgeCommand();
+    command.metaStoreManagerFactory =
+        new FakeMetaStoreManagerFactory(
+            Map.of(
+                realm,
+                new BaseResult(BaseResult.ReturnStatus.ENTITY_NOT_FOUND, "Not bootstrapped")));
+
+    CommandLine commandLine = new CommandLine(command);
+    StringWriter out = new StringWriter();
+    StringWriter err = new StringWriter();
+    commandLine.setOut(new PrintWriter(out));
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("-r", realm);
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_PURGE_ERROR);
+    assertThat(out.toString())
+        .contains(
+            "Realm "
+                + realm
+                + " is not bootstrapped, could not load root principal. Please run Bootstrap command.");
+    assertThat(err.toString()).contains("Purge encountered errors during operation.");
+  }
+
   /**
    * When {@code purgeRealms} fails (e.g. database connection failure, permission denied), the
    * command must surface the underlying exception to stderr so operators can diagnose it, in
@@ -48,7 +75,7 @@ class PurgeCommandTest {
     String failureMessage = "simulated database connection failure";
     PurgeCommand command = new PurgeCommand();
     command.metaStoreManagerFactory =
-        new ThrowingMetaStoreManagerFactory(new RuntimeException(failureMessage));
+        new FakeMetaStoreManagerFactory(new RuntimeException(failureMessage));
 
     CommandLine commandLine = new CommandLine(command);
     StringWriter err = new StringWriter();
@@ -63,17 +90,27 @@ class PurgeCommandTest {
         .contains("Purge encountered errors during operation.");
   }
 
-  /** Minimal {@link MetaStoreManagerFactory} whose {@code purgeRealms} always throws. */
-  private static final class ThrowingMetaStoreManagerFactory implements MetaStoreManagerFactory {
+  /** Minimal {@link MetaStoreManagerFactory} for testing purge command results and failures. */
+  private static final class FakeMetaStoreManagerFactory implements MetaStoreManagerFactory {
+    private final Map<String, BaseResult> results;
     private final RuntimeException failure;
 
-    private ThrowingMetaStoreManagerFactory(RuntimeException failure) {
+    private FakeMetaStoreManagerFactory(Map<String, BaseResult> results) {
+      this.results = results;
+      this.failure = null;
+    }
+
+    private FakeMetaStoreManagerFactory(RuntimeException failure) {
+      this.results = null;
       this.failure = failure;
     }
 
     @Override
     public Map<String, BaseResult> purgeRealms(Iterable<String> realms) {
-      throw failure;
+      if (failure != null) {
+        throw failure;
+      }
+      return results;
     }
 
     @Override

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTestBase.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/PurgeCommandTestBase.java
@@ -28,28 +28,12 @@ import jakarta.enterprise.event.Observes;
 import java.util.List;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusMainTest
 public abstract class PurgeCommandTestBase {
   private static final String REALM1 = "purge-test-realm1";
   private static final String REALM2 = "purge-test-realm2";
-  private static final String MISSING_REALM = "purge-test-missing-realm";
-
-  protected SoftAssertions soft;
-
-  @BeforeEach
-  void setup() {
-    soft = new SoftAssertions();
-  }
-
-  @AfterEach
-  void after() {
-    soft.assertAll();
-  }
 
   void preBootstrap(@Observes StartupEvent event, MetaStoreManagerFactory metaStoreManagerFactory) {
     metaStoreManagerFactory.bootstrapRealms(List.of(REALM1, REALM2), RootCredentialsSet.EMPTY);
@@ -59,18 +43,5 @@ public abstract class PurgeCommandTestBase {
   @Launch(value = {"purge", "-r", REALM1, "-r", REALM2})
   public void testPurge(LaunchResult result) {
     assertThat(result.getOutput()).contains("Purge completed successfully.");
-  }
-
-  @Test
-  @Launch(
-      value = {"purge", "-r", MISSING_REALM},
-      exitCode = BaseCommand.EXIT_CODE_PURGE_ERROR)
-  public void testPurgeFailure(LaunchResult result) {
-    soft.assertThat(result.getOutput())
-        .contains(
-            "Realm "
-                + MISSING_REALM
-                + " is not bootstrapped, could not load root principal. Please run Bootstrap command.");
-    soft.assertThat(result.getErrorOutput()).contains("Purge encountered errors during operation.");
   }
 }


### PR DESCRIPTION
This change moves a few test cases to `PurgeCommandTest` and the new `BootstrapCommandTest`.

Each `@QuarkusMainTest`/`@Launch` test case starts a new Quarkus command tool with fresh test resources. This means that each of these test cases also spawns new Postgres/Cockroach/Mongo container instances, which is time consuming.

Runtime of `:polaris-admin:test` on my machine dropped from ~7 minutes to ~4 minutes.