### PR TITLE
Site: Update community Slack invite

### DIFF
--- a/site/content/community/_index.adoc
+++ b/site/content/community/_index.adoc
@@ -30,7 +30,7 @@ cascade:
 {{% blocks/feature icon="fa-solid fa-graduation-cap" title="Learn, Connect and Collaborate" %}}
 [cols="2,3"]
 |===
-| link:https://join.slack.com/t/apache-polaris/shared_invite/zt-3rw95a9d3-Gk~1cnpjCYpm8JL8vry_ww[Slack]
+| link:https://join.slack.com/t/apache-polaris/shared_invite/zt-3txht5g9x-9NYK98fK6hk40bOaWGW83Q[Slack]
 | Public chat, open to everybody
 
 | link:{{% ref "meetings" %}}[Community Meetings]


### PR DESCRIPTION
## Summary

Update the Slack link on the Community page to use the no-expiration invite already used by the homepage CTA.

The Community page still pointed at the earlier invite from #3985, while #4088 updated only `site/content/_index.adoc`. This keeps `/community/` consistent with the homepage invite.

Related to #4088.

## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Related to #4088
- [x] Added/updated tests with good coverage, or manually tested (and explained how): `./gradlew format compileAll`
- [x] Added comments for complex logic: not needed
- [x] Updated `CHANGELOG.md` (if needed): not needed, docs link only
- [x] Updated documentation in `site/content/in-dev/unreleased` (if needed): not needed, docs link only
