### PR TITLE
polaris-runtime-service/test: slight test-profile improvement

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/Profiles.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/Profiles.java
@@ -50,6 +50,58 @@ public final class Profiles {
     }
   }
 
+  public static class ApplicationIntegrationProfile extends DefaultProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .putAll(super.getConfigOverrides())
+          .put("quarkus.http.limits.max-body-size", "1000000")
+          .put("polaris.realm-context.realms", "POLARIS,OTHER")
+          .put("polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"", "true")
+          .put("polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"", "true")
+          .build();
+    }
+  }
+
+  public static class ManagementIntegrationProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"",
+          "true",
+          "polaris.features.\"ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING\"",
+          "true",
+          "polaris.storage.gcp.token",
+          "token",
+          "polaris.storage.gcp.lifespan",
+          "PT1H");
+    }
+  }
+
+  public static class RestCatalogFileIntegrationProfile extends DefaultProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .putAll(super.getConfigOverrides())
+          .put("polaris.features.\"ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING\"", "false")
+          .put("polaris.features.\"ALLOW_NAMESPACE_CUSTOM_LOCATION\"", "true")
+          .build();
+    }
+  }
+
+  public static class RestCatalogViewFileIntegrationProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
+          "true",
+          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
+          "[\"FILE\"]",
+          "polaris.readiness.ignore-severe-issues",
+          "true");
+    }
+  }
+
   public static class DefaultNoSqlProfile extends DefaultProfile {
     @Override
     public Map<String, String> getConfigOverrides() {

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/ApplicationIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
 import java.time.Instant;
@@ -37,38 +36,15 @@ import org.apache.iceberg.rest.auth.AuthConfig;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.PolarisApiEndpoints;
 import org.apache.polaris.service.it.test.PolarisApplicationIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(ApplicationIntegrationTest.Profile.class)
+@TestProfile(Profiles.ApplicationIntegrationProfile.class)
 public class ApplicationIntegrationTest extends PolarisApplicationIntegrationTest {
-
-  public static class Profile implements QuarkusTestProfile {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "quarkus.http.limits.max-body-size",
-          "1000000",
-          "polaris.realm-context.realms",
-          "POLARIS,OTHER",
-          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"",
-          "true",
-          "polaris.features.\"SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION\"",
-          "true",
-          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
-          "true",
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\",\"S3\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true");
-    }
-  }
-
   @Test
   public void testIcebergRestApiRefreshExpiredToken(
       PolarisApiEndpoints endpoints, ClientCredentials clientCredentials) throws IOException {

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/ManagementServiceIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/ManagementServiceIntegrationTest.java
@@ -19,28 +19,10 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import java.util.Map;
+import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.test.PolarisManagementServiceIntegrationTest;
 
 @QuarkusTest
-@TestProfile(ManagementServiceIntegrationTest.Profile.class)
-public class ManagementServiceIntegrationTest extends PolarisManagementServiceIntegrationTest {
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_OVERLAPPING_CATALOG_URLS\"",
-          "true",
-          "polaris.features.\"ENFORCE_PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_CHECKING\"",
-          "true",
-          "polaris.storage.gcp.token",
-          "token",
-          "polaris.storage.gcp.lifespan",
-          "PT1H");
-    }
-  }
-}
+@TestProfile(Profiles.ManagementIntegrationProfile.class)
+public class ManagementServiceIntegrationTest extends PolarisManagementServiceIntegrationTest {}

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/PolicyServiceIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/PolicyServiceIntegrationTest.java
@@ -19,27 +19,10 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import java.util.Map;
+import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.test.PolarisPolicyServiceIntegrationTest;
 
 @QuarkusTest
-@TestProfile(PolicyServiceIntegrationTest.Profile.class)
-public class PolicyServiceIntegrationTest extends PolarisPolicyServiceIntegrationTest {
-
-  public static class Profile implements QuarkusTestProfile {
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
-          "true",
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\",\"S3\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true");
-    }
-  }
-}
+@TestProfile(Profiles.DefaultProfile.class)
+public class PolicyServiceIntegrationTest extends PolarisPolicyServiceIntegrationTest {}

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
@@ -19,39 +19,17 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
-import java.util.Map;
+import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.test.PolarisRestCatalogFileIntegrationTest;
 import org.apache.polaris.service.task.TaskErrorHandler;
 import org.junit.jupiter.api.AfterEach;
 
 @QuarkusTest
-@TestProfile(RestCatalogFileIntegrationTest.Profile.class)
+@TestProfile(Profiles.RestCatalogFileIntegrationProfile.class)
 public class RestCatalogFileIntegrationTest extends PolarisRestCatalogFileIntegrationTest {
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_SPECIFYING_FILE_IO_IMPL\"",
-          "true",
-          "polaris.features.\"ALLOW_EXTERNAL_CATALOG_CREDENTIAL_VENDING\"",
-          "false",
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\",\"S3\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true",
-          "polaris.features.\"ALLOW_NAMESPACE_CUSTOM_LOCATION\"",
-          "true");
-    }
-  }
-
   @Inject
   @Identifier("task-error-handler")
   TaskErrorHandler taskErrorHandler;

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogViewFileIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogViewFileIntegrationTest.java
@@ -19,27 +19,11 @@
 package org.apache.polaris.service.it;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import java.util.Map;
+import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.test.PolarisRestCatalogViewFileIntegrationTestBase;
 
 @QuarkusTest
-@TestProfile(RestCatalogViewFileIntegrationTest.Profile.class)
+@TestProfile(Profiles.RestCatalogViewFileIntegrationProfile.class)
 public class RestCatalogViewFileIntegrationTest
-    extends PolarisRestCatalogViewFileIntegrationTestBase {
-
-  public static class Profile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return Map.of(
-          "polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"",
-          "true",
-          "polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"",
-          "[\"FILE\"]",
-          "polaris.readiness.ignore-severe-issues",
-          "true");
-    }
-  }
-}
+    extends PolarisRestCatalogViewFileIntegrationTestBase {}


### PR DESCRIPTION
Save one profile (and its Quarkus augmentation), move more test profiles to `Profiles`.