### PR TITLE
Cleanup metadata files on transaction failure

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1286,14 +1286,14 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     // causes doRefresh() to read from the store where the entity hasn't been persisted yet.
     // The pendingUpdates entities have the correct new location set by doCommit().
     List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
-    List<Map.Entry<FileIO, String>> writtenMetadataFiles =
+    List<FileToDelete> writtenMetadataFiles =
         pendingUpdates.stream()
             .map(ewp -> IcebergTableLikeEntity.of(ewp.entity()))
             .filter(entity -> entity != null && entity.getMetadataLocation() != null)
             .filter(entity -> tableFileIOs.containsKey(entity.getTableIdentifier()))
             .map(
                 entity ->
-                    Map.entry(
+                    new FileToDelete(
                         tableFileIOs.get(entity.getTableIdentifier()),
                         entity.getMetadataLocation()))
             .toList();
@@ -1313,16 +1313,18 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     eventAttributeMap().put(EventAttributes.TABLE_METADATAS, tableMetadataObjs);
   }
 
-  private static void cleanupWrittenMetadataFiles(
-      List<Map.Entry<FileIO, String>> writtenMetadataFiles) {
-    for (Map.Entry<FileIO, String> entry : writtenMetadataFiles) {
+  private record FileToDelete(FileIO io, String location) {
+    void cleanup() {
       try {
-        entry.getKey().deleteFile(entry.getValue());
+        io.deleteFile(location);
       } catch (Exception e) {
-        LOGGER.warn(
-            "Failed to clean up metadata file {} after transaction failure", entry.getValue(), e);
+        LOGGER.warn("Failed to clean up metadata file {} after transaction failure", location, e);
       }
     }
+  }
+
+  private static void cleanupWrittenMetadataFiles(List<FileToDelete> writtenMetadataFiles) {
+    writtenMetadataFiles.forEach(FileToDelete::cleanup);
   }
 
   public ListTablesResponse listViews(Namespace namespace, String pageToken, Integer pageSize) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1281,29 +1281,29 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
           tableMetadataObjs.add(currentMetadata);
         });
 
-    // Extract newly written metadata locations from the buffered entity updates.
-    // We cannot use tableOps.current().metadataFileLocation() because requestRefresh()
-    // causes doRefresh() to read from the store where the entity hasn't been persisted yet.
-    // The pendingUpdates entities have the correct new location set by doCommit().
     List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
