### PR TITLE
fix(build): rename GitInfoService Parameters.isRelease to release

### DIFF
--- a/build-logic/src/main/kotlin/GitInfo.kt
+++ b/build-logic/src/main/kotlin/GitInfo.kt
@@ -44,7 +44,7 @@ class GitInfo(val gitHead: String, val gitDescribe: String, private val rawLinkR
           "gitInfo-$isRelease",
           GitInfoService::class.java,
         ) {
-          parameters.isRelease.set(isRelease)
+          parameters.release.set(isRelease)
         }
       return service.get().gitInfo
     }
@@ -53,13 +53,13 @@ class GitInfo(val gitHead: String, val gitDescribe: String, private val rawLinkR
 
 abstract class GitInfoService : BuildService<GitInfoService.Parameters> {
   interface Parameters : BuildServiceParameters {
-    val isRelease: Property<Boolean>
+    val release: Property<Boolean>
   }
 
   @get:Inject abstract val execOperations: ExecOperations
 
   val gitInfo: GitInfo by lazy {
-    val isRelease = parameters.isRelease.get()
+    val isRelease = parameters.release.get()
     val gitHead = execGit("rev-parse", "HEAD")
     val gitDescribe =
       if (isRelease) {


### PR DESCRIPTION
Gradle's managed-property generation rejects an abstract getter that returns `Property<Boolean>` when it uses the is-prefix convention, since isX() getters are only valid for primitive boolean. The Kotlin property isRelease maps to an `isRelease()` getter, so instantiating `GitInfoService.Parameters` fails with:

```
  Cannot have abstract method Parameters.isRelease(): Property<Boolean>.
```

The parameters are only instantiated on the release/publish path (e.g. the releaseEmailTemplate task), so ordinary build/test runs never hit it. The error reproduces identically on Gradle 9.5.1 and 9.6.0: it is a latent bug from the BuildService introduction, not tied to the 9.6.0 upgrade.

Rename the property to release so it generates a valid `getRelease()` getter, and update the two references.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
