### PR TITLE
Refactor duplicated S3 testcontainer access interfaces

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -326,7 +326,7 @@ This product includes code from Project Nessie.
 * tools/config-docs/generator/src/test/java/tests/smallrye/SomeEnum.java
 * tools/config-docs/generator/src/test/java/tests/smallrye/VeryNested.java
 * tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
-* tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3TestcontainerAccess.java
+* tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3Access.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtensionInstanceField.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtension.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtensionParameters.java

--- a/LICENSE
+++ b/LICENSE
@@ -326,6 +326,7 @@ This product includes code from Project Nessie.
 * tools/config-docs/generator/src/test/java/tests/smallrye/SomeEnum.java
 * tools/config-docs/generator/src/test/java/tests/smallrye/VeryNested.java
 * tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
+* tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3TestcontainerAccess.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtensionInstanceField.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtension.java
 * tools/azurite-testcontainer/src/intTest/java/org/projectnessie/testing/azurite/ITAzuriteExtensionParameters.java

--- a/tools/container-spec-helper/build.gradle.kts
+++ b/tools/container-spec-helper/build.gradle.kts
@@ -26,4 +26,7 @@ dependencies {
   implementation(libs.slf4j.api)
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
+
+  api(platform(libs.awssdk.bom))
+  api("software.amazon.awssdk:s3")
 }

