### PR TITLE
Eliminate double existence checks in batch file cleanup

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandler.java
@@ -19,8 +19,10 @@
 package org.apache.polaris.service.task;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.context.CallContext;
@@ -54,8 +56,11 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
     TableIdentifier tableId = cleanupTask.tableId();
     List<String> batchFiles = cleanupTask.batchFiles();
     try (FileIO authorizedFileIO = fileIOSupplier.apply(task, tableId)) {
-      List<String> validFiles =
-          batchFiles.stream().filter(file -> TaskUtils.exists(file, authorizedFileIO)).toList();
+      Map<Boolean, List<String>> partitionedFiles =
+          batchFiles.stream()
+              .collect(Collectors.partitioningBy(file -> TaskUtils.exists(file, authorizedFileIO)));
+      List<String> validFiles = partitionedFiles.get(true);
+      List<String> missingFiles = partitionedFiles.get(false);
       if (validFiles.isEmpty()) {
         LOGGER
             .atWarn()
@@ -64,9 +69,7 @@ public class BatchFileCleanupTaskHandler extends FileCleanupTaskHandler {
             .log("File batch cleanup task scheduled, but none of the files in batch exists");
         return true;
       }
-      if (validFiles.size() < batchFiles.size()) {
-        List<String> missingFiles =
-            batchFiles.stream().filter(file -> !TaskUtils.exists(file, authorizedFileIO)).toList();
+      if (!missingFiles.isEmpty()) {
         LOGGER
             .atWarn()
             .addKeyValue("batchFiles", batchFiles.toString())

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/BatchFileCleanupTaskHandlerTest.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
@@ -227,6 +228,43 @@ public class BatchFileCleanupTaskHandlerTest {
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
     assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+  }
+
+  @Test
+  public void testExistenceCheckIsPerformedOncePerFile() {
+    String presentFile1 = "s3://bucket/present1";
+    String presentFile2 = "s3://bucket/present2";
+    String missingFile = "s3://bucket/missing";
+
+    InputFile presentInput = Mockito.mock(InputFile.class);
+    Mockito.when(presentInput.exists()).thenReturn(true);
+    InputFile missingInput = Mockito.mock(InputFile.class);
+    Mockito.when(missingInput.exists()).thenReturn(false);
+
+    FileIO fileIO = Mockito.mock(FileIO.class);
+    Mockito.when(fileIO.newInputFile(presentFile1)).thenReturn(presentInput);
+    Mockito.when(fileIO.newInputFile(presentFile2)).thenReturn(presentInput);
+    Mockito.when(fileIO.newInputFile(missingFile)).thenReturn(missingInput);
+
+    BatchFileCleanupTaskHandler handler = newBatchFileCleanupTaskHandler(fileIO);
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db1", "schema1"), "table1");
+    TaskEntity task =
+        new TaskEntity.Builder()
+            .withTaskType(AsyncTaskType.BATCH_FILE_CLEANUP)
+            .withData(
+                new BatchFileCleanupTaskHandler.BatchFileCleanupTask(
+                    tableIdentifier,
+                    List.of(presentFile1, presentFile2, missingFile),
+                    BatchFileCleanupTaskHandler.BatchFileType.TABLE_METADATA))
+            .setName(UUID.randomUUID().toString())
+            .build();
+
+    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+
+    // Each file must have been checked exactly once by the pre-delete scan.
+    Mockito.verify(fileIO, Mockito.times(1)).newInputFile(presentFile1);
+    Mockito.verify(fileIO, Mockito.times(1)).newInputFile(presentFile2);
+    Mockito.verify(fileIO, Mockito.times(1)).newInputFile(missingFile);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The `BatchFileCleanupTaskHandler` made two passes over the `batchFiles` list if the initial pass detected missing files, calling `TaskUtils.exists()` both times. This caused unnecessary duplicate remote network calls for every file in the batch.

`TaskUtils.exists()` is not free — it calls `fileIO.newInputFile(path).exists()` and may hit remote storage

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
