### PR TITLE
Follow-up to #4795: use transaction connection for SELECT in inheritable policy check

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -191,7 +191,7 @@ public class DatasourceOperations {
 
   /** Connection-aware version for use inside runWithinTransaction. */
   public <T> void executeSelectOverStream(
-      Connection connection,
+      @NonNull Connection connection,
       @NonNull PreparedQuery query,
       @NonNull Converter<T> converterInstance,
       @NonNull Consumer<Stream<T>> consumer)
@@ -215,7 +215,9 @@ public class DatasourceOperations {
 
   /** Connection-aware version for use inside runWithinTransaction. */
   public <T> List<T> executeSelect(
-      Connection connection, @NonNull PreparedQuery query, @NonNull Converter<T> converterInstance)
+      @NonNull Connection connection,
+      @NonNull PreparedQuery query,
+      @NonNull Converter<T> converterInstance)
       throws SQLException {
     ArrayList<T> results = new ArrayList<>();
     executeSelectOverStream(

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -173,18 +173,9 @@ public class DatasourceOperations {
       throws SQLException {
     withRetries(
         () -> {
-          logQuery(query);
-          try (Connection connection = borrowConnection();
-              PreparedStatement statement = connection.prepareStatement(query.sql())) {
-            List<Object> params = query.parameters();
-            for (int i = 0; i < params.size(); i++) {
-              statement.setObject(i + 1, params.get(i));
-            }
-            try (ResultSet resultSet = statement.executeQuery()) {
-              ResultSetIterator<T> iterator = new ResultSetIterator<>(resultSet, converterInstance);
-              consumer.accept(iterator.toStream());
-              return null;
-            }
+          try (Connection connection = borrowConnection()) {
+            executeSelectOverStreamWithConnection(query, converterInstance, consumer, connection);
+            return null;
           }
         });
   }
@@ -198,19 +189,32 @@ public class DatasourceOperations {
       throws SQLException {
     withRetries(
         () -> {
-          logQuery(query);
-          try (PreparedStatement statement = connection.prepareStatement(query.sql())) {
-            List<Object> params = query.parameters();
-            for (int i = 0; i < params.size(); i++) {
-              statement.setObject(i + 1, params.get(i));
-            }
-            try (ResultSet resultSet = statement.executeQuery()) {
-              ResultSetIterator<T> iterator = new ResultSetIterator<>(resultSet, converterInstance);
-              consumer.accept(iterator.toStream());
-              return null;
-            }
-          }
+          executeSelectOverStreamWithConnection(query, converterInstance, consumer, connection);
+          return null;
         });
+  }
+
+  /**
+   * Internal implementation that executes the SELECT on the provided connection. Does not manage
+   * connection lifecycle or retries.
+   */
+  private <T> void executeSelectOverStreamWithConnection(
+      @NonNull PreparedQuery query,
+      @NonNull Converter<T> converterInstance,
+      @NonNull Consumer<Stream<T>> consumer,
+      @NonNull Connection connection)
+      throws SQLException {
+    logQuery(query);
+    try (PreparedStatement statement = connection.prepareStatement(query.sql())) {
+      List<Object> params = query.parameters();
+      for (int i = 0; i < params.size(); i++) {
+        statement.setObject(i + 1, params.get(i));
+      }
+      try (ResultSet resultSet = statement.executeQuery()) {
+        ResultSetIterator<T> iterator = new ResultSetIterator<>(resultSet, converterInstance);
+        consumer.accept(iterator.toStream());
+      }
+    }
   }
 
   /** Connection-aware version for use inside runWithinTransaction. */

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -189,6 +189,40 @@ public class DatasourceOperations {
         });
   }
 
+  /** Connection-aware version for use inside runWithinTransaction. */
+  public <T> void executeSelectOverStream(
+      Connection connection,
+      @NonNull PreparedQuery query,
+      @NonNull Converter<T> converterInstance,
+      @NonNull Consumer<Stream<T>> consumer)
+      throws SQLException {
+    withRetries(
+        () -> {
+          logQuery(query);
+          try (PreparedStatement statement = connection.prepareStatement(query.sql())) {
+            List<Object> params = query.parameters();
+            for (int i = 0; i < params.size(); i++) {
+              statement.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+              ResultSetIterator<T> iterator = new ResultSetIterator<>(resultSet, converterInstance);
+              consumer.accept(iterator.toStream());
+              return null;
+            }
+          }
+        });
+  }
+
+  /** Connection-aware version for use inside runWithinTransaction. */
+  public <T> List<T> executeSelect(
+      Connection connection, @NonNull PreparedQuery query, @NonNull Converter<T> converterInstance)
+      throws SQLException {
+    ArrayList<T> results = new ArrayList<>();
+    executeSelectOverStream(
+        connection, query, converterInstance, stream -> stream.forEach(results::add));
+    return results;
+  }
+
   /**
    * Executes the UPDATE or INSERT Query
    *

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1084,7 +1084,11 @@ public class JdbcBasePersistenceImpl
       throws SQLException {
     List<PolarisPolicyMappingRecord> existingRecords =
         loadPoliciesOnTargetByType(
-            callCtx, record.getTargetCatalogId(), record.getTargetId(), record.getPolicyTypeCode());
+            callCtx,
+            record.getTargetCatalogId(),
+            record.getTargetId(),
+            record.getPolicyTypeCode(),
+            connection);
     if (existingRecords.size() > 1) {
       throw new PolicyMappingAlreadyExistsException(existingRecords.getFirst());
     } else if (existingRecords.size() == 1) {
@@ -1229,6 +1233,45 @@ public class JdbcBasePersistenceImpl
     return fetchPolicyMappingRecords(
         QueryGenerator.generateSelectQuery(
             ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
+  }
+
+  /**
+   * Connection-aware version for use inside runWithinTransaction (for inheritable policy check).
+   */
+  private List<PolarisPolicyMappingRecord> fetchPolicyMappingRecords(
+      QueryGenerator.PreparedQuery query, Connection connection) {
+    try {
+      var results =
+          datasourceOperations.executeSelect(connection, query, new ModelPolicyMappingRecord());
+      return results == null ? Collections.emptyList() : results;
+    } catch (SQLException e) {
+      throw new RuntimeException(
+          String.format("Failed to retrieve policy mapping records %s", e.getMessage()), e);
+    }
+  }
+
+  /** Connection-aware overload for use inside transaction. */
+  @NonNull
+  public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
+      @NonNull PolarisCallContext callCtx,
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      Connection connection) {
+    Map<String, Object> params =
+        Map.of(
+            "target_catalog_id",
+            targetCatalogId,
+            "target_id",
+            targetId,
+            "policy_type_code",
+            policyTypeCode,
+            "realm_id",
+            realmId);
+    return fetchPolicyMappingRecords(
+        QueryGenerator.generateSelectQuery(
+            ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params),
+        connection);
   }
 
   @NonNull

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1251,8 +1251,7 @@ public class JdbcBasePersistenceImpl
   }
 
   /** Connection-aware overload for use inside transaction. */
-  @NonNull
-  public List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
+  @NonNull List<PolarisPolicyMappingRecord> loadPoliciesOnTargetByType(
       @NonNull PolarisCallContext callCtx,
       long targetCatalogId,
       long targetId,

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1239,7 +1239,7 @@ public class JdbcBasePersistenceImpl
    * Connection-aware version for use inside runWithinTransaction (for inheritable policy check).
    */
   private List<PolarisPolicyMappingRecord> fetchPolicyMappingRecords(
-      QueryGenerator.PreparedQuery query, Connection connection) {
+      QueryGenerator.PreparedQuery query, @NonNull Connection connection) {
     try {
       var results =
           datasourceOperations.executeSelect(connection, query, new ModelPolicyMappingRecord());
@@ -1257,7 +1257,7 @@ public class JdbcBasePersistenceImpl
       long targetCatalogId,
       long targetId,
       int policyTypeCode,
-      Connection connection) {
+      @NonNull Connection connection) {
     Map<String, Object> params =
         Map.of(
             "target_catalog_id",

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -145,6 +145,38 @@ public class DatasourceOperationsTest {
   }
 
   @Test
+  void testExecuteSelect_withConnection_usesProvidedConnection() throws Exception {
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("SELECT * FROM users", List.of());
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenThrow(new SQLException("demo", "42P07"));
+
+    // The connection-aware overload must use the caller-provided Connection
+    // (no internal borrow should occur for the SELECT itself).
+    assertThrows(
+        SQLException.class,
+        () -> datasourceOperations.executeSelect(mockConnection, query, new ModelEntity(1)));
+
+    verify(mockConnection).prepareStatement(query.sql());
+  }
+
+  @Test
+  void testExecuteSelectOverStream_withConnection_usesProvidedConnection() throws Exception {
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("SELECT * FROM users", List.of());
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenThrow(new SQLException("stream demo", "42P07"));
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            datasourceOperations.executeSelectOverStream(
+                mockConnection, query, new ModelEntity(1), stream -> stream.forEach(x -> {})));
+
+    verify(mockConnection).prepareStatement(query.sql());
+  }
+
+  @Test
   void testRunWithinTransaction_commit() throws Exception {
     // reset to ignore constructor interaction
     reset(mockConnection);


### PR DESCRIPTION
## Why this change is needed
This is a direct follow-up to #4795.

In the main PR we fixed the *insert* (and update) path to use the `connection` passed from `runWithinTransaction`. However, the initial SELECT check inside `handleInheritablePolicy` (`loadPoliciesOnTargetByType`) was still going through the normal `callCtx` path and therefore used a separate connection.

This follow-up makes the entire check-then-write for inheritable policies run on the same transaction.

## What changed
- Added connection-aware `executeSelect(...)` and `executeSelectOverStream(...)` overloads in `DatasourceOperations`.
- Added a private `fetchPolicyMappingRecords(PreparedQuery, Connection)` + a connection-aware overload of `loadPoliciesOnTargetByType`.
- Updated the call inside `handleInheritablePolicy` to pass the transaction `connection`.

This change only affects the JDBC backend when the write happens inside a `runWithinTransaction` callback.

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Follow-up to #4795
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how) — existing higher-level policy coverage + manual verification (same approach as #4795)
- [x] Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)