--- a/tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3Access.java
+++ b/tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3Access.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 /** Common S3 access API for testcontainer-backed object storage implementations. */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public interface S3TestcontainerAccess {
+public interface S3Access {
 
   /** Host and port, separated by '{@code :}'. */
   String hostPort();

--- a/tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3TestcontainerAccess.java
+++ b/tools/container-spec-helper/src/main/java/org/apache/polaris/testcontainer/S3TestcontainerAccess.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.testcontainer;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/** Common S3 access API for testcontainer-backed object storage implementations. */
+// CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
+public interface S3TestcontainerAccess {
+
+  /** Host and port, separated by '{@code :}'. */
+  String hostPort();
+
+  String accessKey();
+
+  String secretKey();
+
+  String bucket();
+
+  Optional<String> region();
+
+  /** HTTP protocol endpoint. */
+  String s3endpoint();
+
+  S3Client s3Client();
+
+  /** Properties needed by Apache Iceberg to access this instance. */
+  Map<String, String> icebergProperties();
+
+  /** Properties needed by Apache Hadoop to access this instance. */
+  Map<String, String> hadoopConfig();
+
+  /** S3 scheme URI including the bucket to access the given path. */
+  URI s3BucketUri(String path);
+
+  /** Convenience method to put an object into S3. */
+  @SuppressWarnings("resource")
+  default void s3put(String key, RequestBody body) {
+    s3Client().putObject(b -> b.bucket(bucket()).key(key), body);
+  }
+}

--- a/tools/minio-testcontainer/build.gradle.kts
+++ b/tools/minio-testcontainer/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   api("software.amazon.awssdk:s3")
   api("software.amazon.awssdk:kms")
 
-  implementation(project(":polaris-container-spec-helper"))
+  api(project(":polaris-container-spec-helper"))
   implementation("software.amazon.awssdk:url-connection-client")
   implementation(libs.guava)
 

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
@@ -19,11 +19,7 @@
 
 package org.apache.polaris.test.minio;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.Optional;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.apache.polaris.testcontainer.S3TestcontainerAccess;
 
 /**
  * Provides access to Minio via a preconfigured S3 client and providing the by default randomized
@@ -33,36 +29,4 @@ import software.amazon.awssdk.services.s3.S3Client;
  * Minio}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public interface MinioAccess {
-
-  /** Host and port, separated by '{@code :}'. */
-  String hostPort();
-
-  String accessKey();
-
-  String secretKey();
-
-  String bucket();
-
-  Optional<String> region();
-
-  /** HTTP protocol endpoint. */
-  String s3endpoint();
-
-  S3Client s3Client();
-
-  /** Properties needed by Apache Iceberg to access this instance. */
-  Map<String, String> icebergProperties();
-
-  /** Properties needed by Apache Hadoop to access this instance. */
-  Map<String, String> hadoopConfig();
-
-  /** S3 scheme URI including the bucket to access the given path. */
-  URI s3BucketUri(String path);
-
-  /** Convenience method to put an object into S3. */
-  @SuppressWarnings("resource")
-  default void s3put(String key, RequestBody body) {
-    s3Client().putObject(b -> b.bucket(bucket()).key(key), body);
-  }
-}
+public interface MinioAccess extends S3TestcontainerAccess {}

--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
@@ -19,7 +19,7 @@
 
 package org.apache.polaris.test.minio;
 
-import org.apache.polaris.testcontainer.S3TestcontainerAccess;
+import org.apache.polaris.testcontainer.S3Access;
 
 /**
  * Provides access to Minio via a preconfigured S3 client and providing the by default randomized
@@ -29,4 +29,4 @@ import org.apache.polaris.testcontainer.S3TestcontainerAccess;
  * Minio}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public interface MinioAccess extends S3TestcontainerAccess {}
+public interface MinioAccess extends S3Access {}

--- a/tools/rustfs-testcontainer/build.gradle.kts
+++ b/tools/rustfs-testcontainer/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   api("software.amazon.awssdk:s3")
   api("software.amazon.awssdk:kms")
 
-  implementation(project(":polaris-container-spec-helper"))
+  api(project(":polaris-container-spec-helper"))
   implementation("software.amazon.awssdk:url-connection-client")
   implementation(libs.guava)
 

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsAccess.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsAccess.java
@@ -19,7 +19,7 @@
 
 package org.apache.polaris.test.rustfs;
 
-import org.apache.polaris.testcontainer.S3TestcontainerAccess;
+import org.apache.polaris.testcontainer.S3Access;
 
 /**
  * Provides access to Rustfs via a preconfigured S3 client and providing the by default randomized
@@ -29,4 +29,4 @@ import org.apache.polaris.testcontainer.S3TestcontainerAccess;
  * Rustfs}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public interface RustfsAccess extends S3TestcontainerAccess {}
+public interface RustfsAccess extends S3Access {}

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsAccess.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsAccess.java
@@ -19,11 +19,7 @@
 
 package org.apache.polaris.test.rustfs;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.Optional;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.apache.polaris.testcontainer.S3TestcontainerAccess;
 
 /**
  * Provides access to Rustfs via a preconfigured S3 client and providing the by default randomized
@@ -33,36 +29,4 @@ import software.amazon.awssdk.services.s3.S3Client;
  * Rustfs}.
  */
 // CODE_COPIED_TO_POLARIS from Project Nessie 0.104.2
-public interface RustfsAccess {
-
-  /** Host and port, separated by '{@code :}'. */
-  String hostPort();
-
-  String accessKey();
-
-  String secretKey();
-
-  String bucket();
-
-  Optional<String> region();
-
-  /** HTTP protocol endpoint. */
-  String s3endpoint();
-
-  S3Client s3Client();
-
-  /** Properties needed by Apache Iceberg to access this instance. */
-  Map<String, String> icebergProperties();
-
-  /** Properties needed by Apache Hadoop to access this instance. */
-  Map<String, String> hadoopConfig();
-
-  /** S3 scheme URI including the bucket to access the given path. */
-  URI s3BucketUri(String path);
-
-  /** Convenience method to put an object into S3. */
-  @SuppressWarnings("resource")
-  default void s3put(String key, RequestBody body) {
-    s3Client().putObject(b -> b.bucket(bucket()).key(key), body);
-  }
-}
+public interface RustfsAccess extends S3TestcontainerAccess {}


### PR DESCRIPTION
## Summary

Fixes #4804

Refactor duplicated S3 access APIs shared by `MinioAccess` and `RustfsAccess` into a common `S3Access` interface in `polaris-container-spec-helper`.

### Changes

* Add shared `S3Access` interface.
* Move common S3 access methods and default `s3put()` implementation into the shared interface.
* Update `MinioAccess` and `RustfsAccess` to extend `S3Access`.
* Add required module dependencies for the shared abstraction.
* Update copied-code attribution documentation.
* Rename `S3TestcontainerAccess` to `S3Access` following review feedback.

### Compatibility

Refactoring only. No functional or behavioral changes intended.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