-    List<FileToDelete> writtenMetadataFiles =
-        pendingUpdates.stream()
-            .map(ewp -> IcebergTableLikeEntity.of(ewp.entity()))
-            .filter(entity -> entity != null && entity.getMetadataLocation() != null)
-            .filter(entity -> tableFileIOs.containsKey(entity.getTableIdentifier()))
-            .map(
-                entity ->
-                    new FileToDelete(
-                        tableFileIOs.get(entity.getTableIdentifier()),
-                        entity.getMetadataLocation()))
-            .toList();
-
     EntitiesResult result =
         metaStoreManager()
             .updateEntitiesPropertiesIfNotChanged(
                 callContext().getPolarisCallContext(), pendingUpdates);
     if (!result.isSuccess()) {
       // TODO: Retries on failure
+
+      // Clean up metadata files written during doCommit() since the transaction failed.
+      // We derive locations from pendingUpdates (not tableOps.current()) because
+      // requestRefresh() triggers doRefresh() against the store where the entity
+      // hasn't been persisted yet.
+      List<FileToDelete> writtenMetadataFiles =
+          pendingUpdates.stream()
+              .map(ewp -> IcebergTableLikeEntity.of(ewp.entity()))
+              .filter(entity -> entity != null && entity.getMetadataLocation() != null)
+              .filter(entity -> tableFileIOs.containsKey(entity.getTableIdentifier()))
+              .map(
+                  entity ->
+                      new FileToDelete(
+                          tableFileIOs.get(entity.getTableIdentifier()),
+                          entity.getMetadataLocation()))
+              .toList();
       cleanupWrittenMetadataFiles(writtenMetadataFiles);
       throw new CommitFailedException(
           "Transaction commit failed with status: %s, extraInfo: %s",

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -38,6 +38,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -66,6 +67,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.RESTCatalogProperties;
@@ -1221,6 +1223,7 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     // See also the TODO in TransactionWorkspaceMetaStoreManager for a more general (but more
     // complex) alternative that would intercept at the MetaStoreManager layer.
     List<TableMetadata> tableMetadataObjs = new ArrayList<>();
+    Map<TableIdentifier, FileIO> tableFileIOs = new HashMap<>();
     changesByTable.forEach(
         (tableIdentifier, changes) -> {
           Table table = baseCatalog.loadTable(tableIdentifier);
@@ -1272,25 +1275,54 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
           // Commit all accumulated changes for this table in a single atomic operation
           if (!currentMetadata.changes().isEmpty()) {
             tableOps.commit(baseMetadata, currentMetadata);
+            tableFileIOs.put(tableIdentifier, tableOps.io());
           }
 
           tableMetadataObjs.add(currentMetadata);
         });
 
-    // Commit the collected updates in a single atomic operation
+    // Extract newly written metadata locations from the buffered entity updates.
+    // We cannot use tableOps.current().metadataFileLocation() because requestRefresh()
+    // causes doRefresh() to read from the store where the entity hasn't been persisted yet.
+    // The pendingUpdates entities have the correct new location set by doCommit().
     List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
+    List<Map.Entry<FileIO, String>> writtenMetadataFiles =
+        pendingUpdates.stream()
+            .map(ewp -> IcebergTableLikeEntity.of(ewp.entity()))
+            .filter(entity -> entity != null && entity.getMetadataLocation() != null)
+            .filter(entity -> tableFileIOs.containsKey(entity.getTableIdentifier()))
+            .map(
+                entity ->
+                    Map.entry(
+                        tableFileIOs.get(entity.getTableIdentifier()),
+                        entity.getMetadataLocation()))
+            .toList();
+
     EntitiesResult result =
         metaStoreManager()
             .updateEntitiesPropertiesIfNotChanged(
                 callContext().getPolarisCallContext(), pendingUpdates);
     if (!result.isSuccess()) {
-      // TODO: Retries and server-side cleanup on failure, review possible exceptions
+      // TODO: Retries on failure
+      cleanupWrittenMetadataFiles(writtenMetadataFiles);
       throw new CommitFailedException(
           "Transaction commit failed with status: %s, extraInfo: %s",
           result.getReturnStatus(), result.getExtraInformation());
     }
 
     eventAttributeMap().put(EventAttributes.TABLE_METADATAS, tableMetadataObjs);
+  }
+
+  private static void cleanupWrittenMetadataFiles(
+      List<Map.Entry<FileIO, String>> writtenMetadataFiles) {
+    for (Map.Entry<FileIO, String> entry : writtenMetadataFiles) {
+      try {
+        entry.getKey().deleteFile(entry.getValue());
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Failed to clean up metadata file {} after transaction failure", entry.getValue(), e);
+      }
+    }
   }
 
   public ListTablesResponse listViews(Namespace namespace, String pageToken, Integer pageSize) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
@@ -24,15 +24,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.ws.rs.core.Response;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -42,6 +48,8 @@ import org.apache.polaris.core.admin.model.CatalogProperties;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntitiesResult;
 import org.apache.polaris.service.TestServices;
 import org.apache.polaris.service.events.EventAttributes;
 import org.apache.polaris.service.events.PolarisEvent;
@@ -50,6 +58,7 @@ import org.apache.polaris.service.events.listeners.InMemoryEventCollector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 public class CommitTransactionEventTest {
   private static final String namespace = "ns";
@@ -272,5 +281,80 @@ public class CommitTransactionEventTest {
                 TableIdentifier.of(namespace, table2Name),
                 updateRequirements,
                 List.of(new MetadataUpdate.SetProperties(Map.of(propertyName, "value2"))))));
