### PR TITLE
fix(catalog): encode default table locations with UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Deprecations
 
 ### Fixes
+- Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.
 - `TableCleanupTaskHandler` now clamps `TABLE_METADATA_CLEANUP_BATCH_SIZE` to at least 1. Previously a non-positive realm override caused an infinite loop (0) or `IllegalArgumentException` (<0) when splitting metadata files for cleanup.
 - `ManifestFileCleanupTaskHandler` now handles Iceberg v2 delete manifests in addition to data manifests. Previously, `DROP TABLE PURGE` on a v2 table that had been updated via merge-on-read DML left position-delete files and their manifests as orphans in object storage; the cleanup task failed silently because `ManifestFiles.read()` rejects delete manifests.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1191,11 +1191,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     locationBuilder.append(LocationUtils.computeHash(tableIdentifier.toString()));
 
     for (String ns : tableIdentifier.namespace().levels()) {
-      locationBuilder.append("/").append(URLEncoder.encode(ns, Charset.defaultCharset()));
+      locationBuilder.append("/").append(URLEncoder.encode(ns, StandardCharsets.UTF_8));
     }
     locationBuilder
         .append("/")
-        .append(URLEncoder.encode(defaultTableLikeName(tableIdentifier), Charset.defaultCharset()))
+        .append(URLEncoder.encode(defaultTableLikeName(tableIdentifier), StandardCharsets.UTF_8))
         .append("/");
     return locationBuilder.toString();
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
@@ -19,10 +19,18 @@
 
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_TABLE_LOCATION_OVERLAP;
+import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION;
+import static org.apache.polaris.core.config.FeatureConfiguration.DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED;
+import static org.apache.polaris.core.config.FeatureConfiguration.DEFAULT_UNIQUE_TABLE_LOCATION_ENABLED;
+import static org.apache.polaris.core.config.FeatureConfiguration.OPTIMIZED_SIBLING_CHECK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +39,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -55,6 +64,7 @@ class LocalIcebergCatalogTest {
 
   @Mock ResolverFactory resolverFactory;
   @Mock CallContext callContext;
+  @Mock RealmConfig realmConfig;
   @Mock PolarisResolutionManifestCatalogView resolvedEntityView;
   @Mock CatalogEntity catalogEntity;
   @Mock PolarisDiagnostics diagnostics;
@@ -73,9 +83,13 @@ class LocalIcebergCatalogTest {
 
   @BeforeEach
   void initMocks() {
+    when(callContext.getRealmConfig()).thenReturn(realmConfig);
+    when(catalogEntity.getName()).thenReturn("catalog");
     when(resolvedEntityView.getResolvedCatalogEntity()).thenReturn(catalogEntity);
-    when(resolverFactory.createResolver(any(), any())).thenReturn(resolver);
-    when(resolver.resolveAll()).thenReturn(new ResolverStatus(ResolverStatus.StatusEnum.SUCCESS));
+    lenient().when(resolverFactory.createResolver(any(), any())).thenReturn(resolver);
+    lenient()
+        .when(resolver.resolveAll())
+        .thenReturn(new ResolverStatus(ResolverStatus.StatusEnum.SUCCESS));
 
     rns1 = new ResolvedPolarisEntity(ns1, List.of(), List.of());
     rns2 = new ResolvedPolarisEntity(ns2, List.of(), List.of());
@@ -94,6 +108,29 @@ class LocalIcebergCatalogTest {
             null,
             null,
             null);
+  }
+
+  @Test
+  void testHashedTableLocationsEncodeNonAsciiIdentifiersAsUtf8() {
+    when(realmConfig.getConfig(DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED, catalogEntity))
+        .thenReturn(true);
+    when(realmConfig.getConfig(ALLOW_UNSTRUCTURED_TABLE_LOCATION, catalogEntity)).thenReturn(true);
+    when(realmConfig.getConfig(ALLOW_TABLE_LOCATION_OVERLAP, catalogEntity)).thenReturn(true);
+    when(realmConfig.getConfig(OPTIMIZED_SIBLING_CHECK, catalogEntity)).thenReturn(false);
+    when(realmConfig.getConfig(DEFAULT_UNIQUE_TABLE_LOCATION_ENABLED, catalogEntity))
+        .thenReturn(false);
+    catalog.initialize("catalog", Map.of("warehouse", "s3://bucket/base"));
+
+    String namespace = "n\u00e9\u6f22";
+    String table = "t\u00e9\u6f22";
+    String location = catalog.defaultWarehouseLocation(TableIdentifier.of(namespace, table));
+
+    String expectedSuffix =
+        String.format(
+            "/%s/%s/",
+            URLEncoder.encode(namespace, StandardCharsets.UTF_8),
+            URLEncoder.encode(table, StandardCharsets.UTF_8));
+    assertThat(location).endsWith(expectedSuffix);
   }
 
   @Test


### PR DESCRIPTION
`LocalIcebergCatalog.buildPrefixedLocation` used the JVM default charset when percent-encoding namespace levels and table names. For non-ASCII identifiers, this made derived storage locations platform-dependent and potentially lossy.

This change uses `StandardCharsets.UTF_8` for both segments, matching Polaris's other URL encoding call sites. The rebase also preserves the newer `defaultTableLikeName` behavior for unique table locations.

The regression test now lives in `LocalIcebergCatalogTest` and verifies the UTF-8 encoded suffix directly.

## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic (not needed)
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Updated documentation in `site/content/in-dev/unreleased` (not needed, no API or configuration change)
