### PR TITLE
runtime-service/int-test: reuse Minio + RustFS containers across tests

### DIFF
--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogMinIOIT.java
@@ -22,9 +22,10 @@ import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
 import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
 
 import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
@@ -36,35 +37,42 @@ import org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationBase;
 import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.minio.Minio;
 import org.apache.polaris.test.minio.MinioAccess;
-import org.apache.polaris.test.minio.MinioExtension;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.polaris.test.minio.MinioConditionExtension;
+import org.apache.polaris.test.minio.MinioTestResource;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @QuarkusIntegrationTest
 @TestProfile(MinioRustProfile.class)
-@ExtendWith(MinioExtension.class)
+@QuarkusTestResource(
+    value = MinioTestResource.class,
+    initArgs = {
+      @ResourceArg(name = "accessKey", value = ACCESS_KEY),
+      @ResourceArg(name = "secretKey", value = SECRET_KEY)
+    })
+@ExtendWith(MinioConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 @RestCatalogConfig({"header.X-Iceberg-Access-Delegation", "vended-credentials"})
 public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase {
 
   protected static final String BUCKET_URI_PREFIX = "/minio-test-polaris";
 
-  private static URI storageBase;
-  private static String endpoint;
+  @Minio static MinioAccess minioAccess;
 
   private static Map<String, String> s3Properties;
 
-  @BeforeAll
-  static void setup(
-      @Minio(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) MinioAccess minioAccess) {
-    storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
-    endpoint = minioAccess.s3endpoint();
+  @BeforeEach
+  void setup() {
     s3Properties =
         Map.of(
-            S3FileIOProperties.ENDPOINT, endpoint,
-            S3FileIOProperties.PATH_STYLE_ACCESS, "true",
-            S3FileIOProperties.ACCESS_KEY_ID, ACCESS_KEY,
-            S3FileIOProperties.SECRET_ACCESS_KEY, SECRET_KEY);
+            S3FileIOProperties.ENDPOINT,
+            minioAccess.s3endpoint(),
+            S3FileIOProperties.PATH_STYLE_ACCESS,
+            "true",
+            S3FileIOProperties.ACCESS_KEY_ID,
+            ACCESS_KEY,
+            S3FileIOProperties.SECRET_ACCESS_KEY,
+            SECRET_KEY);
   }
 
   @Override
@@ -78,8 +86,8 @@ public class PolarisRestCatalogMinIOIT extends PolarisRestCatalogIntegrationBase
         AwsStorageConfigInfo.builder()
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setPathStyleAccess(true)
-            .setEndpoint(endpoint)
-            .setAllowedLocations(List.of(storageBase.toString()));
+            .setEndpoint(minioAccess.s3endpoint())
+            .setAllowedLocations(List.of(minioAccess.s3BucketUri(BUCKET_URI_PREFIX).toString()));
 
     return storageConfig.build();
   }

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/PolarisRestCatalogRustFSIT.java
@@ -22,9 +22,10 @@ import static org.apache.polaris.test.commons.MinioRustProfile.ACCESS_KEY;
 import static org.apache.polaris.test.commons.MinioRustProfile.SECRET_KEY;
 
 import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
@@ -35,33 +36,31 @@ import org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationBase;
 import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.rustfs.Rustfs;
 import org.apache.polaris.test.rustfs.RustfsAccess;
-import org.apache.polaris.test.rustfs.RustfsExtension;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.polaris.test.rustfs.RustfsConditionExtension;
+import org.apache.polaris.test.rustfs.RustfsTestResource;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @QuarkusIntegrationTest
 @TestProfile(MinioRustProfile.class)
-@ExtendWith(RustfsExtension.class)
+@QuarkusTestResource(
+    value = RustfsTestResource.class,
+    initArgs = {
+      @ResourceArg(name = "accessKey", value = ACCESS_KEY),
+      @ResourceArg(name = "secretKey", value = SECRET_KEY)
+    })
+@ExtendWith(RustfsConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBase {
 
   protected static final String BUCKET_URI_PREFIX = "/rustfs-test-polaris";
 
-  private static URI storageBase;
-  private static String endpoint;
-
-  @BeforeAll
-  static void setup(
-      @Rustfs(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) RustfsAccess rustfsAccess) {
-    storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
-    endpoint = rustfsAccess.s3endpoint();
-  }
+  @Rustfs static RustfsAccess rustfsAccess;
 
   @Override
   protected ImmutableMap.Builder<String, String> clientFileIOProperties() {
     return super.clientFileIOProperties()
-        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
+        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), rustfsAccess.s3endpoint())
         .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
         .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), ACCESS_KEY)
         .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), SECRET_KEY);
