### PR TITLE
Optimize privilege set BitSet byte-to-long conversion

### DIFF
--- a/persistence/nosql/authz/impl/src/main/java/org/apache/polaris/persistence/nosql/authz/impl/PrivilegeSetImpl.java
+++ b/persistence/nosql/authz/impl/src/main/java/org/apache/polaris/persistence/nosql/authz/impl/PrivilegeSetImpl.java
@@ -271,6 +271,14 @@ record PrivilegeSetImpl(Privileges privileges, byte[] bytes) implements Privileg
     return (byte) (1 << (id & 7));
   }
 
+  static long[] toLongArray(byte[] bytes) {
+    var longs = new long[(bytes.length + Long.BYTES - 1) / Long.BYTES];
+    for (var i = 0; i < bytes.length; i++) {
+      longs[i / Long.BYTES] |= (long) (bytes[i] & 0xFF) << ((i % Long.BYTES) * Byte.SIZE);
+    }
+    return longs;
+  }
+
   static PrivilegeSetBuilder builder(Privileges privileges) {
     return new PrivilegeSetBuilderImpl(privileges);
   }
@@ -310,8 +318,7 @@ record PrivilegeSetImpl(Privileges privileges, byte[] bytes) implements Privileg
           (privilegeSet instanceof PrivilegeSetImpl privilegeSetImpl)
               ? privilegeSetImpl.bytes
               : privilegeSet.toByteArray();
-      // TODO `valueOf(byte[])` is way more expensive than `valueOf(long[])`
-      bitSet.or(BitSet.valueOf(bytes));
+      bitSet.or(BitSet.valueOf(toLongArray(bytes)));
       return this;
     }
 
@@ -346,8 +353,7 @@ record PrivilegeSetImpl(Privileges privileges, byte[] bytes) implements Privileg
           (privilegeSet instanceof PrivilegeSetImpl privilegeSetImpl)
               ? privilegeSetImpl.bytes
               : privilegeSet.toByteArray();
-      // TODO `valueOf(byte[])` is way more expensive than `valueOf(long[])`
-      bitSet.andNot(BitSet.valueOf(bytes));
+      bitSet.andNot(BitSet.valueOf(toLongArray(bytes)));
       return this;
     }
 

--- a/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
+++ b/persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -38,6 +39,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -140,6 +142,41 @@ public class TestPrivilegeSetImpl {
                   .build()
                   .contains(other))
           .isTrue();
+    }
+  }
+
+  @Test
+  public void longArrayConversionPreservesByteArrayBitSetRepresentation() {
+    for (var bytes :
+        new byte[][] {
+          {},
+          {(byte) 0b1010_0101},
+          {(byte) 0x01, (byte) 0x80, (byte) 0x7F},
+          {
+            (byte) 0x01,
+            (byte) 0x23,
+            (byte) 0x45,
+            (byte) 0x67,
+            (byte) 0x89,
+            (byte) 0xAB,
+            (byte) 0xCD,
+            (byte) 0xEF
+          },
+          {
+            (byte) 0xFF,
+            (byte) 0x00,
+            (byte) 0x10,
+            (byte) 0x20,
+            (byte) 0x30,
+            (byte) 0x40,
+            (byte) 0x50,
+            (byte) 0x60,
+            (byte) 0x70,
+            (byte) 0x80
+          }
+        }) {
+      soft.assertThat(BitSet.valueOf(PrivilegeSetImpl.toLongArray(bytes)))
+          .isEqualTo(BitSet.valueOf(bytes));
     }
   }
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
## Summary 
Implement the existing `BitSet.valueOf(byte[])` optimization TODO `// TODO valueOf(byte[]) is way more expensive than valueOf(long[]) `  in `PrivilegeSetImpl`.

`BitSet.valueOf(long[])` is cheaper than `BitSet.valueOf(byte[])`, so this change adds a small little-endian byte-to-long conversion helper and uses it in the `add` and `remove` paths.
## Change
  - Add `PrivilegeSetImpl.toLongArray(byte[])`.
  - Use `BitSet.valueOf(long[])` when merging or subtracting privilege sets.
  - Add coverage to verify the converted `long[]` produces the same `BitSet` representation as the original byte array, including empty, partial, full 8-byte, and multi-long inputs.

#### Explain of toLongArray(byte[]) 
  1. new long[(bytes.length + 7) / 8] allocates enough longs for all bytes, 8 bytes per long.
  2. bytes[i] & 0xFF treats each byte as unsigned, avoiding sign extension.
  3. i / Long.BYTES picks which long the byte belongs to.
  4. (i % Long.BYTES) * Byte.SIZE picks the byte’s bit offset inside that long.
  5. |= adds that byte into the long without overwriting earlier bytes.

So bytes 0..7 become longs[0], bytes 8..15 become longs[1], etc., preserving BitSet’s little-endian layout.

## Test
- Add test coverage in `persistence/nosql/authz/impl/src/test/java/org/apache/polaris/persistence/nosql/authz/impl/TestPrivilegeSetImpl.java`

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
