### PR TITLE
Add bare ADLS vended credential keys for PyIceberg compat

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
@@ -71,6 +71,12 @@ public enum StorageAccessProperty {
   // it expects for SAS
   AZURE_ACCESS_TOKEN(String.class, "", "the azure scoped access token", true),
   AZURE_SAS_TOKEN(String.class, "adls.sas-token.", "an azure shared access signature token", true),
+  AZURE_SAS_TOKEN_BARE(
+      String.class,
+      "adls.sas-token",
+      "an azure shared access signature token without host suffix",
+      true),
+  AZURE_ACCOUNT_NAME(String.class, "adls.account-name", "the azure storage account name", true),
   AZURE_REFRESH_CREDENTIALS_ENDPOINT(
       String.class,
       AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
@@ -74,7 +74,7 @@ public enum StorageAccessProperty {
   AZURE_SAS_TOKEN_BARE(
       String.class,
       "adls.sas-token",
-      "an azure shared access signature token without host suffix",
+      "an azure shared access signature token (bare property name, without the <account-host> suffix)",
       true),
   AZURE_ACCOUNT_NAME(String.class, "adls.account-name", "the azure storage account name", true),
   AZURE_REFRESH_CREDENTIALS_ENDPOINT(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -163,6 +163,7 @@ public class AzureCredentialsStorageIntegration
     validateAccountAndContainer(location, locations, writeLocations);
 
     String storageDnsName = location.getStorageAccount() + "." + location.getEndpoint();
+    String accountName = location.getStorageAccount();
     String filePath = location.getFilePath();
 
     BlobSasPermission blobSasPermission = new BlobSasPermission();
@@ -252,17 +253,19 @@ public class AzureCredentialsStorageIntegration
           String.format("Endpoint %s not supported", location.getEndpoint()));
     }
 
-    return toAccessConfig(sasToken, storageDnsName, sanitizedEndTime.toInstant(), refreshEndpoint);
+    return toAccessConfig(
+        sasToken, storageDnsName, accountName, sanitizedEndTime.toInstant(), refreshEndpoint);
   }
 
   @VisibleForTesting
   static StorageAccessConfig toAccessConfig(
       String sasToken,
       String storageDnsName,
+      String accountName,
       Instant expiresAt,
       Optional<String> refreshCredentialsEndpoint) {
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
-    handleAzureCredential(accessConfig, sasToken, storageDnsName, expiresAt);
+    handleAzureCredential(accessConfig, sasToken, storageDnsName, accountName, expiresAt);
     accessConfig.put(
         StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt.toEpochMilli()));
     refreshCredentialsEndpoint.ifPresent(
@@ -273,7 +276,11 @@ public class AzureCredentialsStorageIntegration
   }
 
   private static void handleAzureCredential(
-      StorageAccessConfig.Builder config, String sasToken, String host, Instant expiresAt) {
+      StorageAccessConfig.Builder config,
+      String sasToken,
+      String host,
+      String accountName,
+      Instant expiresAt) {
     config.putCredential(StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + host, sasToken);
     config.putCredential(
         StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX.getPropertyName() + host,
@@ -298,19 +305,11 @@ public class AzureCredentialsStorageIntegration
       }
     }
 
-    // PyIceberg and other clients need bare adls.sas-token and adls.account-name
+    // PyIceberg and other clients need bare adls.sas-token and adls.account-name for compatibility
+    // with adlfs/fsspec (and similar libraries). The bare keys are emitted in addition to the
+    // suffixed variants used by Spark.
+    // See https://github.com/apache/polaris/issues/418
     config.putCredential(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), sasToken);
