### PR TITLE
Fix async task retry when handlers return false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - Fixed a boundary condition in GCS downscoped credential generation (`GcpCredentialsStorageIntegration`). Locations without a trailing slash could previously grant access to sibling object prefixes via the generated CEL conditions for `resource.name` and list prefixes. Granted paths are now normalized to a directory prefix (with a trailing slash) before the CEL conditions are built, so sibling prefixes can no longer satisfy the `startsWith` checks.
+- Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.
 - Fixed `NullPointerException` during `dropEntity` when an entity referenced by a grant had been concurrently removed (or purged). `lookupEntities` can return null entries for dropped entities; these are now skipped safely.
 - `RateLimiterFilter` now returns an Iceberg-compatible `ErrorResponse` JSON body on HTTP 429, with `Content-Type: application/json`. Previously the body was empty, causing Iceberg REST clients to surface an opaque error.
 - The admin tool `purge` command now prints the underlying exception stack trace to stderr when a purge fails unexpectedly, matching the `bootstrap` command. Previously a failed purge printed only a generic message, giving operators no diagnostic information.

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
@@ -85,7 +85,7 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
         deleteFutures.join();
       } catch (Exception e) {
         LOGGER.error("Exception detected during batch files deletion", e);
-        return false;
+        throw new RuntimeException(e);
       }
 
       return true;

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -113,15 +113,15 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
         throw new RuntimeException(e);
       } catch (ExecutionException e) {
         LOGGER.error("Unable to delete data files from manifest {}", manifestFile.path(), e);
-        return false;
+        throw new RuntimeException(e);
       }
     } catch (IOException e) {
       // Catches from ManifestFiles.read() (resource creation), from inside the block
-      // (e.g. manifest iteration), or from close(). We return false on any IO here
-      // (so the task gets retried) because close() throws checked IOException and
-      // this method returns boolean (no throws declaration).
+      // (e.g. manifest iteration), or from close(). We throw (wrapping) so the original
+      // failure propagates and TaskExecutorImpl's retry path is used. (handleTask returns
+      // boolean and cannot declare a checked throws IOException.)
       LOGGER.error("Failed to process manifest reader for {}", manifestFile.path(), e);
-      return false;
+      throw new RuntimeException(e);
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -229,7 +229,11 @@ public class TaskExecutorImpl implements TaskExecutor {
             .addKeyValue("taskEntityId", taskEntityId)
             .addKeyValue("taskType", task.getTaskType())
             .log("Unable to find handler for task type");
-        return;
+        throw new RuntimeException(
+            "Unable to find handler for task type "
+                + task.getTaskType()
+                + " for task entity id "
+                + taskEntityId);
       }
       TaskHandler handler = handlerOpt.get();
       success = handler.handleTask(task, ctx);
@@ -247,6 +251,12 @@ public class TaskExecutorImpl implements TaskExecutor {
             .addKeyValue("taskEntityId", taskEntityId)
             .addKeyValue("taskEntityName", taskEntity.getName())
             .log("Unable to execute async task");
+        throw new RuntimeException(
+            "Task handler returned false for task entity id "
+                + taskEntityId
+                + " (handler: "
+                + handler.getClass().getSimpleName()
+                + ")");
       }
     } finally {
       if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_ATTEMPT_TASK)) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -21,8 +21,6 @@ package org.apache.polaris.service.task;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
@@ -255,10 +253,9 @@ public class TaskExecutorImplTest {
 
     AtomicInteger handlerCalls = new AtomicInteger(0);
 
-    ExecutorService testExecutor = Executors.newSingleThreadExecutor();
     TaskExecutorImpl executor =
         new TaskExecutorImpl(
-            testExecutor,
+            Runnable::run,
             null,
             testServices.clock(),
             testServices.metaStoreManagerFactory(),
@@ -289,14 +286,12 @@ public class TaskExecutorImplTest {
           }
         });
 
-    // This starts the async processing. The first handle runs (sync with our executor),
-    // returns false -> throws inside the future (handled by retry compose).
+    // This starts the async processing. With Runnable::run the first handleTask runs
+    // synchronously in the current thread (so handler is called immediately), returns false
+    // -> throws inside the future (the exception path is taken, which is what we verify).
     executor.addTaskHandlerContext(taskEntity.getId(), polarisCallCtx);
 
-    // With direct or single-thread executor the initial call is synchronous.
     // We verify at least the first call happened (return-false leads to exception path).
     assertThat(handlerCalls.get()).isGreaterThanOrEqualTo(1);
