### PR TITLE
fix(release): correct LICENSE and NOTICE metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -343,7 +343,6 @@ This product includes code from Project Nessie.
 * tools/gcs-testcontainer/src/main/java/org/projectnessie/testing/gcs/GcsExtension.java
 * tools/gcs-testcontainer/src/main/java/org/projectnessie/testing/gcs/Gcs.java
 * tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/Minio.java
-* tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/Minio.java
 * tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioAccess.java
 * tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioContainer.java
 * tools/minio-testcontainer/src/main/java/org/apache/polaris/test/minio/MinioExtension.java

--- a/runtime/admin/distribution/LICENSE
+++ b/runtime/admin/distribution/LICENSE
@@ -1323,7 +1323,7 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles conscrypt (openjdk-uber).
+This product bundles Conscrypt (openjdk-uber).
 
 * Maven group:artifact IDs: org.conscrypt:conscrypt-openjdk-uber
 

--- a/runtime/admin/distribution/NOTICE
+++ b/runtime/admin/distribution/NOTICE
@@ -606,7 +606,7 @@ This product bundles jakarta.validation-api with the following in its NOTICE fil
 
 --------------------------------------------------------------------------------
 
-This product bundles Conscrypt (openjdk uber) with the following in its NOTICE file:
+This product bundles Conscrypt (openjdk-uber) with the following in its NOTICE file:
 |
 | Copyright 2016 The Android Open Source Project
 | 

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -2181,7 +2181,6 @@ This product bundles GraalVM libraries.
 * Maven group:artifact IDs: org.graalvm.sdk:jniutils
 * Maven group:artifact IDs: org.graalvm.sdk:nativeimage
 * Maven group:artifact IDs: org.graalvm.sdk:word
-* Maven group:artifact IDs: org.graalvm.shadowed:xz
 * Maven group:artifact IDs: org.graalvm.truffle:truffle-api
 * Maven group:artifact IDs: org.graalvm.truffle:truffle-compiler
 * Maven group:artifact IDs: org.graalvm.truffle:truffle-runtime

--- a/runtime/server/distribution/NOTICE
+++ b/runtime/server/distribution/NOTICE
@@ -689,6 +689,16 @@ This product bundles Conscrypt (openjdk-uber) with the following in its NOTICE f
 
 --------------------------------------------------------------------------------
 
+This product bundles Joda Time library with the following in its NOTICE file:
+|
+| =============================================================================
+| = NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+| =============================================================================
+| This product includes software developed by
+| Joda.org (https://www.joda.org/).
+
+--------------------------------------------------------------------------------
+
 This product bundles Jetty with the following in its NOTICE file:
 |
 | Notices for Eclipse Jetty


### PR DESCRIPTION
Address validation findings discovered as part of v1.6.0 release by fixing stale source LICENSE entries, normalizing Conscrypt metadata, avoiding duplicate GraalVM shaded XZ licensing, and adding the Joda-Time NOTICE text.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
