### PR TITLE
Remove dead commented S3 client code from MinioContainer and RustfsContainer

### DIFF
--- a/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioContainer.java
+++ b/tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioContainer.java
@@ -269,8 +269,6 @@ public final class MinioContainer extends GenericContainer<MinioContainer>
         .httpClientBuilder(UrlConnectionHttpClient.builder())
         .applyMutation(builder -> builder.endpointOverride(URI.create(s3endpoint())))
         .applyMutation(builder -> region.ifPresent(r -> builder.region(Region.of(r))))
-        // .serviceConfiguration(s3Configuration(s3PathStyleAccess, s3UseArnRegionEnabled))
-        // credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken)
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey(), secretKey())))
         .build();

--- a/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsContainer.java
+++ b/tools/rustfs-testcontainer/src/main/java/org/apache/polaris/test/rustfs/RustfsContainer.java
@@ -277,8 +277,6 @@ public final class RustfsContainer extends GenericContainer<RustfsContainer>
         .httpClientBuilder(UrlConnectionHttpClient.builder())
         .applyMutation(builder -> builder.endpointOverride(URI.create(s3endpoint())))
         .applyMutation(builder -> region.ifPresent(r -> builder.region(Region.of(r))))
-        // .serviceConfiguration(s3Configuration(s3PathStyleAccess, s3UseArnRegionEnabled))
-        // credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken)
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey(), secretKey())))
         .build();


### PR DESCRIPTION
## Summary



This PR removes a few outdated commented-out lines from the `createS3Client()` implementations in both `MinioContainer` and `RustfsContainer`.

The comments appear to be leftovers from earlier Nessie-related S3 client configuration code that is no longer used. Because they do not reflect the current implementation, they can create confusion for contributors reading the code and make the methods appear more complex than they actually are.

By removing these obsolete comments, the code becomes easier to read and maintain while keeping the implementation focused on the active logic.

## Changes

* Removed obsolete commented-out S3 client configuration code from `MinioContainer#createS3Client()`.
* Removed the same obsolete comments from `RustfsContainer#createS3Client()`.
* No executable code was changed.
* No functional or behavioral changes were introduced.



## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4839
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
