### PR TITLE
fix: PolarisEventMetadata eventId() returns different UUID on each call.

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadata.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/events/PolarisEventMetadata.java
@@ -39,6 +39,7 @@ public interface PolarisEventMetadata {
   }
 
   /** The unique ID of the event. */
+  @Value.Default
   default UUID eventId() {
     return UUID.randomUUID();
   }


### PR DESCRIPTION
…#4952)

PolarisEventMetadata eventId() was missing @Value.Default annotation.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
