### PR TITLE
Add session policy parameter to SigV4 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added `maintenance` support in Helm chart.
 - Added support for publishing histogram buckets for HTTP server request duration as configured SLO boundaries.
 - Added an OpenTelemetry event listener for emitting Polaris audit events as OpenTelemetry log records.
+- Added optional `sessionPolicy` field to `SigV4AuthenticationParameters` for catalog federation. When set, the IAM session policy JSON is attached to the STS AssumeRole request, allowing administrators to restrict vended credentials to only the required AWS services and actions (Principle of Least Privilege).
 
 ### Changes
 - Added REPL support to Polaris CLI.

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/AuthenticationParametersDpo.java
@@ -105,7 +105,8 @@ public abstract class AuthenticationParametersDpo implements IcebergCatalogPrope
                 sigV4AuthenticationParametersModel.getRoleSessionName(),
                 sigV4AuthenticationParametersModel.getExternalId(),
                 sigV4AuthenticationParametersModel.getSigningRegion(),
-                sigV4AuthenticationParametersModel.getSigningName());
+                sigV4AuthenticationParametersModel.getSigningName(),
+                sigV4AuthenticationParametersModel.getSessionPolicy());
         break;
       default:
         throw new IllegalStateException(

--- a/polaris-core/src/main/java/org/apache/polaris/core/connection/SigV4AuthenticationParametersDpo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/connection/SigV4AuthenticationParametersDpo.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.rest.auth.AuthProperties;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
@@ -57,18 +58,24 @@ public class SigV4AuthenticationParametersDpo extends AuthenticationParametersDp
   @JsonProperty(value = "signingName")
   private final String signingName;
 
+  // An optional IAM session policy (JSON) attached to the STS AssumeRole request
+  @JsonProperty(value = "sessionPolicy")
+  private final String sessionPolicy;
+
   public SigV4AuthenticationParametersDpo(
       @JsonProperty(value = "roleArn", required = true) String roleArn,
       @JsonProperty(value = "roleSessionName", required = false) String roleSessionName,
       @JsonProperty(value = "externalId", required = false) String externalId,
       @JsonProperty(value = "signingRegion", required = true) String signingRegion,
-      @JsonProperty(value = "signingName", required = false) String signingName) {
+      @JsonProperty(value = "signingName", required = false) String signingName,
+      @JsonProperty(value = "sessionPolicy", required = false) String sessionPolicy) {
     super(AuthenticationType.SIGV4.getCode());
     this.roleArn = roleArn;
     this.roleSessionName = roleSessionName;
     this.externalId = externalId;
     this.signingRegion = signingRegion;
     this.signingName = signingName;
+    this.sessionPolicy = sessionPolicy;
   }
 
   public @NonNull String getRoleArn() {
@@ -89,6 +96,10 @@ public class SigV4AuthenticationParametersDpo extends AuthenticationParametersDp
 
   public @Nullable String getSigningName() {
     return signingName;
+  }
+
+  public @Nullable String getSessionPolicy() {
+    return sessionPolicy;
   }
 
   @NonNull
@@ -114,6 +125,7 @@ public class SigV4AuthenticationParametersDpo extends AuthenticationParametersDp
         .setExternalId(getExternalId())
         .setSigningRegion(getSigningRegion())
         .setSigningName(getSigningName())
+        .setSessionPolicy(getSessionPolicy())
         .build();
   }
 
@@ -126,6 +138,7 @@ public class SigV4AuthenticationParametersDpo extends AuthenticationParametersDp
         .add("externalId", getExternalId())
         .add("signingRegion", getSigningRegion())
         .add("signingName", getSigningName())
+        .add("hasSessionPolicy", StringUtils.isNotEmpty(getSessionPolicy()))
         .toString();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java
@@ -26,6 +26,7 @@ import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.polaris.core.connection.AuthenticationType;
 import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
 import org.apache.polaris.core.connection.SigV4AuthenticationParametersDpo;
@@ -110,7 +111,6 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
     StsClient stsClient = getStsClient(sigv4Params);
 
     // Build the AssumeRole request with Polaris's credentials
-    // TODO: Generate service-level scoping policy to restrict permissions
     AssumeRoleRequest.Builder requestBuilder =
         AssumeRoleRequest.builder()
             .roleArn(sigv4Params.getRoleArn())
@@ -118,6 +118,11 @@ public class SigV4ConnectionCredentialVendor implements ConnectionCredentialVend
                 Optional.ofNullable(sigv4Params.getRoleSessionName())
                     .orElse(DEFAULT_ROLE_SESSION_NAME))
             .externalId(sigv4Params.getExternalId());
