### PR TITLE
Build: better project isolation

### DIFF
--- a/api/iceberg-service/build.gradle.kts
+++ b/api/iceberg-service/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
   compileOnly(libs.microprofile.fault.tolerance.api)
 }
 
-val rootDir = rootProject.layout.projectDirectory
+val rootDir = layout.settingsDirectory
 val specsDir = rootDir.dir("spec")
 val templatesDir = rootDir.dir("server-templates")
 // Use a different directory than 'generated/', because OpenAPI generator's `GenerateTask` adds the

--- a/api/management-model/build.gradle.kts
+++ b/api/management-model/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
 }
 
-val rootDir = rootProject.layout.projectDirectory
+val rootDir = layout.settingsDirectory
 val specsDir = rootDir.dir("spec")
 val templatesDir = rootDir.dir("server-templates")
 // Use a different directory than 'generated/', because OpenAPI generator's `GenerateTask` adds the

--- a/api/management-service/build.gradle.kts
+++ b/api/management-service/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
   implementation(libs.slf4j.api)
 }
 
-val rootDir = rootProject.layout.projectDirectory
+val rootDir = layout.settingsDirectory
 val specsDir = rootDir.dir("spec")
 val templatesDir = rootDir.dir("server-templates")
 // Use a different directory than 'generated/', because OpenAPI generator's `GenerateTask` adds the

--- a/api/polaris-catalog-service/build.gradle.kts
+++ b/api/polaris-catalog-service/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
 }
 
-val rootDir = rootProject.layout.projectDirectory
+val rootDir = layout.settingsDirectory
 val specsDir = rootDir.dir("spec")
 val templatesDir = rootDir.dir("server-templates")
 // Use a different directory than 'generated/', because OpenAPI generator's `GenerateTask` adds the

