### PR TITLE
Fix NPE when root container resolution returns null in PolarisResolutionManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Deprecations
 
 ### Fixes
+- Fixed potential `NullPointerException` when root container resolution returns null in `PolarisResolutionManifest`. Calls to `getResolvedRootContainerEntityAsPath()` and paths prepending the root container now avoid passing null into `List.of()`.
 - Fixed `NullPointerException` during `dropEntity` when an entity referenced by a grant had been concurrently removed (or purged). `lookupEntities` can return null entries for dropped entities; these are now skipped safely.
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -272,7 +272,10 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
   }
 
   public PolarisResolvedPathWrapper getResolvedRootContainerEntityAsPath() {
-    return new PolarisResolvedPathWrapper(List.of(getResolvedRootContainerEntity()));
+    ResolvedPolarisEntity root = getResolvedRootContainerEntity();
+    return root == null
+        ? new PolarisResolvedPathWrapper(List.of())
+        : new PolarisResolvedPathWrapper(List.of(root));
   }
 
   public PolarisResolvedPathWrapper getResolvedReferenceCatalogEntity(
@@ -290,8 +293,11 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
       // authorization chain.
       // TODO: Throw appropriate Catalog NOT_FOUND exception before any call to
       // getResolvedReferenceCatalogEntity().
-      return new PolarisResolvedPathWrapper(
-          List.of(getResolvedRootContainerEntity(), resolvedReferenceCatalog));
+      ResolvedPolarisEntity root = getResolvedRootContainerEntity();
+      if (root == null) {
+        return new PolarisResolvedPathWrapper(List.of(resolvedReferenceCatalog));
+      }
+      return new PolarisResolvedPathWrapper(List.of(root, resolvedReferenceCatalog));
     } else {
       return new PolarisResolvedPathWrapper(List.of(resolvedReferenceCatalog));
     }
@@ -342,7 +348,10 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
 
     List<ResolvedPolarisEntity> resolvedEntities = new ArrayList<>();
     if (prependRootContainer) {
-      resolvedEntities.add(getResolvedRootContainerEntity());
+      ResolvedPolarisEntity root = getResolvedRootContainerEntity();
+      if (root != null) {
+        resolvedEntities.add(root);
+      }
     }
     resolvedEntities.add(primaryResolver.getResolvedReferenceCatalog());
     resolvedPath.forEach(resolvedEntity -> resolvedEntities.add(resolvedEntity));


### PR DESCRIPTION
Fix NPE when root container resolution returns null in PolarisResolutionManifest

In PolarisResolutionManifest, getResolvedRootContainerEntity() is @Nullable and can return null (it also logs a warning).

Three places were passing this directly into List.of() or list.add() without any check:
- getResolvedRootContainerEntityAsPath()
- getResolvedReferenceCatalogEntity() (when prependRootContainer is true)
- getResolvedPath() (when prependRootContainer is true)

This caused NullPointerException because List.of(null) is not allowed.

Fixed by adding simple null guards (same pattern already used elsewhere in the same file for getResolvedTopLevelEntity).

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [ ] Added/updated tests with good coverage, or manually tested (and explained how) -- small defensive null guard, follows existing pattern in the file, no new test added
- [x] Added comments for complex logic
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)