### PR TITLE
Prepare for Gradle 9.6

### DIFF
--- a/aggregated-license-report/build.gradle.kts
+++ b/aggregated-license-report/build.gradle.kts
@@ -17,22 +17,23 @@
  * under the License.
  */
 
-import org.gradle.kotlin.dsl.support.unzipTo
-
-val licenseReports by configurations.creating { description = "Used to generate license reports" }
+val licenseReports =
+  configurations.create("licenseReports") { description = "Used to generate license reports" }
 
 dependencies {
   licenseReports(project(":polaris-runtime-service", "licenseReports"))
 }
 
-val collectLicenseReportJars by
-  tasks.registering(Sync::class) {
-    destinationDir = project.layout.buildDirectory.dir("tmp/license-report-jars").get().asFile
+val licenseReportJarsDir = layout.buildDirectory.dir("tmp/license-report-jars")
+
+val collectLicenseReportJars =
+  tasks.register<Sync>("collectLicenseReportJars") {
+    into(licenseReportJarsDir)
     from(licenseReports)
   }
 
-val aggregateLicenseReports by
-  tasks.registering {
+val aggregateLicenseReports =
+  tasks.register("aggregateLicenseReports") {
     group = "Build"
     description = "Aggregates license reports"
     val outputDir = project.layout.buildDirectory.dir("licenseReports")
@@ -40,15 +41,18 @@ val aggregateLicenseReports by
     dependsOn(collectLicenseReportJars)
     doLast {
       delete(outputDir)
-      fileTree(collectLicenseReportJars.get().destinationDir).files.forEach { zip ->
+      fileTree(licenseReportJarsDir).files.forEach { zip ->
         val targetDirName = zip.name.replace("-license-report.zip", "")
-        unzipTo(outputDir.get().dir(targetDirName).asFile, zip)
+        copy {
+          from(zipTree(zip))
+          into(outputDir.map { it.dir(targetDirName) })
+        }
       }
     }
   }
 
-val aggregatedLicenseReportsZip by
-  tasks.registering(Zip::class) {
+val aggregatedLicenseReportsZip =
+  tasks.register<Zip>("aggregatedLicenseReportsZip") {
     from(aggregateLicenseReports)
     from(rootProject.layout.projectDirectory) {
       include("NOTICE", "LICENSE")

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Apache Polaris - Bill of Materials (BOM)"
 
 dependencies {
   constraints {
-    api(rootProject)
+    api(project(":"))
     api(project(":polaris-api-catalog-service"))
     api(project(":polaris-api-iceberg-service"))
     api(project(":polaris-api-management-model"))

--- a/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-license-report.gradle.kts
@@ -78,12 +78,13 @@ val licenseReportZip =
     archiveExtension.set("zip")
   }
 
-val licenseReports by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-  description = "License report files"
-  outgoing { artifact(licenseReportZip) }
-}
+val licenseReports =
+  configurations.create("licenseReports") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    description = "License report files"
+    outgoing { artifact(licenseReportZip) }
+  }
 
 plugins.withType<MavenPublishPlugin>().configureEach {
   configure<PublishingExtension> {

--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -31,11 +31,9 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.registering
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
@@ -94,8 +92,8 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     if (isSigningEnabled()) {
       plugins.withType<SigningPlugin>().configureEach {
         configure<SigningExtension> {
-          val signingKey: String? by project
-          val signingPassword: String? by project
+          val signingKey = project.findProperty("signingKey")?.toString()
+          val signingPassword = project.findProperty("signingPassword")?.toString()
           useInMemoryPgpKeys(signingKey, signingPassword)
 
           if (project.providers.gradleProperty("useGpgAgent").isPresent) {
@@ -153,15 +151,15 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
               plugins.hasPlugin("java-test-fixtures") &&
                 project.layout.projectDirectory.dir("src/testFixtures").asFile.exists()
             ) {
-              val testFixturesSourcesJar by
-                tasks.registering(org.gradle.api.tasks.bundling.Jar::class) {
-                  val sourceSets: SourceSetContainer by project
+              val testFixturesSourcesJar =
+                tasks.register<Jar>("testFixturesSourcesJar") {
+                  val sourceSets = project.extensions.getByType<SourceSetContainer>()
                   from(sourceSets.named("testFixtures").map { it.allSource })
                   archiveClassifier.set("test-fixtures-sources")
                 }
               tasks.named<Javadoc>("testFixturesJavadoc") { isFailOnError = false }
-              val testFixturesJavadocJar by
-                tasks.registering(org.gradle.api.tasks.bundling.Jar::class) {
+              val testFixturesJavadocJar =
+                tasks.register<Jar>("testFixturesJavadocJar") {
                   from(tasks.named("testFixturesJavadoc"))
                   archiveClassifier.set("test-fixtures-javadoc")
                 }

--- a/persistence/nosql/idgen/impl/build.gradle.kts
+++ b/persistence/nosql/idgen/impl/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 description = "Polaris ID generation implementation"
 
-val jcstressRuntime by configurations.creating
+val jcstressRuntime = configurations.create("jcstressRuntime")
 val jcstressMode = providers.gradleProperty("jcstressMode").orElse("quick")
 val jcstressSplitPerActor =
   providers.gradleProperty("jcstressSplitPerActor").map(String::toBoolean).orElse(false)

--- a/persistence/nosql/persistence/db/mongodb/build.gradle.kts
+++ b/persistence/nosql/persistence/db/mongodb/build.gradle.kts
@@ -66,15 +66,14 @@ dependencies {
 
 testing {
   suites {
-    val intTest by
-      registering(JvmTestSuite::class) {
-        dependencies {
-          runtimeOnly(platform(libs.testcontainers.bom))
-          runtimeOnly("org.testcontainers:testcontainers-mongodb")
+    register<JvmTestSuite>("intTest") {
+      dependencies {
+        runtimeOnly(platform(libs.testcontainers.bom))
+        runtimeOnly("org.testcontainers:testcontainers-mongodb")
 
-          compileOnly(platform(libs.jackson.bom))
-          compileOnly("com.fasterxml.jackson.core:jackson-annotations")
-        }
+        compileOnly(platform(libs.jackson.bom))
+        compileOnly("com.fasterxml.jackson.core:jackson-annotations")
       }
+    }
   }
 }

--- a/persistence/nosql/persistence/impl/build.gradle.kts
+++ b/persistence/nosql/persistence/impl/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 description = "Polaris NoSQL persistence core implementation"
 
-val jcstressRuntime by configurations.creating
+val jcstressRuntime = configurations.create("jcstressRuntime")
 val jcstressMode = providers.gradleProperty("jcstressMode").orElse("quick")
 val jcstressSplitPerActor =
   providers.gradleProperty("jcstressSplitPerActor").map(String::toBoolean).orElse(false)

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -90,20 +90,24 @@ quarkus {
 }
 
 // Configuration to expose distribution artifacts
-val distributionElements by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-}
+val distributionElements =
+  configurations.create("distributionElements") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+  }
 
-val licenseNoticeElements by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-}
+val licenseNoticeElements =
+  configurations.create("licenseNoticeElements") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+  }
 
 // Register the quarkus app directory as an artifact
 artifacts {
-  add("distributionElements", layout.buildDirectory.dir("quarkus-app")) { builtBy("quarkusBuild") }
-  add("licenseNoticeElements", layout.projectDirectory.dir("distribution"))
+  add(distributionElements.name, layout.buildDirectory.dir("quarkus-app")) {
+    builtBy("quarkusBuild")
+  }
+  add(licenseNoticeElements.name, layout.projectDirectory.dir("distribution"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/runtime/distribution/build.gradle.kts
+++ b/runtime/distribution/build.gradle.kts
@@ -37,20 +37,23 @@ val adminProject = project(":polaris-admin")
 val serverProject = project(":polaris-server")
 
 // Configurations to resolve artifacts from other projects
-val adminDistribution by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
+val adminDistribution =
+  configurations.create("adminDistribution") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+  }
 
-val serverDistribution by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
+val serverDistribution =
+  configurations.create("serverDistribution") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+  }
 
-val licenseNotice by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
+val licenseNotice =
+  configurations.create("licenseNotice") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+  }
 
 dependencies {
   adminDistribution(project(":polaris-admin", "distributionElements"))
@@ -59,8 +62,8 @@ dependencies {
   licenseNotice(project(":polaris-server", "licenseNoticeElements"))
 }
 
-val licenseNoticeMerge by
-  tasks.registering(LicenseNoticeMerge::class) { sourceLicenseNotice = licenseNotice }
+val licenseNoticeMerge =
+  tasks.register<LicenseNoticeMerge>("licenseNoticeMerge") { sourceLicenseNotice = licenseNotice }
 
 tasks.named("assembleDist").configure { dependsOn(licenseNoticeMerge) }
 

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -27,9 +27,10 @@ plugins {
   id("polaris-license-report")
 }
 
-val quarkusRunner by configurations.creating {
-  description = "Used to reference the generated runner-jar"
-}
+val quarkusRunner =
+  configurations.create("quarkusRunner") {
+    description = "Used to reference the generated runner-jar"
+  }
 
 dependencies {
   implementation(project(":polaris-runtime-service"))
@@ -95,15 +96,17 @@ tasks.named<QuarkusDev>("quarkusDev") {
 val quarkusBuild = tasks.named<QuarkusBuild>("quarkusBuild")
 
 // Configuration to expose distribution artifacts
-val distributionElements by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-}
+val distributionElements =
+  configurations.create("distributionElements") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+  }
 
-val licenseNoticeElements by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-}
+val licenseNoticeElements =
+  configurations.create("licenseNoticeElements") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+  }
 
 // Expose runnable jar via quarkusRunner configuration for integration-tests that require the
 // server.
@@ -111,6 +114,8 @@ artifacts {
   add(quarkusRunner.name, quarkusBuild.map { it.fastJar.resolve("quarkus-run.jar") }) {
     builtBy(quarkusBuild)
   }
-  add("distributionElements", layout.buildDirectory.dir("quarkus-app")) { builtBy("quarkusBuild") }
-  add("licenseNoticeElements", layout.projectDirectory.dir("distribution"))
+  add(distributionElements.name, layout.buildDirectory.dir("quarkus-app")) {
+    builtBy("quarkusBuild")
+  }
+  add(licenseNoticeElements.name, layout.projectDirectory.dir("distribution"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,18 +19,23 @@
 
 import com.gradle.develocity.agent.gradle.scan.BuildScanPublishingConfiguration
 import java.util.Properties
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.specs.Spec
+import org.gradle.kotlin.dsl.support.serviceOf
+
+val isCI = providers.environmentVariable("CI").isPresent
 
 // Fail early and hard when Gradle's configuration cache is used in CI.
 // Using the configuration cache in CI can leak secrets to the persisted configuration cache and
 // from there anywhere.
-if (
-  gradle.startParameter.isConfigurationCacheRequested &&
-    providers.environmentVariable("CI").map(String::toBoolean).getOrElse(false)
-) {
-  throw GradleException(
-    "Gradle configuration cache must not be enabled in CI because it can persist build configuration state to disk."
-  )
+if (isCI) {
+  val configurationCacheRequested =
+    gradle.serviceOf<BuildFeatures>().configurationCache.requested.getOrElse(false)
+  if (configurationCacheRequested) {
+    throw GradleException(
+      "Gradle configuration cache must not be enabled in CI because it can persist build configuration state to disk."
+    )
+  }
 }
 
 includeBuild("build-logic") { name = "polaris-build-logic" }
@@ -51,7 +56,7 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
 rootProject.name = "polaris"
 
 val baseVersion =
-  providers.fileContents(layout.rootDirectory.file("version.txt")).asText.map { it.trim() }
+  providers.fileContents(layout.settingsDirectory.file("version.txt")).asText.map { it.trim() }
 
 gradle.beforeProject {
   version = baseVersion.get()
@@ -90,8 +95,6 @@ for (sparkVersion in sparkVersions) {
   val scalaVersions = scalaVersionsStr.split(",").map { it.trim() }
   var first = true
   for (scalaVersion in scalaVersions) {
-    val sparkArtifactId = "polaris-spark-${sparkVersion}_${scalaVersion}"
-    val sparkIntArtifactId = "polaris-spark-integration-${sparkVersion}_${scalaVersion}"
     polarisProject(
       "polaris-spark-${sparkVersion}_${scalaVersion}",
       file("${polarisSparkDir}/v${sparkVersion}/spark"),
@@ -103,9 +106,9 @@ for (sparkVersion in sparkVersions) {
     if (first) {
       first = false
     }
-    // Skip all duplicated spark client projects while using Intelij IDE.
+    // Skip all duplicated spark client projects while using IntelliJ IDE.
     // This is to avoid problems during dependency analysis and sync when
-    // using Intelij, like "Multiple projects in this build have project directory".
+    // using IntelliJ, like "Multiple projects in this build have project directory".
     if (ideaActive) {
       break
     }
@@ -150,7 +153,6 @@ dependencyResolutionManagement {
   }
 }
 
-val isCI = providers.environmentVariable("CI").isPresent
 val isBuildScanRequested = gradle.startParameter.isBuildScan
 
 develocity {

--- a/tools/azurite-testcontainer/build.gradle.kts
+++ b/tools/azurite-testcontainer/build.gradle.kts
@@ -39,6 +39,6 @@ dependencies {
 
 testing {
   suites {
-    val intTest by registering(JvmTestSuite::class)
+    register<JvmTestSuite>("intTest")
   }
 }

--- a/tools/config-docs/generator/build.gradle.kts
+++ b/tools/config-docs/generator/build.gradle.kts
@@ -21,7 +21,7 @@ plugins { id("polaris-server") }
 
 description = "Generates Polaris reference docs"
 
-val genTesting by configurations.registering
+val genTesting = configurations.register("genTesting")
 
 dependencies {
   compileOnly(libs.jspecify)

--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -43,9 +43,9 @@ val genProjectPaths = listOf(
   ":polaris-runtime-service",
 )
 
-val genProjects by configurations.creating
-val genSources by configurations.creating
-val doclet by configurations.creating
+val genProjects = configurations.create("genProjects")
+val genSources = configurations.create("genSources")
+val doclet = configurations.create("doclet")
 
 dependencies {
   doclet(project(":polaris-config-docs-annotations"))
@@ -83,7 +83,7 @@ val generatedMarkdownDocs = tasks.register<JavaExec>("generatedMarkdownDocs") {
   classpath(doclet)
 }
 
-val generateDocs by tasks.registering(Sync::class) {
+val generateDocs = tasks.register<Sync>("generateDocs") {
   dependsOn(generatedMarkdownDocs)
 
   val targetDir = layout.buildDirectory.dir("markdown-docs")
@@ -98,7 +98,7 @@ val generateDocs by tasks.registering(Sync::class) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
 }
 
-val copyConfigSectionsToSite by tasks.registering(CopyConfigSectionsToSite::class) {
+val copyConfigSectionsToSite = tasks.register<CopyConfigSectionsToSite>("copyConfigSectionsToSite") {
   dependsOn(generateDocs)
 
   description = "Copies the generated configuration section files to the site content directory as a headless bundle"

--- a/tools/gcs-testcontainer/build.gradle.kts
+++ b/tools/gcs-testcontainer/build.gradle.kts
@@ -38,6 +38,6 @@ dependencies {
 
 testing {
   suites {
-    val intTest by registering(JvmTestSuite::class)
+    register<JvmTestSuite>("intTest")
   }
 }

--- a/tools/immutables/build.gradle.kts
+++ b/tools/immutables/build.gradle.kts
@@ -19,7 +19,7 @@
 
 plugins { id("polaris-client") }
 
-val processor by configurations.creating
+val processor = configurations.create("processor")
 
 processor.extendsFrom(configurations.api.get())
 

--- a/tools/version/build.gradle.kts
+++ b/tools/version/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
 description =
   "Provides Polaris version information programmatically, includes the NOTICE/LICENSE* files"
 
-val syncNoticeAndLicense by
-  tasks.registering(Sync::class) {
+val syncNoticeAndLicense =
+  tasks.register<Sync>("syncNoticeAndLicense") {
     // Have to manually declare the inputs of this task here on top of the from/include below
     val rootDir = layout.settingsDirectory
     inputs
@@ -52,8 +52,8 @@ val syncNoticeAndLicense by
     }
   }
 
-val versionProperties by
-  tasks.registering(Sync::class) {
+val versionProperties =
+  tasks.register<Sync>("versionProperties") {
     destinationDir = project.layout.buildDirectory.dir("version").get().asFile
     from(project.layout.files("src/main/version"))
     eachFile { path = "org/apache/polaris/version/$path" }
@@ -71,8 +71,8 @@ sourceSets.main.configure {
 // Build a jar for `jarTest` having both the production and test sources including the "fake
 // manifest" - the production implementation expects all resources to be in the jar containing
 // the `polaris-version.properties` file.
-val jarTestJar by
-  tasks.registering(Jar::class) {
+val jarTestJar =
+  tasks.register<Jar>("jarTestJar") {
     archiveClassifier.set("jarTest")
     from(sourceSets.main.map { it.output })
     from(sourceSets.named("jarTest").map { it.output })


### PR DESCRIPTION
Beside fixing a bunch of deprecation, fixes a hard build-script compilation issue with Gradle 9.6 (`org.gradle.kotlin.dsl.support.unzipTo` no longer exists).