@@ -73,8 +72,8 @@ public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBas
         AwsStorageConfigInfo.builder()
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
             .setPathStyleAccess(true)
-            .setEndpoint(endpoint)
-            .setAllowedLocations(List.of(storageBase.toString()));
+            .setEndpoint(rustfsAccess.s3endpoint())
+            .setAllowedLocations(List.of(rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX).toString()));
 
     return storageConfig.build();
   }
@@ -82,7 +81,7 @@ public class PolarisRestCatalogRustFSIT extends PolarisRestCatalogIntegrationBas
   @Override
   protected Map<String, String> extraCatalogProperties(TestInfo testInfo) {
     return ImmutableMap.<String, String>builder()
-        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), endpoint)
+        .put(StorageAccessProperty.AWS_ENDPOINT.getPropertyName(), rustfsAccess.s3endpoint())
         .put(StorageAccessProperty.AWS_PATH_STYLE_ACCESS.getPropertyName(), "true")
         .put(StorageAccessProperty.AWS_KEY_ID.getPropertyName(), ACCESS_KEY)
         .put(StorageAccessProperty.AWS_SECRET_KEY.getPropertyName(), SECRET_KEY)

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -46,7 +46,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -83,9 +82,11 @@ import org.apache.polaris.test.minio.MinioConditionExtension;
 import org.apache.polaris.test.minio.MinioTestResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -109,6 +110,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
     })
 @ExtendWith(MinioConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RestCatalogMinIOSpecialIT {
 
   private static final String BUCKET_URI_PREFIX = "/minio-test";
@@ -123,7 +125,6 @@ public class RestCatalogMinIOSpecialIT {
 
   @Minio static MinioAccess minioAccess;
 
-  private static final AtomicBoolean initialized = new AtomicBoolean(false);
   private static PolarisApiEndpoints endpoints;
   private static PolarisClient client;
   private static ManagementApi managementApi;
@@ -136,24 +137,24 @@ public class RestCatalogMinIOSpecialIT {
   private PrincipalWithCredentials principalCredentials;
   private String catalogName;
 
+  @BeforeAll
+  void setup(PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
+    endpoints = apiEndpoints;
+    s3Client = minioAccess.s3Client();
+    client = polarisClient(endpoints);
+    adminToken = client.obtainToken(credentials);
+    managementApi = client.managementApi(adminToken);
+    storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
+    endpoint = minioAccess.s3endpoint();
+  }
+
   @AfterAll
-  static void close() throws Exception {
+  void close() throws Exception {
     client.close();
   }
 
   @BeforeEach
-  public void before(
-      TestInfo testInfo, PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
-    if (initialized.compareAndSet(false, true)) {
-      endpoints = apiEndpoints;
-      s3Client = minioAccess.s3Client();
-      client = polarisClient(endpoints);
-      adminToken = client.obtainToken(credentials);
-      managementApi = client.managementApi(adminToken);
-      storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
-      endpoint = minioAccess.s3endpoint();
-    }
-
+  public void before(TestInfo testInfo) {
     String principalName = client.newEntityName("test-user");
     principalRoleName = client.newEntityName("test-admin");
     principalCredentials = managementApi.createPrincipalWithRole(principalName, principalRoleName);

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogMinIOSpecialIT.java
@@ -36,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
@@ -44,6 +46,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -76,10 +79,10 @@ import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.minio.Minio;
 import org.apache.polaris.test.minio.MinioAccess;
-import org.apache.polaris.test.minio.MinioExtension;
+import org.apache.polaris.test.minio.MinioConditionExtension;
+import org.apache.polaris.test.minio.MinioTestResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -98,7 +101,13 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
  */
 @QuarkusIntegrationTest
 @TestProfile(MinioRustProfile.class)
-@ExtendWith(MinioExtension.class)
+@QuarkusTestResource(
+    value = MinioTestResource.class,
+    initArgs = {
+      @ResourceArg(name = "accessKey", value = ACCESS_KEY),
+      @ResourceArg(name = "secretKey", value = SECRET_KEY)
+    })
+@ExtendWith(MinioConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class RestCatalogMinIOSpecialIT {
 
@@ -112,6 +121,9 @@ public class RestCatalogMinIOSpecialIT {
           required(1, "id", Types.IntegerType.get(), "doc"),
           optional(2, "data", Types.StringType.get()));
 
+  @Minio static MinioAccess minioAccess;
+
+  private static final AtomicBoolean initialized = new AtomicBoolean(false);
   private static PolarisApiEndpoints endpoints;
   private static PolarisClient client;
   private static ManagementApi managementApi;
@@ -124,27 +136,24 @@ public class RestCatalogMinIOSpecialIT {
   private PrincipalWithCredentials principalCredentials;
   private String catalogName;
 
-  @BeforeAll
-  static void setup(
-      PolarisApiEndpoints apiEndpoints,
-      @Minio(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) MinioAccess minioAccess,
-      ClientCredentials credentials) {
-    s3Client = minioAccess.s3Client();
-    endpoints = apiEndpoints;
-    client = polarisClient(endpoints);
-    adminToken = client.obtainToken(credentials);
-    managementApi = client.managementApi(adminToken);
-    storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
-    endpoint = minioAccess.s3endpoint();
-  }
-
   @AfterAll
   static void close() throws Exception {
     client.close();
   }
 
   @BeforeEach
-  public void before(TestInfo testInfo) {
+  public void before(
+      TestInfo testInfo, PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
+    if (initialized.compareAndSet(false, true)) {
+      endpoints = apiEndpoints;
+      s3Client = minioAccess.s3Client();
+      client = polarisClient(endpoints);
+      adminToken = client.obtainToken(credentials);
+      managementApi = client.managementApi(adminToken);
+      storageBase = minioAccess.s3BucketUri(BUCKET_URI_PREFIX);
+      endpoint = minioAccess.s3endpoint();
+    }
+
     String principalName = client.newEntityName("test-user");
     principalRoleName = client.newEntityName("test-admin");
     principalCredentials = managementApi.createPrincipalWithRole(principalName, principalRoleName);

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
@@ -36,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
@@ -44,6 +46,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -76,10 +79,10 @@ import org.apache.polaris.service.it.ext.PolarisIntegrationTestExtension;
 import org.apache.polaris.test.commons.MinioRustProfile;
 import org.apache.polaris.test.rustfs.Rustfs;
 import org.apache.polaris.test.rustfs.RustfsAccess;
-import org.apache.polaris.test.rustfs.RustfsExtension;
+import org.apache.polaris.test.rustfs.RustfsConditionExtension;
+import org.apache.polaris.test.rustfs.RustfsTestResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -98,7 +101,13 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
  */
 @QuarkusIntegrationTest
 @TestProfile(MinioRustProfile.class)
-@ExtendWith(RustfsExtension.class)
+@QuarkusTestResource(
+    value = RustfsTestResource.class,
+    initArgs = {
+      @ResourceArg(name = "accessKey", value = ACCESS_KEY),
+      @ResourceArg(name = "secretKey", value = SECRET_KEY)
+    })
+@ExtendWith(RustfsConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
 public class RestCatalogRustFSSpecialIT {
 
@@ -112,6 +121,9 @@ public class RestCatalogRustFSSpecialIT {
           required(1, "id", Types.IntegerType.get(), "doc"),
           optional(2, "data", Types.StringType.get()));
 
+  @Rustfs static RustfsAccess rustfsAccess;
+
+  private static final AtomicBoolean initialized = new AtomicBoolean(false);
   private static PolarisApiEndpoints endpoints;
   private static PolarisClient client;
   private static ManagementApi managementApi;
@@ -124,27 +136,24 @@ public class RestCatalogRustFSSpecialIT {
   private PrincipalWithCredentials principalCredentials;
   private String catalogName;
 
-  @BeforeAll
-  static void setup(
-      PolarisApiEndpoints apiEndpoints,
-      @Rustfs(accessKey = ACCESS_KEY, secretKey = SECRET_KEY) RustfsAccess rustfsAccess,
-      ClientCredentials credentials) {
-    s3Client = rustfsAccess.s3Client();
-    endpoints = apiEndpoints;
-    client = polarisClient(endpoints);
-    adminToken = client.obtainToken(credentials);
-    managementApi = client.managementApi(adminToken);
-    storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
-    endpoint = rustfsAccess.s3endpoint();
-  }
-
   @AfterAll
   static void close() throws Exception {
     client.close();
   }
 
   @BeforeEach
-  public void before(TestInfo testInfo) {
+  public void before(
+      TestInfo testInfo, PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
+    if (initialized.compareAndSet(false, true)) {
+      endpoints = apiEndpoints;
+      s3Client = rustfsAccess.s3Client();
+      client = polarisClient(endpoints);
+      adminToken = client.obtainToken(credentials);
+      managementApi = client.managementApi(adminToken);
+      storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
+      endpoint = rustfsAccess.s3endpoint();
+    }
+
     String principalName = client.newEntityName("test-user");
     principalRoleName = client.newEntityName("test-admin");
     principalCredentials = managementApi.createPrincipalWithRole(principalName, principalRoleName);

--- a/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
+++ b/runtime/service/src/intTest/java/org/apache/polaris/service/it/RestCatalogRustFSSpecialIT.java
@@ -46,7 +46,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -83,9 +82,11 @@ import org.apache.polaris.test.rustfs.RustfsConditionExtension;
 import org.apache.polaris.test.rustfs.RustfsTestResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -109,6 +110,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
     })
 @ExtendWith(RustfsConditionExtension.class)
 @ExtendWith(PolarisIntegrationTestExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RestCatalogRustFSSpecialIT {
 
   private static final String BUCKET_URI_PREFIX = "/rustfs-test";
@@ -123,7 +125,6 @@ public class RestCatalogRustFSSpecialIT {
 
   @Rustfs static RustfsAccess rustfsAccess;
 
-  private static final AtomicBoolean initialized = new AtomicBoolean(false);
   private static PolarisApiEndpoints endpoints;
   private static PolarisClient client;
   private static ManagementApi managementApi;
@@ -136,24 +137,24 @@ public class RestCatalogRustFSSpecialIT {
   private PrincipalWithCredentials principalCredentials;
   private String catalogName;
 
+  @BeforeAll
+  void setup(PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
+    endpoints = apiEndpoints;
+    s3Client = rustfsAccess.s3Client();
+    client = polarisClient(endpoints);
+    adminToken = client.obtainToken(credentials);
+    managementApi = client.managementApi(adminToken);
+    storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
+    endpoint = rustfsAccess.s3endpoint();
+  }
+
   @AfterAll
-  static void close() throws Exception {
+  void close() throws Exception {
     client.close();
   }
 
   @BeforeEach
-  public void before(
-      TestInfo testInfo, PolarisApiEndpoints apiEndpoints, ClientCredentials credentials) {
-    if (initialized.compareAndSet(false, true)) {
-      endpoints = apiEndpoints;
-      s3Client = rustfsAccess.s3Client();
-      client = polarisClient(endpoints);
-      adminToken = client.obtainToken(credentials);
-      managementApi = client.managementApi(adminToken);
-      storageBase = rustfsAccess.s3BucketUri(BUCKET_URI_PREFIX);
-      endpoint = rustfsAccess.s3endpoint();
-    }
-
+  public void before(TestInfo testInfo) {
     String principalName = client.newEntityName("test-user");
     principalRoleName = client.newEntityName("test-admin");
     principalCredentials = managementApi.createPrincipalWithRole(principalName, principalRoleName);

--- a/tools/minio-testcontainer/build.gradle.kts
+++ b/tools/minio-testcontainer/build.gradle.kts
@@ -36,4 +36,7 @@ dependencies {
 
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")
+
+  compileOnly(platform(libs.quarkus.bom))
+  compileOnly("io.quarkus:quarkus-test-common")
 }

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioConditionExtension.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioConditionExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.test.minio;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/** JUnit extension that gates whether the Minio container can be run on the current platform. */
+public class MinioConditionExtension implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (OS.current() == OS.LINUX) {
+      return enabled("Running on Linux");
+    }
+    if (OS.current() == OS.MAC
+        && System.getenv("CI_MAC") == null
+        && MinioContainer.canRunOnMacOs()) {
+      // Disable tests on GitHub Actions
+      return enabled("Running on macOS locally");
+    }
+    return disabled(format("Disabled on %s", OS.current().name()));
+  }
+}

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioExtension.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioExtension.java
@@ -19,18 +19,12 @@
 
 package org.apache.polaris.test.minio;
 
-import static java.lang.String.format;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
 import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import java.lang.reflect.Field;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
-import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -46,24 +40,10 @@ import org.junit.platform.commons.util.ReflectionUtils;
  * annotated with {@link Minio}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public class MinioExtension
-    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver, ExecutionCondition {
+public class MinioExtension extends MinioConditionExtension
+    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
   private static final ExtensionContext.Namespace NAMESPACE =
       ExtensionContext.Namespace.create(MinioExtension.class);
-
-  @Override
-  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-    if (OS.current() == OS.LINUX) {
-      return enabled("Running on Linux");
-    }
-    if (OS.current() == OS.MAC
-        && System.getenv("CI_MAC") == null
-        && MinioContainer.canRunOnMacOs()) {
-      // Disable tests on GitHub Actions
-      return enabled("Running on macOS locally");
-    }
-    return disabled(format("Disabled on %s", OS.current().name()));
-  }
 
   @Override
   public void beforeAll(ExtensionContext context) {

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioTestResource.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioTestResource.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.test.minio;
+
+import static java.util.Objects.requireNonNull;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Map;
+
+public class MinioTestResource implements QuarkusTestResourceLifecycleManager {
+
+  private Map<String, String> initArgs = Map.of();
+  private MinioContainer container;
+
+  @Override
+  public void init(Map<String, String> initArgs) {
+    this.initArgs = Map.copyOf(initArgs);
+  }
+
+  @Override
+  public Map<String, String> start() {
+    var accessKey = initArgs.get("accessKey");
+    var secretKey = initArgs.get("secretKey");
+    var bucket = initArgs.get("bucket");
+    var region = initArgs.get("region");
+    this.container =
+        new MinioContainer(null, accessKey, secretKey, bucket, region).withStartupAttempts(5);
+    this.container.start();
+    return Map.of();
+  }
+
+  @Override
+  public void stop() {
+    if (container != null) {
+      try {
+        container.close();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public void inject(TestInjector testInjector) {
+    MinioAccess minioAccess = requireNonNull(container, "Minio not started");
+    testInjector.injectIntoFields(minioAccess, field -> field.isAnnotationPresent(Minio.class));
+  }
+}

--- a/tools/rustfs-testcontainer/build.gradle.kts
+++ b/tools/rustfs-testcontainer/build.gradle.kts
@@ -36,4 +36,7 @@ dependencies {
 
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")
+
+  compileOnly(platform(libs.quarkus.bom))
+  compileOnly("io.quarkus:quarkus-test-common")
 }

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsConditionExtension.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsConditionExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.test.rustfs;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/** JUnit extension that gates whether the Rustfs container can be run on the current platform. */
+public class RustfsConditionExtension implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (OS.current() == OS.LINUX) {
+      return enabled("Running on Linux");
+    }
+    if (OS.current() == OS.MAC
+        && System.getenv("CI_MAC") == null
+        && RustfsContainer.canRunOnMacOs()) {
+      // Disable tests on GitHub Actions
+      return enabled("Running on macOS locally");
+    }
+    return disabled(format("Disabled on %s", OS.current().name()));
+  }
+}

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsExtension.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsExtension.java
@@ -19,18 +19,12 @@
 
 package org.apache.polaris.test.rustfs;
 
-import static java.lang.String.format;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
 import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import java.lang.reflect.Field;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
-import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -46,24 +40,10 @@ import org.junit.platform.commons.util.ReflectionUtils;
  * annotated with {@link Rustfs}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public class RustfsExtension
-    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver, ExecutionCondition {
+public class RustfsExtension extends RustfsConditionExtension
+    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
   private static final ExtensionContext.Namespace NAMESPACE =
       ExtensionContext.Namespace.create(RustfsExtension.class);
-
-  @Override
-  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-    if (OS.current() == OS.LINUX) {
-      return enabled("Running on Linux");
-    }
-    if (OS.current() == OS.MAC
-        && System.getenv("CI_MAC") == null
-        && RustfsContainer.canRunOnMacOs()) {
-      // Disable tests on GitHub Actions
-      return enabled("Running on macOS locally");
-    }
-    return disabled(format("Disabled on %s", OS.current().name()));
-  }
 
   @Override
   public void beforeAll(ExtensionContext context) {

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsTestResource.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsTestResource.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.test.rustfs;
+
+import static java.util.Objects.requireNonNull;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Map;
+
+public class RustfsTestResource implements QuarkusTestResourceLifecycleManager {
+
+  private Map<String, String> initArgs = Map.of();
+  private RustfsContainer container;
+
+  @Override
+  public void init(Map<String, String> initArgs) {
+    this.initArgs = Map.copyOf(initArgs);
+  }
+
+  @Override
+  public Map<String, String> start() {
+    var accessKey = initArgs.get("accessKey");
+    var secretKey = initArgs.get("secretKey");
+    var bucket = initArgs.get("bucket");
+    var region = initArgs.get("region");
+    this.container =
+        new RustfsContainer(null, accessKey, secretKey, bucket, region).withStartupAttempts(5);
+    this.container.start();
+    return Map.of();
+  }
+
+  @Override
+  public void stop() {
+    if (container != null) {
+      try {
+        container.close();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public void inject(TestInjector testInjector) {
+    RustfsAccess rustfsAccess = requireNonNull(container, "RustFS not started");
+    testInjector.injectIntoFields(rustfsAccess, field -> field.isAnnotationPresent(Rustfs.class));
+  }
+}


### PR DESCRIPTION
Introduces Quarkus test resources for Minio and RustFS and replaces the JUnit extension with functionally equivalent usages of those.

This saves the creation of new containers for each integration-test.

Works in combination with #4776