### PR TITLE
Build: Give quarkus-build more heap

### DIFF
--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -87,6 +87,9 @@ quarkus {
         .toMap()
     }
   )
+  buildForkOptions {
+    maxHeapSize = "2G"
+  }
 }
 
 // Configuration to expose distribution artifacts

--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -73,6 +73,9 @@ quarkus {
         .toMap()
     }
   )
+  buildForkOptions {
+    maxHeapSize = "2G"
+  }
 }
 
 tasks.register("run") {


### PR DESCRIPTION
The Quarkus build can require a bit more heap space. Since the actual Quarkus build happens in a separately forked process, this can be controlled on the `quarkusBuild` extension.

This change sets the max heap size for these build-worker processes to 2G, which should be enough and could reduce GC pressure.