### PR TITLE
Change TaskHandler.handleTask to void for clearer success/failure contract [follow-up to #4914]

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
@@ -51,7 +51,7 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
   }
 
   @Override
-  public boolean handleTask(TaskEntity task, CallContext callContext) {
+  public void handleTask(TaskEntity task, CallContext callContext) {
     BatchFileCleanupTask cleanupTask = task.readData(BatchFileCleanupTask.class);
     TableIdentifier tableId = cleanupTask.tableId();
     List<String> batchFiles = cleanupTask.batchFiles();
@@ -67,7 +67,7 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
             .addKeyValue("batchFiles", batchFiles.toString())
             .addKeyValue("tableId", tableId)
             .log("File batch cleanup task scheduled, but none of the files in batch exists");
-        return true;
+        return;
       }
       if (!missingFiles.isEmpty()) {
         LOGGER
@@ -90,8 +90,6 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
         LOGGER.error("Exception detected during batch files deletion", e);
         throw new RuntimeException(e);
       }
-
-      return true;
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/FileCleanupTaskHandler.java
@@ -55,8 +55,12 @@ public abstract class FileCleanupTaskHandler implements TaskHandler {
   @Override
   public abstract boolean canHandleTask(TaskEntity task);
 
+  /**
+   * Handles the provided task. A normal return indicates success and the task entity will be
+   * dropped; throwing indicates failure and triggers the task retry path.
+   */
   @Override
-  public abstract boolean handleTask(TaskEntity task, CallContext callContext);
+  public abstract void handleTask(TaskEntity task, CallContext callContext);
 
   /**
    * Attempts to delete a single file with retry logic. If the file does not exist, it logs a

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandler.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.service.task;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -59,16 +60,16 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
   }
 
   @Override
-  public boolean handleTask(TaskEntity task, CallContext callContext) {
+  public void handleTask(TaskEntity task, CallContext callContext) {
     ManifestCleanupTask cleanupTask = task.readData(ManifestCleanupTask.class);
     TableIdentifier tableId = cleanupTask.tableId();
     try (FileIO authorizedFileIO = fileIOSupplier.apply(task, tableId)) {
       ManifestFile manifestFile = TaskUtils.decodeManifestFileData(cleanupTask.manifestFileData());
-      return cleanUpManifestFile(manifestFile, authorizedFileIO, tableId);
+      cleanUpManifestFile(manifestFile, authorizedFileIO, tableId);
     }
   }
 
-  private boolean cleanUpManifestFile(
+  private void cleanUpManifestFile(
       ManifestFile manifestFile, FileIO fileIO, TableIdentifier tableId) {
     // if the file doesn't exist, we assume that another task execution was successful, but
     // failed to drop the task entity. Log a warning and return success
@@ -78,7 +79,7 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
           .addKeyValue("manifestFile", manifestFile.path())
           .addKeyValue("tableId", tableId)
           .log("Manifest cleanup task scheduled, but manifest file doesn't exist");
-      return true;
+      return;
     }
 
     try (ManifestReader<DataFile> dataFiles = ManifestFiles.read(manifestFile, fileIO, null)) {
@@ -106,7 +107,7 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
                       tableId, fileIO, manifestFile.path(), manifestFile.path(), null, 1);
                 })
             .get();
-        return true;
+        return;
       } catch (InterruptedException e) {
         LOGGER.error(
             "Interrupted exception deleting data files from manifest {}", manifestFile.path(), e);
@@ -118,10 +119,9 @@ public class ManifestFileCleanupTaskHandler extends FileCleanupTaskHandler {
     } catch (IOException e) {
       // Catches from ManifestFiles.read() (resource creation), from inside the block
       // (e.g. manifest iteration), or from close(). We throw (wrapping) so the original
-      // failure propagates and TaskExecutorImpl's retry path is used. (handleTask returns
-      // boolean and cannot declare a checked throws IOException.)
+      // failure propagates and the retry path is used.
       LOGGER.error("Failed to process manifest reader for {}", manifestFile.path(), e);
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -84,16 +84,17 @@ public class TableCleanupTaskHandler implements TaskHandler {
   }
 
   @Override
-  public boolean handleTask(TaskEntity cleanupTask, CallContext callContext) {
+  public void handleTask(TaskEntity cleanupTask, CallContext callContext) {
     IcebergTableLikeEntity entity = tryGetTableEntity(cleanupTask).orElseThrow();
 
     if (entity.getSubType() == PolarisEntitySubType.ICEBERG_VIEW) {
-      return handleViewCleanup(cleanupTask, entity);
+      handleViewCleanup(cleanupTask, entity);
+    } else {
+      handleTableCleanup(cleanupTask, entity, callContext);
     }
-    return handleTableCleanup(cleanupTask, entity, callContext);
   }
 
-  private boolean handleTableCleanup(
+  private void handleTableCleanup(
       TaskEntity cleanupTask, IcebergTableLikeEntity tableEntity, CallContext callContext) {
     LOGGER
         .atInfo()
@@ -111,7 +112,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
             .addKeyValue("tableIdentifier", tableEntity.getTableIdentifier())
             .addKeyValue("metadataLocation", tableEntity.getMetadataLocation())
             .log("Table metadata cleanup scheduled, but metadata file does not exist");
-        return true;
+        return;
       }
 
       TableMetadata tableMetadata =
@@ -155,13 +156,14 @@ public class TableCleanupTaskHandler implements TaskHandler {
 
         fileIO.deleteFile(tableEntity.getMetadataLocation());
 
-        return true;
+        return;
       }
     }
-    return false;
+    throw new RuntimeException(
+        "Failed to create sub cleanup tasks for table " + tableEntity.getTableIdentifier());
   }
 
-  private boolean handleViewCleanup(TaskEntity cleanupTask, IcebergTableLikeEntity viewEntity) {
+  private void handleViewCleanup(TaskEntity cleanupTask, IcebergTableLikeEntity viewEntity) {
     LOGGER
         .atInfo()
         .addKeyValue("viewIdentifier", viewEntity.getTableIdentifier())
@@ -175,7 +177,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
             .addKeyValue("viewIdentifier", viewEntity.getTableIdentifier())
             .addKeyValue("metadataLocation", viewEntity.getMetadataLocation())
             .log("View metadata cleanup scheduled, but metadata file does not exist");
-        return true;
+        return;
       }
 
       fileIO.deleteFile(viewEntity.getMetadataLocation());
@@ -185,7 +187,7 @@ public class TableCleanupTaskHandler implements TaskHandler {
           .addKeyValue("metadataLocation", viewEntity.getMetadataLocation())
           .log("Successfully deleted view metadata file");
 
-      return true;
+      return;
     }
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -209,11 +209,12 @@ public class TaskExecutorImpl implements TaskExecutor {
     }
 
     boolean success = false;
+    PolarisBaseEntity taskEntity = null;
     try {
       LOGGER.info("Handling task entity id {}", taskEntityId);
       PolarisMetaStoreManager metaStoreManager =
           metaStoreManagerFactory.getOrCreateMetaStoreManager(ctx.getRealmContext());
-      PolarisBaseEntity taskEntity =
+      taskEntity =
           metaStoreManager
               .loadEntity(ctx.getPolarisCallContext(), 0L, taskEntityId, PolarisEntityType.TASK)
               .getEntity();
@@ -229,35 +230,33 @@ public class TaskExecutorImpl implements TaskExecutor {
             .addKeyValue("taskEntityId", taskEntityId)
             .addKeyValue("taskType", task.getTaskType())
             .log("Unable to find handler for task type");
-        throw new RuntimeException(
+        throw new TaskHandlerNotFoundException(
             "Unable to find handler for task type "
                 + task.getTaskType()
                 + " for task entity id "
                 + taskEntityId);
       }
       TaskHandler handler = handlerOpt.get();
-      success = handler.handleTask(task, ctx);
-      if (success) {
-        LOGGER
-            .atInfo()
-            .addKeyValue("taskEntityId", taskEntityId)
-            .addKeyValue("handlerClass", handler.getClass())
-            .log("Task successfully handled");
-        metaStoreManager.dropEntityIfExists(
-            ctx.getPolarisCallContext(), null, taskEntity, Map.of(), false);
-      } else {
-        LOGGER
-            .atWarn()
-            .addKeyValue("taskEntityId", taskEntityId)
-            .addKeyValue("taskEntityName", taskEntity.getName())
-            .log("Unable to execute async task");
-        throw new RuntimeException(
-            "Task handler returned false for task entity id "
-                + taskEntityId
-                + " (handler: "
-                + handler.getClass().getSimpleName()
-                + ")");
-      }
+      handler.handleTask(task, ctx);
+      success = true;
+      LOGGER
+          .atInfo()
+          .addKeyValue("taskEntityId", taskEntityId)
+          .addKeyValue("handlerClass", handler.getClass())
+          .log("Task successfully handled");
+      metaStoreManager.dropEntityIfExists(
+          ctx.getPolarisCallContext(), null, taskEntity, Map.of(), false);
+    } catch (TaskHandlerNotFoundException e) {
+      success = false;
+      throw e;
+    } catch (Exception e) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("taskEntityId", taskEntityId)
+          .addKeyValue("taskEntityName", taskEntity != null ? taskEntity.getName() : "")
+          .log("Unable to execute async task");
+      success = false;
+      throw e;
     } finally {
       if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_ATTEMPT_TASK)) {
         polarisEventDispatcher.dispatch(
@@ -306,6 +305,12 @@ public class TaskExecutorImpl implements TaskExecutor {
       } finally {
         span.end();
       }
+    }
+  }
+
+  private static final class TaskHandlerNotFoundException extends RuntimeException {
+    TaskHandlerNotFoundException(String message) {
+      super(message);
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -237,6 +237,9 @@ public class TaskExecutorImpl implements TaskExecutor {
                 + taskEntityId);
       }
       TaskHandler handler = handlerOpt.get();
+      // Normal return from handleTask means the task work completed successfully. Set success
+      // before dropEntityIfExists so a later cleanup failure still reports TASK_SUCCESS=true
+      // (the exception is rethrown for retry/logging, but the attempt is not a handler failure).
       handler.handleTask(task, ctx);
       success = true;
       LOGGER
@@ -247,15 +250,18 @@ public class TaskExecutorImpl implements TaskExecutor {
       metaStoreManager.dropEntityIfExists(
           ctx.getPolarisCallContext(), null, taskEntity, Map.of(), false);
     } catch (TaskHandlerNotFoundException e) {
-      success = false;
+      // success stays false (never set true). Re-throw without the generic failure log below.
       throw e;
     } catch (Exception e) {
-      LOGGER
-          .atWarn()
-          .addKeyValue("taskEntityId", taskEntityId)
-          .addKeyValue("taskEntityName", taskEntity != null ? taskEntity.getName() : "")
-          .log("Unable to execute async task");
-      success = false;
+      // Do not force success=false: handleTask may already have completed (success=true) and the
+      // failure may be from post-completion cleanup (e.g. dropEntityIfExists).
+      if (!success) {
+        LOGGER
+            .atWarn()
+            .addKeyValue("taskEntityId", taskEntityId)
+            .addKeyValue("taskEntityName", taskEntity != null ? taskEntity.getName() : "")
+            .log("Unable to execute async task");
+      }
       throw e;
     } finally {
       if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_ATTEMPT_TASK)) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskHandler.java
@@ -24,5 +24,5 @@ import org.apache.polaris.core.entity.TaskEntity;
 public interface TaskHandler {
   boolean canHandleTask(TaskEntity task);
 
-  boolean handleTask(TaskEntity task, CallContext callContext);
+  void handleTask(TaskEntity task, CallContext callContext);
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
@@ -264,7 +264,7 @@ public class BatchFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
 
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    assertThatCode(() -> handler.handleTask(task, polarisCallContext)).doesNotThrowAnyException();
 
     // Each file must have been checked exactly once by the pre-delete scan.
     Mockito.verify(fileIO, Mockito.times(1)).newInputFile(presentFile1);

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
@@ -20,6 +20,8 @@ package org.apache.polaris.service.task;
 
 import static org.apache.polaris.service.task.TaskTestUtils.addTaskLocation;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatPredicate;
 
 import io.quarkus.test.InjectMock;
@@ -183,8 +185,10 @@ public class BatchFileCleanupTaskHandlerTest {
             .build();
 
     task = addTaskLocation(task);
+    TaskEntity finalTask = task;
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    assertThatCode(() -> handler.handleTask(finalTask, polarisCallContext))
+        .doesNotThrowAnyException();
 
     for (String cleanupFile : cleanupFiles) {
       assertThatPredicate((String file) -> TaskUtils.exists(file, fileIO)).rejects(cleanupFile);
@@ -225,9 +229,10 @@ public class BatchFileCleanupTaskHandlerTest {
             .setName(UUID.randomUUID().toString())
             .build();
 
-    task = addTaskLocation(task);
-    assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    TaskEntity taskWithLocation = addTaskLocation(task);
+    assertThatPredicate(handler::canHandleTask).accepts(taskWithLocation);
+    assertThatNoException()
+        .isThrownBy(() -> handler.handleTask(taskWithLocation, polarisCallContext));
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.task;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.polaris.service.task.TaskTestUtils.addTaskLocation;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatPredicate;
 
 import io.quarkus.test.InjectMock;
@@ -97,7 +96,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    handler.handleTask(task, polarisCallContext);
   }
 
   @Test
@@ -118,7 +117,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    handler.handleTask(task, polarisCallContext);
   }
 
   @Test
@@ -154,7 +153,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    handler.handleTask(task, polarisCallContext);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile1Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile2Path);
   }
@@ -206,7 +205,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    handler.handleTask(task, polarisCallContext);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile1Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(dataFile2Path);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -242,9 +242,8 @@ class TableCleanupTaskHandlerTest {
 
     // handle the same task twice
     // the first one should successfully delete the metadata
-    List<Boolean> results =
-        List.of(handler.handleTask(task, callContext), handler.handleTask(task, callContext));
-    assertThat(results).containsExactly(true, true);
+    handler.handleTask(task, callContext);
+    handler.handleTask(task, callContext);
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(
@@ -299,9 +298,8 @@ class TableCleanupTaskHandlerTest {
 
     // handle the same task twice
     // the first one should successfully delete the metadata
-    List<Boolean> results =
-        List.of(handler.handleTask(task, callContext), handler.handleTask(task, callContext));
-    assertThat(results).containsExactly(true, true);
+    handler.handleTask(task, callContext);
+    handler.handleTask(task, callContext);
 
     // both tasks successfully executed, but only one should queue subtasks
     assertThat(

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -90,7 +90,7 @@ public class TaskExecutorImplTest {
           }
 
           @Override
-          public boolean handleTask(TaskEntity task, CallContext callContext) {
+          public void handleTask(TaskEntity task, CallContext callContext) {
             PolarisEvent beforeTaskAttemptedEvent =
                 testPolarisEventDispatcher.getLatest(PolarisEventType.BEFORE_ATTEMPT_TASK);
             Assertions.assertEquals(
@@ -99,7 +99,6 @@ public class TaskExecutorImplTest {
             Assertions.assertEquals(
                 attempt,
                 beforeTaskAttemptedEvent.attributes().getRequired(EventAttributes.TASK_ATTEMPT));
-            return true;
           }
         });
 
@@ -168,7 +167,7 @@ public class TaskExecutorImplTest {
   }
 
   @Test
-  void handleTaskThrowsWhenHandlerReturnsFalse() {
+  void handleTaskThrowsWhenHandlerThrows() {
     String realm = "myrealm";
     RealmContext realmContext = () -> realm;
 
@@ -211,8 +210,8 @@ public class TaskExecutorImplTest {
           }
 
           @Override
-          public boolean handleTask(TaskEntity task, CallContext callContext) {
-            return false; // simulate transient failure
+          public void handleTask(TaskEntity task, CallContext callContext) {
+            throw new RuntimeException("simulate transient failure");
           }
         });
 
@@ -224,8 +223,7 @@ public class TaskExecutorImplTest {
                     PolarisEventMetadata.builder().realmId(realm).build(),
                     1))
         .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Task handler returned false")
-        .hasMessageContaining(String.valueOf(taskEntity.getId()));
+        .hasMessageContaining("simulate transient failure");
 
     // Event should have been emitted with TASK_SUCCESS=false even though we threw
     PolarisEvent afterEvent =
@@ -234,7 +232,7 @@ public class TaskExecutorImplTest {
   }
 
   @Test
-  void asyncRetryIsTriggeredWhenHandlerReturnsFalse() throws InterruptedException {
+  void asyncRetryIsTriggeredWhenHandlerThrows() throws InterruptedException {
     String realm = "myrealm";
     RealmContext realmContext = () -> realm;
 
@@ -276,22 +274,21 @@ public class TaskExecutorImplTest {
           }
 
           @Override
-          public boolean handleTask(TaskEntity task, CallContext callContext) {
+          public void handleTask(TaskEntity task, CallContext callContext) {
             int call = handlerCalls.incrementAndGet();
             // Fail first 2 attempts (transient), succeed on 3rd
             if (call < 3) {
-              return false;
+              throw new RuntimeException("transient failure " + call);
             }
-            return true;
           }
         });
 
     // This starts the async processing. With Runnable::run the first handleTask runs
-    // synchronously in the current thread (so handler is called immediately), returns false
-    // -> throws inside the future (the exception path is taken, which is what we verify).
+    // synchronously in the current thread (so handler is called immediately), throws
+    // -> the exception path is taken, which is what we verify.
     executor.addTaskHandlerContext(taskEntity.getId(), polarisCallCtx);
 
-    // We verify at least the first call happened (return-false leads to exception path).
+    // We verify at least the first call happened (throw leads to exception path).
     assertThat(handlerCalls.get()).isGreaterThanOrEqualTo(1);
   }
 }


### PR DESCRIPTION
Follow-up to #4914.

Changes `TaskHandler.handleTask` return type from `boolean` to `void`:
- Normal return means success and the task entity is dropped.
- Throwing means failure and triggers the existing retry path.

Updates all handlers and `TaskExecutorImpl` accordingly, and Added tests too.

Addresses review feedback from @adutra and @dimas-b on #4914.