### PR TITLE
Fix NPE when entity is removed during dropEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Deprecations
 
 ### Fixes
+- Fixed `NullPointerException` during `dropEntity` when an entity referenced by a grant had been concurrently removed (or purged). `lookupEntities` can return null entries for dropped entities; these are now skipped safely.
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.
 - The access token carried in `PolarisCredential` is now redacted from its `toString()`, so it is no longer written to authentication logs (including at WARN level on failed authentication).

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -249,6 +249,9 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     List<PolarisBaseEntity> entities =
         ms.lookupEntities(callCtx, new ArrayList<>(entityIdsGrantChanged));
     for (PolarisBaseEntity originalEntity : entities) {
+      if (originalEntity == null) {
+        continue; // entity was concurrently dropped/purged after grants were removed
+      }
       PolarisBaseEntity entityGrantChanged =
           originalEntity.withGrantRecordsVersion(originalEntity.getGrantRecordsVersion() + 1);
       ms.writeEntity(callCtx, entityGrantChanged, false, originalEntity);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -208,6 +208,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
     List<PolarisBaseEntity> entities =
         ms.lookupEntitiesInCurrentTxn(callCtx, new ArrayList<>(entityIdsGrantChanged));
     for (PolarisBaseEntity originalEntity : entities) {
+      if (originalEntity == null) {
+        continue; // entity was concurrently dropped/purged after grants were removed
+      }
       PolarisBaseEntity entityGrantChanged =
           originalEntity.withGrantRecordsVersion(originalEntity.getGrantRecordsVersion() + 1);
       ms.writeEntityInCurrentTxn(callCtx, entityGrantChanged, false, originalEntity);


### PR DESCRIPTION
Fix NPE when entity is removed during `dropEntity`

During `dropEntity`, after we delete the grants, we do lookup on the other entities to increase their grant version.

`lookupEntities` can return null if that entity was already dropped or purged by some other process at the same time. This is mentioned in the `BasePersistence` contract.

We were calling method directly on the entity without checking for null. This was causing `NullPointerException`.

Fixed by adding simple null check like this:

```
if (originalEntity == null) {
  continue; // entity was concurrently dropped/purged after grants were removed
}
```

Same change done in two files:
- AtomicOperationMetaStoreManager.java
- TransactionalMetaStoreManagerImpl.java

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how) - small null guard. Concurrent drop case is difficult to test so no new test added
- [x] Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)