### PR TITLE
Spark tests: add logback-test.xml and remove spurious log managers

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -155,11 +155,12 @@ testing {
         implementation(testFixtures(project()))
         if (!plugins.hasPlugin("io.quarkus")) {
           implementation(requiredLib("logback-classic"))
-          // Exclude the JBoss SLF4J provider from all non-Quarkus test suites to prevent
-          // dual SLF4J provider warnings when a module such as polaris-runtime-test-common
-          // is on the classpath.
+          // Exclude spurious SLF4J providers from all non-Quarkus test suites to prevent
+          // dual SLF4J provider warnings when dependencies such as polaris-runtime-test-common
+          // or Spark (which bundles log4j-slf4j2-impl) are on the classpath.
           configurations.named(sources.implementationConfigurationName) {
             exclude(group = "org.jboss.slf4j", module = "slf4j-jboss-logmanager")
+            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
           }
         }
         implementation(requiredLib("assertj-core"))

--- a/plugins/spark/common/src/intTest/resources/logback-test.xml
+++ b/plugins/spark/common/src/intTest/resources/logback-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${test.log.level:-ERROR}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>


### PR DESCRIPTION
This change introduces two enhancements to Spark tests:

- They were missing a logback-test.xml file and thus logs were being written at DEBUG level.

- The `org.apache.logging.log4j:log4j-slf4j2-impl` artifact is now also excluded from all non-Quarkus modules, since this creates a duplicate manager warning due to the conflict with Logback.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
