### PR TITLE
fix(regtests): make sed in-place edit in setup.sh portable to BSD/macOS

### DIFF
--- a/plugins/spark/v3.5/regtests/setup.sh
+++ b/plugins/spark/v3.5/regtests/setup.sh
@@ -149,7 +149,8 @@ if grep 'POLARIS_TESTCONF_V5' ${SPARK_CONF} 2>/dev/null; then
 else
   echo 'Setting spark conf...'
   # Instead of clobbering existing spark conf, just comment it all out in case it was customized carefully.
-  sed -i 's/^/# /' ${SPARK_CONF}
+  # Use an explicit backup suffix so the in-place edit works on both GNU and BSD/macOS sed, then remove the backup.
+  sed -i.bak 's/^/# /' ${SPARK_CONF} && rm -f ${SPARK_CONF}.bak
 
 # If POLARIS_CLIENT_JAR is provided, set the spark conf to use the jars configuration.
 # Otherwise use the packages setting

--- a/regtests/setup.sh
+++ b/regtests/setup.sh
@@ -103,7 +103,8 @@ if grep 'POLARIS_TESTCONF_V5' ${SPARK_CONF} 2>/dev/null; then
 else
   echo 'Setting spark conf...'
   # Instead of clobbering existing spark conf, just comment it all out in case it was customized carefully.
-  sed -i 's/^/# /' ${SPARK_CONF}
+  # Use an explicit backup suffix so the in-place edit works on both GNU and BSD/macOS sed, then remove the backup.
+  sed -i.bak 's/^/# /' ${SPARK_CONF} && rm -f ${SPARK_CONF}.bak
 cat << EOF >> ${SPARK_CONF}
 
 # POLARIS_TESTCONF_V5


### PR DESCRIPTION

Both regtest setup scripts comment out an existing `spark-defaults.conf` before
appending the Polaris test configuration:

```sh
# Instead of clobbering existing spark conf, just comment it all out in case it was customized carefully.
sed -i 's/^/# /' ${SPARK_CONF}
```

A bare `sed -i` (no suffix) is a GNU extension. On BSD/macOS `sed`, `-i` requires
an explicit backup suffix as its argument, so `-i` consumes the following token
(`'s/^/# /'`) as the suffix and then treats `${SPARK_CONF}` as the sed script.
The command fails with an "invalid command code" error, exits non-zero, and
leaves the file unmodified.

Both `regtests/setup.sh` and `plugins/spark/v3.5/regtests/setup.sh` run under
`set -x` but not `set -e`, so this failure is silent: the run continues and the
intended comment-out step is skipped. When the developer's `spark-defaults.conf`
was previously customized, its old settings stay uncommented above the appended
`POLARIS_TESTCONF_V5` block, producing a conflicting Spark configuration. Both
scripts already special-case macOS (Homebrew `wget`, `$OSTYPE == darwin*`) and
the READMEs document a local `./regtests/run.sh` workflow that runs `setup.sh`,
so a macOS contributor hits this.

### Fix

Use an explicit attached backup suffix and remove the backup afterward:

```sh
sed -i.bak 's/^/# /' ${SPARK_CONF} && rm -f ${SPARK_CONF}.bak
```

This form behaves identically on GNU and BSD/macOS `sed`. It is the same portable
pattern already used in this repository at `releasey/bin/build-helm-index.sh`. The
existing (unquoted) `${SPARK_CONF}` usage is left unchanged to keep the diff
focused.

### How it was tested

There is no unit-test harness for these shell scripts, so this was verified
manually on macOS/BSD `sed`:

- Before: `printf 'a\nb\n' > c && sed -i 's/^/# /' c` exits non-zero and leaves
  `c` unchanged.
- After: `sed -i.bak 's/^/# /' c && rm -f c.bak` yields `# a` / `# b`, exits 0,
  and leaves no `.bak` file behind.
- End-to-end emulation of the conf block for three cases, all correct: a
  pre-customized conf (the real bug; settings are now commented out), an
  idempotent second run (the `grep POLARIS_TESTCONF_V5` guard skips it), and a
  fresh/empty conf.
- `bash -n` passes on both scripts.

The change is dev-only regression-test tooling with no user-facing runtime
behavior, so no `CHANGELOG.md` entry is included.

### Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated `CHANGELOG.md` (if needed) - not needed (dev-only tooling, no user-facing change)
- [x] Updated documentation in `site/content/in-dev/unreleased` (if needed) - not needed

<!-- Optional transparency line, per CONTRIBUTING "Guidelines for AI-assisted
     Contributions". Keep it if disclosing; the human author owns the change and
     can explain it end-to-end. Do NOT name any tool or model. -->
This change was prepared with AI assistance; I have reviewed it, tested it, and
take responsibility for it.
