### PR TITLE
Add readiness check for reflection-free serializers

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -58,6 +58,9 @@ public class ProductionReadinessChecks {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProductionReadinessChecks.class);
 
+  private static final String REFLECTION_FREE_SERIALIZERS_PROPERTY =
+      "quarkus.rest.jackson.optimization.enable-reflection-free-serializers";
+
   /**
    * A warning sign ⚠ {@code 26A0} with variant selector {@code FE0F}. The sign is preceded by a
    * null character {@code 0000} to ensure that the warning sign is displayed correctly regardless
@@ -217,6 +220,18 @@ public class ProductionReadinessChecks {
                 "The realm context resolver is configured to map requests without a realm header to the default realm.",
                 "polaris.realm-context.require-header"));
       }
+    }
+    return ProductionReadinessCheck.OK;
+  }
+
+  @Produces
+  public ProductionReadinessCheck checkReflectionFreeSerializers(Config config) {
+    ConfigValue configValue = config.getConfigValue(REFLECTION_FREE_SERIALIZERS_PROPERTY);
+    if (Boolean.parseBoolean(configValue.getValue())) {
+      return ProductionReadinessCheck.of(
+          Error.ofSevere(
+              "Quarkus REST Jackson reflection-free serializers must be disabled because Polaris REST JSON handling relies on registered ObjectMapper customizations for Iceberg request and response models.",
+              REFLECTION_FREE_SERIALIZERS_PROPERTY));
     }
     return ProductionReadinessCheck.OK;
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/config/ProductionReadinessChecksTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/ProductionReadinessChecksTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.polaris.core.config.ProductionReadinessCheck;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionReadinessChecksTest {
+
+  private static final String REFLECTION_FREE_SERIALIZERS_PROPERTY =
+      "quarkus.rest.jackson.optimization.enable-reflection-free-serializers";
+
+  private ProductionReadinessChecks checks;
+
+  @BeforeEach
+  void setUp() {
+    checks = new ProductionReadinessChecks();
+  }
+
+  @Test
+  void reflectionFreeSerializersDisabledReturnsOk() {
+    ProductionReadinessCheck result =
+        checks.checkReflectionFreeSerializers(configWithReflectionFreeSerializers("false"));
+
+    assertThat(result.ready()).isTrue();
+  }
+
+  @Test
+  void reflectionFreeSerializersUnsetReturnsOk() {
+    ProductionReadinessCheck result =
+        checks.checkReflectionFreeSerializers(configWithReflectionFreeSerializers(null));
+
+    assertThat(result.ready()).isTrue();
+  }
+
+  @Test
+  void reflectionFreeSerializersEnabledReturnsSevereError() {
+    ProductionReadinessCheck result =
+        checks.checkReflectionFreeSerializers(configWithReflectionFreeSerializers("true"));
+
+    assertThat(result.ready()).isFalse();
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error.offendingProperty()).isEqualTo(REFLECTION_FREE_SERIALIZERS_PROPERTY);
+              assertThat(error.severe()).isTrue();
+            });
+  }
+
+  private static Config configWithReflectionFreeSerializers(String value) {
+    Config config = mock(Config.class);
+    ConfigValue configValue = mock(ConfigValue.class);
+    when(config.getConfigValue(REFLECTION_FREE_SERIALIZERS_PROPERTY)).thenReturn(configValue);
+    when(configValue.getValue()).thenReturn(value);
+    return config;
+  }
+}


### PR DESCRIPTION
## Why

Polaris should fail production readiness when Quarkus REST Jackson reflection-free serializers are enabled. Polaris REST JSON handling relies on registered `ObjectMapper` customizations for Iceberg request and response models, so allowing generated reflection-free serializers in production can bypass behavior Polaris depends on.

This follows the Jackson 3 / reflection-free serializer readiness discussion. The default runtime configuration already sets the Quarkus option to `false`; this PR adds a production-readiness guard so an explicit production override to `true` is caught before serving traffic.

## What changed

- Added a severe production readiness check for `quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true`.
- Added unit coverage for unset, `false`, and `true` config values.

## Checklist

- [x] 🛡️ Don't disclose security issues! Security issues should be reported privately via security@apache.org.
- [x] 🔗 Clearly explained why these changes are needed. Related dev-list discussion; no GitHub issue linked.
- [x] 🧪 Added/updated tests, or explained why tests are not needed.
- [x] 💡 Added comments for complex logic, or no complex logic was added.
- [ ] 🧾 Updated `CHANGELOG.md` if the change affects users. Not needed: this guards existing production configuration behavior.
- [ ] 📚 Updated documentation for user-facing behavior/configuration, or explained why not needed. Not needed: the default property is already documented in runtime defaults.