+  }
+
+  @Test
+  void testCommitTransactionCleansUpMetadataOnFailure(@TempDir Path tempDir) {
+    String location = tempDir.toAbsolutePath().toUri().toString();
+    if (location.endsWith("/")) {
+      location = location.substring(0, location.length() - 1);
+    }
+
+    // Create TestServices with a spy that will fail on updateEntitiesPropertiesIfNotChanged
+    // but only AFTER initial setup (table creation) succeeds.
+    AtomicBoolean shouldFail = new AtomicBoolean(false);
+    TestServices testServices =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .metaStoreManagerDecorator(
+                msm -> {
+                  org.apache.polaris.core.persistence.PolarisMetaStoreManager spy =
+                      Mockito.spy(msm);
+                  Mockito.doAnswer(
+                          invocation -> {
+                            if (shouldFail.get()) {
+                              return new EntitiesResult(
+                                  BaseResult.ReturnStatus.ENTITY_CANNOT_BE_RESOLVED,
+                                  "simulated CAS failure");
+                            }
+                            return invocation.callRealMethod();
+                          })
+                      .when(spy)
+                      .updateEntitiesPropertiesIfNotChanged(Mockito.any(), Mockito.any());
+                  return spy;
+                })
+            .build();
+
+    createCatalogAndNamespace(testServices, Map.of(), location);
+
+    String table1Name = "cleanup-table-1";
+    String table2Name = "cleanup-table-2";
+    createTable(testServices, table1Name, location);
+    createTable(testServices, table2Name, location);
+
+    // Capture exact set of metadata file paths before the failing transaction
+    Set<Path> metadataFilesBefore = metadataFiles(tempDir);
+
+    // Now enable the CAS failure and attempt a commitTransaction
+    shouldFail.set(true);
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        generateCommitTransactionRequest(false, table1Name, table2Name),
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Transaction commit failed");
+
+    // After the failed transaction, no new metadata files should remain (they were cleaned up).
+    Set<Path> metadataFilesAfter = metadataFiles(tempDir);
+    assertThat(metadataFilesAfter).isEqualTo(metadataFilesBefore);
+  }
+
+  private static Set<Path> metadataFiles(Path directory) {
+    try (Stream<Path> files = Files.walk(directory)) {
+      return files.filter(p -> p.toString().endsWith(".metadata.json")).collect(Collectors.toSet());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -148,6 +149,8 @@ public record TestServices(
     private StsClient stsClient;
     private boolean useEventDelegator = false;
     private Supplier<FileIOFactory> fileIOFactorySupplier = MeasuredFileIOFactory::new;
+    private UnaryOperator<PolarisMetaStoreManager> metaStoreManagerDecorator =
+        UnaryOperator.identity();
     private final PolarisEventMetadataFactory eventMetadataFactory =
         new PolarisEventMetadataFactory() {
           @Override
@@ -202,6 +205,11 @@ public record TestServices(
       return this;
     }
 
+    public Builder metaStoreManagerDecorator(UnaryOperator<PolarisMetaStoreManager> decorator) {
+      this.metaStoreManagerDecorator = decorator;
+      return this;
+    }
+
     public TestServices build() {
       RealmConfigurationSource configurationSource = (rc, name) -> config.get(name);
       PolarisAuthorizer authorizer = Mockito.mock(PolarisAuthorizer.class);
@@ -235,7 +243,8 @@ public record TestServices(
               configurationSource);
 
       PolarisMetaStoreManager metaStoreManager =
-          metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
+          metaStoreManagerDecorator.apply(
+              metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext));
 
       CreatePrincipalResult createdPrincipal =
           metaStoreManager.createPrincipal(


### PR DESCRIPTION
During `commitTransaction`, Iceberg metadata files are written before Polaris persists the corresponding entity updates. If the final metadata store update (updateEntitiesPropertiesIfNotChanged) fails (for example, due to a CAS/conflict failure), the transaction is aborted, but the newly written metadata files remain in storage. Since these metadata files are never referenced by any committed entity, they become orphaned and accumulate over time, resulting in unnecessary storage usage.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
