### PR TITLE
Add unit tests for HiveFederatedCatalogFactory

### DIFF
--- a/extensions/federation/hive/src/test/java/org/apache/polaris/extensions/federation/hive/HiveFederatedCatalogFactoryTest.java
+++ b/extensions/federation/hive/src/test/java/org/apache/polaris/extensions/federation/hive/HiveFederatedCatalogFactoryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.extensions.federation.hive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.polaris.core.connection.AuthenticationParametersDpo;
+import org.apache.polaris.core.connection.AuthenticationType;
+import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
+import org.apache.polaris.core.connection.ImplicitAuthenticationParametersDpo;
+import org.apache.polaris.core.connection.hive.HiveConnectionConfigInfoDpo;
+import org.apache.polaris.core.credentials.PolarisCredentialManager;
+import org.apache.polaris.core.credentials.connection.ConnectionCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class HiveFederatedCatalogFactoryTest {
+
+  private static final String WAREHOUSE = "file:///tmp/hive-federation-test-warehouse";
+  private static final String HMS_URI = "thrift://127.0.0.1:9083";
+
+  private PolarisCredentialManager polarisCredentialManager;
+  private HiveFederatedCatalogFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    polarisCredentialManager = mock(PolarisCredentialManager.class);
+    factory = new HiveFederatedCatalogFactory();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AuthenticationType.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"IMPLICIT"})
+  void createCatalogRejectsNonImplicitAuthentication(AuthenticationType authenticationType) {
+    ConnectionConfigInfoDpo connectionConfig = mock(ConnectionConfigInfoDpo.class);
+    AuthenticationParametersDpo authenticationParameters = mock(AuthenticationParametersDpo.class);
+    when(connectionConfig.getAuthenticationParameters()).thenReturn(authenticationParameters);
+    when(authenticationParameters.getAuthenticationTypeCode())
+        .thenReturn(authenticationType.getCode());
+
+    assertThatThrownBy(
+            () -> factory.createCatalog(connectionConfig, polarisCredentialManager, Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Hive federation only supports IMPLICIT authentication.");
+  }
+
+  @Test
+  void createCatalogWithImplicitAuthenticationReturnsHiveCatalog() {
+    HiveConnectionConfigInfoDpo connectionConfig =
+        new HiveConnectionConfigInfoDpo(
+            HMS_URI, new ImplicitAuthenticationParametersDpo(), WAREHOUSE, null);
+    when(polarisCredentialManager.getConnectionCredentials(any(ConnectionConfigInfoDpo.class)))
+        .thenReturn(new ConnectionCredentials(Map.of(), Optional.empty()));
+
+    Catalog catalog = factory.createCatalog(connectionConfig, polarisCredentialManager, Map.of());
+
+    assertThat(catalog).isNotNull().isInstanceOf(HiveCatalog.class);
+  }
+
+  @Test
+  void createGenericCatalogThrowsUnsupportedOperationException() {
+    ConnectionConfigInfoDpo connectionConfig = mock(ConnectionConfigInfoDpo.class);
+
+    assertThatThrownBy(
+            () ->
+                factory.createGenericCatalog(connectionConfig, polarisCredentialManager, Map.of()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Generic table federation to this catalog is not supported.");
+  }
+}


### PR DESCRIPTION
## Summary

This change adds unit test coverage for `HiveFederatedCatalogFactory` in the `polaris-extensions-federation-hive` module.

A new `HiveFederatedCatalogFactoryTest` has been added to verify the factory's behavior in isolation, without requiring a running Hive environment or any external infrastructure. The tests focus on validating the factory's core behavior, including authentication handling, catalog creation, and expected exception paths.

Specifically, the test suite verifies that unsupported authentication types are rejected with the appropriate exception, confirms that the supported `IMPLICIT` authentication flow successfully creates a catalog, and ensures that `createGenericCatalog()` continues to throw `UnsupportedOperationException` as designed. Constructor initialization behavior is also covered.

The tests are implemented as lightweight unit tests using Mockito mocks, making them fast, reliable, and independent of external services.

## Changes

* Added `HiveFederatedCatalogFactoryTest`.
* Added coverage for unsupported authentication type validation.
* Added coverage for successful catalog creation using `IMPLICIT` authentication.
* Added verification that `createGenericCatalog()` throws `UnsupportedOperationException`.
* No production code changes.



## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
