### PR TITLE
CLI: Update apache polairs cli version in uv.lock

### DIFF
--- a/client/python/uv.lock
+++ b/client/python/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "apache-polaris"
-version = "1.4.0rc2"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The `uv.lock` is still outdated for `apache-polaris` package while main is already on `1.6.0` (https://github.com/apache/polaris/blob/main/client/python/pyproject.toml#L22). This is not a blocker for release.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
