### PR TITLE
Use CliError for profile validation errors

### DIFF
--- a/client/python/apache_polaris/cli/command/profiles.py
+++ b/client/python/apache_polaris/cli/command/profiles.py
@@ -20,7 +20,6 @@
 import json
 
 import os
-import sys
 from dataclasses import dataclass
 from typing import Dict, Optional, List, Any, cast
 
@@ -91,8 +90,7 @@ class ProfilesCommand(Command):
             }
             self._save_profiles(profiles)
         else:
-            print(f"Profile {name} already exists.")
-            sys.exit(1)
+            raise CliError(f"Profile {name} already exists.")
 
     def _get_profile(self, name: str) -> Optional[Dict[str, Any]]:
         profiles = self._load_profiles()
@@ -142,8 +140,7 @@ class ProfilesCommand(Command):
             }
             self._save_profiles(profiles)
         else:
-            print(f"Profile {name} does not exist.")
-            sys.exit(1)
+            raise CliError(f"Profile {name} does not exist.")
 
     def validate(self) -> None:
         if self.profiles_subcommand in {

--- a/client/python/tests/test_profiles_command.py
+++ b/client/python/tests/test_profiles_command.py
@@ -18,7 +18,9 @@
 #
 
 import io
-from unittest.mock import patch, MagicMock, mock_open, ANY
+from unittest.mock import ANY, MagicMock, mock_open, patch
+
+from apache_polaris.cli.exceptions import CliError
 from cli_test_utils import CLITestBase
 
 
@@ -88,15 +90,14 @@ class TestProfilesCommand(CLITestBase):
         new_callable=mock_open,
         read_data='{"dev": {}}',
     )
-    @patch("apache_polaris.cli.command.profiles.sys.exit")
     def test_profile_create_existing_fails(
-        self, mock_exit: MagicMock, mock_file: MagicMock, mock_exists: MagicMock
+        self, mock_file: MagicMock, mock_exists: MagicMock
     ) -> None:
         mock_client = self.build_mock_client()
         mock_exists.return_value = True
-        with patch("sys.stdout", new_callable=io.StringIO):
+
+        with self.assertRaises(CliError):
             self.mock_execute(mock_client, ["profiles", "create", "dev"])
-        mock_exit.assert_called_once_with(1)
 
     @patch("apache_polaris.cli.command.profiles.os.path.exists")
     @patch(
@@ -145,3 +146,18 @@ class TestProfilesCommand(CLITestBase):
             output = mock_stdout.getvalue()
             self.assertIn("Polaris profile dev updated successfully.", output)
         mock_file.assert_called_with(ANY, "w")
+
+    @patch("apache_polaris.cli.command.profiles.os.path.exists")
+    @patch(
+        "apache_polaris.cli.command.profiles.open",
+        new_callable=mock_open,
+        read_data="{}",
+    )
+    def test_profile_update_missing_fails(
+        self, mock_file: MagicMock, mock_exists: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_exists.return_value = True
+
+        with self.assertRaises(CliError):
+            self.mock_execute(mock_client, ["profiles", "update", "missing"])


### PR DESCRIPTION
Summary

Replace direct sys.exit(1) calls in ProfilesCommand with CliError for profile validation failures.

Changes
Replace sys.exit(1) with CliError when:
creating a profile that already exists
updating a profile that does not exist
Remove unused sys import
Update tests to verify CliError is raised in both cases
Motivation

This aligns profile command error handling with the rest of the CLI, which uses CliError for user-facing validation errors and consistent exit-code handling.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
