### PR TITLE
Adding EJ as Polaris contributor

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -81,6 +81,7 @@ github:
     # Adding renovate-bot as a collaborator, so CI doesn't need to be manually approved.
     # The list of collaborators is limited to 10 elements.
     - renovate-bot
+    - flyingImer
 
 notifications:
   commits:      commits@polaris.apache.org


### PR DESCRIPTION
EJ volunteered to be release manager for Polaris 1.6.0.
I believe he has to be at least contributor to trigger GitHub workflows.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
