### PR TITLE
Fix inheritable policy mapping insert to use transaction connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
 - The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).
 - JWT verification now validates the issuer claim (`"polaris"`) in addition to the active claim. Tokens signed with the same key but carrying a different issuer are now rejected.
+- Inheritable policy mapping inserts in the JDBC backend now use the active transaction connection, so they roll back correctly with the surrounding transaction.
 
 ## [1.5.0]
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1125,7 +1125,7 @@ public class JdbcBasePersistenceImpl
       datasourceOperations.execute(connection, updateQuery);
     } else {
       // record doesn't exist do an insert.
-      datasourceOperations.executeUpdate(insertQuery);
+      datasourceOperations.execute(connection, insertQuery);
     }
     return true;
   }


### PR DESCRIPTION
Previously, when a new inheritable policy mapping was inserted in the JDBC backend, it used `executeUpdate()`, which operated on a separate connection and committed the change immediately.

Now, it uses execute(`connection, insertQuery`), consistent with the update path and non-inheritable insert flow. 

**Result** : _The insert participates in the same transaction, and if a rollback occurs, the newly inserted mapping will be rolled back correctly as well._

## Checklist

- [ ] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] Added comments for complex logic
- [x] Updated CHANGELOG.md (if needed)
- [ ] Updated documentation in site/content/in-dev/unreleased (if needed)