### PR TITLE
Fix ManifestReader resource leak in ManifestFileCleanupTaskHandler

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -116,7 +116,11 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
         return false;
       }
     } catch (IOException e) {
-      LOGGER.error("Failed to close manifest reader for {}", manifestFile.path(), e);
+      // Catches from ManifestFiles.read() (resource creation), from inside the block
+      // (e.g. manifest iteration), or from close(). We return false on any IO here
+      // (so the task gets retried) because close() throws checked IOException and
+      // this method returns boolean (no throws declaration).
+      LOGGER.error("Failed to process manifest reader for {}", manifestFile.path(), e);
       return false;
     }
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -86,7 +86,8 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
           StreamSupport.stream(
                   Spliterators.spliteratorUnknownSize(dataFiles.iterator(), Spliterator.IMMUTABLE),
                   false)
-              .map(file -> tryDelete(tableId, fileIO, manifestFile.path(), file.location(), null, 1))
+              .map(
+                  file -> tryDelete(tableId, fileIO, manifestFile.path(), file.location(), null, 1))
               .toList();
       LOGGER.debug(
           "Scheduled {} data files to be deleted from manifest {}",

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.service.task;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -80,37 +81,41 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
       return true;
     }
 
-    ManifestReader<DataFile> dataFiles = ManifestFiles.read(manifestFile, fileIO, null);
-    List<CompletableFuture<Void>> dataFileDeletes =
-        StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(dataFiles.iterator(), Spliterator.IMMUTABLE),
-                false)
-            .map(file -> tryDelete(tableId, fileIO, manifestFile.path(), file.location(), null, 1))
-            .toList();
-    LOGGER.debug(
-        "Scheduled {} data files to be deleted from manifest {}",
-        dataFileDeletes.size(),
-        manifestFile.path());
-    try {
-      // wait for all data files to be deleted, then wait for the manifest itself to be deleted
-      CompletableFuture.allOf(dataFileDeletes.toArray(CompletableFuture[]::new))
-          .thenCompose(
-              (v) -> {
-                LOGGER
-                    .atInfo()
-                    .addKeyValue("manifestFile", manifestFile.path())
-                    .log("All data files in manifest deleted - deleting manifest");
-                return tryDelete(
-                    tableId, fileIO, manifestFile.path(), manifestFile.path(), null, 1);
-              })
-          .get();
-      return true;
-    } catch (InterruptedException e) {
-      LOGGER.error(
-          "Interrupted exception deleting data files from manifest {}", manifestFile.path(), e);
-      throw new RuntimeException(e);
-    } catch (ExecutionException e) {
-      LOGGER.error("Unable to delete data files from manifest {}", manifestFile.path(), e);
+    try (ManifestReader<DataFile> dataFiles = ManifestFiles.read(manifestFile, fileIO, null)) {
+      List<CompletableFuture<Void>> dataFileDeletes =
+          StreamSupport.stream(
+                  Spliterators.spliteratorUnknownSize(dataFiles.iterator(), Spliterator.IMMUTABLE),
+                  false)
+              .map(file -> tryDelete(tableId, fileIO, manifestFile.path(), file.location(), null, 1))
+              .toList();
+      LOGGER.debug(
+          "Scheduled {} data files to be deleted from manifest {}",
+          dataFileDeletes.size(),
+          manifestFile.path());
+      try {
+        // wait for all data files to be deleted, then wait for the manifest itself to be deleted
+        CompletableFuture.allOf(dataFileDeletes.toArray(CompletableFuture[]::new))
+            .thenCompose(
+                (v) -> {
+                  LOGGER
+                      .atInfo()
+                      .addKeyValue("manifestFile", manifestFile.path())
+                      .log("All data files in manifest deleted - deleting manifest");
+                  return tryDelete(
+                      tableId, fileIO, manifestFile.path(), manifestFile.path(), null, 1);
+                })
+            .get();
+        return true;
+      } catch (InterruptedException e) {
+        LOGGER.error(
+            "Interrupted exception deleting data files from manifest {}", manifestFile.path(), e);
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        LOGGER.error("Unable to delete data files from manifest {}", manifestFile.path(), e);
+        return false;
+      }
+    } catch (IOException e) {
+      LOGGER.error("Failed to close manifest reader for {}", manifestFile.path(), e);
       return false;
     }
   }


### PR DESCRIPTION
Fix ManifestReader resource leak in `ManifestFileCleanupTaskHandler`

ManifestReader`<DataFile>` is created using ManifestFiles.read(...) in `cleanUpManifestFile()` but is never closed.

Since ManifestReader implements Closeable, it should be closed after use. Leaving it open can cause file handle leaks, especially when many cleanup tasks run concurrently, eventually leading to "Too many open files" errors.

This change wraps the reader in a try-with-resources block to ensure it is always closed after processing, including handling any` IOException` raised during close().

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [ ] Added/updated tests with good coverage, or manually tested (and explained how) -- existing higher-level tests + manual verification of close behavior
- [x] Added comments for complex logic
- [ ] Updated CHANGELOG.md (if needed) -- internal robustness fix
- [ ] Updated documentation in site/content/in-dev/unreleased (if needed)