### PR TITLE
Fix PropertiesConfigPageGroup visitor recursion

### DIFF
--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertiesConfigPageGroup.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/PropertiesConfigPageGroup.java
@@ -78,7 +78,8 @@ public class PropertiesConfigPageGroup {
 
       @Override
       public Void visitType(TypeElement e, DocletEnvironment env) {
-        return e.accept(this, env);
+        e.getEnclosedElements().forEach(element -> element.accept(this, env));
+        return null;
       }
 
       @Override

--- a/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
+++ b/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
@@ -267,5 +267,19 @@ public class TestDocGenTool {
                     | `nested.root.nested-c.string-in-c` |  | `string` |  |
                     | `nested.root.nested-c.int-in-c` |  | `int` |  |
                     """);
+
+    var fileNestedProps = dir.resolve("nested-main.md");
+    soft.assertThat(fileNestedProps)
+        .isRegularFile()
+        .content()
+        .isEqualTo(
+            """
+                    | Property | Description |
+                    |----------|-------------|
+                    | `nested.inner` | Nested class property.  |
+                    | `nested.iface` | Nested interface property.  |
+                    | `nested.record` | Nested record property.  |
+                    | `nested.top` | Top-level property.  |
+                    """);
   }
 }

--- a/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
+++ b/tools/config-docs/generator/src/test/java/org/apache/polaris/docs/generator/TestDocGenTool.java
@@ -15,6 +15,7 @@
  */
 package org.apache.polaris.docs.generator;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -269,17 +270,18 @@ public class TestDocGenTool {
                     """);
 
     var fileNestedProps = dir.resolve("nested-main.md");
-    soft.assertThat(fileNestedProps)
-        .isRegularFile()
-        .content()
-        .isEqualTo(
-            """
-                    | Property | Description |
-                    |----------|-------------|
-                    | `nested.inner` | Nested class property.  |
-                    | `nested.iface` | Nested interface property.  |
-                    | `nested.record` | Nested record property.  |
-                    | `nested.top` | Top-level property.  |
-                    """);
+    soft.assertThat(fileNestedProps).isRegularFile();
+    var nestedPropsContent = Files.readString(fileNestedProps);
+    soft.assertThat(nestedPropsContent)
+        .contains(
+            "| Property | Description |",
+            "|----------|-------------|",
+            "| `nested.top` | Top-level property.  |",
+            "| `nested.inner` | Nested class property.  |",
+            "| `nested.iface` | Nested interface property.  |",
+            "| `nested.record` | Nested record property.  |");
+    soft.assertThat(
+            nestedPropsContent.lines().filter(line -> line.startsWith("| `nested.")).count())
+        .isEqualTo(4);
   }
 }

--- a/tools/config-docs/generator/src/test/java/tests/properties/NestedProps.java
+++ b/tools/config-docs/generator/src/test/java/tests/properties/NestedProps.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.properties;
+
+import org.apache.polaris.docs.ConfigDocs.ConfigItem;
+import org.apache.polaris.docs.ConfigDocs.ConfigPageGroup;
+
+@SuppressWarnings("unused")
+@ConfigPageGroup(name = "nested")
+public class NestedProps {
+  /** Top-level property. */
+  @ConfigItem public static final String TOP = "nested.top";
+
+  public static final class Inner {
+    /** Nested class property. */
+    @ConfigItem public static final String INNER = "nested.inner";
+  }
+
+  public interface InnerIface {
+    /** Nested interface property. */
+    @ConfigItem public static final String IFACE = "nested.iface";
+  }
+
+  public record InnerRecord() {
+    /** Nested record property. */
+    @ConfigItem public static final String RECORD = "nested.record";
+  }
+}


### PR DESCRIPTION
## Summary



This change fixes a recursion issue in `PropertiesConfigPageGroup.visitType()` that could cause configuration documentation generation to fail with a `StackOverflowError` when processing nested types inside a `@ConfigPageGroup`.

The previous implementation recursively revisited the same `TypeElement` using `e.accept(this, env)`. When nested classes, interfaces, or records were present, this resulted in the visitor repeatedly dispatching to itself instead of traversing the enclosed elements, eventually exhausting the call stack.

To resolve this, the visitor now processes the type's enclosed elements directly. This aligns the implementation with the traversal approach already used in `PropertiesConfigs` and ensures nested configuration elements are handled correctly.

## Changes

* Replaced self-recursive `TypeElement` visitation with traversal of enclosed elements.
* Added regression tests covering nested classes, interfaces, and records.
* No public API changes.
* No behavioral changes outside of the configuration documentation generator.



## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4822
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
