### PR TITLE
Make OPA file-based bearer token timing configurable

### DIFF
--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaAuthorizationConfig.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaAuthorizationConfig.java
@@ -174,6 +174,14 @@ public interface OpaAuthorizationConfig {
        */
       Optional<Duration> jwtExpirationBuffer();
 
+      /**
+       * How long to wait for the first token load before failing a request. Defaults to 5 seconds.
+       */
+      Optional<Duration> initialTokenWait();
+
+      /** How long to wait before retrying after a failed token refresh. Defaults to 1 second. */
+      Optional<Duration> refreshRetryInterval();
+
       default void validate() {
         checkArgument(
             refreshInterval().isEmpty() || refreshInterval().get().isPositive(),
@@ -181,6 +189,12 @@ public interface OpaAuthorizationConfig {
         checkArgument(
             jwtExpirationBuffer().isEmpty() || jwtExpirationBuffer().get().isPositive(),
             "jwtExpirationBuffer must be positive");
+        checkArgument(
+            initialTokenWait().isEmpty() || initialTokenWait().get().isPositive(),
+            "initialTokenWait must be positive");
+        checkArgument(
+            refreshRetryInterval().isEmpty() || refreshRetryInterval().get().isPositive(),
+            "refreshRetryInterval must be positive");
       }
     }
   }

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactory.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactory.java
@@ -170,13 +170,17 @@ class OpaPolarisAuthorizerFactory implements PolarisAuthorizerFactory {
       Duration refreshInterval = fileConfig.refreshInterval().orElse(Duration.ofMinutes(5));
       boolean jwtExpirationRefresh = fileConfig.jwtExpirationRefresh().orElse(true);
       Duration jwtExpirationBuffer = fileConfig.jwtExpirationBuffer().orElse(Duration.ofMinutes(1));
+      Duration initialTokenWait = fileConfig.initialTokenWait().orElse(Duration.ofSeconds(5));
+      Duration refreshRetryInterval =
+          fileConfig.refreshRetryInterval().orElse(Duration.ofSeconds(1));
 
       return new FileBearerTokenProvider(
           fileConfig.path(),
           refreshInterval,
           jwtExpirationRefresh,
           jwtExpirationBuffer,
-          Duration.ofSeconds(5), // TODO: make configurable
+          initialTokenWait,
+          refreshRetryInterval,
           asyncExec,
           clock::instant);
     } else {

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProvider.java
@@ -68,6 +68,7 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
   private final AsyncExec asyncExec;
   private final CompletableFuture<String> initialTokenFuture = new CompletableFuture<>();
   private final long initialTokenWaitMillis;
+  private final Duration refreshRetryInterval;
 
   private volatile String cachedToken;
   private volatile Instant lastRefresh;
@@ -81,6 +82,9 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
    * @param refreshInterval how often to check for token file changes (fallback for non-JWT tokens)
    * @param jwtExpirationRefresh whether to use JWT expiration for refresh timing
    * @param jwtExpirationBuffer buffer time before JWT expiration to refresh the token
+   * @param initialTokenWait how long getToken waits for the first successful token refresh
+   * @param refreshRetryInterval how long to wait before retrying a failed token refresh
+   * @param asyncExec asynchronous executor used to schedule refresh attempts
    * @param clock clock instance for time operations
    * @throws IllegalStateException if the initial token cannot be loaded from the file
    */
@@ -90,6 +94,7 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
       boolean jwtExpirationRefresh,
       Duration jwtExpirationBuffer,
       Duration initialTokenWait,
+      Duration refreshRetryInterval,
       AsyncExec asyncExec,
       Supplier<Instant> clock) {
     this.tokenFilePath = tokenFilePath;
@@ -97,6 +102,7 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
     this.jwtExpirationRefresh = jwtExpirationRefresh;
     this.jwtExpirationBuffer = jwtExpirationBuffer;
     this.initialTokenWaitMillis = initialTokenWait.toMillis();
+    this.refreshRetryInterval = refreshRetryInterval;
     this.clock = clock;
     this.asyncExec = asyncExec;
 
@@ -155,7 +161,7 @@ public class FileBearerTokenProvider implements BearerTokenProvider {
       }
     } else {
       // Token refresh did not succeed, retry soon
-      delay = Duration.ofSeconds(1); // TODO: make configurable
+      delay = refreshRetryInterval;
     }
     scheduleRefreshAttempt(delay);
   }

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactoryTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerFactoryTest.java
@@ -123,6 +123,7 @@ public class OpaPolarisAuthorizerFactoryTest {
               true,
               Duration.ofMinutes(1),
               Duration.ofSeconds(10),
+              Duration.ofSeconds(1),
               asyncExec,
               Clock.systemUTC()::instant)) {
 

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/token/FileBearerTokenProviderTest.java
@@ -60,6 +60,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofMinutes(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
 
@@ -122,6 +123,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofMinutes(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
 
@@ -131,6 +133,31 @@ public class FileBearerTokenProviderTest {
       // Test token retrieval (should trim whitespace)
       String actualToken = provider.getToken();
       assertThat(actualToken).isEqualTo(expectedToken);
+    }
+  }
+
+  @Test
+  public void testRefreshRetryInterval() throws IOException {
+    Path tokenFile = tempDir.resolve("token.txt");
+    Files.writeString(tokenFile, "");
+
+    MutableMonotonicClock monotonicClock = new MutableMonotonicClock();
+    MockAsyncExec asyncExec = new MockAsyncExec(monotonicClock);
+
+    try (FileBearerTokenProvider provider =
+        new FileBearerTokenProvider(
+            tokenFile,
+            Duration.ofMinutes(5),
+            true,
+            Duration.ofMinutes(1),
+            Duration.ofMillis(1),
+            Duration.ofSeconds(42),
+            asyncExec,
+            monotonicClock::currentInstant)) {
+      asyncExec.readyCallables().forEach(MockAsyncExec.Task::call);
+
+      assertThat(asyncExec.readyCount(monotonicClock.currentInstant().plusSeconds(41))).isZero();
+      assertThat(asyncExec.readyCount(monotonicClock.currentInstant().plusSeconds(42))).isOne();
     }
   }
 
@@ -153,6 +180,7 @@ public class FileBearerTokenProviderTest {
             false,
             Duration.ofMinutes(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
 
@@ -195,6 +223,7 @@ public class FileBearerTokenProviderTest {
                         true,
                         Duration.ofMinutes(1),
                         Duration.ofMillis(1),
+                        Duration.ofSeconds(1),
                         asyncExec,
                         monotonicClock::currentInstant)
                     .close())
@@ -225,6 +254,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofSeconds(3),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
       // run outstanding token-refresh task
@@ -269,6 +299,7 @@ public class FileBearerTokenProviderTest {
             false,
             Duration.ofSeconds(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
       // run outstanding token-refresh task
@@ -315,6 +346,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofSeconds(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
       // run outstanding token-refresh task
@@ -359,6 +391,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofSeconds(60),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
       // run outstanding token-refresh task
@@ -388,6 +421,7 @@ public class FileBearerTokenProviderTest {
             true,
             Duration.ofSeconds(1),
             Duration.ofMillis(1),
+            Duration.ofSeconds(1),
             asyncExec,
             monotonicClock::currentInstant)) {
       // run outstanding token-refresh task

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -274,6 +274,8 @@ polaris.oidc.principal-roles-mapper.type=default
 # polaris.authorization.opa.auth.bearer.file-based.refresh-interval=PT5M
 # polaris.authorization.opa.auth.bearer.file-based.jwt-expiration-refresh=true
 # polaris.authorization.opa.auth.bearer.file-based.jwt-expiration-buffer=PT1M
+# polaris.authorization.opa.auth.bearer.file-based.initial-token-wait=PT5S
+# polaris.authorization.opa.auth.bearer.file-based.refresh-retry-interval=PT1S
 
 # Ranger authorizer
 # polaris.authorization.type=ranger

--- a/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authorization_opa.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authorization_opa.md
@@ -36,6 +36,8 @@ Beta Feature: OPA authorization is currently in Beta and is not a stable  releas
 | `polaris.authorization.opa.auth.bearer.file-based.refresh-interval` |  | `duration` | How often to refresh file-based bearer tokens (defaults to 5 minutes if not specified)  |
 | `polaris.authorization.opa.auth.bearer.file-based.jwt-expiration-refresh` |  | `boolean` | Whether to automatically detect JWT tokens and use their 'exp' field for refresh timing. If  true and the token is a valid JWT with an 'exp' claim, the token will be refreshed based on  the expiration time minus the buffer, rather than the fixed refresh interval. Defaults to  true if not specified.  |
 | `polaris.authorization.opa.auth.bearer.file-based.jwt-expiration-buffer` |  | `duration` | Buffer time before JWT expiration to refresh the token. Only used when jwtExpirationRefresh  is true and the token is a valid JWT. Defaults to 1 minute if not specified.  |
+| `polaris.authorization.opa.auth.bearer.file-based.initial-token-wait` |  | `duration` | How long to wait for the first token load before failing a request. Defaults to 5 seconds. |
+| `polaris.authorization.opa.auth.bearer.file-based.refresh-retry-interval` |  | `duration` | How long to wait before retrying after a failed token refresh. Defaults to 1 second. |
 | `polaris.authorization.opa.http.timeout` | `PT2S` | `duration` |  |
 | `polaris.authorization.opa.http.verify-ssl` | `true` | `boolean` |  |
 | `polaris.authorization.opa.http.trust-store-path` |  | `path` |  |


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
## Summary

 This resolves the TODO around hard-coded token timing by adding optional file-based bearer token settings for:
  - `initial-token-wait`
  - `refresh-retry-interval`
 
Defaults remain unchanged:
  - Initial token wait: `PT5S`
  - Refresh retry interval: `PT1S`
  

## Testing
 - `extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/
  opa/token/FileBearerTokenProviderTest.java`
 - `extensions/auth/opa/impl/src/test/java/org/apache/polaris/extension/auth/
  opa/OpaPolarisAuthorizerFactoryTest.java`


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
