### PR TITLE
Build: refactor some more eager resolutions

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -133,7 +133,7 @@ tasks.register<VerifyBomDependenciesTask>("verifyBomDependencies") {
     configurations.api.map { it.dependencyConstraints.map { "${it.group}:${it.name}" } }
   )
   projectCoordinatesByPath.set(
-    rootProject.allprojects.associate { it.path to "${it.group}:${it.name}" }
+    provider { rootProject.allprojects.associate { it.path to "${it.group}:${it.name}" } }
   )
   excludedProjectPaths.set(
     setOf(

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -164,7 +164,7 @@ testing {
       // Special handling for test-suites with names containing `manualtest`, which are intended to
       // be run on demand rather than implicitly via `check`.
       if (!name.lowercase().contains("manualtest")) {
-        targets.all {
+        targets.configureEach {
           if (testTask.name != "test") {
             testTask.configure { shouldRunAfter("test") }
             tasks.named("check").configure { dependsOn(testTask) }
@@ -298,7 +298,7 @@ class BannedDependencies(
   }
 
   fun applyTo(configurations: ConfigurationContainer) {
-    configurations.all { applyTo(this) }
+    configurations.configureEach { applyTo(this) }
   }
 }
 

--- a/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-runtime.gradle.kts
@@ -33,7 +33,7 @@ plugins { id("polaris-server") }
 testing {
   suites {
     withType<JvmTestSuite> {
-      targets.all {
+      targets.configureEach {
         testTask.configure {
           systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
           // Enable automatic extension detection to execute GradleDuplicateLoggingWorkaround
@@ -44,7 +44,7 @@ testing {
       }
     }
     fun intTestSuiteConfigure(testSuite: JvmTestSuite) = testSuite.run {
-      targets.all {
+      targets.configureEach {
         testTask.configure {
           // For Quarkus...
           //
@@ -60,12 +60,12 @@ testing {
         dependsOn("compileQuarkusTestGeneratedSourcesJava")
       }
       configurations.named(sources.runtimeOnlyConfigurationName).configure {
-        extendsFrom(configurations.getByName("testRuntimeOnly"))
+        extendsFrom(configurations.named("testRuntimeOnly"))
       }
       configurations.named(sources.implementationConfigurationName).configure {
         // Let the test's implementation config extend testImplementation, so it also inherits the
         // project's "main" implementation dependencies (not just the "api" configuration)
-        extendsFrom(configurations.getByName("testImplementation"))
+        extendsFrom(configurations.named("testImplementation"))
       }
       sources { java.srcDirs(tasks.named("quarkusGenerateCodeTests")) }
     }
@@ -81,7 +81,7 @@ dependencies {
   implementation("org.jboss.slf4j:slf4j-jboss-logmanager")
 }
 
-configurations.all {
+configurations.configureEach {
   // Validate that Logback dependencies are not used in Quarkus modules.
   dependencies.configureEach {
     if (group == "ch.qos.logback") {
@@ -94,7 +94,7 @@ configurations.all {
 }
 
 configurations.named("intTestRuntimeOnly").configure {
-  extendsFrom(configurations.getByName("testRuntimeOnly"))
+  extendsFrom(configurations.named("testRuntimeOnly"))
 }
 
 tasks.named("compileJava") { dependsOn("compileQuarkusGeneratedSourcesJava") }

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -156,7 +156,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
               val testFixturesSourcesJar by
                 tasks.registering(org.gradle.api.tasks.bundling.Jar::class) {
                   val sourceSets: SourceSetContainer by project
-                  from(sourceSets.named("testFixtures").get().allSource)
+                  from(sourceSets.named("testFixtures").map { it.allSource })
                   archiveClassifier.set("test-fixtures-sources")
                 }
               tasks.named<Javadoc>("testFixturesJavadoc") { isFailOnError = false }

--- a/build-logic/src/main/kotlin/publishing/shadowPub.kt
+++ b/build-logic/src/main/kotlin/publishing/shadowPub.kt
@@ -85,7 +85,6 @@ internal fun configureShadowPublishing(
       skip()
     }
   }
-  // component.addVariantsFromConfiguration(configurations.getByName("runtimeElements")) {
   component.addVariantsFromConfiguration(
     project.configurations.getByName("shadowRuntimeElements")
   ) {

--- a/persistence/nosql/persistence/correctness/build.gradle.kts
+++ b/persistence/nosql/persistence/correctness/build.gradle.kts
@@ -66,7 +66,9 @@ testing {
             implementation(testFixtures(project(":polaris-persistence-nosql-$prj")))
           }
 
-          targets.all { testTask.configure { systemProperty("polaris.testBackend.name", db) } }
+          targets.configureEach {
+            testTask.configure { systemProperty("polaris.testBackend.name", db) }
+          }
         }
 
         tasks.named("intTest") { dependsOn(dbTaskName) }
@@ -81,7 +83,7 @@ testing {
         // Pass system properties starting with `polaris.` down to the manually executed test(s) so
         // they can setup the backend via
         // `o.a.p.persistence.api.BackendConfigurer.defaultBackendConfigurer` using smallrye-config.
-        targets.all {
+        targets.configureEach {
           testTask.configure {
             providers.systemPropertiesPrefixedBy("polaris").get().forEach { (k, v) ->
               systemProperty(k, v)

--- a/runtime/test-common/build.gradle.kts
+++ b/runtime/test-common/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   id("polaris-runtime")
 }
 
-configurations.all {
+configurations.configureEach {
   if (name != "checkstyle") {
     exclude(group = "org.antlr", module = "antlr4-runtime")
     exclude(group = "org.scala-lang", module = "scala-library")

--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -86,7 +86,7 @@ testing {
     register<JvmTestSuite>("jarTest") {
       dependencies { runtimeOnly(files(jarTestJar.map { it.archiveFile })) }
 
-      targets.all {
+      targets.configureEach {
         testTask.configure {
           dependsOn("jar", jarTestJar)
           systemProperty("rootProjectDir", rootProject.rootDir.relativeTo(project.projectDir))


### PR DESCRIPTION
Makes a couple of eager resolutions across the build scripts lazily evaluated. This should save a bunch of potentially unnecessary resolutions, depending on the Gradle invocation.