### PR TITLE
Removed pinned version for org.graalvm.shadowed:icu4j

### DIFF
--- a/gradle/license/allowed-licenses.json
+++ b/gradle/license/allowed-licenses.json
@@ -97,8 +97,7 @@
     },
     {
        "moduleLicense": "Unicode/ICU License",
-       "moduleName": "org.graalvm.shadowed:icu4j",
-       "moduleVersion": "25.0.3"
+       "moduleName": "org.graalvm.shadowed:icu4j"
     }
   ]
 }


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

`org.graalvm.shadowed:icu4j` had been causing failed renovate jobs twice already (earlier was https://github.com/apache/polaris/pull/4272 and now https://github.com/apache/polaris/pull/4943). I am not sure if we really needed to pinned to a specific version. If not, perhaps we should remove the pinned version so renovate bot can handle this package as rest of the other packages.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
