### PR TITLE
perf(persistence): bound JDBC hasChildren existence check with LIMIT

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -747,7 +747,7 @@ public class JdbcBasePersistenceImpl
       var results =
           datasourceOperations.executeSelect(
               QueryGenerator.generateSelectQuery(
-                  ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params),
+                  ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params, 1),
               new ModelEntity(schemaVersion));
       return results != null && !results.isEmpty();
     } catch (SQLException e) {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -57,13 +57,35 @@ public class QueryGenerator {
    * @param tableName Target table name.
    * @param whereClause Column-value pairs used in WHERE filtering.
    * @return A parameterized SELECT query.
-   * @throws IllegalArgumentException if any whereClause column isn't in projections.
+   * @throws IllegalArgumentException if any whereClause column isn't in projections or if limit is
+   *     not positive.
    */
   public static PreparedQuery generateSelectQuery(
       @NonNull List<String> projections,
       @NonNull String tableName,
       @NonNull Map<String, Object> whereClause) {
     return generateSelectQuery(projections, tableName, whereClause, Map.of(), null);
+  }
+
+  /**
+   * Generates a SELECT query bounded by a row limit. Useful for existence checks that only need to
+   * know whether any matching row exists, avoiding fetching and materializing the full result set.
+   *
+   * @param projections List of columns to retrieve.
+   * @param tableName Target table name.
+   * @param whereClause Column-value pairs used in WHERE filtering.
+   * @param limit Maximum number of rows to return.
+   * @return A parameterized SELECT query with a LIMIT clause.
+   * @throws IllegalArgumentException if any whereClause column isn't in projections.
+   */
+  public static PreparedQuery generateSelectQuery(
+      @NonNull List<String> projections,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereClause,
+      int limit) {
+    QueryFragment where = generateWhereClause(new HashSet<>(projections), whereClause, Map.of());
+    PreparedQuery query = generateSelectQuery(projections, tableName, where.sql(), null, limit);
+    return new PreparedQuery(query.sql(), where.parameters());
   }
 
   /**
@@ -303,6 +325,18 @@ public class QueryGenerator {
       @NonNull String tableName,
       @NonNull String filter,
       @Nullable String orderByColumn) {
+    return generateSelectQuery(columnNames, tableName, filter, orderByColumn, null);
+  }
+
+  private static PreparedQuery generateSelectQuery(
+      @NonNull List<String> columnNames,
+      @NonNull String tableName,
+      @NonNull String filter,
+      @Nullable String orderByColumn,
+      @Nullable Integer limit) {
+    if (limit != null && limit <= 0) {
+      throw new IllegalArgumentException("Limit must be positive");
+    }
     String sql =
         "SELECT "
             + String.join(", ", columnNames)
@@ -311,6 +345,9 @@ public class QueryGenerator {
             + filter;
     if (orderByColumn != null) {
       sql += " ORDER BY " + orderByColumn + " ASC";
+    }
+    if (limit != null) {
+      sql += " LIMIT " + limit;
     }
     return new PreparedQuery(sql, Collections.emptyList());
   }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/QueryGeneratorTest.java
@@ -36,6 +36,8 @@ import org.apache.polaris.core.entity.PolarisEntityId;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class QueryGeneratorTest {
 
@@ -53,6 +55,35 @@ public class QueryGeneratorTest {
         QueryGenerator.generateSelectQuery(
                 ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause)
             .sql());
+  }
+
+  @Test
+  void testGenerateSelectQuery_withLimitAppendsLimitClause() {
+    Map<String, Object> whereClause = new LinkedHashMap<>();
+    whereClause.put("catalog_id", 123L);
+    whereClause.put("parent_id", 1L);
+    String expectedQuery =
+        "SELECT id, catalog_id, parent_id, type_code, name, entity_version, sub_type_code, create_timestamp, drop_timestamp, purge_timestamp, to_purge_timestamp, last_update_timestamp, properties, internal_properties, grant_records_version, location_without_scheme FROM POLARIS_SCHEMA.ENTITIES WHERE catalog_id = ? AND parent_id = ? LIMIT 1";
+    QueryGenerator.PreparedQuery query =
+        QueryGenerator.generateSelectQuery(
+            ModelEntity.getAllColumnNames(2), ModelEntity.TABLE_NAME, whereClause, 1);
+    assertEquals(expectedQuery, query.sql());
+    Assertions.assertThat(query.parameters()).containsExactly(123L, 1L);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1})
+  void testGenerateSelectQuery_withNonPositiveLimitThrows(int limit) {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                QueryGenerator.generateSelectQuery(
+                    ModelEntity.getAllColumnNames(2),
+                    ModelEntity.TABLE_NAME,
+                    Map.of("catalog_id", 123L),
+                    limit));
+    assertEquals("Limit must be positive", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes.
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

`JdbcBasePersistenceImpl.hasChildren` only needs to know whether a parent entity
has at least one child, but it does far more work than that. It builds a SELECT
over every entity column with no row limit, then hands the result to
`DatasourceOperations.executeSelect`, which collects the entire `ResultSet` into
a list (`stream.forEach(results::add)`) before the method simply returns
`results != null && !results.isEmpty()`. Every matching child row is therefore
fetched, transferred over the wire, and deserialized in full, including the
potentially large `properties` and `internal_properties` JSON columns, only to be
discarded.

This path runs when dropping a catalog or a namespace
(`AtomicOperationMetaStoreManager.hasChildren`). When dropping a namespace the
check matches all child types (tables and views included), so dropping a
namespace that holds many tables loads every one of them into memory just to
decide `NAMESPACE_NOT_EMPTY`. That adds needless latency and allocation and risks
`OutOfMemoryError` on large namespaces. The JDBC layer already has a bounded
existence-check pattern next door: `QueryGenerator.generateEntityTableExistQuery`
uses `LIMIT 1` for the table-level check.

This change bounds the existence check:

- Add a `LIMIT`-aware `generateSelectQuery(projections, tableName, whereClause, int limit)`
  overload in `QueryGenerator`. It mirrors the existing 4-arg public overload and
  threads an optional limit through a new private builder, so every existing caller
  keeps emitting no `LIMIT` (the previous private builder now delegates with `null`).
  The `LIMIT` is appended after any `ORDER BY`, which is valid clause order for all
  supported backends. The shared builder rejects non-positive limits.
- Call it from `hasChildren` with a limit of `1`. Behavior is unchanged: with at
  most one row returned, `!results.isEmpty()` still means "has at least one child",
  so the method still returns `true` when a child exists and `false` otherwise.

`LIMIT` is standard SQL accepted by all supported backends (PostgreSQL,
CockroachDB, H2). The projection is intentionally left unchanged: `ModelEntity`
reads every column when converting a row, so narrowing the projection would need
a separate converter and a larger change. `LIMIT 1` alone removes the full scan,
transfer, and materialization.

I kept the projection full and the interface surface additive rather than changing
any existing method signature, per the project's evolution guidelines.

### Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
