### PR TITLE
Fix typo in the release 4 step

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -195,7 +195,7 @@ jobs:
           echo "rc_commit=${rc_commit}" >> $GITHUB_ENV
 
           exec_process git tag -a "${final_release_tag}" "${rc_commit}" -m "Apache Polaris ${version_without_rc} Release"
-          exec_process git push apache "${final_release_tag}"
+          exec_process git push origin "${final_release_tag}"
 
           cat <<EOT >> $GITHUB_STEP_SUMMARY
           ## Git Release Tag


### PR DESCRIPTION
The step 4 of the release process can't be executed due to a typo on the git command.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
