### PR TITLE
Improve ContainerSpecHelper partial image configuration error message

### DIFF
--- a/tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
+++ b/tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.function.Function;
 import org.testcontainers.utility.DockerImageName;
 
 // Spotless/Java doesn't really "like" Javadoc @snippet
@@ -72,14 +73,30 @@ import org.testcontainers.utility.DockerImageName;
 public final class ContainerSpecHelper {
   private final String name;
   private final Class<?> containerClass;
+  private final Function<String, String> systemPropertyLookup;
+  private final Function<String, String> envLookup;
 
   public static ContainerSpecHelper containerSpecHelper(String name, Class<?> containerClass) {
-    return new ContainerSpecHelper(name, containerClass);
+    return containerSpecHelper(name, containerClass, System::getProperty, System::getenv);
   }
 
-  private ContainerSpecHelper(String name, Class<?> containerClass) {
+  static ContainerSpecHelper containerSpecHelper(
+      String name,
+      Class<?> containerClass,
+      Function<String, String> systemPropertyLookup,
+      Function<String, String> envLookup) {
+    return new ContainerSpecHelper(name, containerClass, systemPropertyLookup, envLookup);
+  }
+
+  private ContainerSpecHelper(
+      String name,
+      Class<?> containerClass,
+      Function<String, String> systemPropertyLookup,
+      Function<String, String> envLookup) {
     this.name = name;
     this.containerClass = containerClass;
+    this.systemPropertyLookup = systemPropertyLookup;
+    this.envLookup = envLookup;
   }
 
   public String name() {
@@ -103,19 +120,19 @@ public final class ContainerSpecHelper {
     String systemPropPrefix2 = "polaris.testing." + name() + ".";
     String envPrefix = name().toUpperCase(Locale.ROOT).replaceAll("-", "_") + "_DOCKER_";
 
-    String explicitImage = System.getProperty(systemPropPrefix1 + "image");
+    String explicitImage = systemPropertyLookup.apply(systemPropPrefix1 + "image");
     if (explicitImage == null) {
-      explicitImage = System.getProperty(systemPropPrefix2 + "image");
+      explicitImage = systemPropertyLookup.apply(systemPropPrefix2 + "image");
     }
     if (explicitImage == null) {
-      explicitImage = System.getenv(envPrefix + "IMAGE");
+      explicitImage = envLookup.apply(envPrefix + "IMAGE");
     }
-    String explicitTag = System.getProperty(systemPropPrefix1 + "tag");
+    String explicitTag = systemPropertyLookup.apply(systemPropPrefix1 + "tag");
     if (explicitTag == null) {
-      explicitTag = System.getProperty(systemPropPrefix2 + "tag");
+      explicitTag = systemPropertyLookup.apply(systemPropPrefix2 + "tag");
     }
     if (explicitTag == null) {
-      explicitTag = System.getenv(envPrefix + "TAG");
+      explicitTag = envLookup.apply(envPrefix + "TAG");
     }
 
     if (explicitImage != null && explicitTag != null) {

--- a/tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
+++ b/tools/container-spec-helper/src/main/java/org/apache/polaris/containerspec/ContainerSpecHelper.java
@@ -141,7 +141,7 @@ public final class ContainerSpecHelper {
 
       if (explicitImage != null || explicitTag != null) {
         throw new IllegalArgumentException(
-            "Must specify either BOTH, image name AND tag via system properties or environment  or omit and leave it to the default "
+            "Must specify both image name and tag via system properties or environment variables, or omit both to use the default "
                 + fullImageName
                 + " from "
                 + dockerfile);

--- a/tools/container-spec-helper/src/test/java/org/apache/polaris/containerspec/ContainerSpecHelperTest.java
+++ b/tools/container-spec-helper/src/test/java/org/apache/polaris/containerspec/ContainerSpecHelperTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.containerspec;
+
+import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpecHelper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.utility.DockerImageName;
+
+class ContainerSpecHelperTest {
+
+  private static final String CONTAINER_NAME = "test";
+  private static final String DEFAULT_IMAGE = "docker.io/test/image:1.2.3";
+  private static final String EXPECTED_PARTIAL_CONFIG_MESSAGE =
+      "Must specify both image name and tag via system properties or environment variables, or omit both to use the default "
+          + DEFAULT_IMAGE
+          + " from Dockerfile-test-version";
+
+  @AfterEach
+  void clearContainerImageOverrides() {
+    System.clearProperty("it.polaris.container." + CONTAINER_NAME + ".image");
+    System.clearProperty("it.polaris.container." + CONTAINER_NAME + ".tag");
+    System.clearProperty("polaris.testing." + CONTAINER_NAME + ".image");
+    System.clearProperty("polaris.testing." + CONTAINER_NAME + ".tag");
+  }
+
+  @Test
+  void dockerImageNameUsesDefaultFromDockerfileWhenNoOverrides() {
+    DockerImageName imageName =
+        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class).dockerImageName(null);
+
+    assertThat(imageName).isEqualTo(DockerImageName.parse(DEFAULT_IMAGE));
+  }
+
+  @Test
+  void dockerImageNameUsesExplicitImageNameWhenProvided() {
+    DockerImageName imageName =
+        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+            .dockerImageName("docker.io/explicit:4.5.6");
+
+    assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/explicit:4.5.6"));
+  }
+
+  @Test
+  void dockerImageNameUsesBothSystemPropertiesWhenProvided() {
+    System.setProperty("polaris.testing." + CONTAINER_NAME + ".image", "docker.io/custom/image");
+    System.setProperty("polaris.testing." + CONTAINER_NAME + ".tag", "9.9.9");
+
+    DockerImageName imageName =
+        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class).dockerImageName(null);
+
+    assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/custom/image:9.9.9"));
+  }
+
+  @Test
+  void dockerImageNameRejectsImageWithoutTag() {
+    System.setProperty("polaris.testing." + CONTAINER_NAME + ".image", "docker.io/custom/image");
+
+    assertThatThrownBy(
+            () ->
+                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                    .dockerImageName(null))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
+  }
+
+  @Test
+  void dockerImageNameRejectsTagWithoutImage() {
+    System.setProperty("polaris.testing." + CONTAINER_NAME + ".tag", "9.9.9");
+
+    assertThatThrownBy(
+            () ->
+                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                    .dockerImageName(null))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"it.polaris.container.test.image", "polaris.testing.test.image"})
+  void dockerImageNameRejectsPartialImageOverrideFromAnySystemPropertyPrefix(String imageProperty) {
+    System.setProperty(imageProperty, "docker.io/custom/image");
+
+    assertThatThrownBy(
+            () ->
+                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                    .dockerImageName(null))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
+  }
+}

--- a/tools/container-spec-helper/src/test/java/org/apache/polaris/containerspec/ContainerSpecHelperTest.java
+++ b/tools/container-spec-helper/src/test/java/org/apache/polaris/containerspec/ContainerSpecHelperTest.java
@@ -22,7 +22,7 @@ import static org.apache.polaris.containerspec.ContainerSpecHelper.containerSpec
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.jupiter.api.AfterEach;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -37,18 +37,18 @@ class ContainerSpecHelperTest {
           + DEFAULT_IMAGE
           + " from Dockerfile-test-version";
 
-  @AfterEach
-  void clearContainerImageOverrides() {
-    System.clearProperty("it.polaris.container." + CONTAINER_NAME + ".image");
-    System.clearProperty("it.polaris.container." + CONTAINER_NAME + ".tag");
-    System.clearProperty("polaris.testing." + CONTAINER_NAME + ".image");
-    System.clearProperty("polaris.testing." + CONTAINER_NAME + ".tag");
+  private static ContainerSpecHelper testHelper(
+      Map<String, String> systemProperties, Map<String, String> environmentVariables) {
+    return containerSpecHelper(
+        CONTAINER_NAME,
+        ContainerSpecHelperTest.class,
+        systemProperties::get,
+        environmentVariables::get);
   }
 
   @Test
   void dockerImageNameUsesDefaultFromDockerfileWhenNoOverrides() {
-    DockerImageName imageName =
-        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class).dockerImageName(null);
+    DockerImageName imageName = testHelper(Map.of(), Map.of()).dockerImageName(null);
 
     assertThat(imageName).isEqualTo(DockerImageName.parse(DEFAULT_IMAGE));
   }
@@ -56,30 +56,57 @@ class ContainerSpecHelperTest {
   @Test
   void dockerImageNameUsesExplicitImageNameWhenProvided() {
     DockerImageName imageName =
-        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
-            .dockerImageName("docker.io/explicit:4.5.6");
+        testHelper(Map.of(), Map.of()).dockerImageName("docker.io/explicit:4.5.6");
 
     assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/explicit:4.5.6"));
   }
 
   @Test
   void dockerImageNameUsesBothSystemPropertiesWhenProvided() {
-    System.setProperty("polaris.testing." + CONTAINER_NAME + ".image", "docker.io/custom/image");
-    System.setProperty("polaris.testing." + CONTAINER_NAME + ".tag", "9.9.9");
-
     DockerImageName imageName =
-        containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class).dockerImageName(null);
+        testHelper(
+                Map.of(
+                    "polaris.testing.test.image",
+                    "docker.io/custom/image",
+                    "polaris.testing.test.tag",
+                    "9.9.9"),
+                Map.of())
+            .dockerImageName(null);
 
     assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/custom/image:9.9.9"));
   }
 
   @Test
-  void dockerImageNameRejectsImageWithoutTag() {
-    System.setProperty("polaris.testing." + CONTAINER_NAME + ".image", "docker.io/custom/image");
+  void dockerImageNameUsesBothEnvironmentVariablesWhenProvided() {
+    DockerImageName imageName =
+        testHelper(
+                Map.of(),
+                Map.of("TEST_DOCKER_IMAGE", "docker.io/env/image", "TEST_DOCKER_TAG", "8.8.8"))
+            .dockerImageName(null);
 
+    assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/env/image:8.8.8"));
+  }
+
+  @Test
+  void dockerImageNamePrefersSystemPropertyOverEnvironmentVariable() {
+    DockerImageName imageName =
+        testHelper(
+                Map.of(
+                    "polaris.testing.test.image",
+                    "docker.io/prop/image",
+                    "polaris.testing.test.tag",
+                    "1.0.0"),
+                Map.of("TEST_DOCKER_IMAGE", "docker.io/env/image", "TEST_DOCKER_TAG", "2.0.0"))
+            .dockerImageName(null);
+
+    assertThat(imageName).isEqualTo(DockerImageName.parse("docker.io/prop/image:1.0.0"));
+  }
+
+  @Test
+  void dockerImageNameRejectsImageWithoutTag() {
     assertThatThrownBy(
             () ->
-                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                testHelper(Map.of("polaris.testing.test.image", "docker.io/custom/image"), Map.of())
                     .dockerImageName(null))
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
@@ -87,12 +114,28 @@ class ContainerSpecHelperTest {
 
   @Test
   void dockerImageNameRejectsTagWithoutImage() {
-    System.setProperty("polaris.testing." + CONTAINER_NAME + ".tag", "9.9.9");
-
     assertThatThrownBy(
             () ->
-                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                testHelper(Map.of("polaris.testing.test.tag", "9.9.9"), Map.of())
                     .dockerImageName(null))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
+  }
+
+  @Test
+  void dockerImageNameRejectsImageWithoutTagFromEnvironmentVariable() {
+    assertThatThrownBy(
+            () ->
+                testHelper(Map.of(), Map.of("TEST_DOCKER_IMAGE", "docker.io/env/image"))
+                    .dockerImageName(null))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
+  }
+
+  @Test
+  void dockerImageNameRejectsTagWithoutImageFromEnvironmentVariable() {
+    assertThatThrownBy(
+            () -> testHelper(Map.of(), Map.of("TEST_DOCKER_TAG", "8.8.8")).dockerImageName(null))
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);
   }
@@ -100,11 +143,9 @@ class ContainerSpecHelperTest {
   @ParameterizedTest
   @ValueSource(strings = {"it.polaris.container.test.image", "polaris.testing.test.image"})
   void dockerImageNameRejectsPartialImageOverrideFromAnySystemPropertyPrefix(String imageProperty) {
-    System.setProperty(imageProperty, "docker.io/custom/image");
-
     assertThatThrownBy(
             () ->
-                containerSpecHelper(CONTAINER_NAME, ContainerSpecHelperTest.class)
+                testHelper(Map.of(imageProperty, "docker.io/custom/image"), Map.of())
                     .dockerImageName(null))
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage(EXPECTED_PARTIAL_CONFIG_MESSAGE);

--- a/tools/container-spec-helper/src/test/resources/org/apache/polaris/containerspec/Dockerfile-test-version
+++ b/tools/container-spec-helper/src/test/resources/org/apache/polaris/containerspec/Dockerfile-test-version
@@ -1,0 +1,1 @@
+FROM docker.io/test/image:1.2.3

--- a/tools/container-spec-helper/src/test/resources/org/apache/polaris/containerspec/Dockerfile-test-version
+++ b/tools/container-spec-helper/src/test/resources/org/apache/polaris/containerspec/Dockerfile-test-version
@@ -1,1 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Dockerfile to provide the image name and tag to a test.
 FROM docker.io/test/image:1.2.3


### PR DESCRIPTION
## Summary

Fixes #4806

Improve the error message shown when only one of the container image name or image tag is configured.

### Changes

* Reword the `IllegalArgumentException` message to improve clarity.
* Remove awkward wording and the double-space in the message.
* Clarify that both image name and image tag must be specified together, or both omitted to use the default image configuration.
* Add tests covering valid and invalid image configuration combinations.



## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
