### PR TITLE
Improve setup export UX in the Python CLI.

### DIFF
--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -23,6 +23,10 @@ import json
 from dataclasses import dataclass
 from typing import Dict, Optional, List, Any, Set
 
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.syntax import Syntax
+
 from apache_polaris.cli.command import Command
 from apache_polaris.cli.exceptions import CliError
 from apache_polaris.cli.constants import (
@@ -51,7 +55,20 @@ from apache_polaris.cli.command.privileges import PrivilegesCommand
 from apache_polaris.cli.command.policies import PoliciesCommand
 from apache_polaris.cli.command.utils import get_catalog_api_client
 
-logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO)
+logging.basicConfig(
+    format="%(message)s",
+    level=logging.INFO,
+    handlers=[
+        RichHandler(
+            show_time=True,
+            show_level=True,
+            show_path=False,
+            rich_tracebacks=False,
+            markup=False,
+            omit_repeated_times=False,
+        )
+    ],
+)
 logger = logging.getLogger(__name__)
 
 
@@ -144,7 +161,7 @@ class SetupCommand(Command):
 
     def _export_config(self, api: PolarisDefaultApi) -> None:
         """Export the current Polaris configuration to YAML."""
-        logger.info("--- Exporting Polaris Configuration ---")
+        logger.info("Exporting Polaris configuration...")
         logger.warning(
             "Exporting policy attachments is not currently supported due to performance "
             "considerations. Attachments will be omitted from the exported configuration."
@@ -154,8 +171,21 @@ class SetupCommand(Command):
             "principal_roles": self._export_principal_roles(api),
             "catalogs": self._export_catalogs(api),
         }
-        print(yaml.safe_dump(config, sort_keys=False, indent=2).rstrip())
-        logger.info("--- Finished Exporting Polaris Configuration ---")
+        yaml_text = yaml.safe_dump(config, sort_keys=False, indent=2).rstrip()
+
+        if os.isatty(1):
+            Console().print(
+                Syntax(
+                    yaml_text,
+                    "yaml",
+                    theme="monokai",
+                    background_color="default",
+                    word_wrap=True,
+                )
+            )
+        else:
+            print(yaml_text)
+        logger.info("Finished exporting Polaris configuration.")
 
     def _export_principals(self, api: PolarisDefaultApi) -> Dict[str, Any]:
         """Export all principals and their assigned roles."""

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "boto3~=1.43.1",
     "PyYAML>=6.0.3",
     "prettytable>=3.17.0",
+    "rich>=14.2.0",
 ]
 
 [project.urls]

--- a/client/python/uv.lock
+++ b/client/python/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "apache-polaris"
-version = "1.4.0rc2"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -21,6 +21,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.0,<2.14.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "rich", specifier = ">=14.2.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
     { name = "urllib3", specifier = ">=1.25.3,<3.0.0" },
 ]
@@ -383,7 +385,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
This improves the UX of `polaris setup export` by making interactive terminal output easier to read while preserving script-friendly behavior for redirected output.

When running in a TTY, exported YAML is rendered with Rich syntax highlighting. When output is redirected/non-interactive, the command still emits plain YAML so existing automation remains compatible. Logging was also updated to use RichHandler with cleaner message formatting and consistent timestamps.

Fixes #4090

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4090
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
  - Ran: `cd client/python && uv run --with pytest python -m pytest tests/test_setup_command.py -q` (`4 passed`)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)