### PR TITLE
Remove noisy profile loading message

### DIFF
--- a/client/python/apache_polaris/cli/command/profiles.py
+++ b/client/python/apache_polaris/cli/command/profiles.py
@@ -60,7 +60,6 @@ class ProfilesCommand(Command):
         if not os.path.exists(CONFIG_FILE):
             return {}
         with open(CONFIG_FILE, "r") as f:
-            print(f"Loading profiles from {CONFIG_FILE}")
             return json.load(f)
 
     def _save_profiles(self, profiles: Dict[str, Dict[str, Any]]) -> None:

--- a/client/python/tests/test_profiles_command.py
+++ b/client/python/tests/test_profiles_command.py
@@ -27,7 +27,7 @@ class TestProfilesCommand(CLITestBase):
     @patch(
         "apache_polaris.cli.command.profiles.open",
         new_callable=mock_open,
-        read_data="{}",
+        read_data='{"dev": {}, "prod": {}}',
     )
     def test_profile_list(self, mock_file: MagicMock, mock_exists: MagicMock) -> None:
         mock_client = self.build_mock_client()
@@ -35,7 +35,10 @@ class TestProfilesCommand(CLITestBase):
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
             self.mock_execute(mock_client, ["profiles", "list"])
             output = mock_stdout.getvalue()
+            self.assertNotIn("Loading profiles from", output)
             self.assertIn("Polaris profiles:", output)
+            self.assertIn(" - dev", output)
+            self.assertIn(" - prod", output)
 
     @patch("apache_polaris.cli.command.profiles.os.path.exists")
     @patch(
@@ -49,7 +52,10 @@ class TestProfilesCommand(CLITestBase):
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
             self.mock_execute(mock_client, ["profiles", "get", "dev"])
             output = mock_stdout.getvalue()
+            self.assertNotIn("Loading profiles from", output)
             self.assertIn("Polaris profile dev:", output)
+            self.assertIn("'client_id': 'root'", output)
+            self.assertIn("'host': 'localhost'", output)
 
     @patch("apache_polaris.cli.command.profiles.os.path.exists")
     @patch(
@@ -104,9 +110,7 @@ class TestProfilesCommand(CLITestBase):
         new_callable=mock_open,
         read_data='{"dev": {"client_id": "root", "client_secret": "s3cr3t", "host": "localhost", "port": 8181, "realm": "", "header": "Polaris-Realm"}}',
     )
-    def test_profile_delete(
-        self, mock_file: MagicMock, mock_exists: MagicMock
-    ) -> None:
+    def test_profile_delete(self, mock_file: MagicMock, mock_exists: MagicMock) -> None:
         mock_client = self.build_mock_client()
         mock_exists.return_value = True
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:


### PR DESCRIPTION
## Summary



The Python CLI was printing a profile loading message every time profile data was read from disk:

```text
Loading profiles from ...
```

This message appeared during normal profile operations such as `polaris profiles list` and `polaris profiles get <profile>`. While useful during development, it does not provide actionable information for most users and adds unnecessary noise to command output.

The extra output can also be problematic for scripts and automation that expect profile commands to return only the requested data. This change removes the message to keep CLI output clean and focused on user-facing information.

## Changes

* Removed the unconditional profile loading message from `_load_profiles()`.
* Added regression tests to ensure:

  * `profiles list` does not print the loading message.
  * `profiles get` does not print the loading message.
* Verified that the existing command output and behavior remain unchanged apart from the removal of the extra message.


## Checklist

* [ ] 🛡️ Don't disclose security issues! (contact [[security@apache.org](mailto:security@apache.org)](mailto:security@apache.org))
* [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4818
* [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
* [ ] 💡 Added comments for complex logic
* [ ] 🧾 Updated `CHANGELOG.md` (if needed)
* [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)