### PR TITLE
Fix Renovate grouping and Quarkus platform updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,10 @@
     "main",
   ],
 
+  // Keep monorepo grouping when there are actually multiple updates,
+  // but allow one-dependency PRs to use version-specific titles.
+  groupSingleUpdates: false,
+
   pip_requirements: {
     // fileMatch default: (^|/)([\\w-]*)requirements\\.(txt|pip)$
     "managerFilePatterns": ["(^|/)([\\w-]*)requirements.*\\.txt$"],
@@ -87,9 +91,16 @@
       groupName: "Quarkus, ignore non Platform",
       matchManagers: ["gradle"],
       matchPackageNames: [
+        // Gradle plugin IDs
+        "io.quarkus",
+
+        // Maven coordinates
+        "/^io\\.quarkus:.+/",
         "io.quarkus.platform:quarkus-amazon-services-bom",
         "io.quarkus.platform:quarkus-google-cloud-services-bom",
-        "io.quarkus:io.quarkus.gradle.plugin",
+
+        // Do not disable the main platform BOM.
+        "/^io\\.quarkus\\.platform:(?!quarkus-bom$).+/"
       ],
       enabled: false
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,7 +100,8 @@
         "io.quarkus.platform:quarkus-google-cloud-services-bom",
 
         // Do not disable the main platform BOM.
-        "/^io\\.quarkus\\.platform:(?!quarkus-bom$).+/"
+        "io.quarkus.platform:*",
+        "!io.quarkus.platform:quarkus-bom"
       ],
       enabled: false
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
       #
       - name: Verify Copilot instructions
         run: .github/scripts/check-copilot-instructions.sh
+      - name: Set up Node 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
       - name: Renovate Configuration Validation
         run: npx --yes --package renovate renovate-config-validator --strict --no-global .github/renovate.json5
       # Intentionally unpinned to always use the latest allowlist from the ASF.


### PR DESCRIPTION
Fix two Renovate config issues:

- disable single-update monorepo grouping, so closing a one-dependency Renovate PR does not cause the grouped PR to be recreated indefinitely
- tighten the only-allow `io.quarkus.platform:quarkus-bom` rule to drive Quarkus version updates

The Quarkus platform BOM can be published after individual `io.quarkus:*` artifacts. Without this guard, Renovate can bump the shared Quarkus version before the platform BOM is available.