### PR TITLE
Exclude JBoss Log Manager from test classpaths in non-Quarkus modules

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -155,6 +155,12 @@ testing {
         implementation(testFixtures(project()))
         if (!plugins.hasPlugin("io.quarkus")) {
           implementation(requiredLib("logback-classic"))
+          // Exclude the JBoss SLF4J provider from all non-Quarkus test suites to prevent
+          // dual SLF4J provider warnings when a module such as polaris-runtime-test-common
+          // is on the classpath.
+          configurations.named(sources.implementationConfigurationName) {
+            exclude(group = "org.jboss.slf4j", module = "slf4j-jboss-logmanager")
+          }
         }
         implementation(requiredLib("assertj-core"))
         implementation(requiredLib("mockito-core"))


### PR DESCRIPTION
Leaving this log manager triggers the following warning:

  SLF4J(W): Class path contains multiple SLF4J providers.
  SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@25f0c5e7]
  SLF4J(W): Found provider [org.slf4j.impl.JBossSlf4jServiceProvider@5882b202]
  SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
  SLF4J(I): Actual provider is of type [ch.qos.logback.classic.spi.LogbackServiceProvider@25f0c5e7]

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
