### PR TITLE
Add H2 schema-version metastore integration tests

### DIFF
--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaIT.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaIT.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Runs {@link org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest} integration
+ * tests against every H2 schema version on the classpath.
+ */
+@ParameterizedClass
+@MethodSource("schemaVersions")
+public class AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaIT
+    extends AtomicMetastoreManagerWithJdbcBasePersistenceImplTest {
+
+  @Parameter int schemaVersion;
+
+  static Stream<Integer> schemaVersions() {
+    return SchemaVersions.discoverAsStream(DatabaseType.H2);
+  }
+
+  @Override
+  public int schemaVersion() {
+    return schemaVersion;
+  }
+}


### PR DESCRIPTION
## Summary

This change adds schema-version integration test coverage for H2 by introducing `AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaIT`.

The new test follows the same approach as the existing PostgreSQL schema integration test, providing consistent coverage across database implementations. It runs the full `BasePolarisMetaStoreManagerTest` suite against each H2 schema version discovered through `SchemaVersions`, helping ensure compatibility and correctness across all supported schema revisions.

Adding this coverage increases confidence that schema migrations and persistence behavior continue to work as expected for H2, while keeping the testing strategy aligned with the existing PostgreSQL implementation.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
