### PR TITLE
fix: render diagnostic extra info in PolarisDiagnostics.fail messages

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/PolarisDefaultDiagServiceImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/PolarisDefaultDiagServiceImpl.java
@@ -35,7 +35,8 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
    */
   @Override
   public RuntimeException fail(String signature, String extraInfoFormat, Object... extraInfoArgs) {
-    Preconditions.checkState(false, "%s: %s, %s", signature, extraInfoFormat, extraInfoArgs);
+    Preconditions.checkState(
+        false, "%s: %s, %s", signature, extraInfoFormat, Arrays.toString(extraInfoArgs));
     throw new RuntimeException(signature);
   }
 
@@ -53,7 +54,12 @@ public class PolarisDefaultDiagServiceImpl implements PolarisDiagnostics {
   public RuntimeException fail(
       String signature, Throwable cause, String extraInfoFormat, Object... extraInfoArgs) {
     Preconditions.checkState(
-        false, "%s: %s, %s (cause: %s)", signature, extraInfoFormat, extraInfoArgs, cause);
+        false,
+        "%s: %s, %s (cause: %s)",
+        signature,
+        extraInfoFormat,
+        Arrays.toString(extraInfoArgs),
+        cause);
     throw new RuntimeException(cause.getMessage());
   }
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/PolarisDefaultDiagServiceImplTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/PolarisDefaultDiagServiceImplTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class PolarisDefaultDiagServiceImplTest {
+
+  private final PolarisDiagnostics diagnostics = new PolarisDefaultDiagServiceImpl();
+
+  @Test
+  void testFailRendersExtraInfoArgs() {
+    assertThatThrownBy(() -> diagnostics.fail("someMethodName", "id=%s fileName=%s", 42, "foo.txt"))
+        .hasMessageContaining("someMethodName")
+        .hasMessageContaining("42")
+        .hasMessageContaining("foo.txt")
+        .hasMessageNotContaining("[Ljava.lang.Object");
+  }
+
+  @Test
+  void testFailWithCauseRendersExtraInfoArgs() {
+    Throwable cause = new IllegalArgumentException("boom");
+    assertThatThrownBy(
+            () -> diagnostics.fail("someMethodName", cause, "id=%s fileName=%s", 42, "foo.txt"))
+        .hasMessageContaining("someMethodName")
+        .hasMessageContaining("42")
+        .hasMessageContaining("foo.txt")
+        .hasMessageNotContaining("[Ljava.lang.Object");
+  }
+}


### PR DESCRIPTION

<!--
This fills the repo's .github/pull_request_template.md. The template is only a
Checklist; a short "why" description is added above it per AGENTS.md.
-->

Both `fail(...)` overloads in `PolarisDefaultDiagServiceImpl` passed the raw
`extraInfoArgs` `Object[]` straight into Guava's `Preconditions.checkState(...)`.
Because the array was handed in as a single trailing `%s` argument (rather than
expanded), Guava stringified it with `String.valueOf` on the array reference, so the
extra-info placeholder rendered the array's JVM identity, e.g.:

```
someMethodName: id=%s fileName=%s, [Ljava.lang.Object;@2ff4acd0
```

instead of the actual debug values. Every failure diagnostic raised through `fail`
therefore lost its extra information, which is the array-identity symptom noted in
issue #759.

The sibling `check(...)` and `checkNotNull(...)` methods in the same class already
wrap the args with `Arrays.toString(extraInfoArgs)`. This change applies the same
wrapping in both `fail` overloads so all four methods are consistent:

```
someMethodName: id=%s fileName=%s, [42, foo.txt]
```

`Arrays` is already imported (used by `check`/`checkNotNull`), so there is no new
import. Added `PolarisDefaultDiagServiceImplTest` covering both `fail` overloads; it
asserts the real argument values appear in the message and the `[Ljava.lang.Object`
identity string does not. It fails on `main` and passes with this change.

Scope note: issue #759 raises other, broader points (a `{}` vs `%s` placeholder
mismatch, cryptic signature-only messages, and two larger options to refactor or
remove `PolarisDiagnostics`). This PR intentionally does none of those. It is a
narrow bug fix for the array-identity rendering only, which is why it links
`Related to #759` rather than `Fixes #759`.

### Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #759
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)

<!--
Checklist rationale (delete this comment before submitting):
- Security: N/A, not a security change.
- Comments: N/A, the fix is a one-line change mirroring existing sibling methods; no
  complex logic to comment.
- CHANGELOG: not added. The change fixes the text of an internal assertion/diagnostic
  exception message; it is not a user-facing config, API, or documented behavior
  change. Reviewer may ask for an `## [Unreleased]` entry; see briefing.
- docs (site/content/in-dev/unreleased): N/A for the same reason.
-->
