### PR TITLE
Prepare NoSQL pagination tokens for Jackson 3

### DIFF
--- a/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/index/TestIndexKey.java
+++ b/persistence/nosql/persistence/api/src/test/java/org/apache/polaris/persistence/nosql/api/index/TestIndexKey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.persistence.nosql.api.index;
 
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.polaris.persistence.nosql.api.index.IndexKey.EOF;
 import static org.apache.polaris.persistence.nosql.api.index.IndexKey.ESC;
@@ -30,7 +31,11 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
@@ -249,6 +254,38 @@ public class TestIndexKey {
     ser.position(1234);
     deserialized = deserializeKey(ser.duplicate());
     soft.assertThat(deserialized).isEqualTo(key);
+  }
+
+  static Stream<Arguments> keySerializationJsonRoundTrip() {
+    var jsonMapper = JsonMapper.builder().build();
+    var smileMapper = SmileMapper.builder().build();
+    return Stream.of(
+        arguments(jsonMapper, smileMapper, key("A")),
+        arguments(jsonMapper, smileMapper, key("A\u0001B")),
+        arguments(jsonMapper, smileMapper, key("A\u0001B\u0002C")),
+        arguments(jsonMapper, smileMapper, key("abc")),
+        arguments(jsonMapper, smileMapper, key("abcdefghi")),
+        arguments(jsonMapper, smileMapper, key(STRING_100 + STRING_100)),
+        arguments(
+            jsonMapper,
+            smileMapper,
+            key(STRING_100 + STRING_100 + STRING_100 + STRING_100 + STRING_100)));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void keySerializationJsonRoundTrip(
+      ObjectMapper jsonMapper, ObjectMapper smileMapper, IndexKey indexKey) throws Exception {
+    var serializedJson = jsonMapper.writerFor(IndexKey.class).writeValueAsString(indexKey);
+    var expectedByteBuffer = indexKey.asByteBuffer();
+    var expectedBytes = new byte[expectedByteBuffer.remaining()];
+    expectedByteBuffer.get(expectedBytes);
+    soft.assertThat(serializedJson)
+        .isEqualTo(format("\"%s\"", Base64.getEncoder().encodeToString(expectedBytes)));
+    soft.assertThat(jsonMapper.readValue(serializedJson, IndexKey.class)).isEqualTo(indexKey);
+
+    var serializedSmile = smileMapper.writerFor(IndexKey.class).writeValueAsBytes(indexKey);
+    soft.assertThat(smileMapper.readValue(serializedSmile, IndexKey.class)).isEqualTo(indexKey);
   }
 
   @Test

--- a/persistence/nosql/persistence/metastore/build.gradle.kts
+++ b/persistence/nosql/persistence/metastore/build.gradle.kts
@@ -43,9 +43,12 @@ dependencies {
   implementation(libs.slf4j.api)
 
   implementation(platform(libs.jackson.bom))
-  implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.core:jackson-core")
   implementation("com.fasterxml.jackson.core:jackson-databind")
+  implementation(platform(libs.jackson3.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("tools.jackson.core:jackson-core")
+  implementation("tools.jackson.core:jackson-databind")
 
   compileOnly(project(":polaris-immutables"))
   annotationProcessor(project(":polaris-immutables", configuration = "processor"))
@@ -65,6 +68,9 @@ dependencies {
   testImplementation("org.jboss.weld.se:weld-se-core")
   testImplementation(libs.weld.junit5)
   testRuntimeOnly(libs.smallrye.jandex)
+
+  testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
+  testImplementation("tools.jackson.dataformat:jackson-dataformat-smile")
 
   testFixturesImplementation(project(":polaris-core"))
   testFixturesImplementation(testFixtures(project(":polaris-core")))

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlPaginationToken.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlPaginationToken.java
@@ -19,13 +19,16 @@
 
 package org.apache.polaris.persistence.nosql.metastore;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.nio.ByteBuffer;
 import org.apache.polaris.core.persistence.pagination.Token;
 import org.apache.polaris.immutables.PolarisImmutable;
 import org.apache.polaris.persistence.nosql.api.index.IndexKey;
 import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.immutables.value.Value;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Pagination token for NoSQL that refers to the next {@link IndexKey}. The next request will refer
@@ -34,14 +37,33 @@ import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
 @PolarisImmutable
 @JsonSerialize(as = ImmutableNoSqlPaginationToken.class)
 @JsonDeserialize(as = ImmutableNoSqlPaginationToken.class)
+@com.fasterxml.jackson.databind.annotation.JsonSerialize(as = ImmutableNoSqlPaginationToken.class)
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(as = ImmutableNoSqlPaginationToken.class)
 public interface NoSqlPaginationToken extends Token {
   String ID = "n";
 
+  // This implementation decouples the direct use of the `ObjRef` and `IndexKey` and with
+  // that their Jackson version specific (de)serializers by using "neutral" byte buffers.
+  // Once both `:polaris-core` and `:polaris-persistence-nosql-*` are both using Jackson 3, the
+  // change that introduced the `ByteBuffer` indirection can optionally be reverted.
+
   @JsonProperty("c")
-  ObjRef containerObjRef();
+  ByteBuffer containerObjRefBytes();
+
+  @JsonIgnore
+  @Value.Lazy
+  default ObjRef containerObjRef() {
+    return ObjRef.fromByteBuffer(containerObjRefBytes().duplicate());
+  }
 
   @JsonProperty("k")
-  IndexKey key();
+  ByteBuffer keyBytes();
+
+  @JsonIgnore
+  @Value.Lazy
+  default IndexKey key() {
+    return IndexKey.key(keyBytes().duplicate());
+  }
 
   @Override
   default String getT() {
@@ -50,8 +72,8 @@ public interface NoSqlPaginationToken extends Token {
 
   static NoSqlPaginationToken paginationToken(ObjRef containerObjRef, IndexKey key) {
     return ImmutableNoSqlPaginationToken.builder()
-        .containerObjRef(containerObjRef)
-        .key(key)
+        .containerObjRefBytes(containerObjRef.toByteBuffer())
+        .keyBytes(key.asByteBuffer())
         .build();
   }
 

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlPaginationToken.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlPaginationToken.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.persistence.nosql.metastore;
+
+import static org.apache.polaris.persistence.nosql.api.index.IndexKey.key;
+import static org.apache.polaris.persistence.nosql.api.obj.ObjRef.objRef;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.apache.polaris.core.persistence.pagination.Page;
+import org.apache.polaris.core.persistence.pagination.PageToken;
+import org.apache.polaris.persistence.nosql.api.index.IndexKey;
+import org.apache.polaris.persistence.nosql.api.obj.ObjRef;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestNoSqlPaginationToken {
+  private static final ObjectMapper JSON_MAPPER = JsonMapper.builder().build();
+  private static final ObjectMapper SMILE_MAPPER = SmileMapper.builder().build();
+
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @ParameterizedTest
+  @MethodSource("tokens")
+  public void serializationRoundtripSmile(ObjRef containerObjRef, IndexKey indexKey)
+      throws Exception {
+    var token = NoSqlPaginationToken.paginationToken(containerObjRef, indexKey);
+    var expectedContainerObjRefBytes = containerObjRef.toBytes();
+    var expectedKeyBytes = bytes(indexKey.asByteBuffer());
+
+    var serialized = SMILE_MAPPER.writerFor(NoSqlPaginationToken.class).writeValueAsBytes(token);
+    var jsonNode = SMILE_MAPPER.readTree(serialized);
+    soft.assertThat(jsonNode.fieldNames()).toIterable().containsExactlyInAnyOrder("t", "c", "k");
+    soft.assertThat(jsonNode.path("t").asText()).isEqualTo(NoSqlPaginationToken.ID);
+    soft.assertThat(jsonNode.path("c").asText())
+        .isEqualTo(Base64.getEncoder().encodeToString(expectedContainerObjRefBytes));
+    soft.assertThat(jsonNode.path("k").asText())
+        .isEqualTo(Base64.getEncoder().encodeToString(expectedKeyBytes));
+    assertRoundTrip(
+        SMILE_MAPPER.readValue(serialized, NoSqlPaginationToken.class),
+        containerObjRef,
+        indexKey,
+        expectedContainerObjRefBytes,
+        expectedKeyBytes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("tokens")
+  public void serializationRoundtripJson(ObjRef containerObjRef, IndexKey indexKey)
+      throws Exception {
+    var token = NoSqlPaginationToken.paginationToken(containerObjRef, indexKey);
+    var expectedContainerObjRefBytes = containerObjRef.toBytes();
+    var expectedKeyBytes = bytes(indexKey.asByteBuffer());
+
+    var serialized = JSON_MAPPER.writerFor(NoSqlPaginationToken.class).writeValueAsString(token);
+    var jsonNode = JSON_MAPPER.readTree(serialized);
+    soft.assertThat(jsonNode.fieldNames()).toIterable().containsExactlyInAnyOrder("t", "c", "k");
+    soft.assertThat(jsonNode.path("t").asText()).isEqualTo(NoSqlPaginationToken.ID);
+    soft.assertThat(jsonNode.path("c").asText())
+        .isEqualTo(Base64.getEncoder().encodeToString(expectedContainerObjRefBytes));
+    soft.assertThat(jsonNode.path("k").asText())
+        .isEqualTo(Base64.getEncoder().encodeToString(expectedKeyBytes));
+    assertRoundTrip(
+        JSON_MAPPER.readValue(serialized, NoSqlPaginationToken.class),
+        containerObjRef,
+        indexKey,
+        expectedContainerObjRefBytes,
+        expectedKeyBytes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("tokens")
+  public void tokenSurvivesPageTokenRoundTrip(ObjRef containerObjRef, IndexKey indexKey) {
+    var token = NoSqlPaginationToken.paginationToken(containerObjRef, indexKey);
+    var request = PageToken.fromLimit(10);
+    var page = Page.page(request, List.of("item"), token);
+
+    var roundTripped = PageToken.build(page.encodedResponseToken(), null, () -> true);
+
+    soft.assertThat(roundTripped.pageSize()).isEqualTo(OptionalInt.of(10));
+    soft.assertThat(roundTripped.valueAs(NoSqlPaginationToken.class))
+        .hasValueSatisfying(
+            value -> {
+              soft.assertThat(value.containerObjRef()).isEqualTo(containerObjRef);
+              soft.assertThat(value.key()).isEqualTo(indexKey);
+              soft.assertThat(bytes(value.containerObjRefBytes()))
+                  .containsExactly(containerObjRef.toBytes());
+              soft.assertThat(bytes(value.keyBytes()))
+                  .containsExactly(bytes(indexKey.asByteBuffer()));
+            });
+  }
+
+  private static Stream<Arguments> tokens() {
+    return Stream.of(
+        arguments(objRef("foo", 123L, 1), key("abc")),
+        arguments(objRef("foo", Long.MAX_VALUE, 5), key("A\u0001B")),
+        arguments(objRef("bar", Long.MIN_VALUE, 3), key("A\u0001B\u0002C")),
+        arguments(objRef("baz", 0L, 1), key("foo\u0000\u0001\u0002\u0000bar")),
+        arguments(objRef("qux", 0x1234567890abcdefL, 2), key(Long.MIN_VALUE)),
+        arguments(objRef("max", Long.MAX_VALUE, 7), key(Long.MAX_VALUE)));
+  }
+
+  private void assertRoundTrip(
+      NoSqlPaginationToken actual,
+      ObjRef expectedContainerObjRef,
+      IndexKey expectedIndexKey,
+      byte[] expectedContainerObjRefBytes,
+      byte[] expectedKeyBytes) {
+    soft.assertThat(actual.containerObjRef()).isEqualTo(expectedContainerObjRef);
+    soft.assertThat(actual.key()).isEqualTo(expectedIndexKey);
+    soft.assertThat(bytes(actual.containerObjRefBytes()))
+        .containsExactly(expectedContainerObjRefBytes);
+    soft.assertThat(bytes(actual.keyBytes())).containsExactly(expectedKeyBytes);
+  }
+
+  private static byte[] bytes(ByteBuffer buffer) {
+    var copy = buffer.duplicate();
+    var bytes = new byte[copy.remaining()];
+    copy.get(bytes);
+    return bytes;
+  }
+}


### PR DESCRIPTION
This prepares `NoSqlPaginationToken` for the core pagination Jackson 3 migration in #4910.

`NoSqlPaginationToken` currently embeds `ObjRef` and `IndexKey` directly. Those types have their own Jackson serializers, so migrating `PageToken` / `Token` / `PageTokenUtil` to Jackson 3 without migrating the full NoSQL serialization stack at the same time breaks pagination-token serialization.

This change decouples that dependency by storing the native binary payloads in the token wire format as bytes.

The wire format remains intentionally short and binary-compatible with the previous representation.

This PR adds the Jackson 3 dependencies needed by `NoSqlPaginationToken` so the type can carry both Jackson 2 and Jackson 3 immutable type annotations. That is intentional preparation for the core pagination migration PR #4910, so this has to land before.

The alternative would have been to push all poplaris-core and all NoSQL changes at once in one giant PR.

Additional test coverage for wire-format compatibiltiy has been addded. These tests pin both the current behavior and the wire compatibility that the follow-up Jackson 3 pagination migration depends on.