### PR TITLE
fix(build): restore task dependency for Spark bundle jar Maven publication

### DIFF
--- a/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -136,13 +136,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
             suppressPomMetadataWarningsFor("testFixturesApiElements")
             suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
 
-            project.tasks
-              .matching { task -> task.name == "createPolarisSparkJar" }
-              .configureEach {
-                // if the project contains spark client jar, also publish the jar to maven
-                artifact(this)
-              }
-
             if (project.isSigningEnabled()) {
               configure<SigningExtension> { sign(mavenPublication) }
             }

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -207,7 +207,7 @@ listOf("intTestCompileClasspath", "intTestRuntimeClasspath").forEach {
   }
 }
 
-tasks.register<ShadowJar>("createPolarisSparkJar") {
+val createPolarisSparkJar = tasks.register<ShadowJar>("createPolarisSparkJar") {
   archiveClassifier = "bundle"
   isZip64 = true
 
@@ -253,6 +253,12 @@ tasks.register<ShadowJar>("createPolarisSparkJar") {
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
 // `assemble` and `build` task
-tasks.named("assemble") { dependsOn("createPolarisSparkJar") }
+tasks.named("assemble") { dependsOn(createPolarisSparkJar) }
 
-tasks.named("build") { dependsOn("createPolarisSparkJar") }
+tasks.named("build") { dependsOn(createPolarisSparkJar) }
+
+publishing {
+  publications.named<MavenPublication>("maven") {
+    artifact(createPolarisSparkJar)
+  }
+}

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -207,49 +207,50 @@ listOf("intTestCompileClasspath", "intTestRuntimeClasspath").forEach {
   }
 }
 
-val createPolarisSparkJar = tasks.register<ShadowJar>("createPolarisSparkJar") {
-  archiveClassifier = "bundle"
-  isZip64 = true
+val createPolarisSparkJar =
+  tasks.register<ShadowJar>("createPolarisSparkJar") {
+    archiveClassifier = "bundle"
+    isZip64 = true
 
-  // pack both the source code and dependencies
-  from(sourceSets.main.map { it.output })
-  configurations = provider { listOf(project.configurations.runtimeClasspath.get()) }
+    // pack both the source code and dependencies
+    from(sourceSets.main.map { it.output })
+    configurations = provider { listOf(project.configurations.runtimeClasspath.get()) }
 
-  // Includes _all_ duplicates (this is applied files processed by `ShadowJar`).
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
-  // This setting applies to the _result_ of the `ShadowJar`.
-  failOnDuplicateEntries = true
+    // Includes _all_ duplicates (this is applied files processed by `ShadowJar`).
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // This setting applies to the _result_ of the `ShadowJar`.
+    failOnDuplicateEntries = true
 
-  // Generally, preserve META-INF/maven/*/*/pom.* files for downstream tools that
-  // can analyze dependency jars.
-  //
-  // There are quite a few _duplicated_ occurrences of failureaccess, guava,
-  // listenablefuture, error_prone_annotations, j2objc-annotations, gson.
-  // Leave those here so that dependency analyzing tools can pick those up.
+    // Generally, preserve META-INF/maven/*/*/pom.* files for downstream tools that
+    // can analyze dependency jars.
+    //
+    // There are quite a few _duplicated_ occurrences of failureaccess, guava,
+    // listenablefuture, error_prone_annotations, j2objc-annotations, gson.
+    // Leave those here so that dependency analyzing tools can pick those up.
 
-  exclude(
-    // Recursively remove all LICENSE and NOTICE file under META-INF, includes
-    // directories contains 'license' in the name.
-    "META-INF/**/*LICENSE*",
-    "META-INF/**/*NOTICE*",
-    // exclude the top level LICENSE, LICENSE-*.txt and NOTICE
-    "LICENSE*",
-    "NOTICE*",
+    exclude(
+      // Recursively remove all LICENSE and NOTICE file under META-INF, includes
+      // directories contains 'license' in the name.
+      "META-INF/**/*LICENSE*",
+      "META-INF/**/*NOTICE*",
+      // exclude the top level LICENSE, LICENSE-*.txt and NOTICE
+      "LICENSE*",
+      "NOTICE*",
 
-    // Exclude Jandex indexes
-    "META-INF/jandex.idx",
+      // Exclude Jandex indexes
+      "META-INF/jandex.idx",
 
-    // From Hive/Hadoop - exclude those to not confuse people.
-    "META-INF/DEPENDENCIES",
-  )
+      // From Hive/Hadoop - exclude those to not confuse people.
+      "META-INF/DEPENDENCIES",
+    )
 
-  // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
-  // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
-  // and renamed to LICENSE and NOTICE after include, this is to avoid the file
-  // being excluded due to the exclude pattern matching used above.
-  from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
-  from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
-}
+    // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
+    // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
+    // and renamed to LICENSE and NOTICE after include, this is to avoid the file
+    // being excluded due to the exclude pattern matching used above.
+    from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
+    from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+  }
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
 // `assemble` and `build` task

--- a/plugins/spark/v4.0/spark/build.gradle.kts
+++ b/plugins/spark/v4.0/spark/build.gradle.kts
@@ -210,49 +210,50 @@ configurations.named("intTestRuntimeClasspath") {
   resolutionStrategy { force("jakarta.servlet:jakarta.servlet-api:5.0.0") }
 }
 
-val createPolarisSparkJar = tasks.register<ShadowJar>("createPolarisSparkJar") {
-  archiveClassifier = "bundle"
-  isZip64 = true
+val createPolarisSparkJar =
+  tasks.register<ShadowJar>("createPolarisSparkJar") {
+    archiveClassifier = "bundle"
+    isZip64 = true
 
-  // pack both the source code and dependencies
-  from(sourceSets.main.map { it.output })
-  configurations = provider { listOf(project.configurations.runtimeClasspath.get()) }
+    // pack both the source code and dependencies
+    from(sourceSets.main.map { it.output })
+    configurations = provider { listOf(project.configurations.runtimeClasspath.get()) }
 
-  // Includes _all_ duplicates (this is applied files processed by `ShadowJar`).
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
-  // This setting applies to the _result_ of the `ShadowJar`.
-  failOnDuplicateEntries = true
+    // Includes _all_ duplicates (this is applied files processed by `ShadowJar`).
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // This setting applies to the _result_ of the `ShadowJar`.
+    failOnDuplicateEntries = true
 
-  // Generally, preserve META-INF/maven/*/*/pom.* files for downstream tools that
-  // can analyze dependency jars.
-  //
-  // There are quite a few _duplicated_ occurrences of failureaccess, guava,
-  // listenablefuture, error_prone_annotations, j2objc-annotations, gson.
-  // Leave those here so that dependency analyzing tools can pick those up.
+    // Generally, preserve META-INF/maven/*/*/pom.* files for downstream tools that
+    // can analyze dependency jars.
+    //
+    // There are quite a few _duplicated_ occurrences of failureaccess, guava,
+    // listenablefuture, error_prone_annotations, j2objc-annotations, gson.
+    // Leave those here so that dependency analyzing tools can pick those up.
 
-  exclude(
-    // Recursively remove all LICENSE and NOTICE file under META-INF, includes
-    // directories contains 'license' in the name.
-    "META-INF/**/*LICENSE*",
-    "META-INF/**/*NOTICE*",
-    // exclude the top level LICENSE, LICENSE-*.txt and NOTICE
-    "LICENSE*",
-    "NOTICE*",
+    exclude(
+      // Recursively remove all LICENSE and NOTICE file under META-INF, includes
+      // directories contains 'license' in the name.
+      "META-INF/**/*LICENSE*",
+      "META-INF/**/*NOTICE*",
+      // exclude the top level LICENSE, LICENSE-*.txt and NOTICE
+      "LICENSE*",
+      "NOTICE*",
 
-    // Exclude Jandex indexes
-    "META-INF/jandex.idx",
+      // Exclude Jandex indexes
+      "META-INF/jandex.idx",
 
-    // From Hive/Hadoop - exclude those to not confuse people.
-    "META-INF/DEPENDENCIES",
-  )
+      // From Hive/Hadoop - exclude those to not confuse people.
+      "META-INF/DEPENDENCIES",
+    )
 
-  // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
-  // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
-  // and renamed to LICENSE and NOTICE after include, this is to avoid the file
-  // being excluded due to the exclude pattern matching used above.
-  from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
-  from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
-}
+    // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
+    // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
+    // and renamed to LICENSE and NOTICE after include, this is to avoid the file
+    // being excluded due to the exclude pattern matching used above.
+    from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
+    from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+  }
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
 // `assemble` and `build` task

--- a/plugins/spark/v4.0/spark/build.gradle.kts
+++ b/plugins/spark/v4.0/spark/build.gradle.kts
@@ -210,7 +210,7 @@ configurations.named("intTestRuntimeClasspath") {
   resolutionStrategy { force("jakarta.servlet:jakarta.servlet-api:5.0.0") }
 }
 
-tasks.register<ShadowJar>("createPolarisSparkJar") {
+val createPolarisSparkJar = tasks.register<ShadowJar>("createPolarisSparkJar") {
   archiveClassifier = "bundle"
   isZip64 = true
 
@@ -256,6 +256,12 @@ tasks.register<ShadowJar>("createPolarisSparkJar") {
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
 // `assemble` and `build` task
-tasks.named("assemble") { dependsOn("createPolarisSparkJar") }
+tasks.named("assemble") { dependsOn(createPolarisSparkJar) }
 
-tasks.named("build") { dependsOn("createPolarisSparkJar") }
+tasks.named("build") { dependsOn(createPolarisSparkJar) }
+
+publishing {
+  publications.named<MavenPublication>("maven") {
+    artifact(createPolarisSparkJar)
+  }
+}


### PR DESCRIPTION
`tasks.matching{}.configureEach{ artifact(this) }` registers the artifact file path but does not establish an execution dependency on the producing task in Gradle 9.6, causing `publishMavenPublicationToMavenLocal` to fail with "artifact file does not exist" for `polaris-spark-*`.

Fix: capture the `TaskProvider<ShadowJar>` returned by `tasks.register` in each Spark module's build script and pass it to `artifact()` in a `publishing` block. This wires `createPolarisSparkJar` as a proper task dependency of the publish task. The `createPolarisSparkJar` handling is removed from `PublishingHelperPlugin` entirely — keeping artifact registration local to the modules that define the task.

Regressed in [ddebe520](https://github.com/apache/polaris/commit/ddebe5206b8b7f8f29a82fcaaf63ce45171601e2) ("Build: eliminate cross-project dependencies in publishing related areas").

## Evidence
Before patch (`publishMavenPublicationToMavenLocal` succeeds but produces no bundle JAR):
```
% ./gradlew publishMavenPublicationToMavenLocal --no-build-cache
BUILD SUCCESSFUL in 1s
% find ~/.m2/repository/org/apache/polaris -name "*bundle*"
<no results>
```

After patch (all 3 bundle JARs present):
```
% ./gradlew publishMavenPublicationToMavenLocal --no-build-cache
BUILD SUCCESSFUL
% find ~/.m2/repository/org/apache/polaris -name "*bundle*"
.../polaris-spark-3.5_2.12/1.6.0-SNAPSHOT/polaris-spark-3.5_2.12-1.6.0-SNAPSHOT-bundle.jar
.../polaris-spark-3.5_2.13/1.6.0-SNAPSHOT/polaris-spark-3.5_2.13-1.6.0-SNAPSHOT-bundle.jar
.../polaris-spark-4.0_2.13/1.6.0-SNAPSHOT/polaris-spark-4.0_2.13-1.6.0-SNAPSHOT-bundle.jar
```

## Checklist
- [X] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [X] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)