### PR TITLE
Fix ManifestFileCleanupTaskHandler to handle delete manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Generic table drop now accepts table-scoped `TABLE_DROP` privilege.
 - `TableCleanupTaskHandler` now clamps `TABLE_METADATA_CLEANUP_BATCH_SIZE` to at least 1. Previously a non-positive realm override caused an infinite loop (0) or `IllegalArgumentException` (<0) when splitting metadata files for cleanup.
 - Azure SAS tokens are now signed for the configured duration instead of a hardcoded 1 hour, so long jobs no longer fail with expired credentials.
+- `ManifestFileCleanupTaskHandler` now handles Iceberg v2 delete manifests in addition to data manifests. Previously, `DROP TABLE PURGE` on a v2 table that had been updated via merge-on-read DML left position-delete files and their manifests as orphans in object storage; the cleanup task failed silently because `ManifestFiles.read()` rejects delete manifests.
 
 ## [1.5.0]
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.StreamSupport;
-import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
@@ -81,27 +81,29 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
       return true;
     }
 
-    try (ManifestReader<DataFile> dataFiles = ManifestFiles.read(manifestFile, fileIO, null)) {
-      List<CompletableFuture<Void>> dataFileDeletes =
+    try (ManifestReader<? extends ContentFile<?>> reader =
+        openManifestReader(manifestFile, fileIO)) {
+      List<CompletableFuture<Void>> contentFileDeletes =
           StreamSupport.stream(
-                  Spliterators.spliteratorUnknownSize(dataFiles.iterator(), Spliterator.IMMUTABLE),
+                  Spliterators.spliteratorUnknownSize(reader.iterator(), Spliterator.IMMUTABLE),
                   false)
               .map(
                   file -> tryDelete(tableId, fileIO, manifestFile.path(), file.location(), null, 1))
               .toList();
       LOGGER.debug(
-          "Scheduled {} data files to be deleted from manifest {}",
-          dataFileDeletes.size(),
-          manifestFile.path());
+          "Scheduled {} content files to be deleted from manifest {} (content={})",
+          contentFileDeletes.size(),
+          manifestFile.path(),
+          manifestFile.content());
       try {
-        // wait for all data files to be deleted, then wait for the manifest itself to be deleted
-        CompletableFuture.allOf(dataFileDeletes.toArray(CompletableFuture[]::new))
+        // wait for all content files to be deleted, then wait for the manifest itself to be deleted
+        CompletableFuture.allOf(contentFileDeletes.toArray(CompletableFuture[]::new))
             .thenCompose(
                 (v) -> {
                   LOGGER
                       .atInfo()
                       .addKeyValue("manifestFile", manifestFile.path())
-                      .log("All data files in manifest deleted - deleting manifest");
+                      .log("All content files in manifest deleted - deleting manifest");
                   return tryDelete(
                       tableId, fileIO, manifestFile.path(), manifestFile.path(), null, 1);
                 })
@@ -109,10 +111,12 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
         return true;
       } catch (InterruptedException e) {
         LOGGER.error(
-            "Interrupted exception deleting data files from manifest {}", manifestFile.path(), e);
+            "Interrupted exception deleting content files from manifest {}",
+            manifestFile.path(),
+            e);
         throw new RuntimeException(e);
       } catch (ExecutionException e) {
-        LOGGER.error("Unable to delete data files from manifest {}", manifestFile.path(), e);
+        LOGGER.error("Unable to delete content files from manifest {}", manifestFile.path(), e);
         throw new RuntimeException(e);
       }
     } catch (IOException e) {
@@ -123,6 +127,16 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
       LOGGER.error("Failed to process manifest reader for {}", manifestFile.path(), e);
       throw new RuntimeException(e);
     }
+  }
+
+  // Iceberg requires distinct readers for data manifests (DataFile) and delete manifests
+  // (DeleteFile); using the wrong one throws IllegalArgumentException at read time.
+  private static ManifestReader<? extends ContentFile<?>> openManifestReader(
+      ManifestFile manifestFile, FileIO fileIO) {
+    return switch (manifestFile.content()) {
+      case DATA -> ManifestFiles.read(manifestFile, fileIO, null);
+      case DELETES -> ManifestFiles.readDeleteManifest(manifestFile, fileIO, null);
+    };
   }
 
   /** Serialized Task data sent from the {@link TableCleanupTaskHandler} */

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
@@ -160,6 +160,46 @@ class ManifestFileCleanupTaskHandlerTest {
   }
 
   @Test
