### PR TITLE
Make admin tool bootstrap idempotent for already-bootstrapped realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added `REGISTER_TABLE_OVERWRITE` authorization operation mapped to `TABLE_FULL_METADATA` for deterministic overwrite authorization.
 
 ### Changes
+- The admin tool's `bootstrap` command is now idempotent: bootstrapping a realm that is already
+  bootstrapped is reported as "Realm '<realm>' is already bootstrapped; skipping." and no longer
+  fails the command, making automated bootstrap jobs safe to re-run. Correspondingly,
+  `PolarisMetaStoreManager.bootstrapPolarisService` now returns a result with
+  `ReturnStatus.ENTITY_ALREADY_EXISTS` instead of throwing `IllegalArgumentException` when the
+  root principal already exists. Existing credentials are never returned or altered.
 - Added REPL support to Polaris CLI.
 - The `nosql maintenance-run` admin command now rejects a new run when the latest recorded maintenance run is still unfinished, unless the operator explicitly passes `--supersede-run=<run-id>`.
 - Added version option to Polaris CLI.

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
@@ -32,6 +32,7 @@ import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
@@ -54,11 +55,9 @@ public class AuthBootstrapUtil {
 
     Optional<PrincipalEntity> preliminaryRootPrincipal = metaStoreManager.findRootPrincipal(ctx);
     if (preliminaryRootPrincipal.isPresent()) {
-      String overrideMessage =
-          "It appears this metastore manager has already been bootstrapped. "
-              + "To continue bootstrapping, please first purge the metastore with the `purge` command.";
-      LOGGER.error("\n\n {} \n\n", overrideMessage);
-      throw new IllegalArgumentException(overrideMessage);
+      LOGGER.info("Realm is already bootstrapped (root principal exists); nothing to do.");
+      return new PrincipalSecretsResult(
+          BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, "realm is already bootstrapped");
     }
 
     // Create a root container entity that can represent the securable for any top-level grants.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/LocalPolarisMetaStoreManagerFactory.java
@@ -188,11 +188,11 @@ public abstract class LocalPolarisMetaStoreManagerFactory<StoreType>
     Optional<PrincipalEntity> preliminaryRootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext);
     if (preliminaryRootPrincipal.isPresent()) {
-      String overrideMessage =
-          "It appears this metastore manager has already been bootstrapped. "
-              + "To continue bootstrapping, please first purge the metastore with the `purge` command.";
-      LOGGER.error("\n\n {} \n\n", overrideMessage);
-      throw new IllegalArgumentException(overrideMessage);
+      LOGGER.info(
+          "Realm {} is already bootstrapped (root principal exists); nothing to do.",
+          realmContext.getRealmIdentifier());
+      return new PrincipalSecretsResult(
+          BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, "realm is already bootstrapped");
     }
 
     metaStoreManager.bootstrapPolarisService(polarisContext);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -70,15 +70,16 @@ public interface PolarisMetaStoreManager
 
   /**
    * Bootstrap the Polaris service, creating the root catalog, root principal, and associated
-   * service admin role. Will fail if the service has already been bootstrapped.
+   * service admin role. If the service has already been bootstrapped, this is a no-op that returns
+   * a result with {@link BaseResult.ReturnStatus#ENTITY_ALREADY_EXISTS}.
    *
    * @param callCtx call context
-   * @return the result of the bootstrap attempt
+   * @return the result of the bootstrap attempt; {@code alreadyExists()} is true if the service was
+   *     already bootstrapped
    */
   @NonNull
   default BaseResult bootstrapPolarisService(@NonNull PolarisCallContext callCtx) {
-    AuthBootstrapUtil.createPolarisPrincipalForRealm(this, callCtx);
-    return new BaseResult(BaseResult.ReturnStatus.SUCCESS);
+    return AuthBootstrapUtil.createPolarisPrincipalForRealm(this, callCtx);
   }
 
   /**

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -44,6 +44,7 @@ import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.exceptions.AlreadyExistsException;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -80,6 +81,19 @@ public abstract class BasePolarisMetaStoreManagerTest {
   @Test
   protected void validateBootstrap() {
     // allocate test driver
+    polarisTestMetaStoreManager.validateBootstrap();
+  }
+
+  /** re-bootstrapping an already-bootstrapped service must be a graceful no-op */
+  @Test
+  protected void testBootstrapAgainIsNoOp() {
+    PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
+    // the test driver bootstrapped the service already; bootstrap a second time
+    BaseResult secondBootstrap =
+        metaStoreManager.bootstrapPolarisService(polarisTestMetaStoreManager.polarisCallContext);
+    Assertions.assertThat(secondBootstrap.isSuccess()).isFalse();
+    Assertions.assertThat(secondBootstrap.alreadyExists()).isTrue();
+    // the existing realm must be left fully intact
     polarisTestMetaStoreManager.validateBootstrap();
   }
 

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -91,8 +91,8 @@ public abstract class BasePolarisMetaStoreManagerTest {
     // the test driver bootstrapped the service already; bootstrap a second time
     BaseResult secondBootstrap =
         metaStoreManager.bootstrapPolarisService(polarisTestMetaStoreManager.polarisCallContext);
-    Assertions.assertThat(secondBootstrap.isSuccess()).isFalse();
-    Assertions.assertThat(secondBootstrap.alreadyExists()).isTrue();
+    Assertions.assertThat(secondBootstrap.getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS);
     // the existing realm must be left fully intact
     polarisTestMetaStoreManager.validateBootstrap();
   }

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -154,6 +154,7 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
 
       // Log any errors:
       boolean success = true;
