### PR TITLE
Mark OSI semantic-model API as beta

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -509,7 +509,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
       PolarisConfiguration.<Boolean>builder()
           .key("ENABLE_SEMANTIC_MODELS")
           .description(
-              "If true, the semantic-model (OSI) endpoints are enabled. This is a beta feature: "
+              "If true, the semantic-model (Apache Ossie) endpoints are enabled. This is a beta feature: "
                   + "the API is under active development and may change in a backward-incompatible "
                   + "way. It is disabled by default; enable it with caution and report any issues "
                   + "encountered.")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -508,8 +508,12 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
   public static final FeatureConfiguration<Boolean> ENABLE_SEMANTIC_MODELS =
       PolarisConfiguration.<Boolean>builder()
           .key("ENABLE_SEMANTIC_MODELS")
-          .description("If true, the semantic-model (OSI) endpoints are enabled")
-          .defaultValue(false) // keep it to false until the implementation is done
+          .description(
+              "If true, the semantic-model (OSI) endpoints are enabled. This is a beta feature: "
+                  + "the API is under active development and may change in a backward-incompatible "
+                  + "way. It is disabled by default; enable it with caution and report any issues "
+                  + "encountered.")
+          .defaultValue(false) // beta feature, keep it off by default
           .buildFeatureConfiguration();
 
   public static final FeatureConfiguration<List<String>> SUPPORTED_CATALOG_CONNECTION_TYPES =

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -309,7 +309,7 @@ If true, the policy-store endpoints are enabled
 
 ##### `polaris.features."ENABLE_SEMANTIC_MODELS"`
 
-If true, the semantic-model (OSI) endpoints are enabled
+If true, the semantic-model (OSI) endpoints are enabled. This is a beta feature: the API is under active development and may change in a backward-incompatible way. It is disabled by default; enable it with caution and report any issues encountered.
 
 - **Type:** `Boolean`
 - **Default:** `false`

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -309,7 +309,7 @@ If true, the policy-store endpoints are enabled
 
 ##### `polaris.features."ENABLE_SEMANTIC_MODELS"`
 
-If true, the semantic-model (OSI) endpoints are enabled. This is a beta feature: the API is under active development and may change in a backward-incompatible way. It is disabled by default; enable it with caution and report any issues encountered.
+If true, the semantic-model (Apache Ossie) endpoints are enabled. This is a beta feature: the API is under active development and may change in a backward-incompatible way. It is disabled by default; enable it with caution and report any issues encountered.
 
 - **Type:** `Boolean`
 - **Default:** `false`

--- a/spec/polaris-catalog-apis/semantic-models-api.yaml
+++ b/spec/polaris-catalog-apis/semantic-models-api.yaml
@@ -31,6 +31,9 @@ paths:
       summary: Create a semantic model in the given namespace
       operationId: createSemanticModel
       description: |
+        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        backward-incompatible way.
+
         Creates a semantic model in the specified namespace.
 
         A semantic model is an Open Semantic Interchange (OSI) document describing
@@ -83,6 +86,9 @@ paths:
       summary: List semantic models in the given namespace
       operationId: listSemanticModels
       description: |
+        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        backward-incompatible way.
+
         List semantic-model identifiers under a namespace.
       parameters:
         - $ref: '../iceberg-rest-catalog-open-api.yaml#/components/parameters/page-token'
@@ -122,7 +128,11 @@ paths:
         - Semantic Model API
       summary: Load a semantic model
       operationId: loadSemanticModel
-      description: Load a semantic model from the catalog.
+      description: |
+        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        backward-incompatible way.
+
+        Load a semantic model from the catalog.
       responses:
         200:
           $ref: '#/components/responses/LoadSemanticModelResponse'
@@ -152,6 +162,9 @@ paths:
       summary: Update a semantic model
       operationId: updateSemanticModel
       description: |
+        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        backward-incompatible way.
+
         Replace a semantic model's document with a new one.
 
         Upon a successful update, the model's entity-version changes and the new value is returned.
@@ -205,7 +218,11 @@ paths:
         - Semantic Model API
       summary: Drop a semantic model from the catalog
       operationId: dropSemanticModel
-      description: Remove a semantic model from the catalog.
+      description: |
+        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        backward-incompatible way.
+
+        Remove a semantic model from the catalog.
       responses:
         204:
           description: Success, no content

--- a/spec/polaris-catalog-apis/semantic-models-api.yaml
+++ b/spec/polaris-catalog-apis/semantic-models-api.yaml
@@ -31,12 +31,12 @@ paths:
       summary: Create a semantic model in the given namespace
       operationId: createSemanticModel
       description: |
-        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        **Beta:** The semantic-model (Apache Ossie) API is under active development and may change in a
         backward-incompatible way.
 
         Creates a semantic model in the specified namespace.
 
-        A semantic model is an Open Semantic Interchange (OSI) document describing
+        A semantic model is an Apache Ossie document describing
         datasets, fields, relationships, metrics, and AI context for a logical analytics surface above
         physical tables and views.
 
@@ -86,7 +86,7 @@ paths:
       summary: List semantic models in the given namespace
       operationId: listSemanticModels
       description: |
-        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        **Beta:** The semantic-model (Apache Ossie) API is under active development and may change in a
         backward-incompatible way.
 
         List semantic-model identifiers under a namespace.
@@ -129,7 +129,7 @@ paths:
       summary: Load a semantic model
       operationId: loadSemanticModel
       description: |
-        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        **Beta:** The semantic-model (Apache Ossie) API is under active development and may change in a
         backward-incompatible way.
 
         Load a semantic model from the catalog.
@@ -162,7 +162,7 @@ paths:
       summary: Update a semantic model
       operationId: updateSemanticModel
       description: |
-        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        **Beta:** The semantic-model (Apache Ossie) API is under active development and may change in a
         backward-incompatible way.
 
         Replace a semantic model's document with a new one.
@@ -219,7 +219,7 @@ paths:
       summary: Drop a semantic model from the catalog
       operationId: dropSemanticModel
       description: |
-        **Beta:** The semantic-model (OSI) API is under active development and may change in a
+        **Beta:** The semantic-model (Apache Ossie) API is under active development and may change in a
         backward-incompatible way.
 
         Remove a semantic model from the catalog.
@@ -276,18 +276,18 @@ components:
 
     SemanticModelDocument:
       type: object
-      description: An Open Semantic Interchange (OSI) document body.
+      description: An Apache Ossie document body.
       required:
         - version
         - semantic_model
       properties:
         version:
           type: string
-          description: The OSI spec version.
+          description: The Apache Ossie spec version.
           example: "0.1.1"
         semantic_model:
           type: string
-          description: The OSI semantic model serialized as a JSON string.
+          description: The Apache Ossie semantic model serialized as a JSON string.
       example:
         version: "0.1.1"
         semantic_model: '{"name":"tpcds_retail_model","description":"retail analytics","datasets":[{"name":"store_sales","source":"public.store_sales","primary_key":["ss_item_sk","ss_ticket_number"]}],"metrics":[{"name":"total_sales","expression":{"dialects":[{"dialect":"ANSI_SQL","expression":"SUM(ss_ext_sales_price)"}]}}]}'
@@ -366,7 +366,7 @@ components:
       description: |
         Response when a semantic model is successfully updated.
 
-        The updated OSI document is returned in the `document` field.
+        The updated Apache Ossie document is returned in the `document` field.
       content:
         application/json:
           schema:


### PR DESCRIPTION
Follow-up to #4816: Add beta wording so users know the API is under active development and may change incompatibly.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
