### PR TITLE
Migrate non-critical Jackson tests to Jackson 3

### DIFF
--- a/api/management-model/build.gradle.kts
+++ b/api/management-model/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
 
   testImplementation(platform(libs.junit.bom))
   testImplementation("org.junit.jupiter:junit-jupiter")
-  testImplementation(platform(libs.jackson.bom))
-  testImplementation("com.fasterxml.jackson.core:jackson-databind")
+  testImplementation(platform(libs.jackson3.bom))
+  testImplementation("tools.jackson.core:jackson-databind")
 }
 
 val rootDir = layout.settingsDirectory

--- a/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
+++ b/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
@@ -20,15 +20,14 @@ package org.apache.polaris.core.admin.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class CatalogSerializationTest {
 
@@ -40,20 +39,19 @@ public class CatalogSerializationTest {
 
   @BeforeEach
   public void setUp() {
-    mapper = JsonMapper.builder().build();
+    mapper = JsonMapper.shared();
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("catalogTestCases")
-  public void testCatalogSerialization(String description, Catalog catalog)
-      throws JsonProcessingException {
+  public void testCatalogSerialization(String description, Catalog catalog) {
     String json = mapper.writeValueAsString(catalog);
     Catalog deserialized = mapper.readValue(json, Catalog.class);
     assertThat(deserialized).usingRecursiveComparison().isEqualTo(catalog);
   }
 
   @Test
-  public void testJsonFormat() throws JsonProcessingException {
+  public void testJsonFormat() {
     Catalog catalog =
         new Catalog(
             Catalog.TypeEnum.INTERNAL,
@@ -80,7 +78,7 @@ public class CatalogSerializationTest {
   }
 
   @Test
-  public void testJsonFormatWithKmsProperties() throws JsonProcessingException {
+  public void testJsonFormatWithKmsProperties() {
     Catalog catalog =
         new Catalog(
             Catalog.TypeEnum.INTERNAL,

--- a/extensions/auth/ranger/build.gradle.kts
+++ b/extensions/auth/ranger/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")
 
+  testImplementation(platform(libs.jackson3.bom))
+  testImplementation("tools.jackson.core:jackson-databind")
+
   compileOnly(libs.jspecify)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.inject.api)
@@ -71,6 +74,8 @@ testing {
         implementation(platform(libs.iceberg.bom))
         implementation("org.apache.iceberg:iceberg-api")
         implementation("org.apache.iceberg:iceberg-core")
+        implementation(platform(libs.jackson3.bom))
+        implementation("tools.jackson.core:jackson-databind")
 
         implementation(platform(libs.testcontainers.bom))
         implementation("org.testcontainers:testcontainers-junit-jupiter")

--- a/extensions/auth/ranger/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
+++ b/extensions/auth/ranger/src/intTest/java/org/apache/polaris/extension/auth/ranger/test/RangerIntegrationTestBase.java
@@ -21,11 +21,8 @@ package org.apache.polaris.extension.auth.ranger.test;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +31,9 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Base class for Ranger integration tests providing common helpers for authentication and principal
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public abstract class RangerIntegrationTestBase {
 
-  private static final JsonMapper mapper = JsonMapper.builder().build();
+  private static final JsonMapper mapper = JsonMapper.shared();
   private final List<String> catalogsToCleanup = new ArrayList<>();
 
   protected Map<String, String> user2Token = new HashMap<>();
@@ -60,8 +60,8 @@ public abstract class RangerIntegrationTestBase {
   protected String toJson(Object value) {
     try {
       return mapper.writeValueAsString(value);
-    } catch (java.io.IOException e) {
-      throw new UncheckedIOException("Failed to serialize to JSON", e);
+    } catch (JacksonException e) {
+      throw new IllegalArgumentException("Failed to serialize to JSON", e);
     }
   }
 
@@ -151,9 +151,9 @@ public abstract class RangerIntegrationTestBase {
       if (valueNode == null || valueNode.isMissingNode() || valueNode.isNull()) {
         return null;
       }
-      return valueNode.asText();
-    } catch (java.io.IOException e) {
-      throw new UncheckedIOException("Failed to parse JSON response", e);
+      return valueNode.asString();
+    } catch (JacksonException e) {
+      throw new IllegalArgumentException("Failed to parse JSON response", e);
     }
   }
 

--- a/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizerTest.java
+++ b/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizerTest.java
@@ -29,16 +29,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -55,6 +45,14 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 public class RangerPolarisAuthorizerTest {
   private static final String RESOURCE_TYPE_NAME_SEP = ":";
@@ -184,35 +182,29 @@ public class RangerPolarisAuthorizerTest {
   }
 
   private ObjectMapper getMapper() {
-    ObjectMapper ret = new ObjectMapper();
-
     SimpleModule serDeModule = new SimpleModule("testSerDe");
 
     serDeModule.addDeserializer(PolarisPrincipal.class, new PolarisPrincipalDeserializer());
     serDeModule.addDeserializer(
         PolarisResolvedPathWrapper.class, new PolarisResolvedPathWrapperDeserializer());
 
-    ret.registerModule(serDeModule);
-
-    return ret;
+    return JsonMapper.builder().addModule(serDeModule).build();
   }
 
-  static class PolarisPrincipalDeserializer extends JsonDeserializer<PolarisPrincipal> {
+  static class PolarisPrincipalDeserializer extends ValueDeserializer<PolarisPrincipal> {
     @Override
-    public PolarisPrincipal deserialize(JsonParser parser, DeserializationContext context)
-        throws IOException {
-      ObjectCodec codec = parser.getCodec();
-      TreeNode root = codec.readTree(parser);
-      JsonNode nameNode = root != null ? (JsonNode) root.get("name") : null;
+    public PolarisPrincipal deserialize(JsonParser parser, DeserializationContext context) {
+      JsonNode root = parser.readValueAs(JsonNode.class);
+      JsonNode nameNode = root != null ? root.get("name") : null;
 
-      String name = nameNode != null ? nameNode.asText() : null;
+      String name = nameNode != null ? nameNode.asString() : null;
 
       return PolarisPrincipal.of(name, Collections.emptyMap(), Collections.emptySet());
     }
   }
 
   static class PolarisResolvedPathWrapperDeserializer
-      extends JsonDeserializer<PolarisResolvedPathWrapper> {
+      extends ValueDeserializer<PolarisResolvedPathWrapper> {
     private static final Map<String, PolarisEntityType[]> RESOURCE_PATHS = new HashMap<>();
 
     static {
@@ -263,25 +255,26 @@ public class RangerPolarisAuthorizerTest {
     }
 
     @Override
-    public PolarisResolvedPathWrapper deserialize(JsonParser parser, DeserializationContext context)
-        throws IOException {
+    public PolarisResolvedPathWrapper deserialize(
+        JsonParser parser, DeserializationContext context) {
       String target = parser.getValueAsString();
       String[] typeAndName = target.split(RESOURCE_TYPE_NAME_SEP, 2);
 
       if (typeAndName.length != 2) {
-        throw new JsonParseException(target + ": invalid resource");
+        throw DatabindException.from(parser, target + ": invalid resource");
       }
 
       PolarisEntityType[] path = RESOURCE_PATHS.get(typeAndName[0]);
 
       if (path == null) {
-        throw new JsonParseException(target + ": unsupported resource type");
+        throw DatabindException.from(parser, target + ": unsupported resource type");
       }
 
       String[] pathElements = typeAndName[1].split(RESOURCE_ELEMENTS_SEP, path.length);
 
       if (path.length != pathElements.length) {
-        throw new JsonParseException(
+        throw DatabindException.from(
+            parser,
             target
                 + ": incorrect number of path elements. Expected "
                 + path.length


### PR DESCRIPTION
Move management-model serialization tests and Ranger test fixture helpers to Jackson 3.

OPA remains intentionally out of scope because its schema generator dependency is still Jackson 2 based.

Migration guide: https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md