### PR TITLE
Fix infinite loop from non-positive TABLE_METADATA_CLEANUP_BATCH_SIZE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - JWT verification now validates the issuer claim (`"polaris"`) in addition to the active claim. Tokens signed with the same key but carrying a different issuer are now rejected.
 - Inheritable policy mapping inserts in the JDBC backend now use the active transaction connection, so they roll back correctly with the surrounding transaction.
 - Generic table drop now accepts table-scoped `TABLE_DROP` privilege.
+- `TableCleanupTaskHandler` now clamps `TABLE_METADATA_CLEANUP_BATCH_SIZE` to at least 1. Previously a non-positive realm override caused an infinite loop (0) or `IllegalArgumentException` (<0) when splitting metadata files for cleanup.
 - Azure SAS tokens are now signed for the configured duration instead of a hardcoded 1 hour, so long jobs no longer fail with expired credentials.
 
 ## [1.5.0]

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -246,7 +246,8 @@ public class TableCleanupTaskHandler implements TaskHandler {
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext) {
     PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
-    int batchSize = callContext.getRealmConfig().getConfig(TABLE_METADATA_CLEANUP_BATCH_SIZE);
+    int batchSize =
+        Math.max(1, callContext.getRealmConfig().getConfig(TABLE_METADATA_CLEANUP_BATCH_SIZE));
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -246,8 +246,16 @@ public class TableCleanupTaskHandler implements TaskHandler {
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext) {
     PolarisCallContext polarisCallContext = callContext.getPolarisCallContext();
-    int batchSize =
-        Math.max(1, callContext.getRealmConfig().getConfig(TABLE_METADATA_CLEANUP_BATCH_SIZE));
+    int configuredBatchSize =
+        callContext.getRealmConfig().getConfig(TABLE_METADATA_CLEANUP_BATCH_SIZE);
+    int batchSize = Math.max(1, configuredBatchSize);
+    if (batchSize != configuredBatchSize) {
+      LOGGER
+          .atWarn()
+          .addKeyValue("configuredBatchSize", configuredBatchSize)
+          .addKeyValue("effectiveBatchSize", batchSize)
+          .log("Invalid TABLE_METADATA_CLEANUP_BATCH_SIZE; clamping to minimum value");
+    }
     return getMetadataFileBatches(tableMetadata, batchSize).stream()
         .map(
             metadataBatch -> {

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
+import org.apache.polaris.core.config.FeatureConfiguration;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.AsyncTaskType;
@@ -52,6 +54,7 @@ import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
@@ -143,6 +146,62 @@ class TableCleanupTaskHandlerTest {
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));
+  }
+
+  @Test
+  @Timeout(10)
+  public void testTableCleanupClampsNonPositiveBatchSize() throws IOException {
+    FileIO fileIO = new InMemoryFileIO();
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
+    long snapshotId = 100L;
+    ManifestFile manifestFile =
+        TaskTestUtils.manifestFile(
+            fileIO, "manifest1.avro", snapshotId, "dataFile1.parquet", "dataFile2.parquet");
+    TestSnapshot snapshot =
+        TaskTestUtils.newSnapshot(fileIO, "manifestList.avro", 1, snapshotId, 99L, manifestFile);
+    String metadataFile = "v1-49494949.metadata.json";
+    StatisticsFile statisticsFile =
+        TaskTestUtils.writeStatsFile(
+            snapshot.snapshotId(),
+            snapshot.sequenceNumber(),
+            "/metadata/" + UUID.randomUUID() + ".stats",
+            fileIO);
+    TaskTestUtils.writeTableMetadata(fileIO, metadataFile, List.of(statisticsFile), snapshot);
+
+    TaskEntity task =
+        new TaskEntity.Builder()
+            .setName("cleanup_" + tableIdentifier)
+            .withTaskType(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER)
+            .withData(
+                new IcebergTableLikeEntity.Builder(
+                        PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier, metadataFile)
+                    .setName("table1")
+                    .setCatalogId(1)
+                    .setCreateTimestamp(100)
+                    .build())
+            .build();
+    task = addTaskLocation(task);
+    Assertions.assertThatPredicate(handler::canHandleTask).accepts(task);
+
+    RealmConfig realmConfig = Mockito.mock(RealmConfig.class);
+    CallContext mockCallContext = Mockito.mock(CallContext.class);
+    Mockito.when(mockCallContext.getRealmConfig()).thenReturn(realmConfig);
+    Mockito.when(mockCallContext.getRealmContext()).thenReturn(realmContext);
+    Mockito.when(mockCallContext.getPolarisCallContext())
+        .thenReturn(callContext.getPolarisCallContext());
+    Mockito.when(realmConfig.getConfig(FeatureConfiguration.TABLE_METADATA_CLEANUP_BATCH_SIZE))
+        .thenReturn(0);
+
+    handler.handleTask(task, mockCallContext);
+
+    // batchSize=0 is clamped to 1, so the two metadata files (manifest list + stats file)
+    // are split into two BATCH_FILE_CLEANUP tasks, plus one MANIFEST_FILE_CLEANUP task.
+    assertThat(
+            metaStoreManager
+                .loadTasks(callContext.getPolarisCallContext(), "test", PageToken.fromLimit(5))
+                .getEntities())
+        .hasSize(3);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -149,7 +149,7 @@ class TableCleanupTaskHandlerTest {
   }
 
   @Test
-  @Timeout(10)
+  @Timeout(60)
   public void testTableCleanupClampsNonPositiveBatchSize() throws IOException {
     FileIO fileIO = new InMemoryFileIO();
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");


### PR DESCRIPTION
Fix infinite loop from non-positive TABLE_METADATA_CLEANUP_BATCH_SIZE

`TABLE_METADATA_CLEANUP_BATCH_SIZE` is realm-overridable without bounds. When a realm/catalog override sets the value to `0` or negative, `TableCleanupTaskHandler.getMetadataFileBatches(...)` behaves badly: `0` causes an infinite loop in the batch-splitting logic, and negative values cause `IllegalArgumentException` from `List.subList(...)`.

This change clamps the configured batch size to at least 1 at the use site with `Math.max(1, batchSize)`, preventing the availability issue without changing the existing configuration machinery. A regression test with a short `@Timeout` verifies that a `0` override still results in queued cleanup subtasks instead of hanging.

## Checklist
- [ ]  Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated \`CHANGELOG.md\` (if needed)
- [ ] Updated documentation in \`site/content/in-dev/unreleased\` (if needed)