### PR TITLE
When a vote failed, the vote email subject should not RESULT, it should be CANCEL

### DIFF
--- a/.github/workflows/release-X-cancel-release-candidate.yml
+++ b/.github/workflows/release-X-cancel-release-candidate.yml
@@ -225,7 +225,7 @@ jobs:
           # Vote Failure Email
 
           ## Subject
-          [RESULT][VOTE] Release Apache Polaris ${version_without_rc} (rc${rc_number})
+          [CANCEL][VOTE] Release Apache Polaris ${version_without_rc} (rc${rc_number})
 
           ## Body
           Hello everyone,


### PR DESCRIPTION
When a vote fails, the email subject should be CANCEL (not RESULT).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