+
+    // Attach user-provided session policy to restrict assumed role permissions (PoLP)
+    if (StringUtils.isNotEmpty(sigv4Params.getSessionPolicy())) {
+      requestBuilder.policy(sigv4Params.getSessionPolicy());
+    }
 
     // Configure the request to use Polaris's service identity credentials
     requestBuilder.overrideConfiguration(

--- a/runtime/service/src/test/java/org/apache/polaris/service/credentials/DefaultPolarisCredentialManagerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/credentials/DefaultPolarisCredentialManagerTest.java
@@ -121,7 +121,7 @@ public class DefaultPolarisCredentialManagerTest {
     // Create SIGV4 auth parameters
     SigV4AuthenticationParametersDpo authParams =
         new SigV4AuthenticationParametersDpo(
-            "arn:aws:iam::123456789012:role/test-role", null, null, "us-west-2", "glue");
+            "arn:aws:iam::123456789012:role/test-role", null, null, "us-west-2", "glue", null);
 
     // Create connection config
     IcebergRestConnectionConfigInfoDpo connectionConfig =

--- a/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendorTest.java
@@ -110,7 +110,8 @@ public class SigV4ConnectionCredentialVendorTest {
             "my-session",
             "external-id-123",
             "us-west-2",
-            "glue");
+            "glue",
+            null);
 
     // Create connection config with service identity and auth params
     IcebergRestConnectionConfigInfoDpo connectionConfig =
@@ -141,6 +142,8 @@ public class SigV4ConnectionCredentialVendorTest {
         .isEqualTo("arn:aws:iam::123456789012:role/customer-role");
     Assertions.assertThat(capturedRequest.roleSessionName()).isEqualTo("my-session");
     Assertions.assertThat(capturedRequest.externalId()).isEqualTo("external-id-123");
+    // No session policy → no policy attached
+    Assertions.assertThat(capturedRequest.policy()).isNull();
   }
 
   @Test
@@ -153,7 +156,7 @@ public class SigV4ConnectionCredentialVendorTest {
     // SigV4 auth without explicit session name
     SigV4AuthenticationParametersDpo authParams =
         new SigV4AuthenticationParametersDpo(
-            "arn:aws:iam::123456789012:role/customer-role", null, null, "us-west-2", "glue");
+            "arn:aws:iam::123456789012:role/customer-role", null, null, "us-west-2", "glue", null);
 
     // Create connection config with service identity and auth params
     IcebergRestConnectionConfigInfoDpo connectionConfig =
@@ -191,7 +194,8 @@ public class SigV4ConnectionCredentialVendorTest {
             "my-session",
             "external-id-123",
             "eu-west-1",
-            "glue");
+            "glue",
+            null);
 
     IcebergRestConnectionConfigInfoDpo connectionConfig =
         createConnectionConfig(authParams, serviceIdentity);
@@ -204,6 +208,39 @@ public class SigV4ConnectionCredentialVendorTest {
   }
 
   @Test
+  public void testSessionPolicyPassedToAssumeRole() {
+    ServiceIdentityInfoDpo serviceIdentity =
+        new AwsIamServiceIdentityInfoDpo(
+            new SecretReference("urn:polaris-secret:test:my-realm:AWS_IAM", Map.of()));
+
+    String customPolicy =
+        "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Action\":[\"glue:*\",\"s3:GetObject\",\"s3:ListBucket\"],"
+            + "\"Resource\":\"*\"}]}";
+
+    SigV4AuthenticationParametersDpo authParams =
+        new SigV4AuthenticationParametersDpo(
+            "arn:aws:iam::123456789012:role/customer-role",
+            "my-session",
+            "external-id-123",
+            "us-west-2",
+            "glue",
+            customPolicy);
+
+    IcebergRestConnectionConfigInfoDpo connectionConfig =
+        createConnectionConfig(authParams, serviceIdentity);
+
+    vendor.getConnectionCredentials(connectionConfig);
+
+    // Verify the session policy is passed to AssumeRole
+    ArgumentCaptor<AssumeRoleRequest> requestCaptor =
+        ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(mockStsClient).assumeRole(requestCaptor.capture());
+
+    Assertions.assertThat(requestCaptor.getValue().policy()).isEqualTo(customPolicy);
+  }
+
+  @Test
   public void testStsDestinationUsesDifferentRegions() {
     ServiceIdentityInfoDpo serviceIdentity =
         new AwsIamServiceIdentityInfoDpo(
@@ -211,7 +248,12 @@ public class SigV4ConnectionCredentialVendorTest {
 
     SigV4AuthenticationParametersDpo authParams =
         new SigV4AuthenticationParametersDpo(
-            "arn:aws:iam::123456789012:role/customer-role", null, null, "ap-southeast-1", null);
+            "arn:aws:iam::123456789012:role/customer-role",
+            null,
+            null,
+            "ap-southeast-1",
+            null,
+            null);
 
     IcebergRestConnectionConfigInfoDpo connectionConfig =
         createConnectionConfig(authParams, serviceIdentity);

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -1073,6 +1073,14 @@ components:
           type: string
           description: The service name to be used by the SigV4 protocol for signing requests, the default signing name is "execute-api" is if not provided
           example: "glue"
+        sessionPolicy:
+          type: string
+          description: >-
+            An optional IAM session policy (JSON) attached to the STS AssumeRole request.
+            This policy intersects with the IAM role's permissions to further restrict
+            the vended credentials. When omitted, no session policy is applied and the
+            credentials inherit the full permissions of the assumed role.
+          example: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["glue:*","s3:GetObject","s3:ListBucket"],"Resource":"*"}]}'
       required:
         - roleArn
         - signingRegion


### PR DESCRIPTION
Adds session policy to Sig4 connections.

Resolves the TODO as well
https://github.com/apache/polaris/blob/1fc52b4c649f28b62cbe97281be589ab0c627687/runtime/service/src/main/java/org/apache/polaris/service/credentials/connection/SigV4ConnectionCredentialVendor.java#L113-L120
## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