--- a/build-logic/src/main/kotlin/GitInfo.kt
+++ b/build-logic/src/main/kotlin/GitInfo.kt
@@ -36,9 +36,9 @@ class GitInfo(val gitHead: String, val gitDescribe: String, private val rawLinkR
 
   companion object {
     fun memoized(project: Project): GitInfo {
-      val rootProject = project.rootProject
       val isRelease =
-        rootProject.hasProperty("release") || rootProject.hasProperty("jarWithGitInfo")
+        project.providers.gradleProperty("release").isPresent ||
+          project.providers.gradleProperty("jarWithGitInfo").isPresent
       val service =
         project.gradle.sharedServices.registerIfAbsent(
           "gitInfo-$isRelease",

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -72,7 +72,7 @@ checkstyle {
       .orElseThrow { GradleException("checkstyle version not found in libs.versions.toml") }
       .requiredVersion
   toolVersion = checkstyleVersion
-  configFile = rootProject.file("codestyle/checkstyle.xml")
+  configFile = layout.settingsDirectory.file("codestyle/checkstyle.xml").asFile
   isIgnoreFailures = false
   maxErrors = 0
   maxWarnings = 0
@@ -95,8 +95,7 @@ tasks.withType(JavaCompile::class.java).configureEach {
   options.errorprone.disableWarningsInGeneratedCode = true
   options.errorprone.excludedPaths =
     ".*/${project.layout.buildDirectory.get().asFile.relativeTo(projectDir)}/generated(-openapi)?/.*"
-  val errorproneRules =
-    rootProject.layout.projectDirectory.file("codestyle/errorprone-rules.properties")
+  val errorproneRules = layout.settingsDirectory.file("codestyle/errorprone-rules.properties")
   inputs.file(errorproneRules).withPathSensitivity(PathSensitivity.RELATIVE)
   options.errorprone.checks.putAll(
     provider {
@@ -309,10 +308,10 @@ fun bannedDependencies(): BannedDependencies {
       BannedDependenciesService::class.java,
     ) {
       parameters.globallyBannedFile.set(
-        rootProject.layout.projectDirectory.file("gradle/banned-dependencies.txt")
+        layout.settingsDirectory.file("gradle/banned-dependencies.txt")
       )
       parameters.quarkusProdBannedFile.set(
-        rootProject.layout.projectDirectory.file("gradle/banned-quarkus-prod-dependencies.txt")
+        layout.settingsDirectory.file("gradle/banned-quarkus-prod-dependencies.txt")
       )
     }
   return service.get().bannedDependencies
@@ -365,7 +364,7 @@ tasks.withType<Test>().configureEach {
   val constraintName =
     if (isTestTask) "testParallelismConstraint" else "intTestParallelismConstraint"
   usesService(gradle.sharedServices.registrations.named(constraintName).get().service)
-  if (project.hasProperty("noIntegrationTests") && !isTestTask) {
+  if (providers.gradleProperty("noIntegrationTests").isPresent && !isTestTask) {
     enabled = false
   }
 }

--- a/build-logic/src/main/kotlin/polaris-spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-spotless.gradle.kts
@@ -50,7 +50,7 @@ spotless {
       target("src/**/*.xml", "src/**/*.xsd")
       targetExclude("codestyle/copyright-header.xml")
       eclipseWtp(com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML)
-        .configFile(rootProject.file("codestyle/org.eclipse.wst.xml.core.prefs"))
+        .configFile(layout.settingsDirectory.file("codestyle/org.eclipse.wst.xml.core.prefs"))
       // getting the license-header delimiter right is a bit tricky.
       // licenseHeaderFile(rootProject.file("codestyle/copyright-header.xml"), '<^[!?].*$')
     }

--- a/build-logic/src/main/kotlin/publishing/MemoizedJarInfo.kt
+++ b/build-logic/src/main/kotlin/publishing/MemoizedJarInfo.kt
@@ -29,19 +29,21 @@ import org.gradle.api.java.archives.Attributes
  */
 internal class MemoizedJarInfo {
   companion object {
-    fun applyJarManifestAttributes(rootProject: Project, attribs: Attributes) {
-      val props = jarManifestAttributes(rootProject)
+    fun applyJarManifestAttributes(project: Project, attribs: Attributes) {
+      val props = jarManifestAttributes(project)
       attribs.putAll(props)
     }
 
-    private fun jarManifestAttributes(rootProject: Project): Map<String, String> {
-      val version = rootProject.version.toString()
-      val javaSpecificationVersion = System.getProperty("java.specification.version")
+    private fun jarManifestAttributes(project: Project): Map<String, String> {
+      val version = project.version.toString()
+      val javaSpecificationVersion =
+        project.providers.systemProperty("java.specification.version").get()
       val includeGitInformation =
-        rootProject.hasProperty("release") || rootProject.hasProperty("jarWithGitInfo")
+        project.providers.gradleProperty("release").isPresent ||
+          project.providers.gradleProperty("jarWithGitInfo").isPresent
 
       return if (includeGitInformation) {
-        val gi = GitInfo.memoized(rootProject)
+        val gi = GitInfo.memoized(project)
         mapOf(
           "Implementation-Version" to version,
           "Apache-Polaris-Version" to version,

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -79,7 +79,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     extensions.create("publishingHelper", PublishingHelperExtension::class.java)
 
     tasks.withType<Jar>().configureEach {
-      manifest { MemoizedJarInfo.applyJarManifestAttributes(rootProject, attributes) }
+      manifest { MemoizedJarInfo.applyJarManifestAttributes(project, attributes) }
     }
 
     apply(plugin = "maven-publish")
@@ -98,7 +98,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
           val signingPassword: String? by project
           useInMemoryPgpKeys(signingKey, signingPassword)
 
-          if (project.hasProperty("useGpgAgent")) {
+          if (project.providers.gradleProperty("useGpgAgent").isPresent) {
             useGpgCmd()
           }
         }

--- a/build-logic/src/main/kotlin/publishing/maven-utils.kt
+++ b/build-logic/src/main/kotlin/publishing/maven-utils.kt
@@ -86,7 +86,10 @@ fun addAdditionalJarContent(project: Project): Unit = project.run {
     // Letting jars depend on the pom.xml (Gradle's `GenerateMavenPom` task, annotated with
     // `@UntrackedTask`) breaks up-to-date checks for all jars and dependent project
     // dependencies, leading to unnecessarily long build times.
-    if (rootProject.hasProperty("release") || rootProject.hasProperty("jarWithGitInfo")) {
+    if (
+      providers.gradleProperty("release").isPresent ||
+        providers.gradleProperty("jarWithGitInfo").isPresent
+    ) {
       val pomPath = "META-INF/maven/${project.group}/${project.name}/pom.xml"
       val generatePomFileTask = tasks.named<GenerateMavenPom>("generatePomFileForMavenPublication")
       tasks.withType(Jar::class).configureEach {

--- a/build-logic/src/main/kotlin/publishing/rootProject.kt
+++ b/build-logic/src/main/kotlin/publishing/rootProject.kt
@@ -37,7 +37,7 @@ import org.gradle.kotlin.dsl.register
 internal fun configureOnRootProject(project: Project) = project.run {
   apply<NexusPublishPlugin>()
 
-  val isRelease = project.hasProperty("release")
+  val isRelease = project.providers.gradleProperty("release").isPresent
 
   val sourceTarball = tasks.register<Exec>("sourceTarball")
   sourceTarball.configure {

--- a/build-logic/src/main/kotlin/publishing/signing.kt
+++ b/build-logic/src/main/kotlin/publishing/signing.kt
@@ -24,7 +24,9 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.plugins.signing.SigningExtension
 
-fun Project.isSigningEnabled(): Boolean = hasProperty("release") || hasProperty("signArtifacts")
+fun Project.isSigningEnabled(): Boolean =
+  providers.gradleProperty("release").isPresent ||
+    providers.gradleProperty("signArtifacts").isPresent
 
 /**
  * Convenience function to sign all output files of the given task.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,7 +162,7 @@ tasks.register<Exec>("buildPythonClient") {
   description = "Build the python client"
 
   workingDir = project.projectDir
-  if (project.hasProperty("python.format")) {
+  if (providers.gradleProperty("python.format").isPresent) {
     environment("FORMAT", project.property("python.format") as String)
   }
   commandLine("make", "client-build")

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -41,11 +41,11 @@ dependencies {
   runtimeOnly(project(":polaris-extensions-auth-opa"))
   runtimeOnly(project(":polaris-extensions-auth-ranger"))
 
-  if ((project.findProperty("NonRESTCatalogs") as String?)?.contains("HIVE") == true) {
+  val nonRestCatalogs = providers.gradleProperty("NonRESTCatalogs").orNull
+  if (nonRestCatalogs?.contains("HIVE") == true) {
     runtimeOnly(project(":polaris-extensions-federation-hive"))
   }
-
-  if ((project.findProperty("NonRESTCatalogs") as String?)?.contains("BIGQUERY") == true) {
+  if (nonRestCatalogs?.contains("BIGQUERY") == true) {
     runtimeOnly(project(":polaris-extensions-federation-bigquery"))
   }
 

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -231,9 +231,7 @@ val quarkusTestArgLine =
 val quarkusProperties = providers.systemPropertiesPrefixedBy("quarkus.")
 
 tasks.withType(Test::class.java).configureEach {
-  if (System.getenv("AWS_REGION") == null) {
-    environment("AWS_REGION", "us-west-2")
-  }
+  environment("AWS_REGION", providers.environmentVariable("AWS_REGION").getOrElse("us-west-2"))
   // Note: the test secrets are referenced in
   // org.apache.polaris.service.it.ServerManager
   environment("POLARIS_BOOTSTRAP_CREDENTIALS", "POLARIS,test-admin,test-secret")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,10 +50,11 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
 
 rootProject.name = "polaris"
 
-val baseVersion = layout.rootDirectory.file("version.txt").asFile.readText().trim()
+val baseVersion =
+  providers.fileContents(layout.rootDirectory.file("version.txt")).asText.map { it.trim() }
 
 gradle.beforeProject {
-  version = baseVersion
+  version = baseVersion.get()
   group = "org.apache.polaris"
 }
 
@@ -149,12 +150,13 @@ dependencyResolutionManagement {
   }
 }
 
-val isCI = System.getenv("CI") != null
+val isCI = providers.environmentVariable("CI").isPresent
 val isBuildScanRequested = gradle.startParameter.isBuildScan
 
 develocity {
-  val isApachePolarisGitHub = "apache/polaris" == System.getenv("GITHUB_REPOSITORY")
-  val gitHubRef: String? = System.getenv("GITHUB_REF")
+  val isApachePolarisGitHub =
+    "apache/polaris" == providers.environmentVariable("GITHUB_REPOSITORY").orNull
+  val gitHubRef: String? = providers.environmentVariable("GITHUB_REF").orNull
   val isGitHubBranchOrTag =
     gitHubRef != null && (gitHubRef.startsWith("refs/heads/") || gitHubRef.startsWith("refs/tags/"))
   if (isApachePolarisGitHub && isGitHubBranchOrTag) {
@@ -170,25 +172,29 @@ develocity {
     }
   } else {
     // In all other cases, especially PR CI runs, use Gradle's public Develocity instance.
-    var cfgPrjId: String? = System.getenv("DEVELOCITY_PROJECT_ID")
-    projectId = if (cfgPrjId.isNullOrEmpty()) "polaris" else cfgPrjId
+    projectId =
+      providers
+        .environmentVariable("DEVELOCITY_PROJECT_ID")
+        .filter { it.isNotBlank() }
+        .getOrElse("polaris")
     buildScan {
-      val isGradleTosAccepted = "true" == System.getenv("GRADLE_TOS_ACCEPTED")
+      val isGradleTosAccepted =
+        "true" == providers.environmentVariable("GRADLE_TOS_ACCEPTED").orNull
       val isGitHubPullRequest = gitHubRef?.startsWith("refs/pull/") ?: false
       if (isGradleTosAccepted || (isCI && isGitHubPullRequest && isApachePolarisGitHub)) {
         // Leave TOS agreement to the user, if not running in CI.
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
       }
-      System.getenv("DEVELOCITY_SERVER")?.run {
-        if (isNotEmpty()) {
-          server = this
-        }
-      }
+      providers
+        .environmentVariable("DEVELOCITY_SERVER")
+        .filter { it.isNotBlank() }
+        .orNull
+        ?.run { server = this }
       if (isGitHubPullRequest) {
-        System.getenv("GITHUB_SERVER_URL")?.run {
+        providers.environmentVariable("GITHUB_SERVER_URL").orNull?.run {
           val ghUrl = this
-          val ghRepo = System.getenv("GITHUB_REPOSITORY")
+          val ghRepo = providers.environmentVariable("GITHUB_REPOSITORY").get()
           val prNumber = gitHubRef.substringAfter("refs/pull/").substringBefore("/merge")
           link("GitHub pull request", "$ghUrl/$ghRepo/pull/$prNumber")
         }

--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -32,20 +32,19 @@ description =
 val syncNoticeAndLicense by
   tasks.registering(Sync::class) {
     // Have to manually declare the inputs of this task here on top of the from/include below
+    val rootDir = layout.settingsDirectory
     inputs
-      .files(
-        rootProject.fileTree(rootProject.rootDir) { include("NOTICE*", "LICENSE*", "version.txt") }
-      )
+      .files(fileTree(rootDir) { include("NOTICE*", "LICENSE*", "version.txt") })
       .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("version", project.version)
     destinationDir = project.layout.buildDirectory.dir("notice-licenses").get().asFile
-    from(rootProject.rootDir) {
+    from(rootDir) {
       include("NOTICE*", "LICENSE*")
       // Put NOTICE/LICENSE* files under META-INF/resources/ so those files can be directly
       // accessed as static web resources in Quarkus.
       eachFile { path = "META-INF/resources/apache-polaris/${file.name}.txt" }
     }
-    from(rootProject.rootDir) {
+    from(rootDir) {
       include("version.txt")
       // Put NOTICE/LICENSE* files under META-INF/resources/ so those files can be directly
       // accessed as static web resources in Quarkus.


### PR DESCRIPTION
This change mostly focuses on isolating projects even further. Also a few more direct usages of `System.getenv` are moved to the Gradle provider.
