### PR TITLE
Avoid metrics persistence setup for in-memory event buffering

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/listeners/inmemory/InMemoryBufferEventListenerBufferSizeTest.java
@@ -24,6 +24,8 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -46,6 +48,7 @@ class InMemoryBufferEventListenerBufferSizeTest extends InMemoryBufferEventListe
     sendAsync("test2", 10);
     assertRows("test1", 10);
     assertRows("test2", 10);
+    verify(metaStoreManagerFactory, never()).getOrCreateMetricsPersistence(any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #4594.

This avoids creating MetricsPersistence for InMemoryBufferEventListener. The listener only needs to write buffered event entities, so it now passes a no-op MetricsPersistence into PolarisCallContext instead of asking the MetaStoreManagerFactory to create one.

The focused buffer-size test now verifies that flushing events does not request metrics persistence.

## Tests

- `./gradlew :polaris-runtime-service:test --tests "org.apache.polaris.service.events.listeners.inmemory.InMemoryBufferEventListenerBufferSizeTest"`
- `./gradlew format`
- `./gradlew compileAll`
- Fork CI: https://github.com/mj006648/polaris/actions/runs/28075950818

## Checklist

- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #4594
- [x] Added/updated tests with good coverage, or manually tested
- [x] Added comments for complex logic, if needed
- [x] Updated `CHANGELOG.md`, if needed
- [x] Updated documentation in `site/content/in-dev/unreleased`, if needed