+      int alreadyBootstrappedCount = 0;
       for (Map.Entry<String, PrincipalSecretsResult> result : results.entrySet()) {
         if (result.getValue().isSuccess()) {
           String realm = result.getKey();
@@ -172,6 +173,7 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
           // Re-running bootstrap on an existing realm is a no-op, not an error; this
           // keeps automated bootstrap jobs idempotent. Existing credentials are never
           // returned or altered.
+          alreadyBootstrappedCount++;
           String realm = result.getKey();
           spec.commandLine()
               .getOut()
@@ -188,7 +190,15 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
       }
 
       if (success) {
-        spec.commandLine().getOut().println("Bootstrap completed successfully.");
+        if (alreadyBootstrappedCount > 0) {
+          spec.commandLine()
+              .getOut()
+              .printf(
+                  "Bootstrap completed (%d realm(s) already bootstrapped).%n",
+                  alreadyBootstrappedCount);
+        } else {
+          spec.commandLine().getOut().println("Bootstrap completed successfully.");
+        }
         return 0;
       } else {
         spec.commandLine().getErr().println("Bootstrap encountered errors during operation.");

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -168,6 +168,14 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
                     result.getValue().getPrincipalSecrets().getMainSecret());
             spec.commandLine().getOut().println(msg);
           }
+        } else if (result.getValue().alreadyExists()) {
+          // Re-running bootstrap on an existing realm is a no-op, not an error; this
+          // keeps automated bootstrap jobs idempotent. Existing credentials are never
+          // returned or altered.
+          String realm = result.getKey();
+          spec.commandLine()
+              .getOut()
+              .printf("Realm '%s' is already bootstrapped; skipping.%n", realm);
         } else {
           String realm = result.getKey();
           spec.commandLine()


### PR DESCRIPTION
Running the admin tool's `bootstrap` against a realm that is already bootstrapped currently throws `IllegalArgumentException` ("It appears this metastore manager has already been bootstrapped…") and exits with the generic `EXIT_CODE_BOOTSTRAP_ERROR` (3) — the same code as every real failure. That makes automated deployments (Kubernetes Jobs, ArgoCD hook Jobs that run bootstrap on every deploy) fail on any redeploy, with no reliable way to distinguish the benign case short of matching the error text, and Kubernetes offers no "treat exit N as success" escape hatch. See #4995 for full context.

This change makes re-bootstrap a graceful no-op:

- `AuthBootstrapUtil.createPolarisPrincipalForRealm` returns a `PrincipalSecretsResult` with `ReturnStatus.ENTITY_ALREADY_EXISTS` instead of throwing when the root principal already exists (same for the duplicated check in `LocalPolarisMetaStoreManagerFactory`).
- `PolarisMetaStoreManager.bootstrapPolarisService` propagates that result (javadoc updated).
- `BootstrapCommand` prints `Realm '<realm>' is already bootstrapped; skipping.` for such realms and keeps exit code 0; all other failures still exit 3. `--print-credentials` never prints anything for skipped realms — existing credentials are never returned or altered, and realms in the same invocation that are *not* yet bootstrapped are still bootstrapped normally.

**Testing:** new `testBootstrapAgainIsNoOp` in `BasePolarisMetaStoreManagerTest` (runs for both TreeMap metastore variants) asserts the second bootstrap reports `alreadyExists()` and the realm stays fully intact; existing bootstrap/purge CLI tests pass unchanged (`:polaris-core:test`, `:polaris-admin:test` in-memory variants run locally; an admin-CLI-level double-bootstrap test isn't possible yet because consecutive launches don't reuse the dev-services container — see the existing TODO in `RelationalJdbcBootstrapCommandTest`). Also verified behaviorally against a live 1.5.0 deployment (relational-jdbc on PostgreSQL 16) where re-running bootstrap on an existing realm currently fails.

**AI assistance disclosure:** this PR was developed with the assistance of Claude (Anthropic's coding assistant), per the [Guidelines for AI-assisted Contributions](https://polaris.apache.org/community/contributing-guidelines/#guidelines-for-ai-assisted-contributions). I have reviewed, tested, and understand all of the changes, and assume full authorship of and responsibility for the contribution.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #4995
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)

