### PR TITLE
fix(build): make semantic models OpenAPI generation cacheable

### DIFF
--- a/extensions/semantic-models/build.gradle.kts
+++ b/extensions/semantic-models/build.gradle.kts
@@ -126,5 +126,5 @@ sourceSets { main { java { srcDir(generatedOpenApiSrcDir) } } }
 tasks.named<GenerateTask>("openApiGenerate") {
   inputs.dir(templatesDir)
   inputs.dir(specsDir)
-  actions.addFirst { delete { delete(generatedDir) } }
+  cleanupOutput = true
 }


### PR DESCRIPTION
Fixes #4978

This updates the semantic-models OpenAPI generation task to use `GenerateTask.cleanupOutput` instead of adding a custom Gradle script action. The custom action captures build-script state, which prevents Gradle from storing the configuration cache; the built-in flag performs the same output cleanup using task-owned state, matching the existing generated API modules.

Verified locally with `./gradlew --configuration-cache format compileAll`, `./gradlew :polaris-extensions-semantic-models:check`, and `./gradlew --configuration-cache compileAll`.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4978
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)