-    String accountName;
-    if (host.endsWith(AzureLocation.ADLS_ENDPOINT) || host.endsWith(AzureLocation.BLOB_ENDPOINT)) {
-      int dotIndex = host.indexOf('.');
-      if (dotIndex > 0) {
-        accountName = host.substring(0, dotIndex);
-      } else {
-        accountName = host;
-      }
-    } else {
-      accountName = host;
-    }
     config.putCredential(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), accountName);
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -278,31 +278,26 @@ public class AzureCredentialsStorageIntegration
   private static void handleAzureCredential(
       StorageAccessConfig.Builder config,
       String sasToken,
-      String host,
+      String storageDnsName,
       String accountName,
       Instant expiresAt) {
-    config.putCredential(StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + host, sasToken);
     config.putCredential(
-        StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX.getPropertyName() + host,
+        StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + storageDnsName, sasToken);
+    config.putCredential(
+        StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX.getPropertyName()
+            + storageDnsName,
         String.valueOf(expiresAt.toEpochMilli()));
 
-    // Iceberg 1.7.x may expect the credential key to _not_ be suffixed with endpoint
-    if (host.endsWith(AzureLocation.ADLS_ENDPOINT)) {
-      int suffixIndex = host.lastIndexOf(AzureLocation.ADLS_ENDPOINT) - 1;
-      if (suffixIndex > 0) {
-        String withSuffixStripped = host.substring(0, suffixIndex);
-        config.putCredential(
-            StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + withSuffixStripped, sasToken);
-      }
+    // Iceberg 1.7.x may expect the credential key to _not_ be suffixed with endpoint.
+    // We use the clean accountName (sourced from AzureLocation) for the stripped variant.
+    if (storageDnsName.endsWith(AzureLocation.ADLS_ENDPOINT)) {
+      config.putCredential(
+          StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
     }
 
-    if (host.endsWith(AzureLocation.BLOB_ENDPOINT)) {
-      int suffixIndex = host.lastIndexOf(AzureLocation.BLOB_ENDPOINT) - 1;
-      if (suffixIndex > 0) {
-        String withSuffixStripped = host.substring(0, suffixIndex);
-        config.putCredential(
-            StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + withSuffixStripped, sasToken);
-      }
+    if (storageDnsName.endsWith(AzureLocation.BLOB_ENDPOINT)) {
+      config.putCredential(
+          StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
     }
 
     // PyIceberg and other clients need bare adls.sas-token and adls.account-name for compatibility

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -163,7 +163,6 @@ public class AzureCredentialsStorageIntegration
     validateAccountAndContainer(location, locations, writeLocations);
 
     String storageDnsName = location.getStorageAccount() + "." + location.getEndpoint();
-    String accountName = location.getStorageAccount();
     String filePath = location.getFilePath();
 
     BlobSasPermission blobSasPermission = new BlobSasPermission();
@@ -253,19 +252,21 @@ public class AzureCredentialsStorageIntegration
           String.format("Endpoint %s not supported", location.getEndpoint()));
     }
 
-    return toAccessConfig(
-        sasToken, storageDnsName, accountName, sanitizedEndTime.toInstant(), refreshEndpoint);
+    return toAccessConfig(sasToken, storageDnsName, sanitizedEndTime.toInstant(), refreshEndpoint);
   }
 
   @VisibleForTesting
   static StorageAccessConfig toAccessConfig(
       String sasToken,
       String storageDnsName,
-      String accountName,
       Instant expiresAt,
       Optional<String> refreshCredentialsEndpoint) {
+    // For tests we build a fake location from the provided host part so we can pass the whole
+    // AzureLocation to handle (addresses review suggestion).
+    String fakeUri = "abfss://container@" + storageDnsName + "/path";
+    AzureLocation location = new AzureLocation(fakeUri);
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
-    handleAzureCredential(accessConfig, sasToken, storageDnsName, accountName, expiresAt);
+    handleAzureCredential(accessConfig, sasToken, location, expiresAt);
     accessConfig.put(
         StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt.toEpochMilli()));
     refreshCredentialsEndpoint.ifPresent(
@@ -278,9 +279,11 @@ public class AzureCredentialsStorageIntegration
   private static void handleAzureCredential(
       StorageAccessConfig.Builder config,
       String sasToken,
-      String storageDnsName,
-      String accountName,
+      AzureLocation location,
       Instant expiresAt) {
+    String storageDnsName = location.getStorageAccount() + "." + location.getEndpoint();
+    String accountName = location.getStorageAccount();
+
     config.putCredential(
         StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + storageDnsName, sasToken);
     config.putCredential(
@@ -289,13 +292,13 @@ public class AzureCredentialsStorageIntegration
         String.valueOf(expiresAt.toEpochMilli()));
 
     // Iceberg 1.7.x may expect the credential key to _not_ be suffixed with endpoint.
-    // We use the clean accountName (sourced from AzureLocation) for the stripped variant.
-    if (storageDnsName.endsWith(AzureLocation.ADLS_ENDPOINT)) {
+    // Use accountName (from location) for the stripped variant.
+    if (location.isAdls()) {
       config.putCredential(
           StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
     }
 
-    if (storageDnsName.endsWith(AzureLocation.BLOB_ENDPOINT)) {
+    if (location.isBlob()) {
       config.putCredential(
           StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -297,6 +297,21 @@ public class AzureCredentialsStorageIntegration
             StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + withSuffixStripped, sasToken);
       }
     }
+
+    // PyIceberg and other clients need bare adls.sas-token and adls.account-name
+    config.putCredential(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), sasToken);
+    String accountName;
+    if (host.endsWith(AzureLocation.ADLS_ENDPOINT) || host.endsWith(AzureLocation.BLOB_ENDPOINT)) {
+      int dotIndex = host.indexOf('.');
+      if (dotIndex > 0) {
+        accountName = host.substring(0, dotIndex);
+      } else {
+        accountName = host;
+      }
+    } else {
+      accountName = host;
+    }
+    config.putCredential(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), accountName);
   }
 
   private static String getBlobUserDelegationSas(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -162,7 +162,7 @@ public class AzureCredentialsStorageIntegration
     AzureLocation location = new AzureLocation(loc);
     validateAccountAndContainer(location, locations, writeLocations);
 
-    String storageDnsName = location.getStorageAccount() + "." + location.getEndpoint();
+    String storageDnsName = location.getStorageDnsName();
     String filePath = location.getFilePath();
 
     BlobSasPermission blobSasPermission = new BlobSasPermission();
@@ -252,19 +252,15 @@ public class AzureCredentialsStorageIntegration
           String.format("Endpoint %s not supported", location.getEndpoint()));
     }
 
-    return toAccessConfig(sasToken, storageDnsName, sanitizedEndTime.toInstant(), refreshEndpoint);
+    return toAccessConfig(sasToken, location, sanitizedEndTime.toInstant(), refreshEndpoint);
   }
 
   @VisibleForTesting
   static StorageAccessConfig toAccessConfig(
       String sasToken,
-      String storageDnsName,
+      AzureLocation location,
       Instant expiresAt,
       Optional<String> refreshCredentialsEndpoint) {
-    // For tests we build a fake location from the provided host part so we can pass the whole
-    // AzureLocation to handle (addresses review suggestion).
-    String fakeUri = "abfss://container@" + storageDnsName + "/path";
-    AzureLocation location = new AzureLocation(fakeUri);
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
     handleAzureCredential(accessConfig, sasToken, location, expiresAt);
     accessConfig.put(
@@ -281,7 +277,7 @@ public class AzureCredentialsStorageIntegration
       String sasToken,
       AzureLocation location,
       Instant expiresAt) {
-    String storageDnsName = location.getStorageAccount() + "." + location.getEndpoint();
+    String storageDnsName = location.getStorageDnsName();
     String accountName = location.getStorageAccount();
 
     config.putCredential(

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -88,6 +88,16 @@ public class AzureLocation extends StorageLocation {
     return endpoint;
   }
 
+  /** Returns true if this location uses the ADLS (DFS) endpoint. */
+  public boolean isAdls() {
+    return ADLS_ENDPOINT.equalsIgnoreCase(endpoint);
+  }
+
+  /** Returns true if this location uses the Blob endpoint. */
+  public boolean isBlob() {
+    return BLOB_ENDPOINT.equalsIgnoreCase(endpoint);
+  }
+
   /** Get the file path */
   public String getFilePath() {
     return filePath;

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureLocation.java
@@ -88,6 +88,11 @@ public class AzureLocation extends StorageLocation {
     return endpoint;
   }
 
+  /** Get the storage DNS name, for example: myaccount.blob.core.windows.net */
+  public String getStorageDnsName() {
+    return storageAccount + "." + endpoint;
+  }
+
   /** Returns true if this location uses the ADLS (DFS) endpoint. */
   public boolean isAdls() {
     return ADLS_ENDPOINT.equalsIgnoreCase(endpoint);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -35,7 +35,7 @@ public class AzureCredentialsStorageIntegrationTest {
     Instant expiresAt = Instant.ofEpochMilli(Long.MAX_VALUE);
 
     StorageAccessConfig noSuffixResult =
-        toAccessConfig("sasToken", "some_account", expiresAt, Optional.empty());
+        toAccessConfig("sasToken", "some_account", "some_account", expiresAt, Optional.empty());
     Assertions.assertThat(noSuffixResult.credentials()).hasSize(5);
     Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
     Assertions.assertThat(noSuffixResult.credentials())
@@ -54,6 +54,7 @@ public class AzureCredentialsStorageIntegrationTest {
         toAccessConfig(
             "sasToken",
             "some_account." + AzureLocation.ADLS_ENDPOINT,
+            "some_account",
             expiresAt,
             Optional.of("endpoint/credentials"));
     Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(6);
@@ -75,7 +76,11 @@ public class AzureCredentialsStorageIntegrationTest {
 
     StorageAccessConfig blobSuffixResult =
         toAccessConfig(
-            "sasToken", "some_account." + AzureLocation.BLOB_ENDPOINT, expiresAt, Optional.empty());
+            "sasToken",
+            "some_account." + AzureLocation.BLOB_ENDPOINT,
+            "some_account",
+            expiresAt,
+            Optional.empty());
     Assertions.assertThat(blobSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account");

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -33,13 +33,13 @@ public class AzureCredentialsStorageIntegrationTest {
   @Test
   public void testAzureCredentialFormatting() {
     Instant expiresAt = Instant.ofEpochMilli(Long.MAX_VALUE);
+    AzureLocation adlsLocation =
+        new AzureLocation("abfss://container@myaccount." + AzureLocation.ADLS_ENDPOINT + "/path");
+    AzureLocation blobLocation =
+        new AzureLocation("abfss://container@myaccount." + AzureLocation.BLOB_ENDPOINT + "/path");
 
-    // Use distinct values for storageDnsName and accountName so that asserts on bare
-    // AZURE_ACCOUNT_NAME and stripped keys clearly come from the accountName parameter
-    // (not the storageDnsName). Addresses review feedback on test conclusiveness.
     StorageAccessConfig noSuffixResult =
-        toAccessConfig(
-            "sasToken", "myaccount." + AzureLocation.ADLS_ENDPOINT, expiresAt, Optional.empty());
+        toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.empty());
     Assertions.assertThat(noSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(noSuffixResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
@@ -57,11 +57,7 @@ public class AzureCredentialsStorageIntegrationTest {
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName());
 
     StorageAccessConfig adlsSuffixResult =
-        toAccessConfig(
-            "sasToken",
-            "myaccount." + AzureLocation.ADLS_ENDPOINT,
-            expiresAt,
-            Optional.of("endpoint/credentials"));
+        toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.of("endpoint/credentials"));
     Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(adlsSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(adlsSuffixResult.credentials())
@@ -79,8 +75,7 @@ public class AzureCredentialsStorageIntegrationTest {
             "endpoint/credentials");
 
     StorageAccessConfig blobSuffixResult =
-        toAccessConfig(
-            "sasToken", "myaccount." + AzureLocation.BLOB_ENDPOINT, expiresAt, Optional.empty());
+        toAccessConfig("sasToken", blobLocation, expiresAt, Optional.empty());
     Assertions.assertThat(blobSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(blobSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(blobSuffixResult.credentials())

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -36,7 +36,7 @@ public class AzureCredentialsStorageIntegrationTest {
     AzureLocation adlsLocation =
         new AzureLocation("abfss://container@myaccount." + AzureLocation.ADLS_ENDPOINT + "/path");
     AzureLocation blobLocation =
-        new AzureLocation("abfss://container@myaccount." + AzureLocation.BLOB_ENDPOINT + "/path");
+        new AzureLocation("wasbs://container@myaccount." + AzureLocation.BLOB_ENDPOINT + "/path");
 
     // ADLS location without refresh credentials endpoint.
     StorageAccessConfig adlsNoRefreshResult =

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -38,53 +38,58 @@ public class AzureCredentialsStorageIntegrationTest {
     AzureLocation blobLocation =
         new AzureLocation("abfss://container@myaccount." + AzureLocation.BLOB_ENDPOINT + "/path");
 
-    StorageAccessConfig noSuffixResult =
+    // ADLS location without refresh credentials endpoint.
+    StorageAccessConfig adlsNoRefreshResult =
         toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.empty());
-    Assertions.assertThat(noSuffixResult.credentials()).hasSize(6);
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials()).hasSize(6);
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsKey("adls.sas-token-expires-at-ms.myaccount." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
+        .containsKey("adls.sas-token.myaccount");
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsKey(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName());
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
-    Assertions.assertThat(noSuffixResult.credentials())
+    Assertions.assertThat(adlsNoRefreshResult.credentials())
         .doesNotContainKey(
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName());
 
-    StorageAccessConfig adlsSuffixResult =
+    // ADLS location with refresh credentials endpoint.
+    StorageAccessConfig adlsWithRefreshResult =
         toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.of("endpoint/credentials"));
-    Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(6);
-    Assertions.assertThat(adlsSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
-    Assertions.assertThat(adlsSuffixResult.credentials())
+    Assertions.assertThat(adlsWithRefreshResult.credentials()).hasSize(6);
+    Assertions.assertThat(adlsWithRefreshResult.credentials())
+        .containsKey("adls.sas-token.myaccount");
+    Assertions.assertThat(adlsWithRefreshResult.credentials())
         .containsKey("adls.sas-token-expires-at-ms.myaccount." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(adlsSuffixResult.credentials())
+    Assertions.assertThat(adlsWithRefreshResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(adlsSuffixResult.credentials())
+    Assertions.assertThat(adlsWithRefreshResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
-    Assertions.assertThat(adlsSuffixResult.credentials())
+    Assertions.assertThat(adlsWithRefreshResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
 
-    Assertions.assertThat(adlsSuffixResult.extraProperties())
+    Assertions.assertThat(adlsWithRefreshResult.extraProperties())
         .containsEntry(
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName(),
             "endpoint/credentials");
 
-    StorageAccessConfig blobSuffixResult =
+    // Blob location.
+    StorageAccessConfig blobResult =
         toAccessConfig("sasToken", blobLocation, expiresAt, Optional.empty());
-    Assertions.assertThat(blobSuffixResult.credentials()).hasSize(6);
-    Assertions.assertThat(blobSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
-    Assertions.assertThat(blobSuffixResult.credentials())
+    Assertions.assertThat(blobResult.credentials()).hasSize(6);
+    Assertions.assertThat(blobResult.credentials()).containsKey("adls.sas-token.myaccount");
+    Assertions.assertThat(blobResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.BLOB_ENDPOINT);
-    Assertions.assertThat(blobSuffixResult.credentials())
+    Assertions.assertThat(blobResult.credentials())
         .containsKey("adls.sas-token-expires-at-ms.myaccount.blob.core.windows.net");
-    Assertions.assertThat(blobSuffixResult.credentials())
+    Assertions.assertThat(blobResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
-    Assertions.assertThat(blobSuffixResult.credentials())
+    Assertions.assertThat(blobResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -36,10 +36,16 @@ public class AzureCredentialsStorageIntegrationTest {
 
     StorageAccessConfig noSuffixResult =
         toAccessConfig("sasToken", "some_account", expiresAt, Optional.empty());
-    Assertions.assertThat(noSuffixResult.credentials()).hasSize(3);
+    Assertions.assertThat(noSuffixResult.credentials()).hasSize(5);
     Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
     Assertions.assertThat(noSuffixResult.credentials())
         .containsKey("adls.sas-token-expires-at-ms.some_account");
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsKey(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName());
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
     Assertions.assertThat(noSuffixResult.credentials())
         .doesNotContainKey(
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName());
@@ -50,13 +56,17 @@ public class AzureCredentialsStorageIntegrationTest {
             "some_account." + AzureLocation.ADLS_ENDPOINT,
             expiresAt,
             Optional.of("endpoint/credentials"));
-    Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(4);
+    Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(adlsSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account");
-    Assertions.assertThat(noSuffixResult.credentials())
-        .containsKey("adls.sas-token-expires-at-ms.some_account");
+    Assertions.assertThat(adlsSuffixResult.credentials())
+        .containsKey("adls.sas-token-expires-at-ms.some_account." + AzureLocation.ADLS_ENDPOINT);
     Assertions.assertThat(adlsSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
+    Assertions.assertThat(adlsSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
+    Assertions.assertThat(adlsSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
 
     Assertions.assertThat(adlsSuffixResult.extraProperties())
         .containsEntry(
@@ -66,12 +76,16 @@ public class AzureCredentialsStorageIntegrationTest {
     StorageAccessConfig blobSuffixResult =
         toAccessConfig(
             "sasToken", "some_account." + AzureLocation.BLOB_ENDPOINT, expiresAt, Optional.empty());
-    Assertions.assertThat(blobSuffixResult.credentials()).hasSize(4);
+    Assertions.assertThat(blobSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account");
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsKey("adls.sas-token-expires-at-ms.some_account.blob.core.windows.net");
+    Assertions.assertThat(blobSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
+    Assertions.assertThat(blobSuffixResult.credentials())
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -34,12 +34,23 @@ public class AzureCredentialsStorageIntegrationTest {
   public void testAzureCredentialFormatting() {
     Instant expiresAt = Instant.ofEpochMilli(Long.MAX_VALUE);
 
+    // Use a suffixed storageDnsName + clean accountName so the bare credential asserts
+    // clearly exercise the accountName parameter (addresses review feedback).
     StorageAccessConfig noSuffixResult =
-        toAccessConfig("sasToken", "some_account", "some_account", expiresAt, Optional.empty());
-    Assertions.assertThat(noSuffixResult.credentials()).hasSize(5);
-    Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
+        toAccessConfig(
+            "sasToken",
+            "some_account." + AzureLocation.ADLS_ENDPOINT,
+            "some_account",
+            expiresAt,
+            Optional.empty());
     Assertions.assertThat(noSuffixResult.credentials())
-        .containsKey("adls.sas-token-expires-at-ms.some_account");
+        .withFailMessage("Actual keys: " + noSuffixResult.credentials().keySet())
+        .hasSize(6);
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
+    Assertions.assertThat(noSuffixResult.credentials())
+        .containsKey("adls.sas-token-expires-at-ms.some_account." + AzureLocation.ADLS_ENDPOINT);
+    Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
     Assertions.assertThat(noSuffixResult.credentials())
         .containsKey(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName());
     Assertions.assertThat(noSuffixResult.credentials())

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -34,29 +34,24 @@ public class AzureCredentialsStorageIntegrationTest {
   public void testAzureCredentialFormatting() {
     Instant expiresAt = Instant.ofEpochMilli(Long.MAX_VALUE);
 
-    // Use a suffixed storageDnsName + clean accountName so the bare credential asserts
-    // clearly exercise the accountName parameter (addresses review feedback).
+    // Use distinct values for storageDnsName and accountName so that asserts on bare
+    // AZURE_ACCOUNT_NAME and stripped keys clearly come from the accountName parameter
+    // (not the storageDnsName). Addresses review feedback on test conclusiveness.
     StorageAccessConfig noSuffixResult =
         toAccessConfig(
-            "sasToken",
-            "some_account." + AzureLocation.ADLS_ENDPOINT,
-            "some_account",
-            expiresAt,
-            Optional.empty());
+            "sasToken", "myaccount." + AzureLocation.ADLS_ENDPOINT, expiresAt, Optional.empty());
+    Assertions.assertThat(noSuffixResult.credentials()).hasSize(6);
     Assertions.assertThat(noSuffixResult.credentials())
-        .withFailMessage("Actual keys: " + noSuffixResult.credentials().keySet())
-        .hasSize(6);
+        .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
     Assertions.assertThat(noSuffixResult.credentials())
-        .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(noSuffixResult.credentials())
-        .containsKey("adls.sas-token-expires-at-ms.some_account." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.some_account");
+        .containsKey("adls.sas-token-expires-at-ms.myaccount." + AzureLocation.ADLS_ENDPOINT);
+    Assertions.assertThat(noSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(noSuffixResult.credentials())
         .containsKey(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName());
     Assertions.assertThat(noSuffixResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
     Assertions.assertThat(noSuffixResult.credentials())
-        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
     Assertions.assertThat(noSuffixResult.credentials())
         .doesNotContainKey(
             StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT.getPropertyName());
@@ -64,21 +59,19 @@ public class AzureCredentialsStorageIntegrationTest {
     StorageAccessConfig adlsSuffixResult =
         toAccessConfig(
             "sasToken",
-            "some_account." + AzureLocation.ADLS_ENDPOINT,
-            "some_account",
+            "myaccount." + AzureLocation.ADLS_ENDPOINT,
             expiresAt,
             Optional.of("endpoint/credentials"));
     Assertions.assertThat(adlsSuffixResult.credentials()).hasSize(6);
+    Assertions.assertThat(adlsSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(adlsSuffixResult.credentials())
-        .containsKey("adls.sas-token.some_account");
+        .containsKey("adls.sas-token-expires-at-ms.myaccount." + AzureLocation.ADLS_ENDPOINT);
     Assertions.assertThat(adlsSuffixResult.credentials())
-        .containsKey("adls.sas-token-expires-at-ms.some_account." + AzureLocation.ADLS_ENDPOINT);
-    Assertions.assertThat(adlsSuffixResult.credentials())
-        .containsKey("adls.sas-token.some_account." + AzureLocation.ADLS_ENDPOINT);
+        .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
     Assertions.assertThat(adlsSuffixResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
     Assertions.assertThat(adlsSuffixResult.credentials())
-        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
 
     Assertions.assertThat(adlsSuffixResult.extraProperties())
         .containsEntry(
@@ -87,21 +80,16 @@ public class AzureCredentialsStorageIntegrationTest {
 
     StorageAccessConfig blobSuffixResult =
         toAccessConfig(
-            "sasToken",
-            "some_account." + AzureLocation.BLOB_ENDPOINT,
-            "some_account",
-            expiresAt,
-            Optional.empty());
+            "sasToken", "myaccount." + AzureLocation.BLOB_ENDPOINT, expiresAt, Optional.empty());
     Assertions.assertThat(blobSuffixResult.credentials()).hasSize(6);
+    Assertions.assertThat(blobSuffixResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(blobSuffixResult.credentials())
-        .containsKey("adls.sas-token.some_account");
+        .containsKey("adls.sas-token.myaccount." + AzureLocation.BLOB_ENDPOINT);
     Assertions.assertThat(blobSuffixResult.credentials())
-        .containsKey("adls.sas-token.some_account." + AzureLocation.BLOB_ENDPOINT);
-    Assertions.assertThat(blobSuffixResult.credentials())
-        .containsKey("adls.sas-token-expires-at-ms.some_account.blob.core.windows.net");
+        .containsKey("adls.sas-token-expires-at-ms.myaccount.blob.core.windows.net");
     Assertions.assertThat(blobSuffixResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
     Assertions.assertThat(blobSuffixResult.credentials())
-        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "some_account");
+        .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureLocationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureLocationTest.java
@@ -31,6 +31,8 @@ public class AzureLocationTest {
     Assertions.assertThat(azureLocation.getContainer()).isEqualTo("container");
     Assertions.assertThat(azureLocation.getStorageAccount()).isEqualTo("storageaccount");
     Assertions.assertThat(azureLocation.getEndpoint()).isEqualTo("blob.core.windows.net");
+    Assertions.assertThat(azureLocation.getStorageDnsName())
+        .isEqualTo("storageaccount.blob.core.windows.net");
     Assertions.assertThat(azureLocation.getFilePath()).isEqualTo("myfile");
   }
 


### PR DESCRIPTION
PyIceberg (via adlfs/fsspec) and other non-Spark clients fail to authenticate with Azure ADLS vended credentials because Polaris only emitted the suffixed form `adls.sas-token.<account-host>`.

added the bare credential keys that those clients expect `adls.sas-token` and `adls.account-name`
`adls.account-host` was considered but omitted. It can cause clients to hit the DFS endpoint instead of the Blob endpoint, and the main clients we are targeting (PyIceberg/adlfs, PyArrow) do not require it.

Fixes #418