### PR TITLE
Support staged table creates in commitTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added an OpenTelemetry event listener for emitting Polaris audit events as OpenTelemetry log records.
 - Added optional `sessionPolicy` field to `SigV4AuthenticationParameters` for catalog federation. When set, the IAM session policy JSON is attached to the STS AssumeRole request, allowing administrators to restrict vended credentials to only the required AWS services and actions (Principle of Least Privilege).
 - Added opt-in idempotency for `createTable` in the Iceberg REST catalog. When enabled via `polaris.idempotency.enabled=true` (default `false`), a client-supplied `Idempotency-Key` header is embedded into the new table entity and committed in the same transaction; a retry carrying the same key within the TTL window (`polaris.idempotency.ttl`, default `PT5M`) replays the original success instead of failing with `AlreadyExists`.
+- Added support for staged table creates inside `commitTransaction`.
 
 ### Changes
 - The admin tool's `bootstrap` command is now idempotent: bootstrapping a realm that is already

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -932,6 +932,31 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
 
   /** {@inheritDoc} */
   @Override
+  public @NonNull EntitiesResult commitTransactionBatch(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull List<EntityWithPath> creates,
+      @NonNull List<EntityWithPath> updates) {
+    getDiagnostics().checkNotNull(creates, "unexpected_null_creates");
+    getDiagnostics().checkNotNull(updates, "unexpected_null_updates");
+    EntitiesResult empty = emptyBatchShortCircuit(creates, updates);
+    if (empty != null) {
+      return empty;
+    }
+    if (creates.isEmpty()) {
+      return updateEntitiesPropertiesIfNotChanged(callCtx, updates);
+    }
+    // Persist creates and CAS-updates in a single writeEntities call, atomic on JDBC.
+    BasePersistence ms = callCtx.getMetaStore();
+    return commitTransactionBatchViaWriteEntities(
+        callCtx,
+        ms,
+        creates,
+        updates,
+        (entities, originals) -> ms.writeEntities(callCtx, entities, originals));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public @NonNull EntitiesResult updateEntitiesPropertiesIfNotChanged(
       @NonNull PolarisCallContext callCtx, @NonNull List<EntityWithPath> entities) {
     // get metastore we should be using

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -933,9 +933,9 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
   /** {@inheritDoc} */
   @Override
   public @NonNull EntitiesResult commitTransactionBatch(
-      @NonNull PolarisCallContext callCtx,
-      @NonNull List<EntityWithPath> creates,
-      @NonNull List<EntityWithPath> updates) {
+      @NonNull PolarisCallContext callCtx, @NonNull MetaStoreChangeSet changeSet) {
+    List<EntityWithPath> creates = changeSet.creates();
+    List<EntityWithPath> updates = changeSet.updates();
     getDiagnostics().checkNotNull(creates, "unexpected_null_creates");
     getDiagnostics().checkNotNull(updates, "unexpected_null_updates");
     EntitiesResult empty = emptyBatchShortCircuit(creates, updates);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BaseMetaStoreManager.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.persistence;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -25,9 +27,14 @@ import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntitiesResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
+import org.apache.polaris.core.persistence.pagination.Page;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /** Shared basic PolarisMetaStoreManager logic for transactional and non-transactional impls. */
 public abstract class BaseMetaStoreManager implements PolarisMetaStoreManager {
@@ -171,5 +178,67 @@ public abstract class BaseMetaStoreManager implements PolarisMetaStoreManager {
     BasePersistence ms = callCtx.getMetaStore();
 
     return new GenerateEntityIdResult(ms.generateNewId(callCtx));
+  }
+
+  /** Persists a merged (entities, originalEntities) batch within the caller's transaction. */
+  @FunctionalInterface
+  protected interface BatchWriteAction {
+    void write(List<PolarisBaseEntity> entities, List<PolarisBaseEntity> originalEntities);
+  }
+
+  /**
+   * Merges {@code creates} and CAS {@code updates} into a single write call. Creates land at
+   * indices with a null originalEntity; updates land at indices with the prior entity state.
+   */
+  protected @NonNull EntitiesResult commitTransactionBatchViaWriteEntities(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull BasePersistence ms,
+      @NonNull List<EntityWithPath> creates,
+      @NonNull List<EntityWithPath> updates,
+      @NonNull BatchWriteAction write) {
+    List<PolarisBaseEntity> mergedEntities = new ArrayList<>(creates.size() + updates.size());
+    List<PolarisBaseEntity> mergedOriginals = new ArrayList<>(creates.size() + updates.size());
+
+    for (EntityWithPath create : creates) {
+      mergedEntities.add(
+          prepareToPersistNewEntity(
+              callCtx, ms, new PolarisBaseEntity.Builder(create.entity()).build()));
+      mergedOriginals.add(null);
+    }
+    for (EntityWithPath update : updates) {
+      mergedEntities.add(
+          prepareToPersistEntityAfterChange(
+              callCtx,
+              ms,
+              new PolarisBaseEntity.Builder(update.entity()).build(),
+              false,
+              update.entity()));
+      mergedOriginals.add(update.entity());
+    }
+
+    try {
+      write.write(mergedEntities, mergedOriginals);
+    } catch (EntityAlreadyExistsException e) {
+      return new EntitiesResult(
+          BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS,
+          String.format(
+              "Existing entity id: '%s', type %s subtype %s",
+              e.getExistingEntity().getId(),
+              e.getExistingEntity().getTypeCode(),
+              e.getExistingEntity().getSubTypeCode()));
+    } catch (RetryOnConcurrencyException e) {
+      return new EntitiesResult(
+          BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, e.getMessage());
+    }
+    return new EntitiesResult(Page.fromItems(mergedEntities));
+  }
+
+  /** Returns an empty successful result if both lists are empty, otherwise {@code null}. */
+  protected static @Nullable EntitiesResult emptyBatchShortCircuit(
+      List<EntityWithPath> creates, List<EntityWithPath> updates) {
+    if (creates.isEmpty() && updates.isEmpty()) {
+      return new EntitiesResult(Page.fromItems(List.of()));
+    }
+    return null;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreChangeSet.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/MetaStoreChangeSet.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import java.util.List;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a set of metastore mutations to be committed atomically by {@link
+ * PolarisMetaStoreManager#commitTransactionBatch}. Simpler single-entity operations ({@link
+ * PolarisMetaStoreManager#createEntityIfNotExists}, {@link
+ * PolarisMetaStoreManager#updateEntitiesPropertiesIfNotChanged}) can be expressed as a changeset
+ * with a single entry, allowing them to ride on top of the same atomic commit path.
+ *
+ * <p>This is intentionally minimal: only creates and CAS-updates are supported now. Drops and
+ * renames are explicit empty lists, reserved for future support.
+ */
+public record MetaStoreChangeSet(
+    @NonNull List<EntityWithPath> creates, @NonNull List<EntityWithPath> updates) {
+
+  /** A changeset with no mutations — no-op commit. */
+  public static final MetaStoreChangeSet EMPTY = new MetaStoreChangeSet(List.of(), List.of());
+
+  /** A changeset for a single entity creation. */
+  public static MetaStoreChangeSet ofCreate(
+      @Nullable List<PolarisEntityCore> catalogPath, @NonNull PolarisBaseEntity entity) {
+    return new MetaStoreChangeSet(List.of(new EntityWithPath(catalogPath, entity)), List.of());
+  }
+
+  /** A changeset for a single entity CAS-update. */
+  public static MetaStoreChangeSet ofUpdate(
+      @Nullable List<PolarisEntityCore> catalogPath, @NonNull PolarisBaseEntity entity) {
+    return new MetaStoreChangeSet(List.of(), List.of(new EntityWithPath(catalogPath, entity)));
+  }
+
+  /** A changeset for a batch of CAS-updates. */
+  public static MetaStoreChangeSet ofUpdates(@NonNull List<EntityWithPath> updates) {
+    return new MetaStoreChangeSet(List.of(), updates);
+  }
+
+  /** A changeset for a mixed batch of creates and CAS-updates. */
+  public static MetaStoreChangeSet ofBatch(
+      @NonNull List<EntityWithPath> creates, @NonNull List<EntityWithPath> updates) {
+    return new MetaStoreChangeSet(creates, updates);
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -213,6 +213,32 @@ public interface PolarisMetaStoreManager
       @NonNull List<PolarisEntityCore> principalRoles);
 
   /**
+   * Commits a {@link MetaStoreChangeSet} atomically. This is the primary mutation method; simpler
+   * per-entity operations are thin wrappers on top of it.
+   *
+   * <p>The default implementation falls back to calling individual per-entity methods in sequence
+   * and is therefore not atomic. Backends should override this method to provide the atomic
+   * guarantee.
+   *
+   * @param callCtx call context
+   * @param changeSet the set of entity creations and CAS-updates to commit
+   * @return result indicating success or failure
+   */
+  default @NonNull EntitiesResult commitTransactionBatch(
+      @NonNull PolarisCallContext callCtx, @NonNull MetaStoreChangeSet changeSet) {
+    for (EntityWithPath create : changeSet.creates()) {
+      EntityResult result = createEntityIfNotExists(callCtx, create.catalogPath(), create.entity());
+      if (!result.isSuccess()) {
+        return new EntitiesResult(result.getReturnStatus(), result.getExtraInformation());
+      }
+    }
+    if (!changeSet.updates().isEmpty()) {
+      return updateEntitiesPropertiesIfNotChanged(callCtx, changeSet.updates());
+    }
+    return new EntitiesResult(Page.fromItems(List.of()));
+  }
+
+  /**
    * Persist a newly created entity under the specified catalog path if specified, else this is a
    * top-level entity. We will re-resolve the specified path to ensure nothing has changed since the
    * Polaris app resolved the path. If the entity already exists with the same specified id, we will
@@ -284,30 +310,6 @@ public interface PolarisMetaStoreManager
    */
   @NonNull EntitiesResult updateEntitiesPropertiesIfNotChanged(
       @NonNull PolarisCallContext callCtx, @NonNull List<EntityWithPath> entities);
-
-  /**
-   * Commits a batch of entity creations and property updates within a single transaction.
-   *
-   * @param callCtx call context
-   * @param creates entities to create
-   * @param updates entities to update (compare-and-swap)
-   * @return result indicating success or failure
-   */
-  default @NonNull EntitiesResult commitTransactionBatch(
-      @NonNull PolarisCallContext callCtx,
-      @NonNull List<EntityWithPath> creates,
-      @NonNull List<EntityWithPath> updates) {
-    for (EntityWithPath create : creates) {
-      EntityResult result = createEntityIfNotExists(callCtx, create.catalogPath(), create.entity());
-      if (!result.isSuccess()) {
-        return new EntitiesResult(result.getReturnStatus(), result.getExtraInformation());
-      }
-    }
-    if (!updates.isEmpty()) {
-      return updateEntitiesPropertiesIfNotChanged(callCtx, updates);
-    }
-    return new EntitiesResult(Page.fromItems(List.of()));
-  }
 
   /**
    * Rename an entity, potentially re-parenting it.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -286,6 +286,30 @@ public interface PolarisMetaStoreManager
       @NonNull PolarisCallContext callCtx, @NonNull List<EntityWithPath> entities);
 
   /**
+   * Commits a batch of entity creations and property updates within a single transaction.
+   *
+   * @param callCtx call context
+   * @param creates entities to create
+   * @param updates entities to update (compare-and-swap)
+   * @return result indicating success or failure
+   */
+  default @NonNull EntitiesResult commitTransactionBatch(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull List<EntityWithPath> creates,
+      @NonNull List<EntityWithPath> updates) {
+    for (EntityWithPath create : creates) {
+      EntityResult result = createEntityIfNotExists(callCtx, create.catalogPath(), create.entity());
+      if (!result.isSuccess()) {
+        return new EntitiesResult(result.getReturnStatus(), result.getExtraInformation());
+      }
+    }
+    if (!updates.isEmpty()) {
+      return updateEntitiesPropertiesIfNotChanged(callCtx, updates);
+    }
+    return new EntitiesResult(Page.fromItems(List.of()));
+  }
+
+  /**
    * Rename an entity, potentially re-parenting it.
    *
    * @param callCtx call context

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/TransactionWorkspaceMetaStoreManager.java
@@ -86,6 +86,7 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   // to serve reads within the same transaction while also storing the ordered list of
   // pendingUpdates that ultimately need to be applied in order within the real MetaStoreManager.
   private final List<EntityWithPath> pendingUpdates = new ArrayList<>();
+  private final List<EntityWithPath> pendingCreations = new ArrayList<>();
 
   public TransactionWorkspaceMetaStoreManager(
       PolarisDiagnostics diagnostics, PolarisMetaStoreManager delegate) {
@@ -99,6 +100,10 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
 
   public List<EntityWithPath> getPendingUpdates() {
     return ImmutableList.copyOf(pendingUpdates);
+  }
+
+  public List<EntityWithPath> getPendingCreations() {
+    return ImmutableList.copyOf(pendingCreations);
   }
 
   @Override
@@ -128,7 +133,9 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
       @NonNull PolarisEntityType entityType,
       @NonNull PolarisEntitySubType entitySubType,
       @NonNull PageToken pageToken) {
-    throw illegalMethodError("listEntities");
+    // Return empty result to make validation a no-op during the transaction loop.
+    // Real validation is deferred to commit time when the real metastore is restored.
+    return new ListEntitiesResult(Page.fromItems(List.of()));
   }
 
   @Override
@@ -143,7 +150,8 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
 
   @Override
   public @NonNull GenerateEntityIdResult generateNewEntityId(@NonNull PolarisCallContext callCtx) {
-    throw illegalMethodError("generateNewEntityId");
+    // Entity ID allocation is side-effect-free; delegate to the real metastore.
+    return delegate.generateNewEntityId(callCtx);
   }
 
   @Override
@@ -196,7 +204,9 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
       @NonNull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
       @NonNull PolarisBaseEntity entity) {
-    throw illegalMethodError("createEntityIfNotExists");
+    // Buffer the creation for deferred atomic commit.
+    pendingCreations.add(new EntityWithPath(catalogPath, entity));
+    return new EntityResult(entity);
   }
 
   @Override
@@ -356,7 +366,9 @@ public class TransactionWorkspaceMetaStoreManager implements PolarisMetaStoreMan
   public <T extends PolarisEntity & LocationBasedEntity>
       Optional<Optional<String>> hasOverlappingSiblings(
           @NonNull PolarisCallContext callContext, T entity) {
-    throw illegalMethodError("hasOverlappingSiblings");
+    // Return "no overlap" to skip validation during the transaction loop.
+    // Real validation is deferred to commit time when the real metastore is restored.
+    return Optional.of(Optional.empty());
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -51,6 +51,7 @@ import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.BaseMetaStoreManager;
+import org.apache.polaris.core.persistence.MetaStoreChangeSet;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
@@ -1175,9 +1176,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
   /** {@inheritDoc} */
   @Override
   public @NonNull EntitiesResult commitTransactionBatch(
-      @NonNull PolarisCallContext callCtx,
-      @NonNull List<EntityWithPath> creates,
-      @NonNull List<EntityWithPath> updates) {
+      @NonNull PolarisCallContext callCtx, @NonNull MetaStoreChangeSet changeSet) {
+    List<EntityWithPath> creates = changeSet.creates();
+    List<EntityWithPath> updates = changeSet.updates();
     getDiagnostics().checkNotNull(creates, "unexpected_null_creates");
     getDiagnostics().checkNotNull(updates, "unexpected_null_updates");
     EntitiesResult empty = emptyBatchShortCircuit(creates, updates);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -1172,6 +1172,44 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         callCtx, () -> this.updateEntitiesPropertiesIfNotChanged(callCtx, ms, entities));
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public @NonNull EntitiesResult commitTransactionBatch(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull List<EntityWithPath> creates,
+      @NonNull List<EntityWithPath> updates) {
+    getDiagnostics().checkNotNull(creates, "unexpected_null_creates");
+    getDiagnostics().checkNotNull(updates, "unexpected_null_updates");
+    EntitiesResult empty = emptyBatchShortCircuit(creates, updates);
+    if (empty != null) {
+      return empty;
+    }
+    if (creates.isEmpty()) {
+      return updateEntitiesPropertiesIfNotChanged(callCtx, updates);
+    }
+
+    TransactionalPersistence ms = ((TransactionalPersistence) callCtx.getMetaStore());
+
+    // Merge creates + CAS-updates and write within a single runInTransaction block so both
+    // are covered by the same underlying transaction.
+    return ms.runInTransaction(
+        callCtx,
+        () -> {
+          EntitiesResult result =
+              commitTransactionBatchViaWriteEntities(
+                  callCtx,
+                  ms,
+                  creates,
+                  updates,
+                  (entities, originals) ->
+                      ms.writeEntitiesInCurrentTxn(callCtx, entities, originals));
+          if (!result.isSuccess()) {
+            ms.rollback();
+          }
+          return result;
+        });
+  }
+
   /**
    * See {@link PolarisMetaStoreManager#renameEntity(PolarisCallContext, List, PolarisBaseEntity,
    * List, PolarisEntity)}

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.storage;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -105,28 +106,31 @@ public class StorageUtil {
    */
   public static void validateNoOverlapWithinBatch(
       List<Map.Entry<TableIdentifier, TableMetadata>> batch) {
+    // Collect one (location, identifier) pair per data location across all batch entries, then
+    // sort alphabetically by location string. Overlapping paths will be alphabetically adjacent
+    // after sorting, so a single linear scan catches all conflicts in O(n log n) rather than
+    // the O(n^2) pairwise scan.
     List<Map.Entry<TableIdentifier, StorageLocation>> entries =
         batch.stream()
             .flatMap(
                 e ->
                     getLocationsUsedByTable(e.getValue()).stream()
                         .map(loc -> Map.entry(e.getKey(), StorageLocation.of(loc))))
+            .sorted(Comparator.comparing(e -> e.getValue().toString()))
             .toList();
-    for (int i = 0; i < entries.size(); i++) {
-      for (int j = i + 1; j < entries.size(); j++) {
-        TableIdentifier idA = entries.get(i).getKey();
-        TableIdentifier idB = entries.get(j).getKey();
-        if (idA.equals(idB)) {
-          continue;
-        }
-        StorageLocation a = entries.get(i).getValue();
-        StorageLocation b = entries.get(j).getValue();
-        if (a.isChildOf(b) || b.isChildOf(a)) {
-          throw new BadRequestException(
-              "Transaction contains changes whose locations overlap: '%s' for table '%s' and"
-                  + " '%s' for table '%s'",
-              a, idA, b, idB);
-        }
+    for (int i = 0; i < entries.size() - 1; i++) {
+      TableIdentifier idA = entries.get(i).getKey();
+      TableIdentifier idB = entries.get(i + 1).getKey();
+      if (idA.equals(idB)) {
+        continue;
+      }
+      StorageLocation a = entries.get(i).getValue();
+      StorageLocation b = entries.get(i + 1).getValue();
+      if (a.isChildOf(b) || b.isChildOf(a)) {
+        throw new BadRequestException(
+            "Transaction contains changes whose locations overlap: '%s' for table '%s' and"
+                + " '%s' for table '%s'",
+            a, idA, b, idB);
       }
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -19,9 +19,12 @@
 package org.apache.polaris.core.storage;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.jspecify.annotations.NonNull;
@@ -81,6 +84,51 @@ public class StorageUtil {
   /** Given a ViewMetadata, extracts the locations where the view's [meta]data might be found. */
   public static @NonNull Set<String> getLocationsUsedByTable(ViewMetadata viewMetadata) {
     return Set.of(viewMetadata.location());
+  }
+
+  /**
+   * Returns true if the set of locations used by {@code current} differs from the set used by
+   * {@code base}. Covers the table location as well as write.data.path and write.metadata.path
+   * property overrides.
+   */
+  public static boolean locationsChanged(TableMetadata base, TableMetadata current) {
+    return !getLocationsUsedByTable(base).equals(getLocationsUsedByTable(current));
+  }
+
+  /**
+   * Checks that no two distinct tables in {@code batch} use overlapping locations (pairwise
+   * containment check across all data locations returned by {@link #getLocationsUsedByTable}).
+   * Same-identifier pairs are skipped so a table's own write.data.path and write.metadata.path
+   * don't count as self-overlap.
+   *
+   * @throws BadRequestException if any two distinct tables have overlapping locations
+   */
+  public static void validateNoOverlapWithinBatch(
+      List<Map.Entry<TableIdentifier, TableMetadata>> batch) {
+    List<Map.Entry<TableIdentifier, StorageLocation>> entries =
+        batch.stream()
+            .flatMap(
+                e ->
+                    getLocationsUsedByTable(e.getValue()).stream()
+                        .map(loc -> Map.entry(e.getKey(), StorageLocation.of(loc))))
+            .toList();
+    for (int i = 0; i < entries.size(); i++) {
+      for (int j = i + 1; j < entries.size(); j++) {
+        TableIdentifier idA = entries.get(i).getKey();
+        TableIdentifier idB = entries.get(j).getKey();
+        if (idA.equals(idB)) {
+          continue;
+        }
+        StorageLocation a = entries.get(i).getValue();
+        StorageLocation b = entries.get(j).getValue();
+        if (a.isChildOf(b) || b.isChildOf(a)) {
+          throw new BadRequestException(
+              "Transaction contains changes whose locations overlap: '%s' for table '%s' and"
+                  + " '%s' for table '%s'",
+              a, idA, b, idB);
+        }
+      }
+    }
   }
 
   /** Removes "redundant" locations, so {/a/b/, /a/b/c, /a/b/d} will be reduced to just {/a/b/} */

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
@@ -212,7 +212,8 @@ public class AtomicOperationMetaStoreManagerTest {
     List<EntityWithPath> creates = List.of(newTable(11L, "create-a"), newTable(12L, "create-b"));
     List<EntityWithPath> updates = List.of(newTable(21L, "update-a"), newTable(22L, "update-b"));
 
-    EntitiesResult result = manager.commitTransactionBatch(callCtx, creates, updates);
+    EntitiesResult result =
+        manager.commitTransactionBatch(callCtx, MetaStoreChangeSet.ofBatch(creates, updates));
 
     assertThat(result.isSuccess()).isTrue();
     verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
@@ -224,7 +225,8 @@ public class AtomicOperationMetaStoreManagerTest {
   public void testCommitBatchCreatesOnlyUsesOneWriteEntitiesCall() {
     List<EntityWithPath> creates = List.of(newTable(11L, "c1"), newTable(12L, "c2"));
 
-    EntitiesResult result = manager.commitTransactionBatch(callCtx, creates, List.of());
+    EntitiesResult result =
+        manager.commitTransactionBatch(callCtx, MetaStoreChangeSet.ofBatch(creates, List.of()));
 
     assertThat(result.isSuccess()).isTrue();
     verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
@@ -234,7 +236,8 @@ public class AtomicOperationMetaStoreManagerTest {
   public void testCommitBatchUpdatesOnlyUsesOneWriteEntitiesCall() {
     List<EntityWithPath> updates = List.of(newTable(21L, "u1"), newTable(22L, "u2"));
 
-    EntitiesResult result = manager.commitTransactionBatch(callCtx, List.of(), updates);
+    EntitiesResult result =
+        manager.commitTransactionBatch(callCtx, MetaStoreChangeSet.ofBatch(List.of(), updates));
 
     assertThat(result.isSuccess()).isTrue();
     verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
@@ -242,7 +245,7 @@ public class AtomicOperationMetaStoreManagerTest {
 
   @Test
   public void testCommitBatchEmptyBatchIsANoOp() {
-    EntitiesResult result = manager.commitTransactionBatch(callCtx, List.of(), List.of());
+    EntitiesResult result = manager.commitTransactionBatch(callCtx, MetaStoreChangeSet.EMPTY);
 
     assertThat(result.isSuccess()).isTrue();
     verify(metaStore, never()).writeEntities(any(), any(), any());

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
@@ -22,6 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -35,13 +39,15 @@ import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntitiesResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-/** Regression tests for {@link AtomicOperationMetaStoreManager#refreshResolvedEntity} (#3836). */
-public class AtomicOperationMetaStoreManagerRefreshTest {
+/** Unit tests for {@link AtomicOperationMetaStoreManager}. */
+public class AtomicOperationMetaStoreManagerTest {
 
   private static final long CATALOG_ID = 100L;
   private static final long ENTITY_ID = 200L;
@@ -182,5 +188,63 @@ public class AtomicOperationMetaStoreManagerRefreshTest {
     assertThat(result.getEntityGrantRecords()).isNotNull();
     Mockito.verify(metaStore).loadAllGrantRecordsOnGrantee(any(), anyLong(), anyLong());
     Mockito.verify(metaStore).loadAllGrantRecordsOnSecurable(any(), anyLong(), anyLong());
+  }
+
+  private static EntityWithPath newTable(long id, String name) {
+    PolarisBaseEntity entity =
+        new PolarisBaseEntity.Builder()
+            .catalogId(100L)
+            .id(id)
+            .parentId(50L)
+            .typeCode(PolarisEntityType.TABLE_LIKE.getCode())
+            .subTypeCode(PolarisEntitySubType.ICEBERG_TABLE.getCode())
+            .name(name)
+            .entityVersion(1)
+            .createTimestamp(System.currentTimeMillis())
+            .build();
+    return new EntityWithPath(List.of(), entity);
+  }
+
+  @Test
+  public void testCommitBatchMixedCreatesAndUpdatesUseOneWriteEntitiesCall() {
+    // Two creates + two CAS updates.The manager must issue exactly one writeEntities call — that
+    // call runs inside one JDBC transaction.
+    List<EntityWithPath> creates = List.of(newTable(11L, "create-a"), newTable(12L, "create-b"));
+    List<EntityWithPath> updates = List.of(newTable(21L, "update-a"), newTable(22L, "update-b"));
+
+    EntitiesResult result = manager.commitTransactionBatch(callCtx, creates, updates);
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
+    verify(metaStore, never())
+        .writeEntity(any(), any(), Mockito.anyBoolean(), Mockito.nullable(PolarisBaseEntity.class));
+  }
+
+  @Test
+  public void testCommitBatchCreatesOnlyUsesOneWriteEntitiesCall() {
+    List<EntityWithPath> creates = List.of(newTable(11L, "c1"), newTable(12L, "c2"));
+
+    EntitiesResult result = manager.commitTransactionBatch(callCtx, creates, List.of());
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
+  }
+
+  @Test
+  public void testCommitBatchUpdatesOnlyUsesOneWriteEntitiesCall() {
+    List<EntityWithPath> updates = List.of(newTable(21L, "u1"), newTable(22L, "u2"));
+
+    EntitiesResult result = manager.commitTransactionBatch(callCtx, List.of(), updates);
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(metaStore, times(1)).writeEntities(eq(callCtx), any(), any());
+  }
+
+  @Test
+  public void testCommitBatchEmptyBatchIsANoOp() {
+    EntitiesResult result = manager.commitTransactionBatch(callCtx, List.of(), List.of());
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(metaStore, never()).writeEntities(any(), any(), any());
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -387,7 +387,7 @@ public class CatalogHandlerUtils {
     return isCreate;
   }
 
-  private TableMetadata create(TableOperations ops, UpdateTableRequest request) {
+  TableMetadata create(TableOperations ops, UpdateTableRequest request) {
     // the only valid requirement is that the table will be created
     request.requirements().forEach(requirement -> requirement.validate(ops.current()));
     Optional<Integer> formatVersion =

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -23,6 +23,7 @@ import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_FEDERATE
 import static org.apache.polaris.core.config.FeatureConfiguration.LIST_PAGINATION_ENABLED;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.alreadyExistsExceptionForTableLikeEntity;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
 import com.google.common.base.Preconditions;
@@ -36,7 +37,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
@@ -112,6 +113,7 @@ import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverPath;
+import org.apache.polaris.core.persistence.resolver.ResolverStatus;
 import org.apache.polaris.core.storage.PolarisStorageActions;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageUtil;
@@ -1284,18 +1286,106 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     catalogHandlerUtils().renameTable(baseCatalog, request);
   }
 
+  private void authorizeCommitTransactionOrThrow(List<UpdateTableRequest> tableChanges) {
+    List<UpdateTableRequest> stagedCreates = new ArrayList<>();
+    List<UpdateTableRequest> regularUpdates = new ArrayList<>();
+    for (UpdateTableRequest change : tableChanges) {
+      if (CatalogHandlerUtils.isCreate(change)) {
+        stagedCreates.add(change);
+      } else {
+        regularUpdates.add(change);
+      }
+    }
+
+    resolutionManifest = newResolutionManifest();
+
+    // Add table paths for regular updates (must exist)
+    for (UpdateTableRequest change : regularUpdates) {
+      resolutionManifest.addPassthroughPath(
+          new ResolverPath(
+              PolarisCatalogHelpers.tableIdentifierToList(change.identifier()),
+              PolarisEntityType.TABLE_LIKE));
+    }
+
+    // Add namespace paths (required) + table paths (optional) for staged creates
+    for (UpdateTableRequest change : stagedCreates) {
+      TableIdentifier id = change.identifier();
+      resolutionManifest.addPath(
+          new ResolverPath(Arrays.asList(id.namespace().levels()), PolarisEntityType.NAMESPACE));
+      resolutionManifest.addPassthroughPath(
+          new ResolverPath(
+              PolarisCatalogHelpers.tableIdentifierToList(id),
+              PolarisEntityType.TABLE_LIKE,
+              true /* optional */));
+    }
+
+    ResolverStatus status = resolutionManifest.resolveAll();
+    if (status.getStatus() == ResolverStatus.StatusEnum.PATH_COULD_NOT_BE_FULLY_RESOLVED) {
+      ResolverPath failedPath = status.getFailedToResolvePath();
+      if (failedPath.lastEntityType() == PolarisEntityType.NAMESPACE) {
+        // Staged-create: the parent namespace does not exist
+        throw noSuchNamespaceException(
+            Namespace.of(failedPath.entityNames().toArray(String[]::new)));
+      }
+      TableIdentifier identifier =
+          PolarisCatalogHelpers.listToTableIdentifier(failedPath.entityNames());
+      throw notFoundExceptionForTableLikeEntity(identifier, PolarisEntitySubType.ICEBERG_TABLE);
+    }
+
+    // Authorize regular updates: TABLE_WRITE_PROPERTIES on table entities
+    if (!regularUpdates.isEmpty()) {
+      List<PolarisResolvedPathWrapper> updateTargets =
+          regularUpdates.stream()
+              .map(
+                  change ->
+                      Optional.ofNullable(
+                              resolutionManifest.getResolvedPath(
+                                  ResolvedPathKey.ofTableLike(change.identifier()),
+                                  PolarisEntitySubType.ICEBERG_TABLE,
+                                  true))
+                          .orElseThrow(
+                              () ->
+                                  notFoundExceptionForTableLikeEntity(
+                                      change.identifier(), PolarisEntitySubType.ICEBERG_TABLE)))
+              .toList();
+      authorizer()
+          .authorizeOrThrow(
+              polarisPrincipal(),
+              resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
+              PolarisAuthorizableOperation.UPDATE_TABLE,
+              updateTargets,
+              null);
+    }
+
+    // Authorize staged creates: TABLE_CREATE on parent namespace
+    if (!stagedCreates.isEmpty()) {
+      List<PolarisResolvedPathWrapper> createTargets =
+          stagedCreates.stream()
+              .map(
+                  change -> {
+                    Namespace ns = change.identifier().namespace();
+                    PolarisResolvedPathWrapper nsTarget =
+                        resolutionManifest.getResolvedPath(ResolvedPathKey.ofNamespace(ns), true);
+                    if (nsTarget == null) {
+                      throw noSuchNamespaceException(ns);
+                    }
+                    return nsTarget;
+                  })
+              .toList();
+      authorizer()
+          .authorizeOrThrow(
+              polarisPrincipal(),
+              resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
+              PolarisAuthorizableOperation.UPDATE_TABLE_FOR_STAGED_CREATE,
+              createTargets,
+              null);
+    }
+
+    initializeCatalog();
+  }
+
   public void commitTransaction(CommitTransactionRequest commitTransactionRequest) {
-    PolarisAuthorizableOperation op = PolarisAuthorizableOperation.COMMIT_TRANSACTION;
-    // TODO: The authz actually needs to detect hidden updateForStagedCreate UpdateTableRequests
-    // and have some kind of per-item conditional privilege requirement if we want to make it
-    // so that only the stageCreate updates need TABLE_CREATE whereas everything else only
-    // needs TABLE_WRITE_PROPERTIES.
-    authorizeCollectionOfTableLikeOperationOrThrow(
-        op,
-        PolarisEntitySubType.ICEBERG_TABLE,
-        commitTransactionRequest.tableChanges().stream()
-            .map(UpdateTableRequest::identifier)
-            .toList());
+    authorizeCommitTransactionOrThrow(commitTransactionRequest.tableChanges());
     CatalogEntity catalog = getResolvedCatalogEntity();
     if (catalog.isStaticFacade()) {
       throw new BadRequestException("Cannot update table on static-facade external catalogs.");
@@ -1307,135 +1397,203 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
           baseCatalog.getClass().getName());
     }
 
-    // Swap in TransactionWorkspaceMetaStoreManager for all mutations made by this baseCatalog to
-    // only go into an in-memory collection that we can commit as a single atomic unit after all
-    // validations.
+    LocalIcebergCatalog localCatalog = (LocalIcebergCatalog) baseCatalog;
+
+    // Buffer mutations in a workspace metastore so we can commit them as one atomic unit.
+    // Location validation is deferred: the workspace no-ops the sibling/overlap checks
+    // during the loop, and real validation runs after the loop with the real metastore.
     TransactionWorkspaceMetaStoreManager transactionMetaStoreManager =
         new TransactionWorkspaceMetaStoreManager(diagnostics(), metaStoreManager());
 
     List<MetadataFileCleanup> pendingCleanups = new ArrayList<>();
+    localCatalog.setMetaStoreManager(transactionMetaStoreManager, pendingCleanups::add);
 
-    ((LocalIcebergCatalog) baseCatalog)
-        .setMetaStoreManager(transactionMetaStoreManager, pendingCleanups::add);
-
-    // Group all changes by table identifier to handle them atomically.
-    // This prevents conflicts when multiple changes target the same table entity.
-    // LinkedHashMap preserves insertion order for deterministic processing.
+    // Group changes by table so multiple requests against the same table are handled together.
     Map<TableIdentifier, List<UpdateTableRequest>> changesByTable = new LinkedHashMap<>();
     for (UpdateTableRequest change : commitTransactionRequest.tableChanges()) {
-      if (CatalogHandlerUtils.isCreate(change)) {
-        throw new BadRequestException(
-            "Unsupported operation: commitTranaction with updateForStagedCreate: %s", change);
-      }
       changesByTable.computeIfAbsent(change.identifier(), k -> new ArrayList<>()).add(change);
     }
 
-    // Process each table's changes in order.
-    // Note: All UpdateTableRequests for a given table are coalesced into a single metadata
-    // update and a single tableOps.commit(), which results in one Polaris entity update per
-    // table. This is subtly different from applying each UpdateTableRequest as an independent
-    // commit (as if each were under a lock). Requirements are still validated sequentially
-    // against the evolving metadata, so conflicts are detected correctly.
-    // See also the TODO in TransactionWorkspaceMetaStoreManager for a more general (but more
-    // complex) alternative that would intercept at the MetaStoreManager layer.
-    List<TableMetadata> tableMetadataObjs = new ArrayList<>();
-    Map<TableIdentifier, FileIO> tableFileIOs = new HashMap<>();
-    changesByTable.forEach(
-        (tableIdentifier, changes) -> {
-          Table table = baseCatalog.loadTable(tableIdentifier);
-          if (!(table instanceof BaseTable baseTable)) {
-            throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
-          }
-
-          TableOperations tableOps = baseTable.operations();
-          TableMetadata baseMetadata = tableOps.current();
-
-          // Apply each change sequentially: validate requirements against current state,
-          // then apply updates. This ensures conflicts are detected (e.g., if two changes
-          // both expect schema ID 0, the second will fail after the first increments it).
-          TableMetadata currentMetadata = baseMetadata;
-          for (UpdateTableRequest change : changes) {
-            // Validate requirements against the current metadata state
-            final TableMetadata metadataForValidation = currentMetadata;
-            change
-                .requirements()
-                .forEach(requirement -> requirement.validate(metadataForValidation));
-
-            // TODO: Refactor to share/reconcile the update-application logic below with
-            // CatalogHandlerUtils to avoid divergence as complexity grows.
-            TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(currentMetadata);
-            for (MetadataUpdate singleUpdate : change.updates()) {
-              // Note: If location-overlap checking is refactored to be atomic, we could
-              // support validation within a single multi-table transaction as well, but
-              // will need to update the TransactionWorkspaceMetaStoreManager to better
-              // expose the concept of being able to read uncommitted updates.
-              if (singleUpdate instanceof MetadataUpdate.SetLocation setLocation) {
-                if (!currentMetadata.location().equals(setLocation.location())
-                    && !realmConfig()
-                        .getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
-                  throw new BadRequestException(
-                      "Unsupported operation: commitTransaction containing SetLocation"
-                          + " for table '%s' and new location '%s'",
-                      change.identifier(), ((MetadataUpdate.SetLocation) singleUpdate).location());
-                }
-              }
-
-              // Apply updates to builder
-              singleUpdate.applyTo(metadataBuilder);
+    TransactionState state = new TransactionState();
+    try {
+      changesByTable.forEach(
+          (tableIdentifier, changes) -> {
+            if (changes.stream().anyMatch(CatalogHandlerUtils::isCreate)) {
+              processCreateInTransaction(localCatalog, tableIdentifier, changes, state);
+            } else {
+              processUpdateInTransaction(tableIdentifier, changes, state);
             }
+          });
 
-            // Update currentMetadata to reflect this change for subsequent requirement validation
-            currentMetadata = metadataBuilder.build();
+      // Restore the real metastore before deferred validation so sibling/overlap checks see it.
+      localCatalog.setMetaStoreManager(metaStoreManager());
+      validateDeferredLocations(localCatalog, state);
+
+      List<EntityWithPath> pendingCreations = transactionMetaStoreManager.getPendingCreations();
+      List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
+
+      EntitiesResult result =
+          metaStoreManager()
+              .commitTransactionBatch(
+                  callContext().getPolarisCallContext(), pendingCreations, pendingUpdates);
+      if (!result.isSuccess()) {
+        // TODO: Retries on failure
+
+        // Concurrent create between tableExists() and commit surfaces as ENTITY_ALREADY_EXISTS.
+        // extraInformation carries the existing DB row's ID, not our attempted entity's ID, so
+        // we cannot reliably identify the conflicting table in a multi-create batch. Name the
+        // table only when there is exactly one create (blame is unambiguous); otherwise throw
+        // a generic AlreadyExistsException.
+        if (result.alreadyExists()) {
+          if (state.createEntries.size() == 1) {
+            throw alreadyExistsExceptionForTableLikeEntity(
+                state.createEntries.get(0).getKey(), PolarisEntitySubType.ICEBERG_TABLE);
           }
-
-          // Commit all accumulated changes for this table in a single atomic operation.
-          // The delete logic (set above to collectCleanup) will record instead of delete.
-          if (!currentMetadata.changes().isEmpty()) {
-            tableOps.commit(baseMetadata, currentMetadata);
-            tableFileIOs.put(tableIdentifier, tableOps.io());
-          }
-
-          tableMetadataObjs.add(currentMetadata);
-        });
-
-    List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
-    EntitiesResult result =
-        metaStoreManager()
-            .updateEntitiesPropertiesIfNotChanged(
-                callContext().getPolarisCallContext(), pendingUpdates);
-    if (!result.isSuccess()) {
-      // TODO: Retries on failure
-
-      // Clean up metadata files written during doCommit() since the transaction failed.
-      // We derive locations from pendingUpdates (not tableOps.current()) because
-      // requestRefresh() triggers doRefresh() against the store where the entity
-      // hasn't been persisted yet.
-      List<FileToDelete> writtenMetadataFiles =
-          pendingUpdates.stream()
-              .map(ewp -> IcebergTableLikeEntity.of(ewp.entity()))
-              .filter(entity -> entity != null && entity.getMetadataLocation() != null)
-              .filter(entity -> tableFileIOs.containsKey(entity.getTableIdentifier()))
-              .map(
-                  entity ->
-                      new FileToDelete(
-                          tableFileIOs.get(entity.getTableIdentifier()),
-                          entity.getMetadataLocation()))
-              .toList();
-      cleanupWrittenMetadataFiles(writtenMetadataFiles);
-      throw new CommitFailedException(
-          "Transaction commit failed with status: %s, extraInfo: %s",
-          result.getReturnStatus(), result.getExtraInformation());
+          throw new AlreadyExistsException(
+              "Table already exists: one of the tables in this transaction conflicts with an"
+                  + " existing table");
+        }
+        throw new CommitFailedException(
+            "Transaction commit failed with status: %s, extraInfo: %s",
+            result.getReturnStatus(), result.getExtraInformation());
+      }
+    } catch (RuntimeException e) {
+      // Any failure before a successful commit may have written metadata files to storage;
+      // remove them so aborted transactions don't leave orphans.
+      cleanupWrittenMetadataFiles(state.writtenMetadataFiles());
+      throw e;
+    } finally {
+      // Restore the real metastore even if processing threw before the in-try restore above.
+      localCatalog.setMetaStoreManager(metaStoreManager());
     }
 
-    // It is now safe to delete removed metadata files for all tables that were part of
-    // this transaction (if the table has write.metadata.delete-after-commit.enabled).
-    // Because we reach here, the DB pointers have been updated to the new metadata.
+    // Persistence committed; now it's safe to delete removed metadata files (for tables with
+    // write.metadata.delete-after-commit.enabled).
     for (MetadataFileCleanup cleanup : pendingCleanups) {
       CatalogUtil.deleteRemovedMetadataFiles(
           cleanup.io(), cleanup.baseMetadata(), cleanup.newMetadata());
     }
 
-    eventAttributeMap().put(EventAttributes.TABLE_METADATAS, tableMetadataObjs);
+    eventAttributeMap().put(EventAttributes.TABLE_METADATAS, state.tableMetadataObjs);
+  }
+
+  /** Container for state built during the workspace loop and consumed by later phases. */
+  private static final class TransactionState {
+    final List<TableMetadata> tableMetadataObjs = new ArrayList<>();
+    final List<Map.Entry<TableIdentifier, TableMetadata>> createEntries = new ArrayList<>();
+    final List<Map.Entry<TableIdentifier, TableMetadata>> locationChangedUpdates =
+        new ArrayList<>();
+
+    /** Metadata files written during the loop; deleted on failure. */
+    final List<FileToDelete> writtenMetadataFiles = new ArrayList<>();
+
+    List<FileToDelete> writtenMetadataFiles() {
+      return writtenMetadataFiles;
+    }
+  }
+
+  /**
+   * Processes a single create in the transaction workspace. Rejects anything other than exactly one
+   * {@link UpdateTableRequest} carrying {@code AssertTableDoesNotExist}, then delegates to {@link
+   * CatalogHandlerUtils#create}.
+   */
+  private void processCreateInTransaction(
+      LocalIcebergCatalog localCatalog,
+      TableIdentifier tableIdentifier,
+      List<UpdateTableRequest> changes,
+      TransactionState state) {
+    if (changes.size() != 1) {
+      throw new BadRequestException(
+          "Invalid transaction: table '%s' has %d change requests; a create must be"
+              + " expressed as a single UpdateTableRequest",
+          tableIdentifier, changes.size());
+    }
+    // Fail fast so an existing-table create surfaces as AlreadyExistsException rather than
+    // the CommitFailedException raised by AssertTableDoesNotExist against non-null metadata.
+    if (baseCatalog.tableExists(tableIdentifier)) {
+      throw alreadyExistsExceptionForTableLikeEntity(
+          tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
+    }
+
+    UpdateTableRequest createRequest = applyUpdateFilters(changes.get(0));
+    TableOperations tableOps = localCatalog.newTableOps(tableIdentifier);
+    TableMetadata createdMetadata = catalogHandlerUtils().create(tableOps, createRequest);
+
+    state.tableMetadataObjs.add(createdMetadata);
+    state.createEntries.add(Map.entry(tableIdentifier, createdMetadata));
+    // Track the newly-written metadata file so failure paths can clean it up.
+    if (createdMetadata.metadataFileLocation() != null) {
+      state.writtenMetadataFiles.add(
+          new FileToDelete(tableOps.io(), createdMetadata.metadataFileLocation()));
+    }
+  }
+
+  /**
+   * Processes one table's non-create updates in the transaction workspace. Requirements are
+   * validated against the running metadata so conflicts across multiple changes to the same table
+   * are surfaced.
+   */
+  private void processUpdateInTransaction(
+      TableIdentifier tableIdentifier, List<UpdateTableRequest> changes, TransactionState state) {
+    Table table = baseCatalog.loadTable(tableIdentifier);
+    if (!(table instanceof BaseTable baseTable)) {
+      throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+    }
+
+    TableOperations tableOps = baseTable.operations();
+    TableMetadata baseMetadata = tableOps.current();
+
+    TableMetadata currentMetadata = baseMetadata;
+    for (UpdateTableRequest change : changes) {
+      UpdateTableRequest filteredChange = applyUpdateFilters(change);
+      final TableMetadata metadataForValidation = currentMetadata;
+      filteredChange.requirements().forEach(req -> req.validate(metadataForValidation));
+
+      TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(currentMetadata);
+      for (MetadataUpdate singleUpdate : filteredChange.updates()) {
+        if (singleUpdate instanceof MetadataUpdate.SetLocation setLocation) {
+          if (!currentMetadata.location().equals(setLocation.location())
+              && !realmConfig().getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {
+            throw new BadRequestException(
+                "Unsupported operation: commitTransaction containing SetLocation"
+                    + " for table '%s' and new location '%s'",
+                filteredChange.identifier(), setLocation.location());
+          }
+        }
+        singleUpdate.applyTo(metadataBuilder);
+      }
+      currentMetadata = metadataBuilder.build();
+    }
+
+    if (!currentMetadata.changes().isEmpty()) {
+      tableOps.commit(baseMetadata, currentMetadata);
+      // Track the newly-written metadata file for cleanup on failure.
+      if (currentMetadata.metadataFileLocation() != null) {
+        state.writtenMetadataFiles.add(
+            new FileToDelete(tableOps.io(), currentMetadata.metadataFileLocation()));
+      }
+    }
+
+    if (StorageUtil.locationsChanged(baseMetadata, currentMetadata)) {
+      state.locationChangedUpdates.add(Map.entry(tableIdentifier, currentMetadata));
+    }
+    state.tableMetadataObjs.add(currentMetadata);
+  }
+
+  /** Runs deferred location validations against the real metastore after the workspace loop. */
+  private void validateDeferredLocations(LocalIcebergCatalog localCatalog, TransactionState state) {
+    if (!realmConfig()
+        .getConfig(FeatureConfiguration.ALLOW_TABLE_LOCATION_OVERLAP, getResolvedCatalogEntity())) {
+      StorageUtil.validateNoOverlapWithinBatch(
+          Stream.concat(state.createEntries.stream(), state.locationChangedUpdates.stream())
+              .toList());
+    }
+    for (Map.Entry<TableIdentifier, TableMetadata> entry : state.createEntries) {
+      localCatalog.validateStagedTableCreate(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<TableIdentifier, TableMetadata> entry : state.locationChangedUpdates) {
+      localCatalog.validateTableLocationUpdate(entry.getKey(), entry.getValue());
+    }
   }
 
   private record FileToDelete(FileIO io, String location) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -105,10 +105,10 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.core.persistence.MetaStoreChangeSet;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.TransactionWorkspaceMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.EntitiesResult;
-import org.apache.polaris.core.persistence.dao.entity.EntityWithPath;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
@@ -1429,13 +1429,14 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
       localCatalog.setMetaStoreManager(metaStoreManager());
       validateDeferredLocations(localCatalog, state);
 
-      List<EntityWithPath> pendingCreations = transactionMetaStoreManager.getPendingCreations();
-      List<EntityWithPath> pendingUpdates = transactionMetaStoreManager.getPendingUpdates();
+      MetaStoreChangeSet changeSet =
+          MetaStoreChangeSet.ofBatch(
+              transactionMetaStoreManager.getPendingCreations(),
+              transactionMetaStoreManager.getPendingUpdates());
 
       EntitiesResult result =
           metaStoreManager()
-              .commitTransactionBatch(
-                  callContext().getPolarisCallContext(), pendingCreations, pendingUpdates);
+              .commitTransactionBatch(callContext().getPolarisCallContext(), changeSet);
       if (!result.isSuccess()) {
         // TODO: Retries on failure
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -1276,6 +1276,37 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   /**
+   * Validates location overlap for an existing table whose locations changed. Unlike {@link
+   * #validateStagedTableCreate}, this uses the parent (namespace) path for resolution since the
+   * table already exists and its resolved path includes the table entity itself.
+   */
+  void validateTableLocationUpdate(TableIdentifier tableIdentifier, TableMetadata tableMetadata) {
+    PolarisResolvedPathWrapper resolvedTableEntities =
+        resolvedEntityView.getPassthroughResolvedPath(
+            ResolvedPathKey.ofTableLike(tableIdentifier), PolarisEntitySubType.ICEBERG_TABLE);
+    PolarisResolvedPathWrapper resolvedStorageEntity =
+        resolvedTableEntities != null
+            ? resolvedTableEntities
+            : resolvedEntityView.getResolvedPath(
+                ResolvedPathKey.ofNamespace(tableIdentifier.namespace()));
+    if (resolvedStorageEntity == null) {
+      throw noSuchNamespaceException(tableIdentifier.namespace());
+    }
+    Set<String> dataLocations =
+        StorageUtil.getLocationsUsedByTable(tableMetadata.location(), tableMetadata.properties());
+    // Use parent path (namespace) for overlap check — the table itself is not a sibling
+    List<PolarisEntity> resolvedNamespace =
+        resolvedTableEntities != null
+            ? resolvedTableEntities.getRawParentPath()
+            : resolvedStorageEntity.getRawFullPath();
+    PolarisEntity storageLeafEntity = resolvedStorageEntity.getRawLeafEntity();
+    dataLocations.forEach(
+        location ->
+            validateNoLocationOverlap(
+                catalogEntity, tableIdentifier, resolvedNamespace, location, storageLeafEntity));
+  }
+
+  /**
    * Validates that the specified {@code location} is valid for whatever storage config is found for
    * this TableLike's parent hierarchy.
    */

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -1376,9 +1377,9 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
 
     return authzTestsBuilder("commitTransaction")
         .action(() -> newHandler().commitTransaction(req))
+        .shouldPassWith(PolarisPrivilege.TABLE_WRITE_PROPERTIES)
+        .shouldPassWith(PolarisPrivilege.TABLE_WRITE_DATA)
         .shouldPassWith(PolarisPrivilege.TABLE_FULL_METADATA)
-        .shouldPassWith(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_DATA)
-        .shouldPassWith(PolarisPrivilege.TABLE_CREATE, PolarisPrivilege.TABLE_WRITE_PROPERTIES)
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_CONTENT)
         .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_METADATA)
         .createTests();
@@ -1431,18 +1432,86 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         newRootAdminService()
             .grantPrivilegeOnTableToRole(
                 CATALOG_NAME, CATALOG_ROLE1, TABLE_NS2_1, PolarisPrivilege.TABLE_WRITE_PROPERTIES));
+    newHandler().commitTransaction(req);
+  }
+
+  @Test
+  public void testCommitTransactionStagedCreateRequiresTableCreateOnNamespace() {
+    // A staged-create is identified by having AssertTableDoesNotExist in requirements.
+    // The updates must include enough metadata to create a valid table.
+    TableIdentifier stagedTable = TableIdentifier.of(NS1, "staged_new_table");
+    List<MetadataUpdate> createUpdates =
+        List.of(
+            new MetadataUpdate.AssignUUID(java.util.UUID.randomUUID().toString()),
+            new MetadataUpdate.SetLocation("file:///tmp/authz/ns1/staged_new_table"),
+            new MetadataUpdate.AddSchema(SCHEMA),
+            new MetadataUpdate.SetCurrentSchema(0),
+            new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()),
+            new MetadataUpdate.SetDefaultPartitionSpec(0),
+            new MetadataUpdate.AddSortOrder(SortOrder.unsorted()),
+            new MetadataUpdate.SetDefaultSortOrder(0));
+    UpdateTableRequest stagedCreateChange =
+        UpdateTableRequest.create(
+            stagedTable, List.of(new UpdateRequirement.AssertTableDoesNotExist()), createUpdates);
+
+    CommitTransactionRequest req = new CommitTransactionRequest(List.of(stagedCreateChange));
+
+    // Without TABLE_CREATE on the namespace, should fail with ForbiddenException
     Assertions.assertThatThrownBy(() -> newHandler().commitTransaction(req))
         .isInstanceOf(ForbiddenException.class);
 
-    // Also grant TABLE_CREATE directly on TABLE_NS2_1
-    // TODO: If we end up having fine-grained differentiation between updateForStagedCreate
-    // and update, then this one should only be TABLE_CREATE on the *parent* of this last table
-    // and the table shouldn't exist.
+    // Grant TABLE_CREATE on NS1 (the parent namespace of the staged table)
     assertSuccess(
         newRootAdminService()
-            .grantPrivilegeOnTableToRole(
-                CATALOG_NAME, CATALOG_ROLE1, TABLE_NS2_1, PolarisPrivilege.TABLE_CREATE));
-    newHandler().commitTransaction(req);
+            .grantPrivilegeOnNamespaceToRole(
+                CATALOG_NAME, CATALOG_ROLE1, NS1, PolarisPrivilege.TABLE_CREATE));
+
+    // Now auth passes and the staged-create commits successfully
+    Assertions.assertThatCode(() -> newHandler().commitTransaction(req)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testCommitTransactionMixedUpdatesAndStagedCreates() {
+    // Mix of regular updates (on existing tables) and a staged-create
+    TableIdentifier stagedTable = TableIdentifier.of(NS1, "staged_mixed_table");
+    List<MetadataUpdate> createUpdates =
+        List.of(
+            new MetadataUpdate.AssignUUID(java.util.UUID.randomUUID().toString()),
+            new MetadataUpdate.SetLocation("file:///tmp/authz/ns1/staged_mixed_table"),
+            new MetadataUpdate.AddSchema(SCHEMA),
+            new MetadataUpdate.SetCurrentSchema(0),
+            new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()),
+            new MetadataUpdate.SetDefaultPartitionSpec(0),
+            new MetadataUpdate.AddSortOrder(SortOrder.unsorted()),
+            new MetadataUpdate.SetDefaultSortOrder(0));
+    UpdateTableRequest regularUpdate = UpdateTableRequest.create(TABLE_NS1_1, List.of(), List.of());
+    UpdateTableRequest stagedCreateChange =
+        UpdateTableRequest.create(
+            stagedTable, List.of(new UpdateRequirement.AssertTableDoesNotExist()), createUpdates);
+
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(regularUpdate, stagedCreateChange));
+
+    // Without any privileges: ForbiddenException
+    Assertions.assertThatThrownBy(() -> newHandler().commitTransaction(req))
+        .isInstanceOf(ForbiddenException.class);
+
+    // Grant TABLE_WRITE_PROPERTIES on NS1 (covers the regular update on TABLE_NS1_1)
+    assertSuccess(
+        newRootAdminService()
+            .grantPrivilegeOnNamespaceToRole(
+                CATALOG_NAME, CATALOG_ROLE1, NS1, PolarisPrivilege.TABLE_WRITE_PROPERTIES));
+    // Still fails - staged-create needs TABLE_CREATE on namespace
+    Assertions.assertThatThrownBy(() -> newHandler().commitTransaction(req))
+        .isInstanceOf(ForbiddenException.class);
+
+    // Grant TABLE_CREATE on NS1 (covers the staged-create)
+    assertSuccess(
+        newRootAdminService()
+            .grantPrivilegeOnNamespaceToRole(
+                CATALOG_NAME, CATALOG_ROLE1, NS1, PolarisPrivilege.TABLE_CREATE));
+    // Both auth checks pass and the transaction commits successfully
+    Assertions.assertThatCode(() -> newHandler().commitTransaction(req)).doesNotThrowAnyException();
   }
 
   @TestFactory

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
@@ -1037,7 +1037,7 @@ public class CommitTransactionEventTest {
                             return invocation.callRealMethod();
                           })
                       .when(spy)
-                      .commitTransactionBatch(Mockito.any(), Mockito.any(), Mockito.any());
+                      .commitTransactionBatch(Mockito.any(), Mockito.any());
                   return spy;
                 })
             .build();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
@@ -35,16 +35,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SnapshotRefType;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogProperties;
 import org.apache.polaris.core.admin.model.CreateCatalogRequest;
@@ -287,6 +299,459 @@ public class CommitTransactionEventTest {
             services.securityContext());
   }
 
+  /**
+   * Tests the full Iceberg REST client staged-create flow as documented in the IRC spec:
+   *
+   * <ol>
+   *   <li>Client calls POST /namespaces/{ns}/tables with stageCreate=true (server initializes
+   *       metadata but does NOT create the table)
+   *   <li>Client constructs updates locally (e.g., writes data files)
+   *   <li>Client calls POST /transactions/commit with AssertTableDoesNotExist requirement
+   * </ol>
+   *
+   * <p>See: open-api/rest-catalog-open-api.yaml (createTable endpoint): "If stage-create is true,
+   * the table is not created, but table metadata is initialized and returned. The service should
+   * prepare as needed for a commit to the table commit endpoint to complete the create
+   * transaction."
+   *
+   * <p>Client reference: RESTSessionCatalog.stageCreate() → RESTTableOperations.commit() with
+   * UpdateType.CREATE → UpdateRequirements.forCreateTable() generates AssertTableDoesNotExist →
+   * sent via RESTSessionCatalog.commitTransaction() as CommitTransactionRequest.
+   */
+  @Test
+  void testFullStagedCreateFlowMatchingIcebergRestClient() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    String tableName = "irc-staged-table";
+    String tableLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, tableName);
+
+    // Step 1: Client calls createTable with stageCreate=true.
+    // The server initializes metadata and returns it, but does NOT persist the table.
+    CreateTableRequest stageCreateRequest =
+        CreateTableRequest.builder()
+            .withName(tableName)
+            .withLocation(tableLocation)
+            .withSchema(SCHEMA)
+            .stageCreate()
+            .build();
+
+    LoadTableResponse stageResponse;
+    try (Response response =
+        testServices
+            .restApi()
+            .createTable(
+                catalog,
+                namespace,
+                stageCreateRequest,
+                null,
+                IDEMPOTENCY_KEY,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      stageResponse = (LoadTableResponse) response.getEntity();
+    }
+
+    // Verify: table is NOT yet loadable (not persisted)
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .loadTable(
+                        catalog,
+                        namespace,
+                        tableName,
+                        null,
+                        null,
+                        null,
+                        null,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(NoSuchTableException.class);
+
+    // Step 2: Client builds the commit request with AssertTableDoesNotExist + all metadata
+    // updates. This is exactly what RESTTableOperations.commit() does for UpdateType.CREATE:
+    // it calls UpdateRequirements.forCreateTable(updates) which produces AssertTableDoesNotExist,
+    // then sends via CommitTransactionRequest.
+    TableMetadata stagedMetadata = stageResponse.tableMetadata();
+    List<MetadataUpdate> createUpdates =
+        List.of(
+            new MetadataUpdate.AssignUUID(stagedMetadata.uuid()),
+            new MetadataUpdate.SetLocation(stagedMetadata.location()),
+            new MetadataUpdate.AddSchema(SCHEMA),
+            new MetadataUpdate.SetCurrentSchema(0),
+            new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()),
+            new MetadataUpdate.SetDefaultPartitionSpec(0),
+            new MetadataUpdate.AddSortOrder(SortOrder.unsorted()),
+            new MetadataUpdate.SetDefaultSortOrder(0));
+
+    UpdateTableRequest commitRequest =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, tableName),
+            List.of(new UpdateRequirement.AssertTableDoesNotExist()),
+            createUpdates);
+
+    // Step 3: Client calls commitTransaction
+    CommitTransactionRequest txnRequest = new CommitTransactionRequest(List.of(commitRequest));
+    try (Response response =
+        testServices
+            .restApi()
+            .commitTransaction(
+                catalog,
+                txnRequest,
+                IDEMPOTENCY_KEY,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+    }
+
+    // Verify: table now exists and matches the staged metadata
+    try (Response loadResponse =
+        testServices
+            .restApi()
+            .loadTable(
+                catalog,
+                namespace,
+                tableName,
+                null,
+                null,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(loadResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      LoadTableResponse loadTableResponse = (LoadTableResponse) loadResponse.getEntity();
+      assertThat(loadTableResponse.tableMetadata().location()).isEqualTo(tableLocation);
+      assertThat(loadTableResponse.tableMetadata().schema().columns()).isNotEmpty();
+    }
+  }
+
+  @Test
+  void testStagedCreateViaCommitTransaction() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // Table 1: empty staged-create (no data files)
+    String emptyTableName = "staged-empty-table";
+    String emptyTableLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, emptyTableName);
+    UpdateTableRequest emptyTableCreate =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, emptyTableName), emptyTableLocation);
+
+    // Table 2: staged-create with a snapshot (simulating stageCreate → write → commit flow).
+    // The server doesn't read manifest/data files during commit — it only persists metadata.
+    String dataTableName = "staged-data-table";
+    String dataTableLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, dataTableName);
+    String manifestListPath = dataTableLocation + "/metadata/snap-1-manifest-list.avro";
+    long snapshotId = 1L;
+
+    Snapshot snapshot =
+        SnapshotParser.fromJson(
+            String.format(
+                "{\"snapshot-id\":%d,\"timestamp-ms\":%d,\"summary\":{\"operation\":\"append\"},"
+                    + "\"manifest-list\":\"%s\",\"schema-id\":0}",
+                snapshotId, System.currentTimeMillis(), manifestListPath));
+
+    List<MetadataUpdate> dataTableUpdates =
+        List.of(
+            new MetadataUpdate.AssignUUID(UUID.randomUUID().toString()),
+            new MetadataUpdate.SetLocation(dataTableLocation),
+            new MetadataUpdate.AddSchema(SCHEMA),
+            new MetadataUpdate.SetCurrentSchema(0),
+            new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()),
+            new MetadataUpdate.SetDefaultPartitionSpec(0),
+            new MetadataUpdate.AddSortOrder(SortOrder.unsorted()),
+            new MetadataUpdate.SetDefaultSortOrder(0),
+            new MetadataUpdate.AddSnapshot(snapshot),
+            new MetadataUpdate.SetSnapshotRef(
+                SnapshotRef.MAIN_BRANCH, snapshotId, SnapshotRefType.BRANCH, null, null, null));
+
+    UpdateTableRequest dataTableCreate =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, dataTableName),
+            List.of(new UpdateRequirement.AssertTableDoesNotExist()),
+            dataTableUpdates);
+
+    // Commit both tables together
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(emptyTableCreate, dataTableCreate));
+
+    try (Response response =
+        testServices
+            .restApi()
+            .commitTransaction(
+                catalog,
+                req,
+                IDEMPOTENCY_KEY,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+    }
+
+    // Verify the empty table was created with no snapshot
+    try (Response loadResponse =
+        testServices
+            .restApi()
+            .loadTable(
+                catalog,
+                namespace,
+                emptyTableName,
+                null,
+                null,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(loadResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      LoadTableResponse loadTableResponse = (LoadTableResponse) loadResponse.getEntity();
+      assertThat(loadTableResponse.tableMetadata().currentSnapshot()).isNull();
+    }
+
+    // Verify the data table was created with the snapshot visible
+    try (Response loadResponse =
+        testServices
+            .restApi()
+            .loadTable(
+                catalog,
+                namespace,
+                dataTableName,
+                null,
+                null,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(loadResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      LoadTableResponse loadTableResponse = (LoadTableResponse) loadResponse.getEntity();
+      TableMetadata loadedMetadata = loadTableResponse.tableMetadata();
+      assertThat(loadedMetadata.currentSnapshot()).isNotNull();
+      assertThat(loadedMetadata.currentSnapshot().snapshotId()).isEqualTo(snapshotId);
+      assertThat(loadedMetadata.currentSnapshot().manifestListLocation())
+          .isEqualTo(manifestListPath);
+    }
+  }
+
+  @Test
+  void testMixedStagedCreateAndUpdateViaCommitTransaction() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // First, create an existing table that we'll update in the same transaction
+    String existingTableName = "existing-table-for-mixed";
+    createTable(testServices, existingTableName, catalogLocation);
+
+    // Build a staged-create for a brand new table
+    String newTableName = "staged-mixed-new-table";
+    String newTableLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, newTableName);
+
+    UpdateTableRequest stagedCreateChange =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, newTableName), newTableLocation);
+
+    // Build a regular update for the existing table (set a property)
+    UpdateTableRequest regularUpdate =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, existingTableName),
+            List.of(),
+            List.of(new MetadataUpdate.SetProperties(Map.of("key1", "value1"))));
+
+    // Commit both in the same transaction: regular update + staged-create
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(regularUpdate, stagedCreateChange));
+
+    try (Response response =
+        testServices
+            .restApi()
+            .commitTransaction(
+                catalog,
+                req,
+                IDEMPOTENCY_KEY,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+    }
+
+    // Verify the new table was created
+    try (Response listResponse =
+        testServices
+            .restApi()
+            .listTables(
+                catalog,
+                namespace,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(listResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      ListTablesResponse tablesResponse = (ListTablesResponse) listResponse.getEntity();
+      assertThat(tablesResponse.identifiers())
+          .contains(TableIdentifier.of(namespace, newTableName));
+    }
+  }
+
+  @Test
+  void testStagedCreateFailsWhenTableAlreadyExists() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // Create an existing table first
+    String existingTableName = "already-existing-table";
+    createTable(testServices, existingTableName, catalogLocation);
+
+    // Now attempt a staged-create for the same table via commitTransaction
+    String tableLocation =
+        String.format("%s/%s/%s/%s-new", catalogLocation, catalog, namespace, existingTableName);
+
+    UpdateTableRequest stagedCreateChange =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, existingTableName), tableLocation);
+
+    CommitTransactionRequest req = new CommitTransactionRequest(List.of(stagedCreateChange));
+
+    // Should fail because the table already exists
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(AlreadyExistsException.class);
+  }
+
+  @Test
+  void testStagedCreateFailsOnLocationOverlapWithExistingTable() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // Create an existing table at a specific location
+    String existingTableName = "overlap-existing-table";
+    String sharedLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, existingTableName);
+    createTable(testServices, existingTableName, catalogLocation);
+
+    // Attempt a staged-create for a DIFFERENT table but at the SAME location
+    String newTableName = "overlap-new-table";
+
+    UpdateTableRequest stagedCreateChange =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, newTableName), sharedLocation);
+
+    CommitTransactionRequest req = new CommitTransactionRequest(List.of(stagedCreateChange));
+
+    // Should fail due to location overlap with existing table
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("conflicts with existing");
+  }
+
+  /**
+   * Two creates in the same commit that target overlapping locations must be rejected. The
+   * persistence-layer overlap check only looks at committed siblings, so peers created within the
+   * same batch are invisible to it — commitTransaction has to catch the collision itself.
+   */
+  @Test
+  void testStagedCreateFailsOnLocationOverlapWithinBatch() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // Two brand-new tables staged at the same location.
+    String sharedLocation =
+        String.format("%s/%s/%s/shared-location", catalogLocation, catalog, namespace);
+
+    UpdateTableRequest stagedCreateA =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, "batch-overlap-a"), sharedLocation);
+    UpdateTableRequest stagedCreateB =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, "batch-overlap-b"), sharedLocation);
+
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(stagedCreateA, stagedCreateB));
+
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("locations overlap");
+  }
+
+  @Test
+  void testRollbackOnFailedUpdate_stagedCreateNotPersisted() {
+    TestServices testServices = createTestServices();
+    createCatalogAndNamespace(testServices, Map.of(), catalogLocation);
+
+    // Create an existing table that we'll attempt to update with a failing requirement
+    String existingTableName = "rollback-existing-table";
+    createTable(testServices, existingTableName, catalogLocation);
+
+    // Build a staged-create for a brand new table
+    String newTableName = "rollback-new-table";
+    String newTableLocation =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, newTableName);
+    UpdateTableRequest stagedCreateChange =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, newTableName), newTableLocation);
+
+    // Build a failing update for the existing table (schema ID -1 does not exist)
+    UpdateTableRequest failingUpdate =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, existingTableName),
+            List.of(new UpdateRequirement.AssertCurrentSchemaID(-1)),
+            List.of(new MetadataUpdate.SetProperties(Map.of("key1", "value1"))));
+
+    // Commit both: staged-create + failing update
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(stagedCreateChange, failingUpdate));
+
+    // The transaction should fail due to the bad schema requirement on the existing table
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("current schema");
+
+    // Verify the staged-create was NOT persisted — the table should not exist
+    try (Response listResponse =
+        testServices
+            .restApi()
+            .listTables(
+                catalog,
+                namespace,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(listResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      ListTablesResponse tablesResponse = (ListTablesResponse) listResponse.getEntity();
+      assertThat(tablesResponse.identifiers())
+          .doesNotContain(TableIdentifier.of(namespace, newTableName));
+    }
+  }
+
   private void createCatalogAndNamespace(
       TestServices services, Map<String, String> catalogConfig, String catalogLocation) {
     CatalogProperties.Builder propertiesBuilder =
@@ -386,6 +851,66 @@ public class CommitTransactionEventTest {
     }
   }
 
+  @Test
+  void testUpdateChangingWriteDataPathFailsOnOverlap() {
+    TestServices testServices = createTestServices();
+    // Enable unstructured table locations so that storage validation passes (the write.data.path
+    // is within the catalog's allowed locations) — this isolates the overlap validation.
+    createCatalogAndNamespace(
+        testServices, Map.of("allow.unstructured.table.location", "true"), catalogLocation);
+
+    // Create two tables at distinct locations
+    String table1Name = "update-overlap-table1";
+    String table2Name = "update-overlap-table2";
+    createTable(testServices, table1Name, catalogLocation);
+    createTable(testServices, table2Name, catalogLocation);
+
+    // Try to change table1's write.data.path to point at table2's location via commitTransaction.
+    // With unstructured locations allowed, storage validation passes — but our overlap check
+    // should catch this.
+    String table2Location =
+        String.format("%s/%s/%s/%s", catalogLocation, catalog, namespace, table2Name);
+
+    UpdateTableRequest updateWithOverlappingWritePath =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, table1Name),
+            List.of(),
+            List.of(new MetadataUpdate.SetProperties(Map.of("write.data.path", table2Location))));
+
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(updateWithOverlappingWritePath));
+
+    // Should fail due to location overlap — write.data.path conflicts with table2's location
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("conflicts with existing");
+  }
+
+  private UpdateTableRequest buildStagedCreateRequest(
+      TableIdentifier tableIdentifier, String location) {
+    List<MetadataUpdate> createUpdates =
+        List.of(
+            new MetadataUpdate.AssignUUID(UUID.randomUUID().toString()),
+            new MetadataUpdate.SetLocation(location),
+            new MetadataUpdate.AddSchema(SCHEMA),
+            new MetadataUpdate.SetCurrentSchema(0),
+            new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()),
+            new MetadataUpdate.SetDefaultPartitionSpec(0),
+            new MetadataUpdate.AddSortOrder(SortOrder.unsorted()),
+            new MetadataUpdate.SetDefaultSortOrder(0));
+    return UpdateTableRequest.create(
+        tableIdentifier, List.of(new UpdateRequirement.AssertTableDoesNotExist()), createUpdates);
+  }
+
   private CommitTransactionRequest generateCommitTransactionRequest(
       boolean shouldFail, String table1Name, String table2Name) {
     List<UpdateRequirement> updateRequirements;
@@ -476,4 +1001,122 @@ public class CommitTransactionEventTest {
 
   // Positive test added in AbstractLocalIcebergCatalogTest to avoid making this event-focused test
   // class depend on full transaction setup that can be slow/heavy in some envs.
+
+  /**
+   * A create+update batch whose persistence step fails must leave neither change visible and must
+   * clean up the newly-written metadata files.
+   */
+  @Test
+  void testMixedBatchRollbackOnPersistenceFailure(@TempDir Path tempDir) throws Exception {
+    String location = tempDir.toAbsolutePath().toUri().toString();
+    if (location.endsWith("/")) {
+      location = location.substring(0, location.length() - 1);
+    }
+
+    // Force commitTransactionBatch to return a CAS-failure after the workspace loop completes.
+    AtomicBoolean shouldFail = new AtomicBoolean(false);
+    TestServices testServices =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .metaStoreManagerDecorator(
+                msm -> {
+                  org.apache.polaris.core.persistence.PolarisMetaStoreManager spy =
+                      Mockito.spy(msm);
+                  Mockito.doAnswer(
+                          invocation -> {
+                            if (shouldFail.get()) {
+                              return new EntitiesResult(
+                                  BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED,
+                                  "simulated CAS failure");
+                            }
+                            return invocation.callRealMethod();
+                          })
+                      .when(spy)
+                      .commitTransactionBatch(Mockito.any(), Mockito.any(), Mockito.any());
+                  return spy;
+                })
+            .build();
+
+    createCatalogAndNamespace(testServices, Map.of(), location);
+
+    // Pre-create an existing table we will attempt to update in the same batch.
+    String existingTableName = "mixed-rollback-existing";
+    createTable(testServices, existingTableName, location);
+
+    // Capture the pre-transaction metadata file set so we can compare afterwards.
+    Set<Path> metadataFilesBefore = metadataFiles(tempDir);
+
+    String newTableName = "mixed-rollback-new";
+    String newTableLocation =
+        String.format("%s/%s/%s/%s", location, catalog, namespace, newTableName);
+    UpdateTableRequest stagedCreate =
+        buildStagedCreateRequest(TableIdentifier.of(namespace, newTableName), newTableLocation);
+    UpdateTableRequest regularUpdate =
+        UpdateTableRequest.create(
+            TableIdentifier.of(namespace, existingTableName),
+            List.of(),
+            List.of(new MetadataUpdate.SetProperties(Map.of("rollback-key", "rollback-value"))));
+
+    CommitTransactionRequest req =
+        new CommitTransactionRequest(List.of(stagedCreate, regularUpdate));
+
+    shouldFail.set(true);
+    assertThatThrownBy(
+            () ->
+                testServices
+                    .restApi()
+                    .commitTransaction(
+                        catalog,
+                        req,
+                        IDEMPOTENCY_KEY,
+                        testServices.realmContext(),
+                        testServices.securityContext()))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Transaction commit failed");
+
+    // Create was rolled back: the new table should not be listed.
+    try (Response listResponse =
+        testServices
+            .restApi()
+            .listTables(
+                catalog,
+                namespace,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(listResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      ListTablesResponse tablesResponse = (ListTablesResponse) listResponse.getEntity();
+      assertThat(tablesResponse.identifiers())
+          .doesNotContain(TableIdentifier.of(namespace, newTableName));
+    }
+
+    // Update was rolled back: the existing table's properties must not carry the change.
+    try (Response loadResponse =
+        testServices
+            .restApi()
+            .loadTable(
+                catalog,
+                namespace,
+                existingTableName,
+                null,
+                null,
+                null,
+                null,
+                testServices.realmContext(),
+                testServices.securityContext())) {
+      assertThat(loadResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+      LoadTableResponse loadResp = (LoadTableResponse) loadResponse.getEntity();
+      assertThat(loadResp.tableMetadata().properties()).doesNotContainKey("rollback-key");
+    }
+
+    // Neither the create's newly-written metadata file nor the update's metadata file survive.
+    Set<Path> metadataFilesAfter = metadataFiles(tempDir);
+    assertThat(metadataFilesAfter).isEqualTo(metadataFilesBefore);
+  }
 }


### PR DESCRIPTION
Implement staged creates in the transaction workspace. Polaris previously rejected these and authorized
the whole batch with `TABLE_WRITE_PROPERTIES` + `TABLE_CREATE` on every
table identifier.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
