### PR TITLE
perf: remove redundant exists check before deleteFile (saves cloud API calls)

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.TaskEntity;
@@ -90,16 +91,17 @@ public abstract class FileCleanupTaskHandler implements TaskHandler {
     }
     return CompletableFuture.runAsync(
             () -> {
-              // totally normal for a file to already be missing, e.g. a data file
-              // may be in multiple manifests. There's a possibility we check the
-              // file's existence, but then it is deleted before we have a chance to
-              // send the delete request. In such a case, we <i>should</i> retry
-              // and find
-              if (TaskUtils.exists(file, fileIO)) {
+              // deleteFile is idempotent on cloud object stores (S3 DeleteObject, etc.).
+              // It is totally normal for a data file to already be missing (e.g. present
+              // in multiple manifests across snapshots). We call delete directly.
+              // Some FileIO impls (e.g. InMemory) throw NotFound on missing; we treat that
+              // as success (already deleted).
+              try {
                 fileIO.deleteFile(file);
-              } else {
+              } catch (NotFoundException nfe) {
+                // already gone (e.g. InMemoryFileIO or race)
                 LOGGER
-                    .atInfo()
+                    .atDebug()
                     .addKeyValue("file", file)
                     .addKeyValue("baseFile", baseFile != null ? baseFile : "")
                     .addKeyValue("tableId", tableId)


### PR DESCRIPTION
When deleting individual data files asynchronously, the worker first makes a HEAD request (TaskUtils.exists) and then a DELETE request (deleteFile). Cloud storage DELETE operations (like S3 DeleteObject) are generally idempotent and do not fail if the file is absent. Performing a HEAD before every DELETE doubles the number of API calls and latency, severely impacting cloud billing and cleanup performance.

Fix: Remove the TaskUtils.exists check and simply call fileIO.deleteFile(file). Added a narrow catch for NotFoundException only to preserve test behavior for InMemoryFileIO (real cloud FileIOs succeed silently on missing objects).

## Checklist
- [ ] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated \`CHANGELOG.md\` (if needed)
- [ ] Updated documentation in \`site/content/in-dev/unreleased\` (if needed)