### PR TITLE
Fix default location prefix config docs

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -617,7 +617,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .description(
               "When enabled, Iceberg tables and views created without a location specified will have a prefix "
                   + "applied to the location within the catalog's base location, rather than a location directly "
-                  + "inside the parent namespace. Note that this requires ALLOW_EXTERNAL_TABLE_LOCATION to be "
+                  + "inside the parent namespace. Note that this requires ALLOW_UNSTRUCTURED_TABLE_LOCATION to be "
                   + "enabled, but with OPTIMIZED_SIBLING_CHECK enabled "
                   + "it is still possible to enforce the uniqueness of table locations within a catalog.")
           .defaultValue(false)

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -243,7 +243,7 @@ If set to true, clean up data when a namespace is dropped
 
 ##### `polaris.features."DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED"`
 
-When enabled, Iceberg tables and views created without a location specified will have a prefix applied to the location within the catalog's base location, rather than a location directly inside the parent namespace. Note that this requires ALLOW_EXTERNAL_TABLE_LOCATION to be enabled, but with OPTIMIZED_SIBLING_CHECK enabled it is still possible to enforce the uniqueness of table locations within a catalog.
+When enabled, Iceberg tables and views created without a location specified will have a prefix applied to the location within the catalog's base location, rather than a location directly inside the parent namespace. Note that this requires ALLOW_UNSTRUCTURED_TABLE_LOCATION to be enabled, but with OPTIMIZED_SIBLING_CHECK enabled it is still possible to enforce the uniqueness of table locations within a catalog.
 
 - **Type:** `Boolean`
 - **Default:** `false`


### PR DESCRIPTION
## Summary

Fix the `DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED` documentation to say it requires `ALLOW_UNSTRUCTURED_TABLE_LOCATION`, matching the implementation check.

This updates both the source config description and the in-dev site documentation so generated/reference text stays consistent.


## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: no issue, docs mismatch fix
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [x] Updated `CHANGELOG.md` (not needed)
- [x] Updated documentation in `site/content/in-dev/unreleased` (if needed)
