### PR TITLE
Keep setup-python pin comments accurate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,7 @@ jobs:
         with:
           name: polaris-server-app
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release-3-build-and-publish-artifacts.yml
+++ b/.github/workflows/release-3-build-and-publish-artifacts.yml
@@ -549,7 +549,7 @@ jobs:
           echo "LIBS_DIR=$(pwd)/releasey/libs" >> $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/site-guides.yml
+++ b/.github/workflows/site-guides.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
       - name: Setup test environment


### PR DESCRIPTION
Summary

Zizmor reports ref-version-mismatch for several setup-python pins because the pinned SHA matches v6.2.0 while the comments currently say v6.

This updates the comments only. The pinned action SHA is unchanged.

Tests

- Checked that the pinned setup-python SHA matches refs/tags/v6.2.0
- Checked that no old setup-python # v6 comments remain for that SHA

Checklist

- [x] Don't disclose security issues
- [x] Clearly explained why the changes are needed
- [x] Manually verified the pin/comment match
- [x] No complex logic comments needed
- [x] CHANGELOG update not needed
- [x] Documentation update not needed
