### PR TITLE
Migrate JDBC metrics serialization to Jackson 3

### DIFF
--- a/persistence/relational-jdbc/build.gradle.kts
+++ b/persistence/relational-jdbc/build.gradle.kts
@@ -27,10 +27,9 @@ dependencies {
   implementation(libs.slf4j.api)
   implementation(libs.guava)
 
-  compileOnly(platform(libs.jackson.bom))
-  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
-  compileOnly("com.fasterxml.jackson.core:jackson-core")
-  compileOnly("com.fasterxml.jackson.core:jackson-databind")
+  implementation(platform(libs.jackson3.bom))
+  implementation("tools.jackson.core:jackson-core")
+  implementation("tools.jackson.core:jackson-databind")
   compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelCommitMetricsReport.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.persistence.relational.jdbc.models;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -29,6 +27,9 @@ import org.apache.polaris.core.persistence.metrics.CommitMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /** Model class for commit_metrics_report table - stores commit metrics as first-class entities. */
 @PolarisImmutable
@@ -250,7 +251,7 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
 
   // === Static conversion methods (following ModelEntity pattern) ===
 
-  ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  ObjectMapper OBJECT_MAPPER = JsonMapper.shared();
 
   /**
    * Converts a CommitMetricsRecord (SPI) to ModelCommitMetricsReport (JDBC).
@@ -310,7 +311,7 @@ public interface ModelCommitMetricsReport extends Converter<ModelCommitMetricsRe
     }
     try {
       return OBJECT_MAPPER.writeValueAsString(map);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
   }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/models/ModelScanMetricsReport.java
@@ -18,8 +18,6 @@
  */
 package org.apache.polaris.persistence.relational.jdbc.models;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -30,6 +28,8 @@ import org.apache.polaris.core.persistence.metrics.ScanMetricsRecord;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.relational.jdbc.DatabaseType;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 /** Model class for scan_metrics_report table - stores scan metrics as first-class entities. */
 @PolarisImmutable
@@ -251,8 +251,6 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
 
   // === Static conversion methods (following ModelEntity pattern) ===
 
-  ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   /**
    * Converts a ScanMetricsRecord (SPI) to ModelScanMetricsReport (JDBC).
    *
@@ -317,8 +315,8 @@ public interface ModelScanMetricsReport extends Converter<ModelScanMetricsReport
       return "{}";
     }
     try {
-      return OBJECT_MAPPER.writeValueAsString(map);
-    } catch (JsonProcessingException e) {
+      return JsonMapper.shared().writeValueAsString(map);
+    } catch (JacksonException e) {
       return "{}";
     }
   }

--- a/runtime/admin/distribution/LICENSE
+++ b/runtime/admin/distribution/LICENSE
@@ -448,6 +448,8 @@ This product bundles Jackson.
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-guava
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-jdk8
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+* Maven group:artifact IDs: tools.jackson.core:jackson-core
+* Maven group:artifact IDs: tools.jackson.core:jackson-databind
 
 Project URL: https://github.com/FasterXML/jackson
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -537,6 +537,8 @@ This product bundles Jackson.
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-jdk8
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
 * Maven group:artifact IDs: com.fasterxml.jackson.module:jackson-module-parameter-names
+* Maven group:artifact IDs: tools.jackson.core:jackson-core
+* Maven group:artifact IDs: tools.jackson.core:jackson-databind
 
 Project URL: https://github.com/FasterXML/jackson
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
Move relational JDBC commit and scan metrics report JSON serialization to Jackson 3.

The mapper construction is simplified to JsonMapper.shared() where no custom configuration is needed, and JSON failures now catch JacksonException explicitly.

Migration guide: https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md