### PR TITLE
Remove obsolete commented readBinaryLicenseFile code

### DIFF
--- a/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
+++ b/tools/version/src/jarTest/java/org/apache/polaris/version/TestPolarisVersion.java
@@ -104,7 +104,5 @@ public class TestPolarisVersion {
     return Stream.of(
         Arguments.arguments("NOTICE", (Supplier<String>) PolarisVersion::readNoticeFile),
         Arguments.arguments("LICENSE", (Supplier<String>) PolarisVersion::readSourceLicenseFile));
-    // Arguments.arguments(//   "LICENSE-BINARY-DIST", (Supplier<String>)
-    // PolarisVersion::readBinaryLicenseFile));
   }
 }

--- a/tools/version/src/main/java/org/apache/polaris/version/PolarisVersion.java
+++ b/tools/version/src/main/java/org/apache/polaris/version/PolarisVersion.java
@@ -118,12 +118,6 @@ public final class PolarisVersion {
     return readResource("LICENSE");
   }
 
-  /*
-  public static String readBinaryLicenseFile() {
-    return readResource("LICENSE-BINARY-DIST");
-  }
-   */
-
   private static final String MF_VERSION = "Apache-Polaris-Version";
   private static final String MF_IS_RELEASE = "Apache-Polaris-Is-Release";
   private static final String MF_BUILD_GIT_HEAD = "Apache-Polaris-Build-Git-Head";


### PR DESCRIPTION
## Summary



This change removes outdated commented code related to the previously removed `readBinaryLicenseFile()` API from the `polaris-version` module.

Although the implementation was removed earlier, a few commented references remained in both the production and test code. Since the API is no longer part of the codebase, these comments no longer provide useful context and can be misleading to contributors who may assume the functionality still exists or is planned to return.

Removing these remnants helps keep the codebase clean, improves readability, and makes it easier for contributors to understand the current implementation.

## Changes

* Removed obsolete commented `readBinaryLicenseFile()` code from `PolarisVersion.java`.
* Removed the corresponding commented test reference from `TestPolarisVersion.java`.
* No functional or behavioral changes were made.




## Checklist

* [ ] 🛡️ Don't disclose security issues! (contact security@apache.com)
* [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4820
* [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
* [ ] 💡 Added comments for complex logic (not applicable)
* [ ] 🧾 Updated CHANGELOG.md (not needed)
* [ ] 📚 Updated documentation in site/content/in-dev/unreleased (not needed)
