### PR TITLE
Fix catalog create secret cleanup

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -801,7 +801,9 @@ public class PolarisAdminService {
                     .atWarn()
                     .setCause(e)
                     .addKeyValue("secretReference", secretReference.urn())
-                    .log("Failed to clean up secret after catalog creation failure");
+                    .log(
+                        "Failed to clean up secret {} after catalog creation failure",
+                        secretReference.urn());
               }
             });
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -788,6 +788,24 @@ public class PolarisAdminService {
     return secretReferences;
   }
 
+  private void deleteSecretReferencesAfterFailedCatalogCreate(
+      Map<String, SecretReference> secretReferences) {
+    secretReferences
+        .values()
+        .forEach(
+            secretReference -> {
+              try {
+                getUserSecretsManager().deleteSecret(secretReference);
+              } catch (RuntimeException e) {
+                LOGGER
+                    .atWarn()
+                    .setCause(e)
+                    .addKeyValue("secretReference", secretReference.urn())
+                    .log("Failed to clean up secret after catalog creation failure");
+              }
+            });
+  }
+
   /**
    * @see #extractSecretReferences
    */
@@ -819,77 +837,83 @@ public class PolarisAdminService {
             .setProperties(reservedProperties.removeReservedProperties(entity.getPropertiesAsMap()))
             .build();
 
-    if (catalog instanceof ExternalCatalog externalCatalog) {
-      ConnectionConfigInfo connectionConfigInfo = externalCatalog.getConnectionConfigInfo();
+    Map<String, SecretReference> processedSecretReferences = Map.of();
+    boolean catalogCreated = false;
+    try {
+      if (catalog instanceof ExternalCatalog externalCatalog) {
+        ConnectionConfigInfo connectionConfigInfo = externalCatalog.getConnectionConfigInfo();
 
-      if (connectionConfigInfo != null) {
-        LOGGER
-            .atDebug()
-            .addKeyValue("catalogName", entity.getName())
-            .log("Creating a federated catalog");
-        FeatureConfiguration.enforceFeatureEnabledOrThrow(
-            realmConfig, FeatureConfiguration.ENABLE_CATALOG_FEDERATION);
-        Map<String, SecretReference> processedSecretReferences = Map.of();
-        List<String> supportedAuthenticationTypes =
-            realmConfig
-                .getConfig(FeatureConfiguration.SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES)
-                .stream()
-                .map(s -> s.toUpperCase(Locale.ROOT))
-                .toList();
-        if (requiresSecretReferenceExtraction(connectionConfigInfo)) {
-          // For fields that contain references to secrets, we'll separately process the secrets
-          // from the original request first, and then populate those fields with the extracted
-          // secret references as part of the construction of the internal persistence entity.
-          checkState(
-              supportedAuthenticationTypes.contains(
-                  connectionConfigInfo
-                      .getAuthenticationParameters()
-                      .getAuthenticationType()
-                      .name()),
-              "Authentication type %s is not supported.",
-              connectionConfigInfo.getAuthenticationParameters().getAuthenticationType());
-          processedSecretReferences = extractSecretReferences(externalCatalog, entity);
-        } else {
-          // Support no-auth catalog federation only when the feature is enabled.
-          checkState(
-              supportedAuthenticationTypes.contains(
-                  AuthenticationParameters.AuthenticationTypeEnum.IMPLICIT.name()),
-              "Implicit authentication based catalog federation is not supported.");
+        if (connectionConfigInfo != null) {
+          LOGGER
+              .atDebug()
+              .addKeyValue("catalogName", entity.getName())
+              .log("Creating a federated catalog");
+          FeatureConfiguration.enforceFeatureEnabledOrThrow(
+              realmConfig, FeatureConfiguration.ENABLE_CATALOG_FEDERATION);
+          List<String> supportedAuthenticationTypes =
+              realmConfig
+                  .getConfig(FeatureConfiguration.SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES)
+                  .stream()
+                  .map(s -> s.toUpperCase(Locale.ROOT))
+                  .toList();
+          if (requiresSecretReferenceExtraction(connectionConfigInfo)) {
+            // For fields that contain references to secrets, we'll separately process the secrets
+            // from the original request first, and then populate those fields with the extracted
+            // secret references as part of the construction of the internal persistence entity.
+            checkState(
+                supportedAuthenticationTypes.contains(
+                    connectionConfigInfo
+                        .getAuthenticationParameters()
+                        .getAuthenticationType()
+                        .name()),
+                "Authentication type %s is not supported.",
+                connectionConfigInfo.getAuthenticationParameters().getAuthenticationType());
+            processedSecretReferences = extractSecretReferences(externalCatalog, entity);
+          } else {
+            // Support no-auth catalog federation only when the feature is enabled.
+            checkState(
+                supportedAuthenticationTypes.contains(
+                    AuthenticationParameters.AuthenticationTypeEnum.IMPLICIT.name()),
+                "Implicit authentication based catalog federation is not supported.");
+          }
+
+          // Allocate service identity if needed for the authentication type.
+          // The provider will determine if a service identity is required based on the connection
+          // config.
+          Optional<ServiceIdentityInfoDpo> serviceIdentityInfoDpoOptional =
+              serviceIdentityProvider.allocateServiceIdentity(connectionConfigInfo);
+
+          entity =
+              new CatalogEntity.Builder(entity)
+                  .setConnectionConfigInfoDpoWithSecrets(
+                      connectionConfigInfo,
+                      processedSecretReferences,
+                      serviceIdentityInfoDpoOptional.orElse(null))
+                  .build();
         }
+      }
 
-        // Allocate service identity if needed for the authentication type.
-        // The provider will determine if a service identity is required based on the connection
-        // config.
-        Optional<ServiceIdentityInfoDpo> serviceIdentityInfoDpoOptional =
-            serviceIdentityProvider.allocateServiceIdentity(connectionConfigInfo);
-
-        entity =
-            new CatalogEntity.Builder(entity)
-                .setConnectionConfigInfoDpoWithSecrets(
-                    connectionConfigInfo,
-                    processedSecretReferences,
-                    serviceIdentityInfoDpoOptional.orElse(null))
-                .build();
+      CreateCatalogResult catalogResult =
+          metaStoreManager.createCatalog(getCurrentPolarisContext(), entity, List.of());
+      if (catalogResult.alreadyExists()) {
+        throw new AlreadyExistsException(
+            "Cannot create Catalog %s. Catalog already exists or resolution failed",
+            entity.getName());
+      } else if (!catalogResult.isSuccess()) {
+        throw new IllegalStateException(
+            String.format(
+                "Cannot create Catalog %s: %s with extraInfo %s",
+                entity.getName(),
+                catalogResult.getReturnStatus(),
+                catalogResult.getExtraInformation()));
+      }
+      catalogCreated = true;
+      return PolarisEntity.of(catalogResult.getCatalog());
+    } finally {
+      if (!catalogCreated) {
+        deleteSecretReferencesAfterFailedCatalogCreate(processedSecretReferences);
       }
     }
-
-    CreateCatalogResult catalogResult =
-        metaStoreManager.createCatalog(getCurrentPolarisContext(), entity, List.of());
-    if (catalogResult.alreadyExists()) {
-      // TODO: Proactive garbage-collection of any inline secrets that were written to the
-      // secrets manager, here and on any other unexpected exception as well.
-      throw new AlreadyExistsException(
-          "Cannot create Catalog %s. Catalog already exists or resolution failed",
-          entity.getName());
-    } else if (!catalogResult.isSuccess()) {
-      throw new IllegalStateException(
-          String.format(
-              "Cannot create Catalog %s: %s with extraInfo %s",
-              entity.getName(),
-              catalogResult.getReturnStatus(),
-              catalogResult.getExtraInformation()));
-    }
-    return PolarisEntity.of(catalogResult.getCatalog());
   }
 
   public void deleteCatalog(String name) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -24,25 +24,44 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisCallContext;
+import org.apache.polaris.core.admin.model.AuthenticationParameters;
+import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
+import org.apache.polaris.core.admin.model.Catalog;
+import org.apache.polaris.core.admin.model.CatalogProperties;
+import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
+import org.apache.polaris.core.admin.model.CreateCatalogRequest;
+import org.apache.polaris.core.admin.model.ExternalCatalog;
+import org.apache.polaris.core.admin.model.IcebergRestConnectionConfigInfo;
+import org.apache.polaris.core.admin.model.OAuthClientCredentialsParameters;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.catalog.PolarisCatalogHelpers;
+import org.apache.polaris.core.config.BehaviorChangeConfiguration;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.NamespaceEntity;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrivilege;
@@ -51,6 +70,7 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.PrivilegeResult;
@@ -58,6 +78,7 @@ import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.ResolverStatus;
+import org.apache.polaris.core.secrets.SecretReference;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.service.config.ReservedProperties;
 import org.assertj.core.api.Assertions;
@@ -126,6 +147,62 @@ public class PolarisAdminServiceTest {
 
   protected static void assertSuccess(BaseResult result) {
     Assertions.assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
+  void testCreateCatalogCleansUpInlineSecretsWhenCatalogAlreadyExists() {
+    SecretReference secretReference =
+        new SecretReference("urn:polaris-secret:test:oauth", Map.of());
+    setupExternalCatalogCreate(secretReference);
+    when(metaStoreManager.createCatalog(any(), any(), any()))
+        .thenReturn(new CreateCatalogResult(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, null));
+
+    assertThatThrownBy(
+            () ->
+                adminService.createCatalog(new CreateCatalogRequest(createExternalOauthCatalog())))
+        .isInstanceOf(AlreadyExistsException.class);
+
+    verify(userSecretsManager).deleteSecret(secretReference);
+  }
+
+  @Test
+  void testCreateCatalogCleanupFailureDoesNotHideOriginalFailure() {
+    SecretReference secretReference =
+        new SecretReference("urn:polaris-secret:test:oauth", Map.of());
+    setupExternalCatalogCreate(secretReference);
+    CreateCatalogResult resultWithError =
+        new CreateCatalogResult(
+            BaseResult.ReturnStatus.UNEXPECTED_ERROR_SIGNALED, "Unexpected Error Occurred");
+    when(metaStoreManager.createCatalog(any(), any(), any())).thenReturn(resultWithError);
+    doThrow(new RuntimeException("cleanup failed")).when(userSecretsManager).deleteSecret(any());
+
+    assertThatThrownBy(
+            () ->
+                adminService.createCatalog(new CreateCatalogRequest(createExternalOauthCatalog())))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            String.format(
+                "Cannot create Catalog %s: %s with extraInfo %s",
+                "external-catalog",
+                resultWithError.getReturnStatus(),
+                resultWithError.getExtraInformation()));
+
+    verify(userSecretsManager).deleteSecret(secretReference);
+  }
+
+  @Test
+  void testCreateCatalogDoesNotCleanUpInlineSecretsOnSuccess() {
+    SecretReference secretReference =
+        new SecretReference("urn:polaris-secret:test:oauth", Map.of());
+    setupExternalCatalogCreate(secretReference);
+    when(metaStoreManager.createCatalog(any(), any(), any()))
+        .thenReturn(
+            new CreateCatalogResult(
+                createBaseCatalog("external-catalog"), createBaseCatalogRole()));
+
+    adminService.createCatalog(new CreateCatalogRequest(createExternalOauthCatalog()));
+
+    verify(userSecretsManager, never()).deleteSecret(any());
   }
 
   @Test
@@ -703,6 +780,77 @@ public class PolarisAdminServiceTest {
         .setCatalogId(1L)
         .setCreateTimestamp(System.currentTimeMillis())
         .build();
+  }
+
+  private void setupExternalCatalogCreate(SecretReference secretReference) {
+    when(realmConfig.getConfig(FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS))
+        .thenReturn(true);
+    when(realmConfig.getConfig(BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS))
+        .thenReturn(-1);
+    when(realmConfig.getConfig(FeatureConfiguration.ENABLE_CATALOG_FEDERATION)).thenReturn(true);
+    when(realmConfig.getConfig(
+            FeatureConfiguration.SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES))
+        .thenReturn(List.of(AuthenticationParameters.AuthenticationTypeEnum.OAUTH.name()));
+
+    GenerateEntityIdResult idResult = mock(GenerateEntityIdResult.class);
+    when(idResult.getId()).thenReturn(2L);
+    when(metaStoreManager.generateNewEntityId(any())).thenReturn(idResult);
+    when(reservedProperties.removeReservedProperties(Mockito.<Map<String, String>>any()))
+        .thenReturn(Map.of());
+    when(userSecretsManager.writeSecret(any(), any())).thenReturn(secretReference);
+    when(identityProvider.allocateServiceIdentity(any())).thenReturn(Optional.empty());
+  }
+
+  private Catalog createExternalOauthCatalog() {
+    AwsStorageConfigInfo awsConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::123456789012:role/my-role")
+            .setExternalId("externalId")
+            .setUserArn("userArn")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of("s3://bucket/path/to/data"))
+            .build();
+    ConnectionConfigInfo connectionConfigInfo =
+        IcebergRestConnectionConfigInfo.builder(
+                ConnectionConfigInfo.ConnectionTypeEnum.ICEBERG_REST)
+            .setUri("https://example.com/polaris/api/catalog")
+            .setRemoteCatalogName("remote-catalog")
+            .setAuthenticationParameters(
+                OAuthClientCredentialsParameters.builder(
+                        AuthenticationParameters.AuthenticationTypeEnum.OAUTH)
+                    .setClientId("client-id")
+                    .setClientSecret("client-secret")
+                    .setScopes(List.of("PRINCIPAL_ROLE:ALL"))
+                    .build())
+            .build();
+
+    return ExternalCatalog.builder()
+        .setType(Catalog.TypeEnum.EXTERNAL)
+        .setName("external-catalog")
+        .setProperties(CatalogProperties.builder("s3://bucket/path/to/data").build())
+        .setStorageConfigInfo(awsConfigModel)
+        .setConnectionConfigInfo(connectionConfigInfo)
+        .build();
+  }
+
+  private PolarisBaseEntity createBaseCatalog(String name) {
+    return new PolarisBaseEntity(
+        PolarisEntityConstants.getNullId(),
+        2L,
+        PolarisEntityType.CATALOG,
+        PolarisEntitySubType.NULL_SUBTYPE,
+        PolarisEntityConstants.getRootEntityId(),
+        name);
+  }
+
+  private PolarisBaseEntity createBaseCatalogRole() {
+    return new PolarisBaseEntity(
+        2L,
+        3L,
+        PolarisEntityType.CATALOG_ROLE,
+        PolarisEntitySubType.NULL_SUBTYPE,
+        2L,
+        PolarisEntityConstants.getNameOfCatalogAdminRole());
   }
 
   private PolarisEntity createEntity(String name, PolarisEntityType type, long id) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
+import org.apache.polaris.core.admin.model.BearerAuthenticationParameters;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogProperties;
 import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
@@ -160,6 +161,23 @@ public class PolarisAdminServiceTest {
     assertThatThrownBy(
             () ->
                 adminService.createCatalog(new CreateCatalogRequest(createExternalOauthCatalog())))
+        .isInstanceOf(AlreadyExistsException.class);
+
+    verify(userSecretsManager).deleteSecret(secretReference);
+  }
+
+  @Test
+  void testCreateCatalogCleansUpInlineBearerSecretWhenCatalogAlreadyExists() {
+    SecretReference secretReference =
+        new SecretReference("urn:polaris-secret:test:bearer", Map.of());
+    setupExternalCatalogCreate(
+        secretReference, AuthenticationParameters.AuthenticationTypeEnum.BEARER);
+    when(metaStoreManager.createCatalog(any(), any(), any()))
+        .thenReturn(new CreateCatalogResult(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, null));
+
+    assertThatThrownBy(
+            () ->
+                adminService.createCatalog(new CreateCatalogRequest(createExternalBearerCatalog())))
         .isInstanceOf(AlreadyExistsException.class);
 
     verify(userSecretsManager).deleteSecret(secretReference);
@@ -783,6 +801,12 @@ public class PolarisAdminServiceTest {
   }
 
   private void setupExternalCatalogCreate(SecretReference secretReference) {
+    setupExternalCatalogCreate(
+        secretReference, AuthenticationParameters.AuthenticationTypeEnum.OAUTH);
+  }
+
+  private void setupExternalCatalogCreate(
+      SecretReference secretReference, AuthenticationParameters.AuthenticationTypeEnum authType) {
     when(realmConfig.getConfig(FeatureConfiguration.ALLOW_OVERLAPPING_CATALOG_URLS))
         .thenReturn(true);
     when(realmConfig.getConfig(BehaviorChangeConfiguration.STORAGE_CONFIGURATION_MAX_LOCATIONS))
@@ -790,7 +814,7 @@ public class PolarisAdminServiceTest {
     when(realmConfig.getConfig(FeatureConfiguration.ENABLE_CATALOG_FEDERATION)).thenReturn(true);
     when(realmConfig.getConfig(
             FeatureConfiguration.SUPPORTED_EXTERNAL_CATALOG_AUTHENTICATION_TYPES))
-        .thenReturn(List.of(AuthenticationParameters.AuthenticationTypeEnum.OAUTH.name()));
+        .thenReturn(List.of(authType.name()));
 
     GenerateEntityIdResult idResult = mock(GenerateEntityIdResult.class);
     when(idResult.getId()).thenReturn(2L);
@@ -801,15 +825,17 @@ public class PolarisAdminServiceTest {
     when(identityProvider.allocateServiceIdentity(any())).thenReturn(Optional.empty());
   }
 
+  private AwsStorageConfigInfo createAwsStorageConfig() {
+    return AwsStorageConfigInfo.builder()
+        .setRoleArn("arn:aws:iam::123456789012:role/my-role")
+        .setExternalId("externalId")
+        .setUserArn("userArn")
+        .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+        .setAllowedLocations(List.of("s3://bucket/path/to/data"))
+        .build();
+  }
+
   private Catalog createExternalOauthCatalog() {
-    AwsStorageConfigInfo awsConfigModel =
-        AwsStorageConfigInfo.builder()
-            .setRoleArn("arn:aws:iam::123456789012:role/my-role")
-            .setExternalId("externalId")
-            .setUserArn("userArn")
-            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
-            .setAllowedLocations(List.of("s3://bucket/path/to/data"))
-            .build();
     ConnectionConfigInfo connectionConfigInfo =
         IcebergRestConnectionConfigInfo.builder(
                 ConnectionConfigInfo.ConnectionTypeEnum.ICEBERG_REST)
@@ -828,7 +854,29 @@ public class PolarisAdminServiceTest {
         .setType(Catalog.TypeEnum.EXTERNAL)
         .setName("external-catalog")
         .setProperties(CatalogProperties.builder("s3://bucket/path/to/data").build())
-        .setStorageConfigInfo(awsConfigModel)
+        .setStorageConfigInfo(createAwsStorageConfig())
+        .setConnectionConfigInfo(connectionConfigInfo)
+        .build();
+  }
+
+  private Catalog createExternalBearerCatalog() {
+    ConnectionConfigInfo connectionConfigInfo =
+        IcebergRestConnectionConfigInfo.builder(
+                ConnectionConfigInfo.ConnectionTypeEnum.ICEBERG_REST)
+            .setUri("https://example.com/polaris/api/catalog")
+            .setRemoteCatalogName("remote-catalog")
+            .setAuthenticationParameters(
+                BearerAuthenticationParameters.builder(
+                        AuthenticationParameters.AuthenticationTypeEnum.BEARER)
+                    .setBearerToken("bearer-token")
+                    .build())
+            .build();
+
+    return ExternalCatalog.builder()
+        .setType(Catalog.TypeEnum.EXTERNAL)
+        .setName("external-catalog")
+        .setProperties(CatalogProperties.builder("s3://bucket/path/to/data").build())
+        .setStorageConfigInfo(createAwsStorageConfig())
         .setConnectionConfigInfo(connectionConfigInfo)
         .build();
   }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->
## Summary
Solve the TODO for `// TODO: Proactive garbage-collection of any inline secrets that were written to the secrets manager, here and on any other unexpected exception as well.`
Clean up inline external catalog secrets when catalog creation fails.
External catalog creation can write inline OAuth or bearer credentials to `UserSecretsManager` before the catalog entity is created in the metastore.
If catalog creation then fails, those stored secrets could be left behind without a catalog referencing them.

This change tracks the `SecretReference`s produced during catalog creation and deletes them if the catalog is not successfully created.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