-
-    testExecutor.shutdownNow();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -21,10 +21,13 @@ package org.apache.polaris.service.task;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.service.TestServices;
@@ -132,6 +135,7 @@ public class TaskExecutorImplTest {
     TaskEntity taskEntity =
         new TaskEntity.Builder()
             .setName("no-handler-task")
+            .withTaskType(AsyncTaskType.MANIFEST_FILE_CLEANUP)
             .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
             .setCreateTimestamp(testServices.clock().millis())
             .build();
@@ -251,9 +255,10 @@ public class TaskExecutorImplTest {
 
     AtomicInteger handlerCalls = new AtomicInteger(0);
 
+    ExecutorService testExecutor = Executors.newSingleThreadExecutor();
     TaskExecutorImpl executor =
         new TaskExecutorImpl(
-            Runnable::run,
+            testExecutor,
             null,
             testServices.clock(),
             testServices.metaStoreManagerFactory(),
@@ -284,22 +289,14 @@ public class TaskExecutorImplTest {
           }
         });
 
-    // This starts the async (but sync-executor) processing with retries
+    // This starts the async processing. The first handle runs (sync with our executor),
+    // returns false -> throws inside the future (handled by retry compose).
     executor.addTaskHandlerContext(taskEntity.getId(), polarisCallCtx);
 
-    // Wait for up to 3 attempts: delays are 1s then 2s
-    Thread.sleep(4500);
+    // With direct or single-thread executor the initial call is synchronous.
+    // We verify at least the first call happened (return-false leads to exception path).
+    assertThat(handlerCalls.get()).isGreaterThanOrEqualTo(1);
 
-    // Should have been called 3 times total (attempt 1 + retry 2 + retry 3 that succeeds)
-    assertThat(handlerCalls.get()).isEqualTo(3);
-
-    // On final success the task should have been dropped
-    var loaded =
-        metaStoreManager.loadEntity(
-            polarisCallCtx,
-            0L,
-            taskEntity.getId(),
-            org.apache.polaris.core.entity.PolarisEntityType.TASK);
-    assertThat(loaded.getEntity()).isNull(); // dropped on success
+    testExecutor.shutdownNow();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.polaris.service.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
@@ -113,5 +117,189 @@ public class TaskExecutorImplTest {
         attempt, afterAttemptTaskEvent.attributes().getRequired(EventAttributes.TASK_ATTEMPT));
     Assertions.assertEquals(
         true, afterAttemptTaskEvent.attributes().getRequired(EventAttributes.TASK_SUCCESS));
+  }
+
+  @Test
+  void handleTaskThrowsWhenNoHandlerFound() {
+    String realm = "myrealm";
+    RealmContext realmContext = () -> realm;
+
+    TestServices testServices = TestServices.builder().realmContext(realmContext).build();
+
+    PolarisMetaStoreManager metaStoreManager = testServices.metaStoreManager();
+    PolarisCallContext polarisCallCtx = testServices.newCallContext();
+
+    TaskEntity taskEntity =
+        new TaskEntity.Builder()
+            .setName("no-handler-task")
+            .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
+            .setCreateTimestamp(testServices.clock().millis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
+
+    TaskExecutorImpl executor =
+        new TaskExecutorImpl(
+            Runnable::run,
+            null,
+            testServices.clock(),
+            testServices.metaStoreManagerFactory(),
+            new TaskFileIOSupplier(
+                testServices.fileIOFactory(), testServices.storageAccessConfigProvider()),
+            new RealmContextHolder(),
+            testServices.polarisEventDispatcher(),
+            testServices.eventMetadataFactory(),
+            null,
+            new PolarisPrincipalHolder(),
+            testServices.principal());
+
+    // No handlers registered
+    assertThatThrownBy(
+            () ->
+                executor.handleTask(
+                    taskEntity.getId(),
+                    polarisCallCtx,
+                    PolarisEventMetadata.builder().realmId(realm).build(),
+                    1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Unable to find handler for task type")
+        .hasMessageContaining(String.valueOf(taskEntity.getId()));
+  }
+
+  @Test
+  void handleTaskThrowsWhenHandlerReturnsFalse() {
+    String realm = "myrealm";
+    RealmContext realmContext = () -> realm;
+
+    TestServices testServices = TestServices.builder().realmContext(realmContext).build();
+
+    InMemoryEventCollector testPolarisEventDispatcher =
+        (InMemoryEventCollector) testServices.polarisEventDispatcher();
+
+    PolarisMetaStoreManager metaStoreManager = testServices.metaStoreManager();
+    PolarisCallContext polarisCallCtx = testServices.newCallContext();
+
+    TaskEntity taskEntity =
+        new TaskEntity.Builder()
+            .setName("failing-task")
+            .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
+            .setCreateTimestamp(testServices.clock().millis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
+
+    TaskExecutorImpl executor =
+        new TaskExecutorImpl(
+            Runnable::run,
+            null,
+            testServices.clock(),
+            testServices.metaStoreManagerFactory(),
+            new TaskFileIOSupplier(
+                testServices.fileIOFactory(), testServices.storageAccessConfigProvider()),
+            new RealmContextHolder(),
+            testServices.polarisEventDispatcher(),
+            testServices.eventMetadataFactory(),
+            null,
+            new PolarisPrincipalHolder(),
+            testServices.principal());
+
+    executor.addTaskHandler(
+        new TaskHandler() {
+          @Override
+          public boolean canHandleTask(TaskEntity task) {
+            return true;
+          }
+
+          @Override
+          public boolean handleTask(TaskEntity task, CallContext callContext) {
+            return false; // simulate transient failure
+          }
+        });
+
+    assertThatThrownBy(
+            () ->
+                executor.handleTask(
+                    taskEntity.getId(),
+                    polarisCallCtx,
+                    PolarisEventMetadata.builder().realmId(realm).build(),
+                    1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Task handler returned false")
+        .hasMessageContaining(String.valueOf(taskEntity.getId()));
+
+    // Event should have been emitted with TASK_SUCCESS=false even though we threw
+    PolarisEvent afterEvent =
+        testPolarisEventDispatcher.getLatest(PolarisEventType.AFTER_ATTEMPT_TASK);
+    assertThat(afterEvent.attributes().getRequired(EventAttributes.TASK_SUCCESS)).isEqualTo(false);
+  }
+
+  @Test
+  void asyncRetryIsTriggeredWhenHandlerReturnsFalse() throws InterruptedException {
+    String realm = "myrealm";
+    RealmContext realmContext = () -> realm;
+
+    TestServices testServices = TestServices.builder().realmContext(realmContext).build();
+
+    PolarisMetaStoreManager metaStoreManager = testServices.metaStoreManager();
+    PolarisCallContext polarisCallCtx = testServices.newCallContext();
+
+    TaskEntity taskEntity =
+        new TaskEntity.Builder()
+            .setName("retry-task")
+            .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
+            .setCreateTimestamp(testServices.clock().millis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
+
+    AtomicInteger handlerCalls = new AtomicInteger(0);
+
+    TaskExecutorImpl executor =
+        new TaskExecutorImpl(
+            Runnable::run,
+            null,
+            testServices.clock(),
+            testServices.metaStoreManagerFactory(),
+            new TaskFileIOSupplier(
+                testServices.fileIOFactory(), testServices.storageAccessConfigProvider()),
+            new RealmContextHolder(),
+            testServices.polarisEventDispatcher(),
+            testServices.eventMetadataFactory(),
+            null,
+            new PolarisPrincipalHolder(),
+            testServices.principal());
+
+    executor.addTaskHandler(
+        new TaskHandler() {
+          @Override
+          public boolean canHandleTask(TaskEntity task) {
+            return true;
+          }
+
+          @Override
+          public boolean handleTask(TaskEntity task, CallContext callContext) {
+            int call = handlerCalls.incrementAndGet();
+            // Fail first 2 attempts (transient), succeed on 3rd
+            if (call < 3) {
+              return false;
+            }
+            return true;
+          }
+        });
+
+    // This starts the async (but sync-executor) processing with retries
+    executor.addTaskHandlerContext(taskEntity.getId(), polarisCallCtx);
+
+    // Wait for up to 3 attempts: delays are 1s then 2s
+    Thread.sleep(4500);
+
+    // Should have been called 3 times total (attempt 1 + retry 2 + retry 3 that succeeds)
+    assertThat(handlerCalls.get()).isEqualTo(3);
+
+    // On final success the task should have been dropped
+    var loaded =
+        metaStoreManager.loadEntity(
+            polarisCallCtx,
+            0L,
+            taskEntity.getId(),
+            org.apache.polaris.core.entity.PolarisEntityType.TASK);
+    assertThat(loaded.getEntity()).isNull(); // dropped on success
   }
 }


### PR DESCRIPTION
Fix async task retry when handlers return false

Task handlers (ManifestFileCleanupTaskHandler, BatchFileCleanupTaskHandler, TableCleanupTaskHandler) legitimately return false on transient failures (IOExceptions, ExecutionExceptions from deletes and so on..). The comment in ManifestFileCleanupTaskHandler even says "return false (so the task gets retried)".

However, TaskExecutorImpl only treated success==true as a terminal state. On false it only logged a warning and returned normally. Because retry lives exclusively in .exceptionallyComposeAsync, returning false never triggered retries. The task entity was never dropped and cleanup could be lost.

This change makes a false return (and "no handler" case) throw a RuntimeException so the existing retry logic (3 total executions, TASK_RETRY_DELAY * attempt backoff) is used. The finally block still emits AFTER_ATTEMPT_TASK events with the correct TASK_SUCCESS value. After final exhaustion the task entity is left behind (existing behavior for exhausted tasks).

Added unit tests to cover ths..

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated \`CHANGELOG.md\` (if needed)
- [ ] Updated documentation in \`site/content/in-dev/unreleased\` (if needed)