### PR TITLE
Fix ALLOW_EXTERNAL_METADATA_FILE_LOCATION is not overridable at catalog level

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -305,6 +305,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_METADATA_FILE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_METADATA_FILE_LOCATION")
+          .catalogConfig("polaris.config.allow.external.metadata.file.location")
+          .legacyCatalogConfig("allow.external.metadata.file.location")
           .description(
               "If set to true, Polaris allows metadata files to be located outside the table's "
                   + "default metadata directory. This relaxes the normal check that metadata "

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -306,7 +306,6 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_METADATA_FILE_LOCATION")
           .catalogConfig("polaris.config.allow.external.metadata.file.location")
-          .legacyCatalogConfig("allow.external.metadata.file.location")
           .description(
               "If set to true, Polaris allows metadata files to be located outside the table's "
                   + "default metadata directory. This relaxes the normal check that metadata "

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2413,9 +2413,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
   private void validateMetadataFileInTableDir(
       TableIdentifier identifier, String tableLocation, String metadataLocation) {
-    boolean allowEscape = realmConfig.getConfig(FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION);
+    boolean allowEscape =
+        realmConfig.getConfig(FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION, catalogEntity);
     if (!allowEscape
-        && !realmConfig.getConfig(FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION)) {
+        && !realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION, catalogEntity)) {
       LOGGER.debug(
           "Validating base location {} for table {} in metadata file {}",
           tableLocation,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -2775,8 +2775,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     updateCatalogProperties(
         Map.of(
             FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
-            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true",
-            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false"));
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
 
     catalog.createNamespace(NS);
     Table table = catalog.buildTable(TABLE, SCHEMA).create();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -1199,15 +1199,10 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     final String anotherTableLocation =
         String.format("s3://my-bucket/path/to/data/another_table_%s/", tableSuffix);
 
-    metaStoreManager.updateEntityPropertiesIfNotChanged(
-        polarisContext,
-        List.of(PolarisEntity.toCore(catalogEntity)),
-        new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
-            .addProperty(
-                FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
-            .addProperty(
-                FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-            .build());
+    updateCatalogProperties(
+        Map.of(
+            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
     TableMetadata tableMetadata =
         TableMetadata.buildFromEmpty()
@@ -1259,15 +1254,10 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     final String anotherTableLocation =
         String.format("s3://my-bucket/path/to/data/another_table_%s", tableSuffix);
 
-    metaStoreManager.updateEntityPropertiesIfNotChanged(
-        polarisContext,
-        List.of(PolarisEntity.toCore(catalogEntity)),
-        new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
-            .addProperty(
-                FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
-            .addProperty(
-                FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-            .build());
+    updateCatalogProperties(
+        Map.of(
+            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
     TableMetadata tableMetadata =
         TableMetadata.buildFromEmpty()
@@ -1316,15 +1306,10 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     final String anotherTableLocation =
         String.format("s3://my-bucket/path/to/data/another_table_%s/", tableSuffix);
 
-    metaStoreManager.updateEntityPropertiesIfNotChanged(
-        polarisContext,
-        List.of(PolarisEntity.toCore(catalogEntity)),
-        new CatalogEntity.Builder(CatalogEntity.of(catalogEntity))
-            .addProperty(
-                FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false")
-            .addProperty(
-                FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
-            .build());
+    updateCatalogProperties(
+        Map.of(
+            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
 
     fileIO.addFile(
@@ -2790,7 +2775,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     updateCatalogProperties(
         Map.of(
             FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
-            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false"));
 
     catalog.createNamespace(NS);
     Table table = catalog.buildTable(TABLE, SCHEMA).create();
@@ -2823,7 +2809,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     updateCatalogProperties(
         Map.of(
             FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
-            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "true"));
 
     catalog.createNamespace(NS);
     Table table = catalog.buildTable(TABLE, SCHEMA).create();
@@ -2846,6 +2833,26 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThat(inMemoryFilesUnderPrefix(metadataPrefix)).contains(metadataFileLocation);
     Assertions.assertThat(updatedTable.properties())
         .containsEntry(TableProperties.WRITE_METADATA_LOCATION, metadataDirectory);
+
+    // Out-of-table metadata location — allowed because catalog-level
+    // ALLOW_EXTERNAL_METADATA_FILE_LOCATION is true
+    String externalMetadataDir =
+        "%s/table-metadata/%s"
+            .formatted(LocationUtil.stripTrailingSlash(STORAGE_LOCATION), UUID.randomUUID());
+    String externalPrefix = externalMetadataDir + "/";
+    updatedTable
+        .updateProperties()
+        .set(TableProperties.WRITE_METADATA_LOCATION, externalMetadataDir)
+        .commit();
+
+    Table reloaded = catalog.loadTable(TABLE);
+    String externalMetadataFile =
+        ((BaseTable) reloaded).operations().current().metadataFileLocation();
+
+    Assertions.assertThat(externalMetadataFile).startsWith(externalPrefix);
+    Assertions.assertThat(fileIO.fileExists(externalMetadataFile)).isTrue();
+    Assertions.assertThat(reloaded.properties())
+        .containsEntry(TableProperties.WRITE_METADATA_LOCATION, externalMetadataDir);
   }
 
   private void validatePropertiesUpdated(
@@ -2876,6 +2883,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     Assertions.assertThat(result).returns(true, EntityResult::isSuccess);
     catalogEntity = PolarisEntity.of(result.getEntity());
+    this.catalog = initCatalog("my-catalog", ImmutableMap.of());
   }
 
   @SuppressWarnings("unchecked")

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -61,6 +61,7 @@ If set to true, Polaris allows metadata files to be located outside the table's 
 
 - **Type:** `Boolean`
 - **Default:** `false`
+- **Catalog Config:** `polaris.config.allow.external.metadata.file.location`
 
 ---
 


### PR DESCRIPTION
Fixes: https://github.com/apache/polaris/pull/4963#discussion_r3521094048

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
