### PR TITLE
Restore gradle/actions setup-gradle v6

### DIFF
--- a/.github/actions/ci-incr-build-cache-prepare/action.yml
+++ b/.github/actions/ci-incr-build-cache-prepare/action.yml
@@ -71,7 +71,7 @@ runs:
         fi
 
     - name: Gradle / Setup
-      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
         validate-wrappers: false


### PR DESCRIPTION
## Summary
Reverts #4518 by restoring the incremental build cache prepare workflow's `gradle/actions/setup-gradle` pin from v5 back to v6.

## Why
#4518 intentionally moved this workflow back to v5 while the project evaluated the Gradle actions v6 licensing and caching tradeoff. This change applies the inverse so the workflow uses the v6 pin again.

## Validation
- `./gradlew format compileAll`

## Notes
Assumption: "revert #4518" means restoring the exact v6 pinned commit that was replaced by #4518.

Disclosure: Prepared with AI assistance; the PR submitter remains responsible for the change.

## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Reverts #4518
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Updated documentation in `site/content/in-dev/unreleased` (if needed)
