### PR TITLE
Migrate core serialization helpers to Jackson 3

### DIFF
--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlPaginationToken.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlPaginationToken.java
@@ -23,9 +23,6 @@ import static org.apache.polaris.persistence.nosql.api.index.IndexKey.key;
 import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.List;
@@ -42,6 +39,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.smile.SmileMapper;
 
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestNoSqlPaginationToken {
@@ -52,19 +52,18 @@ public class TestNoSqlPaginationToken {
 
   @ParameterizedTest
   @MethodSource("tokens")
-  public void serializationRoundtripSmile(ObjRef containerObjRef, IndexKey indexKey)
-      throws Exception {
+  public void serializationRoundtripSmile(ObjRef containerObjRef, IndexKey indexKey) {
     var token = NoSqlPaginationToken.paginationToken(containerObjRef, indexKey);
     var expectedContainerObjRefBytes = containerObjRef.toBytes();
     var expectedKeyBytes = bytes(indexKey.asByteBuffer());
 
     var serialized = SMILE_MAPPER.writerFor(NoSqlPaginationToken.class).writeValueAsBytes(token);
     var jsonNode = SMILE_MAPPER.readTree(serialized);
-    soft.assertThat(jsonNode.fieldNames()).toIterable().containsExactlyInAnyOrder("t", "c", "k");
-    soft.assertThat(jsonNode.path("t").asText()).isEqualTo(NoSqlPaginationToken.ID);
-    soft.assertThat(jsonNode.path("c").asText())
+    soft.assertThat(jsonNode.asObject().propertyNames()).containsExactlyInAnyOrder("t", "c", "k");
+    soft.assertThat(jsonNode.path("t").asString()).isEqualTo(NoSqlPaginationToken.ID);
+    soft.assertThat(jsonNode.path("c").asString())
         .isEqualTo(Base64.getEncoder().encodeToString(expectedContainerObjRefBytes));
-    soft.assertThat(jsonNode.path("k").asText())
+    soft.assertThat(jsonNode.path("k").asString())
         .isEqualTo(Base64.getEncoder().encodeToString(expectedKeyBytes));
     assertRoundTrip(
         SMILE_MAPPER.readValue(serialized, NoSqlPaginationToken.class),
@@ -76,19 +75,18 @@ public class TestNoSqlPaginationToken {
 
   @ParameterizedTest
   @MethodSource("tokens")
-  public void serializationRoundtripJson(ObjRef containerObjRef, IndexKey indexKey)
-      throws Exception {
+  public void serializationRoundtripJson(ObjRef containerObjRef, IndexKey indexKey) {
     var token = NoSqlPaginationToken.paginationToken(containerObjRef, indexKey);
     var expectedContainerObjRefBytes = containerObjRef.toBytes();
     var expectedKeyBytes = bytes(indexKey.asByteBuffer());
 
     var serialized = JSON_MAPPER.writerFor(NoSqlPaginationToken.class).writeValueAsString(token);
     var jsonNode = JSON_MAPPER.readTree(serialized);
-    soft.assertThat(jsonNode.fieldNames()).toIterable().containsExactlyInAnyOrder("t", "c", "k");
-    soft.assertThat(jsonNode.path("t").asText()).isEqualTo(NoSqlPaginationToken.ID);
-    soft.assertThat(jsonNode.path("c").asText())
+    soft.assertThat(jsonNode.asObject().propertyNames()).containsExactlyInAnyOrder("t", "c", "k");
+    soft.assertThat(jsonNode.path("t").asString()).isEqualTo(NoSqlPaginationToken.ID);
+    soft.assertThat(jsonNode.path("c").asString())
         .isEqualTo(Base64.getEncoder().encodeToString(expectedContainerObjRefBytes));
-    soft.assertThat(jsonNode.path("k").asText())
+    soft.assertThat(jsonNode.path("k").asString())
         .isEqualTo(Base64.getEncoder().encodeToString(expectedKeyBytes));
     assertRoundTrip(
         JSON_MAPPER.readValue(serialized, NoSqlPaginationToken.class),

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -38,6 +38,12 @@ dependencies {
   runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
   runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
+  implementation(platform(libs.jackson3.bom))
+  implementation("tools.jackson.core:jackson-core")
+  implementation("tools.jackson.core:jackson-databind")
+  implementation("tools.jackson.dataformat:jackson-dataformat-smile")
+  implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
+
   implementation(libs.caffeine)
   implementation(libs.guava)
   implementation(libs.slf4j.api)

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpo.java
@@ -23,10 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -46,6 +42,9 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.secrets.SecretReference;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * The internal persistence-object counterpart to ConnectionConfigInfo defined in the API model.
@@ -145,9 +144,10 @@ public abstract class ConnectionConfigInfoDpo implements IcebergCatalogPropertie
   static {
     DEFAULT_MAPPER =
         JsonMapper.builder()
-            .defaultPropertyInclusion(
-                JsonInclude.Value.construct(
-                    JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .changeDefaultPropertyInclusion(
+                incl ->
+                    incl.withValueInclusion(JsonInclude.Include.NON_NULL)
+                        .withContentInclusion(JsonInclude.Include.NON_NULL))
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build();
   }
@@ -161,11 +161,7 @@ public abstract class ConnectionConfigInfoDpo implements IcebergCatalogPropertie
   }
 
   public static ConnectionConfigInfoDpo deserialize(final @NonNull String jsonStr) {
-    try {
-      return DEFAULT_MAPPER.readValue(jsonStr, ConnectionConfigInfoDpo.class);
-    } catch (JsonProcessingException ex) {
-      throw new RuntimeException("deserialize failed: " + ex.getMessage(), ex);
-    }
+    return DEFAULT_MAPPER.readValue(jsonStr, ConnectionConfigInfoDpo.class);
   }
 
   /** Validates the remote URI. */

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/EventEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/EventEntity.java
@@ -20,12 +20,11 @@
 package org.apache.polaris.core.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class EventEntity {
   public static final String EMPTY_MAP_STRING = "{}";
@@ -47,7 +46,7 @@ public class EventEntity {
 
   // to serialize/deserialize properties
   // TODO: Look into using the CDI-managed `ObjectMapper` object
-  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+  private static final ObjectMapper MAPPER = JsonMapper.shared();
 
   /**
    * Identifier of the catalog this event was scoped to, or {@link #REALM_SCOPED} for events that
@@ -142,7 +141,7 @@ public class EventEntity {
     String properties = getAdditionalProperties();
     try {
       return MAPPER.readValue(properties, new TypeReference<>() {});
-    } catch (JsonProcessingException ex) {
+    } catch (Exception ex) {
       throw new IllegalStateException(
           String.format("Failed to deserialize json. properties %s", properties), ex);
     }
@@ -152,7 +151,7 @@ public class EventEntity {
   public void setAdditionalProperties(Map<String, String> properties) {
     try {
       this.additionalProperties = properties == null ? null : MAPPER.writeValueAsString(properties);
-    } catch (JsonProcessingException ex) {
+    } catch (Exception ex) {
       throw new IllegalStateException(
           String.format("Failed to serialize json. properties %s", properties), ex);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentials.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentials.java
@@ -27,6 +27,8 @@ import org.immutables.value.Value;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableRootCredentials.class)
 @JsonDeserialize(as = ImmutableRootCredentials.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRootCredentials.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRootCredentials.class)
 public interface RootCredentials {
 
   @Value.Parameter(order = 1)

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/bootstrap/RootCredentialsSet.java
@@ -18,18 +18,11 @@
  */
 package org.apache.polaris.core.persistence.bootstrap;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
@@ -38,6 +31,11 @@ import java.util.Map;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 /**
  * A utility to parse and provide credentials for Polaris realms and principals during a bootstrap
@@ -150,8 +148,9 @@ public interface RootCredentialsSet {
     }
   }
 
-  private static RootCredentialsSet fromInputStream(InputStream in) throws IOException {
-    ObjectMapper mapper = YAMLMapper.builder().configure(FAIL_ON_UNKNOWN_PROPERTIES, false).build();
+  private static RootCredentialsSet fromInputStream(InputStream in) {
+    ObjectMapper mapper =
+        YAMLMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
     try (var parser = mapper.createParser(in)) {
       var values = mapper.readValues(parser, RootCredentialsSet.class);
       var builder = ImmutableRootCredentialsSet.builder();

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/EntityIdToken.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/EntityIdToken.java
@@ -31,6 +31,8 @@ import org.jspecify.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableEntityIdToken.class)
 @JsonDeserialize(as = ImmutableEntityIdToken.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableEntityIdToken.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableEntityIdToken.class)
 public interface EntityIdToken extends Token {
   String ID = "e";
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageToken.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageToken.java
@@ -31,6 +31,8 @@ import org.jspecify.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutablePageToken.class)
 @JsonDeserialize(as = ImmutablePageToken.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutablePageToken.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutablePageToken.class)
 public interface PageToken {
   // Serialization property names are intentionally short to reduce the size of the serialized
   // paging token.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -24,14 +24,7 @@ import static java.lang.String.format;
 import static java.util.Collections.unmodifiableMap;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DatabindContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
-import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Locale;
@@ -41,6 +34,11 @@ import java.util.OptionalInt;
 import java.util.ServiceLoader;
 import java.util.function.BooleanSupplier;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import tools.jackson.dataformat.smile.SmileMapper;
 
 final class PageTokenUtil {
 
@@ -125,19 +123,15 @@ final class PageTokenUtil {
         && !requestedPageToken.isEmpty()
         && shouldDecodeToken.getAsBoolean()) {
       var bytes = Base64.getUrlDecoder().decode(requestedPageToken);
-      try {
-        var pageToken = SMILE_MAPPER.readValue(bytes, PageToken.class);
-        if (requestedPageSize != null) {
-          int pageSizeInt = requestedPageSize;
-          checkArgument(pageSizeInt >= 0, "Invalid page size");
-          if (pageToken.pageSize().orElse(-1) != pageSizeInt) {
-            pageToken = ImmutablePageToken.builder().from(pageToken).pageSize(pageSizeInt).build();
-          }
+      var pageToken = SMILE_MAPPER.readValue(bytes, PageToken.class);
+      if (requestedPageSize != null) {
+        int pageSizeInt = requestedPageSize;
+        checkArgument(pageSizeInt >= 0, "Invalid page size");
+        if (pageToken.pageSize().orElse(-1) != pageSizeInt) {
+          pageToken = ImmutablePageToken.builder().from(pageToken).pageSize(pageSizeInt).build();
         }
-        return pageToken;
-      } catch (IOException e) {
-        throw new RuntimeException(e);
       }
+      return pageToken;
     } else if (requestedPageSize != null && shouldDecodeToken.getAsBoolean()) {
       int pageSizeInt = requestedPageSize;
       checkArgument(pageSizeInt >= 0, "Invalid page size");
@@ -181,12 +175,8 @@ final class PageTokenUtil {
       return null;
     }
 
-    try {
-      var serialized = SMILE_MAPPER.writeValueAsBytes(pageToken);
-      return Base64.getUrlEncoder().encodeToString(serialized);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    var serialized = SMILE_MAPPER.writeValueAsBytes(pageToken);
+    return Base64.getUrlEncoder().encodeToString(serialized);
   }
 
   /** Lazily initialized registry of all token-types. */
@@ -225,12 +215,13 @@ final class PageTokenUtil {
     }
 
     @Override
-    public String idFromValue(Object value) {
+    public String idFromValue(DatabindContext databindContext, Object value) {
       return getId(value);
     }
 
     @Override
-    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+    public String idFromValueAndType(
+        DatabindContext databindContext, Object value, Class<?> suggestedType) {
       return getId(value);
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/Token.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/Token.java
@@ -21,8 +21,8 @@ package org.apache.polaris.core.persistence.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import org.immutables.value.Value;
+import tools.jackson.databind.annotation.JsonTypeIdResolver;
 
 /**
  * Token base interface.

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/PolarisPolicyMappingRecord.java
@@ -20,18 +20,17 @@ package org.apache.polaris.core.policy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class PolarisPolicyMappingRecord {
   // to serialize/deserialize properties
   public static final String EMPTY_MAP_STRING = "{}";
-  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+  private static final ObjectMapper MAPPER = JsonMapper.shared();
 
   // id of the catalog where target entity resides
   private long targetCatalogId;
@@ -107,7 +106,7 @@ public class PolarisPolicyMappingRecord {
     }
     try {
       return MAPPER.readValue(parameters, new TypeReference<>() {});
-    } catch (JsonProcessingException ex) {
+    } catch (Exception ex) {
       throw new IllegalStateException(
           String.format("Failed to deserialize json. parameters %s", parameters), ex);
     }
@@ -117,7 +116,7 @@ public class PolarisPolicyMappingRecord {
     try {
       this.parameters =
           parameters == null ? EMPTY_MAP_STRING : MAPPER.writeValueAsString(parameters);
-    } catch (JsonProcessingException ex) {
+    } catch (Exception ex) {
       throw new IllegalStateException(
           String.format("Failed to serialize json. properties %s", parameters), ex);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/content/PolicyContentUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/content/PolicyContentUtil.java
@@ -18,19 +18,20 @@
  */
 package org.apache.polaris.core.policy.content;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class PolicyContentUtil {
   public static final ObjectMapper MAPPER = configureMapper();
 
   private static ObjectMapper configureMapper() {
-    ObjectMapper mapper = JsonMapper.builder().build();
-    // Fails if a required field (in the constructor) is missing
-    mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
-    // Fails if a required field is present but explicitly null, e.g., {"enable": null}
-    mapper.configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true);
-    return mapper;
+    return JsonMapper.builder()
+        // Fails if a required field (in the constructor) is missing
+        .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true)
+        // Fails if a required field is present but explicitly null, e.g., {"enable": null}
+        .configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+        .build();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/FileStorageConfigurationInfo.java
@@ -32,6 +32,8 @@ import org.apache.polaris.immutables.PolarisImmutable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableFileStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableFileStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableFileStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableFileStorageConfigurationInfo.class)
 @JsonTypeName("FileStorageConfigurationInfo")
 public abstract class FileStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -23,10 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +42,9 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * The polaris storage configuration information, is part of a polaris entity's internal property,
@@ -94,19 +93,16 @@ public abstract class PolarisStorageConfigurationInfo {
   static {
     DEFAULT_MAPPER =
         JsonMapper.builder()
-            .defaultPropertyInclusion(
-                JsonInclude.Value.construct(
-                    JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .changeDefaultPropertyInclusion(
+                incl ->
+                    incl.withValueInclusion(JsonInclude.Include.NON_NULL)
+                        .withContentInclusion(JsonInclude.Include.NON_NULL))
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build();
   }
 
   public String serialize() {
-    try {
-      return DEFAULT_MAPPER.writeValueAsString(this);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("serialize failed: " + e.getMessage(), e);
-    }
+    return DEFAULT_MAPPER.writeValueAsString(this);
   }
 
   /**
@@ -116,11 +112,7 @@ public abstract class PolarisStorageConfigurationInfo {
    * @return the PolarisStorageConfiguration object
    */
   public static PolarisStorageConfigurationInfo deserialize(final @NonNull String jsonStr) {
-    try {
-      return DEFAULT_MAPPER.readValue(jsonStr, PolarisStorageConfigurationInfo.class);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("deserialize failed: " + e.getMessage(), e);
-    }
+    return DEFAULT_MAPPER.readValue(jsonStr, PolarisStorageConfigurationInfo.class);
   }
 
   public static Optional<LocationRestrictions> forEntityPath(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -38,6 +38,8 @@ import org.jspecify.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableAwsStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableAwsStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAwsStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAwsStorageConfigurationInfo.class)
 @JsonTypeName("AwsStorageConfigurationInfo")
 public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureStorageConfigurationInfo.java
@@ -30,6 +30,9 @@ import org.jspecify.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableAzureStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableAzureStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAzureStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableAzureStorageConfigurationInfo.class)
 @JsonTypeName("AzureStorageConfigurationInfo")
 public abstract class AzureStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -20,9 +20,6 @@ package org.apache.polaris.core.storage.gcp;
 
 import static org.apache.polaris.core.storage.StorageLocation.ensureTrailingSlash;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.CredentialAccessBoundary;
@@ -63,6 +60,9 @@ import org.apache.polaris.core.storage.cache.StorageCredentialCacheKey;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * GCS implementation of {@link PolarisStorageIntegration} with support for scoping credentials for
@@ -76,7 +76,7 @@ public class GcpCredentialsStorageIntegration
   public static final String IMPERSONATION_SCOPE =
       "https://www.googleapis.com/auth/devstorage.read_write";
 
-  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.shared();
 
   private final GoogleCredentials sourceCredentials;
   private final HttpTransportFactory transportFactory;
@@ -430,7 +430,7 @@ public class GcpCredentialsStorageIntegration
   private static String convertToString(CredentialAccessBoundary accessBoundary) {
     try {
       return OBJECT_MAPPER.writeValueAsString(accessBoundary);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       LOGGER.warn("Unable to convert access boundary to json", e);
       return Objects.toString(accessBoundary);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpStorageConfigurationInfo.java
@@ -29,6 +29,8 @@ import org.jspecify.annotations.Nullable;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableGcpStorageConfigurationInfo.class)
 @JsonDeserialize(as = ImmutableGcpStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableGcpStorageConfigurationInfo.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableGcpStorageConfigurationInfo.class)
 @JsonTypeName("GcpStorageConfigurationInfo")
 public abstract class GcpStorageConfigurationInfo extends PolarisStorageConfigurationInfo {
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/connection/ConnectionConfigInfoDpoTest.java
@@ -18,11 +18,6 @@
  */
 package org.apache.polaris.core.connection;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.Optional;
 import org.apache.polaris.core.admin.model.AwsIamServiceIdentityInfo;
 import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
@@ -33,13 +28,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class ConnectionConfigInfoDpoTest {
-  private static final ObjectMapper objectMapper = JsonMapper.builder().build();
-
-  static {
-    objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
-  }
+  private static final ObjectMapper objectMapper =
+      JsonMapper.builder().enable(StreamWriteFeature.STRICT_DUPLICATE_DETECTION).build();
 
   private ServiceIdentityProvider serviceIdentityProvider;
 
@@ -60,7 +56,7 @@ public class ConnectionConfigInfoDpoTest {
   }
 
   @Test
-  void testOAuthClientCredentialsParameters() throws JsonProcessingException {
+  void testOAuthClientCredentialsParameters() {
     // Test deserialization and reserialization of the persistence JSON.
     String json =
         ""
@@ -110,7 +106,7 @@ public class ConnectionConfigInfoDpoTest {
   }
 
   @Test
-  void testBearerAuthenticationParameters() throws JsonProcessingException {
+  void testBearerAuthenticationParameters() {
     // Test deserialization and reserialization of the persistence JSON.
     String json =
         ""
@@ -154,7 +150,7 @@ public class ConnectionConfigInfoDpoTest {
   }
 
   @Test
-  void testImplicitAuthenticationParameters() throws JsonProcessingException {
+  void testImplicitAuthenticationParameters() {
     // Test deserialization and reserialization of the persistence JSON.
     String json =
         ""
@@ -191,7 +187,7 @@ public class ConnectionConfigInfoDpoTest {
   }
 
   @Test
-  void testSigV4AuthenticationParameters() throws JsonProcessingException {
+  void testSigV4AuthenticationParameters() {
     // Test deserialization and reserialization of the persistence JSON.
     String json =
         ""
@@ -252,7 +248,7 @@ public class ConnectionConfigInfoDpoTest {
   }
 
   @Test
-  void testBigQueryMetastoreConnectionConfig() throws JsonProcessingException {
+  void testBigQueryMetastoreConnectionConfig() {
     // Test deserialization and reserialization of the persistence JSON.
     String json =
         ""

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/EntityWeigherTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/cache/EntityWeigherTest.java
@@ -20,8 +20,6 @@ package org.apache.polaris.core.persistence.cache;
 
 import static org.apache.polaris.core.policy.content.PolicyContentUtil.MAPPER;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,10 +32,11 @@ import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 public class EntityWeigherTest {
 
-  private PolarisDiagnostics diagnostics;
+  private final PolarisDiagnostics diagnostics;
 
   public EntityWeigherTest() {
     diagnostics = new PolarisDefaultDiagServiceImpl();
@@ -129,10 +128,6 @@ public class EntityWeigherTest {
 
   private static Map<String, String> getPropertiesMap(String properties) {
     if (properties == null || properties.isEmpty()) return new HashMap<>();
-    try {
-      return MAPPER.readValue(properties, new TypeReference<>() {});
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    return MAPPER.readValue(properties, new TypeReference<>() {});
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/DummyTestToken.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/DummyTestToken.java
@@ -18,11 +18,11 @@
  */
 package org.apache.polaris.core.persistence.pagination;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.apache.polaris.immutables.PolarisImmutable;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @PolarisImmutable
 @JsonSerialize(as = ImmutableDummyTestToken.class)

--- a/polaris-core/src/test/java/org/apache/polaris/core/secrets/UserSecretsManagerBaseTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/secrets/UserSecretsManagerBaseTest.java
@@ -18,20 +18,17 @@
  */
 package org.apache.polaris.core.secrets;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Base test class for implementations of UserSecretsManager which can be extended by different
  * implementation-specific unittests.
  */
 public abstract class UserSecretsManagerBaseTest {
-  private static final ObjectMapper DEFAULT_MAPPER = JsonMapper.builder().build();
 
   /**
    * @return a fresh instance of a UserSecretsManager to use in test cases.
@@ -39,7 +36,7 @@ public abstract class UserSecretsManagerBaseTest {
   protected abstract UserSecretsManager newSecretsManager();
 
   @Test
-  public void testBasicSecretStorageAndRetrieval() throws JsonProcessingException {
+  public void testBasicSecretStorageAndRetrieval() {
     UserSecretsManager secretsManager = newSecretsManager();
 
     PolarisEntity entity1 = new CatalogEntity.Builder().setId(1111L).setName("entity1").build();
@@ -52,13 +49,13 @@ public abstract class UserSecretsManagerBaseTest {
     SecretReference reference2 = secretsManager.writeSecret(secret2, entity2);
 
     // Make sure we can JSON-serialize and deserialize the SecretReference objects.
-    String serializedReference1 = DEFAULT_MAPPER.writeValueAsString(reference1);
-    String serializedReference2 = DEFAULT_MAPPER.writeValueAsString(reference2);
+    String serializedReference1 = JsonMapper.shared().writeValueAsString(reference1);
+    String serializedReference2 = JsonMapper.shared().writeValueAsString(reference2);
 
     SecretReference reassembledReference1 =
-        DEFAULT_MAPPER.readValue(serializedReference1, SecretReference.class);
+        JsonMapper.shared().readValue(serializedReference1, SecretReference.class);
     SecretReference reassembledReference2 =
-        DEFAULT_MAPPER.readValue(serializedReference2, SecretReference.class);
+        JsonMapper.shared().readValue(serializedReference2, SecretReference.class);
 
     Assertions.assertThat(reassembledReference1).isEqualTo(reference1);
     Assertions.assertThat(reassembledReference2).isEqualTo(reference2);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/PolarisStorageConfigurationInfoTest.java
@@ -21,9 +21,6 @@ package org.apache.polaris.core.storage;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.stream.Stream;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.azure.AzureStorageConfigurationInfo;
@@ -31,22 +28,16 @@ import org.apache.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(SoftAssertionsExtension.class)
 public class PolarisStorageConfigurationInfoTest {
   @InjectSoftAssertions protected SoftAssertions soft;
-
-  private static ObjectMapper mapper;
-
-  @BeforeAll
-  public static void setup() {
-    mapper = JsonMapper.builder().build();
-  }
 
   @ParameterizedTest
   @MethodSource
@@ -54,14 +45,16 @@ public class PolarisStorageConfigurationInfoTest {
       throws Exception {
     var jsonStr = configInfo.serialize();
 
-    var asJsonNode = mapper.readValue(jsonStr, JsonNode.class);
-    var serializedJsonNode = mapper.readValue(serialized, JsonNode.class);
+    var asJsonNode = JsonMapper.shared().readValue(jsonStr, JsonNode.class);
+    var serializedJsonNode = JsonMapper.shared().readValue(serialized, JsonNode.class);
     soft.assertThat(asJsonNode).isEqualTo(serializedJsonNode);
 
-    var deserialized = mapper.readValue(serialized, PolarisStorageConfigurationInfo.class);
+    var deserialized =
+        JsonMapper.shared().readValue(serialized, PolarisStorageConfigurationInfo.class);
     soft.assertThat(deserialized).isEqualTo(configInfo);
 
-    var reserialized = mapper.readValue(jsonStr, PolarisStorageConfigurationInfo.class);
+    var reserialized =
+        JsonMapper.shared().readValue(jsonStr, PolarisStorageConfigurationInfo.class);
     soft.assertThat(reserialized).isEqualTo(configInfo);
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -25,10 +25,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
@@ -82,6 +78,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
@@ -92,9 +92,10 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
 
   private static final ObjectMapper MAPPER =
       JsonMapper.builder()
-          .defaultPropertyInclusion(
-              JsonInclude.Value.construct(
-                  JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+          .changeDefaultPropertyInclusion(
+              incl ->
+                  incl.withValueInclusion(JsonInclude.Include.NON_NULL)
+                      .withContentInclusion(JsonInclude.Include.NON_NULL))
           .build();
 
   private static List<LocationGrant> toGrants(
@@ -238,11 +239,11 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
   private Set<JsonNode> canonicalRules(JsonNode rules) {
     Set<JsonNode> canonical = new HashSet<>();
     for (JsonNode rule : rules.path("accessBoundaryRules")) {
-      ObjectNode copy = rule.deepCopy();
+      JsonNode copy = rule.deepCopy();
       JsonNode condition = copy.path("availabilityCondition");
       JsonNode expression = condition.path("expression");
-      if (expression.isTextual()) {
-        String[] clauses = expression.asText().split(" \\|\\| ");
+      if (expression.isString()) {
+        String[] clauses = expression.asString().split(" \\|\\| ");
         Arrays.sort(clauses);
         ((ObjectNode) condition).put("expression", String.join(" || ", clauses));
       }
@@ -428,7 +429,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
                 .get(0)
                 .path("availabilityCondition")
                 .path("expression")
-                .asText())
+                .asString())
         .contains("projects/_/buckets/bucket1/objects/path/to/data?with?question")
         .contains("path/to/data?with?question");
   }
@@ -550,7 +551,7 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
         .path(ruleIndex)
         .path("availabilityCondition")
         .path("expression")
-        .asText();
+        .asString();
   }
 
   private static RealmConfig configWith(Map<String, String> values) {

--- a/runtime/admin/distribution/LICENSE
+++ b/runtime/admin/distribution/LICENSE
@@ -480,8 +480,19 @@ This product bundles Jackson.
 * Maven group:artifact IDs: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
 * Maven group:artifact IDs: tools.jackson.core:jackson-core
 * Maven group:artifact IDs: tools.jackson.core:jackson-databind
+* Maven group:artifact IDs: tools.jackson.dataformat:jackson-dataformat-smile
+* Maven group:artifact IDs: tools.jackson.dataformat:jackson-dataformat-yaml
 
 Project URL: https://github.com/FasterXML/jackson
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This product bundles SnakeYAML Engine.
+
+* Maven group:artifact IDs: org.snakeyaml:snakeyaml-engine
+
+Project URL: https://bitbucket.org/snakeyaml/snakeyaml-engine
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------

--- a/runtime/server/distribution/LICENSE
+++ b/runtime/server/distribution/LICENSE
@@ -539,6 +539,8 @@ This product bundles Jackson.
 * Maven group:artifact IDs: com.fasterxml.jackson.module:jackson-module-parameter-names
 * Maven group:artifact IDs: tools.jackson.core:jackson-core
 * Maven group:artifact IDs: tools.jackson.core:jackson-databind
+* Maven group:artifact IDs: tools.jackson.dataformat:jackson-dataformat-smile
+* Maven group:artifact IDs: tools.jackson.dataformat:jackson-dataformat-yaml
 
 Project URL: https://github.com/FasterXML/jackson
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -1922,6 +1924,15 @@ This product bundles SnakeYAML.
 * Maven group:artifact IDs: org.yaml:snakeyaml
 
 Project URL: https://bitbucket.org/snakeyaml/snakeyaml
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This product bundles SnakeYAML Engine.
+
+* Maven group:artifact IDs: org.snakeyaml:snakeyaml-engine
+
+Project URL: https://bitbucket.org/snakeyaml/snakeyaml-engine
 License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------

--- a/runtime/service/build.gradle.kts
+++ b/runtime/service/build.gradle.kts
@@ -111,6 +111,11 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-core")
   implementation("com.fasterxml.jackson.core:jackson-databind")
 
+  implementation(platform(libs.jackson3.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("tools.jackson.core:jackson-core")
+  implementation("tools.jackson.core:jackson-databind")
+
   implementation(libs.jakarta.servlet.api)
 
   runtimeOnly(project(":polaris-async-vertx"))

--- a/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -21,8 +21,6 @@ package org.apache.polaris.service.entity;
 import static org.apache.polaris.core.config.RealmConfigurationSource.EMPTY_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -55,9 +53,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class CatalogEntityTest {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = JsonMapper.shared();
 
   private RealmConfig realmConfig;
   private ServiceIdentityProvider serviceIdentityProvider;
@@ -385,7 +385,7 @@ public class CatalogEntityTest {
   }
 
   @Test
-  public void testAwsConfigJsonPropertiesPresence() throws JsonProcessingException {
+  public void testAwsConfigJsonPropertiesPresence() {
     AwsStorageConfigInfo.Builder b =
         AwsStorageConfigInfo.builder()
             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
@@ -405,7 +405,7 @@ public class CatalogEntityTest {
 
   @ParameterizedTest
   @MethodSource
-  public void testStorageConfigRoundTrip(StorageConfigInfo config) throws JsonProcessingException {
+  public void testStorageConfigRoundTrip(StorageConfigInfo config) {
     String configStr = MAPPER.writeValueAsString(config);
     CatalogEntity catalogEntity =
         new CatalogEntity.Builder()
@@ -506,7 +506,7 @@ public class CatalogEntityTest {
   }
 
   @Test
-  public void testAzureConfigJsonPropertiesPresence() throws JsonProcessingException {
+  public void testAzureConfigJsonPropertiesPresence() {
     AzureStorageConfigInfo.Builder b =
         AzureStorageConfigInfo.builder().setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE);
     assertThat(MAPPER.writeValueAsString(b.build())).contains("storageType");

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/AttributeKeyTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/AttributeKeyTest.java
@@ -21,10 +21,9 @@ package org.apache.polaris.service.events;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.TypeToken;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 class AttributeKeyTest {
 
@@ -58,11 +57,10 @@ class AttributeKeyTest {
   }
 
   @Test
-  void testJsonSerializesToName() throws JsonProcessingException {
+  void testJsonSerializesToName() {
     AttributeKey<String> key = new AttributeKey<>(TEST_KEY, String.class);
-    ObjectMapper mapper = new ObjectMapper();
 
-    String json = mapper.writeValueAsString(key);
+    String json = JsonMapper.shared().writeValueAsString(key);
 
     assertThat(json).isEqualTo("\"" + TEST_KEY + "\"");
   }


### PR DESCRIPTION
Move core pagination, storage configuration, connection configuration, event, policy, and GCP credential JSON helpers to Jackson 3.

This keeps Jackson 2 in place for Iceberg/Quarkus-bound paths while adding runtime dependency and LICENSE entries needed by the migrated core types.

Migration guide: https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md