+  public void testCleanupDeleteManifest() throws IOException {
+    FileIO fileIO =
+        new InMemoryFileIO() {
+          @Override
+          public void close() {
+            // no-op
+          }
+        };
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
+    ManifestFileCleanupTaskHandler handler = newManifestFileCleanupTaskHandler(fileIO);
+    String deleteFile1Path = "deleteFile1.parquet";
+    OutputFile deleteFile1 = fileIO.newOutputFile(deleteFile1Path);
+    PositionOutputStream out1 = deleteFile1.createOrOverwrite();
+    out1.write("position deletes".getBytes(UTF_8));
+    out1.close();
+    String deleteFile2Path = "deleteFile2.parquet";
+    OutputFile deleteFile2 = fileIO.newOutputFile(deleteFile2Path);
+    PositionOutputStream out2 = deleteFile2.createOrOverwrite();
+    out2.write("position deletes".getBytes(UTF_8));
+    out2.close();
+    ManifestFile manifestFile =
+        TaskTestUtils.deleteManifestFile(
+            fileIO, "deleteManifest1.avro", 100L, deleteFile1Path, deleteFile2Path);
+    TaskEntity task =
+        new TaskEntity.Builder()
+            .withTaskType(AsyncTaskType.MANIFEST_FILE_CLEANUP)
+            .withData(
+                ManifestFileCleanupTaskHandler.ManifestCleanupTask.buildFrom(
+                    tableIdentifier, manifestFile))
+            .setName(UUID.randomUUID().toString())
+            .build();
+    task = addTaskLocation(task);
+    assertThatPredicate(handler::canHandleTask).accepts(task);
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(deleteFile1Path);
+    assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(deleteFile2Path);
+    assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(manifestFile.path());
+  }
+
+  @Test
   public void testCleanupFilesWithRetries() throws IOException {
     Map<String, AtomicInteger> retryCounter = new HashMap<>();
     FileIO fileIO =

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskTestUtils.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskTestUtils.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.ImmutableGenericPartitionStatisticsFile;
@@ -70,6 +72,27 @@ public class TaskTestUtils {
               .withFileSizeInBytes(100L)
               .withFormat(FileFormat.PARQUET)
               .withPath(dataFile)
+              .withRecordCount(10)
+              .build());
+    }
+    writer.close();
+    return writer.toManifestFile();
+  }
+
+  static ManifestFile deleteManifestFile(
+      FileIO fileIO, String manifestFilePath, long snapshotId, String... deleteFiles)
+      throws IOException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(
+            2, spec, fileIO.newOutputFile(manifestFilePath), snapshotId);
+    for (String deleteFile : deleteFiles) {
+      writer.add(
+          FileMetadata.deleteFileBuilder(spec)
+              .ofPositionDeletes()
+              .withFormat(FileFormat.PARQUET)
+              .withPath(deleteFile)
+              .withFileSizeInBytes(100L)
               .withRecordCount(10)
               .build());
     }


### PR DESCRIPTION
Iceberg v2 delete manifests caused the cleanup task to fail silently because ManifestFiles.read() rejects them with IllegalArgumentException. Route to ManifestFiles.readDeleteManifest() when the manifest's content type is DELETES, so DROP TABLE PURGE no longer leaves position-delete files and their manifests as orphans in object storage.

## Summary

Fix #4891: `ManifestFileCleanupTaskHandler` crashed silently on Iceberg v2 delete
manifests, leaving position-delete files as orphans in object storage after
`DROP TABLE PURGE`.

`cleanUpManifestFile()` unconditionally called `ManifestFiles.read()`, which
rejects delete manifests (`content() == DELETES`) with `IllegalArgumentException`.
The exception is a `RuntimeException` and was not caught, so the async cleanup
task failed silently while the DROP returned success to the client.

## Changes

- Extract `openManifestReader()` helper that switches on `manifestFile.content()`
  to route DATA manifests to `ManifestFiles.read()` and DELETES manifests to
  `ManifestFiles.readDeleteManifest()`.
- Use `ManifestReader<? extends ContentFile<?>>` so iteration works for both
  `DataFile` and `DeleteFile`.
- Update log messages to refer to "content files" instead of "data files".
- Add `TaskTestUtils.deleteManifestFile()` helper to write a v2 delete manifest
  with position-delete file entries.
- Add `testCleanupDeleteManifest` covering the new code path.
- Update CHANGELOG `[Unreleased] / Fixes`.

## Validation

- New unit test (`testCleanupDeleteManifest`) reproduces the bug scenario and
  passes with the fix. All existing tests in `ManifestFileCleanupTaskHandlerTest`
  still pass (no regression for data manifests).
- End-to-end verified on a downstream deployment (Trino + Polaris + S3):
  v2 table → `DELETE … WHERE` → `DROP TABLE … PURGE` no longer leaves
  orphan files in the bucket.

## Checklist

- [x] 🛡️ Don't disclose security issues
- [x] 🔗 Clearly explained why the changes are needed: Fixes #4891
- [x] 🧪 Added unit test covering the new code path; e2e tested downstream
- [x] 💡 Comments added where helpful (helper rationale)
- [x] 🧾 Updated CHANGELOG.md
- [ ] 📚 site/content/in-dev/unreleased — N/A (restores documented behavior, no config/API change)

## AI assistance

Drafted with assistance from Claude Code; design, validation, and review
performed by me. End-to-end testing executed on a downstream deployment
under my control.

Fixes #4891