### PR TITLE
Update to correct URL for ProductionReadinessChecks.java

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -102,7 +102,7 @@ public class ProductionReadinessChecks {
       LOGGER
           .makeLoggingEventBuilder(hasSevere ? Level.ERROR : Level.WARN)
           .log(
-              "Refer to https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production for more information.");
+              "Refer to https://polaris.apache.org/in-dev/unreleased/configuration/configuring-polaris-for-production/ for more information.");
 
       if (hasSevere) {
         if (!config.ignoreSevereIssues()) {


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently we have following which is not a valid URL:
```
2026-07-06 23:15:12,619 ERROR [org.apa.pol.ser.con.ProductionReadinessChecks] [,] [,,,] (Quarkus Main Thread) Refer to https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production for more information.
```

This PR updates the runtime console to show the correct URL for config:
```
➜  ~ curl -s -o /dev/null -w "%{http_code}" https://polaris.apache.org/in-dev/unreleased/configuring-polaris-for-production
404%

➜  ~ curl -s -o /dev/null -w "%{http_code}" https://polaris.apache.org/in-dev/unreleased/configuration/configuring-polaris-for-production/
200%
```

Here is the new sample log:
```
2026-07-06 23:21:36,879 ERROR [org.apa.pol.ser.con.ProductionReadinessChecks] [,] [,,,] (Quarkus Main Thread) Refer to https://polaris.apache.org/in-dev/unreleased/configuration/configuring-polaris-for-production/ for more information.
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
