### PR TITLE
Fix duplicate setId() in TableCleanupTaskHandler wasting entity IDs

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -189,7 +189,6 @@ public class TableCleanupTaskHandler implements TaskHandler {
                   .log("Queueing task to delete manifest file");
               return new TaskEntity.Builder()
                   .setName(taskName)
-                  .setId(metaStoreManager.generateNewEntityId(polarisCallContext).getId())
                   .setCreateTimestamp(clock.millis())
                   .withTaskType(AsyncTaskType.MANIFEST_FILE_CLEANUP)
                   .withData(


### PR DESCRIPTION
## Summary

Remove the duplicate `setId()` call in `TableCleanupTaskHandler#getManifestTaskStream()`.

## Why this is needed

`TaskEntity.Builder` was calling `generateNewEntityId()` twice when creating manifest cleanup tasks. Since the second `setId()` overwrites the first, the first generated ID was never used.

This results in an unnecessary ID allocation for every manifest cleanup task.

## Changes

- Remove the redundant early `setId(...)` call.
- Keep the later `setId(...)` call, which is the value actually used by the created task.

## Checklist

- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: N/A (internal cleanup bug)
- [ ] Added/updated tests with good coverage, or manually tested 
- [ ] Added comments for complex logic: N/A (simple one-line removal)
- [ ] Updated CHANGELOG.md (if needed): N/A (internal cleanup, no user-facing change)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed): N/A