### PR TITLE
Deprecate external table location flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 
 ### Deprecations
-- Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for
-  external metadata file locations and `ALLOW_UNSTRUCTURED_TABLE_LOCATION` for table locations
-  outside the structured namespace layout.
+- Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations.
 
 ### Fixes
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 
 ### Deprecations
-- Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations.
+- Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations, including catalog config `polaris.config.allow.external.metadata.file.location`.
 
 ### Fixes
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 
 ### Deprecations
+- Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for
+  external metadata file locations and `ALLOW_UNSTRUCTURED_TABLE_LOCATION` for table locations
+  outside the structured namespace layout.
 
 ### Fixes
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -133,7 +133,7 @@ public class PolarisPolicyServiceIntegrationTest {
   private static final Map<String, String> DEFAULT_CATALOG_PROPERTIES =
       Map.of(
           "polaris.config.allow.unstructured.table.location", "true",
-          "polaris.config.allow.external.table.location", "true");
+          "polaris.config.allow.external.metadata.file.location", "true");
 
   @BeforeAll
   public static void setup(

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -186,7 +186,7 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   private static final Map<String, String> DEFAULT_CATALOG_PROPERTIES =
       Map.of(
           "polaris.config.allow.unstructured.table.location", "true",
-          "polaris.config.allow.external.table.location", "true",
+          "polaris.config.allow.external.metadata.file.location", "true",
           "polaris.config.list-pagination-enabled", "true",
           "polaris.config.namespace-custom-location.enabled", "true");
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -120,7 +120,8 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
 
     CatalogProperties props =
         CatalogProperties.builder(defaultBaseLocation)
-            .addProperty(FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+            .addProperty(
+                FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "true")
             .addProperty(
                 FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true")
             .addProperty(FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -336,8 +336,9 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .buildFeatureConfiguration();
 
   /**
-   * @deprecated Use {@link #ALLOW_EXTERNAL_METADATA_FILE_LOCATION} instead. This legacy flag is
-   *     retained as a compatibility alias for external metadata file locations.
+   * @deprecated since 1.7.0, will be removed in 1.8.0. Use {@link
+   *     #ALLOW_EXTERNAL_METADATA_FILE_LOCATION} instead. This legacy flag is retained as a
+   *     compatibility alias for external metadata file locations.
    */
   @SuppressWarnings("DeprecatedIsStillUsed")
   @Deprecated

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -341,7 +341,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
    *     compatibility alias for external metadata file locations.
    */
   @SuppressWarnings("DeprecatedIsStillUsed")
-  @Deprecated
+  @Deprecated(since = "1.7.0", forRemoval = true)
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_TABLE_LOCATION")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -310,7 +310,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
               "If set to true, Polaris allows metadata files to be located outside the table's "
                   + "default metadata directory. This relaxes the normal check that metadata "
                   + "stays under the table location and should only be used when metadata is "
-                  + "intentionally stored in separately controlled locations.")
+                  + "intentionally stored in separately controlled locations. Use this instead "
+                  + "of deprecated ALLOW_EXTERNAL_TABLE_LOCATION.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 
@@ -335,17 +336,21 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildFeatureConfiguration();
 
+  /**
+   * @deprecated Use {@link #ALLOW_EXTERNAL_METADATA_FILE_LOCATION} instead. This legacy flag is
+   *     retained as a compatibility alias for external metadata file locations.
+   */
+  @Deprecated
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_EXTERNAL_TABLE_LOCATION")
           .catalogConfig("polaris.config.allow.external.table.location")
           .legacyCatalogConfig("allow.external.table.location")
           .description(
-              "If set to true, Polaris treats table locations as externally managed instead of "
-                  + "assuming the default managed structure. Allowed-location validation still "
-                  + "applies, but metadata location checks are relaxed, so operators should keep "
-                  + "allowed locations narrow and specific. This setting is typically used "
-                  + "together with ALLOW_UNSTRUCTURED_TABLE_LOCATION.")
+              "Deprecated. Use ALLOW_EXTERNAL_METADATA_FILE_LOCATION instead. When enabled, this "
+                  + "legacy compatibility flag relaxes metadata location checks; it does not "
+                  + "control whether table locations may escape the structured namespace layout. "
+                  + "Use ALLOW_UNSTRUCTURED_TABLE_LOCATION for that behavior.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -339,6 +339,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
    * @deprecated Use {@link #ALLOW_EXTERNAL_METADATA_FILE_LOCATION} instead. This legacy flag is
    *     retained as a compatibility alias for external metadata file locations.
    */
+  @SuppressWarnings("DeprecatedIsStillUsed")
   @Deprecated
   public static final FeatureConfiguration<Boolean> ALLOW_EXTERNAL_TABLE_LOCATION =
       PolarisConfiguration.<Boolean>builder()

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -310,8 +310,7 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
               "If set to true, Polaris allows metadata files to be located outside the table's "
                   + "default metadata directory. This relaxes the normal check that metadata "
                   + "stays under the table location and should only be used when metadata is "
-                  + "intentionally stored in separately controlled locations. Use this instead "
-                  + "of deprecated ALLOW_EXTERNAL_TABLE_LOCATION.")
+                  + "intentionally stored in separately controlled locations.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -1227,8 +1227,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
               FeatureConfiguration.DEFAULT_LOCATION_OBJECT_STORAGE_PREFIX_ENABLED.key(),
               FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.key()));
     } else if (!allowTableLocationOverlap) {
-      // TODO consider doing this check any time ALLOW_EXTERNAL_TABLE_LOCATION is enabled, not just
-      // here
+      // TODO consider doing this check any time ALLOW_UNSTRUCTURED_TABLE_LOCATION is enabled, not
+      // just here
       if (!optimizedSiblingCheck) {
         throw new IllegalStateException(
             String.format(
@@ -2509,11 +2509,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
   private void validateMetadataFileInTableDir(
       TableIdentifier identifier, String tableLocation, String metadataLocation) {
-    boolean allowEscape =
-        realmConfig.getConfig(FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION, catalogEntity);
-    if (!allowEscape
-        && !realmConfig.getConfig(
-            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION, catalogEntity)) {
+    if (!allowExternalMetadataFileLocation()) {
       LOGGER.debug(
           "Validating base location {} for table {} in metadata file {}",
           tableLocation,
@@ -2527,6 +2523,18 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             metadataLocation, tableLocation);
       }
     }
+  }
+
+  @SuppressWarnings("deprecation")
+  private boolean allowExternalMetadataFileLocation() {
+    // ALLOW_EXTERNAL_TABLE_LOCATION is deprecated, but remains honored as a compatibility alias for
+    // existing catalogs during the migration to ALLOW_EXTERNAL_METADATA_FILE_LOCATION.
+    CatalogEntity resolvedCatalogEntity =
+        Optional.ofNullable(resolvedEntityView.getResolvedCatalogEntity()).orElse(catalogEntity);
+    return realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION, resolvedCatalogEntity)
+        || realmConfig.getConfig(
+            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION, resolvedCatalogEntity);
   }
 
   private FileIO loadFileIOForTableLike(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2525,7 +2525,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   private boolean allowExternalMetadataFileLocation() {
     // ALLOW_EXTERNAL_TABLE_LOCATION is deprecated, but remains honored as a compatibility alias for
     // existing catalogs during the migration to ALLOW_EXTERNAL_METADATA_FILE_LOCATION.

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -184,7 +184,8 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
                     .setName(CATALOG_NAME)
                     .setDefaultBaseLocation(storageLocation)
                     .addProperty(
-                        FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                        FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(),
+                        "true")
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
@@ -164,7 +164,8 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
                     .setName(CATALOG_NAME)
                     .setDefaultBaseLocation(STORAGE_LOCATION)
                     .addProperty(
-                        FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                        FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(),
+                        "true")
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -318,7 +318,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
                         .setName(CATALOG_NAME)
                         .setDefaultBaseLocation(STORAGE_LOCATION)
                         .addProperty(
-                            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(),
+                            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION
+                                .catalogConfig(),
                             "true")
                         .addProperty(
                             FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
@@ -1229,7 +1230,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     updateCatalogProperties(
         Map.of(
-            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false",
             FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
     TableMetadata tableMetadata =
@@ -1284,7 +1285,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     updateCatalogProperties(
         Map.of(
-            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false",
             FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
     TableMetadata tableMetadata =
@@ -1336,7 +1337,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     updateCatalogProperties(
         Map.of(
-            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false",
             FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
     LocalIcebergCatalog catalog = catalog();
 
@@ -2008,7 +2009,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
                     .setName(noPurgeCatalogName)
                     .setDefaultBaseLocation(storageLocation)
                     .addProperty(
-                        FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                        FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(),
+                        "true")
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")
@@ -2958,7 +2960,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     updateCatalogProperties(
         Map.of(
-            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "false",
             FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
 
     catalog.createNamespace(NS);
@@ -2991,9 +2993,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     updateCatalogProperties(
         Map.of(
-            FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "false",
-            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true",
-            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "true"));
+            FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(), "true",
+            FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(), "true"));
 
     catalog.createNamespace(NS);
     Table table = catalog.buildTable(TABLE, SCHEMA).create();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
@@ -171,7 +171,8 @@ public abstract class AbstractLocalIcebergCatalogViewTest
                 new CatalogEntity.Builder()
                     .setName(CATALOG_NAME)
                     .addProperty(
-                        FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                        FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(),
+                        "true")
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -205,7 +205,8 @@ public abstract class AbstractPolicyCatalogTest {
                     .setName(CATALOG_NAME)
                     .setDefaultBaseLocation(storageLocation)
                     .addProperty(
-                        FeatureConfiguration.ALLOW_EXTERNAL_TABLE_LOCATION.catalogConfig(), "true")
+                        FeatureConfiguration.ALLOW_EXTERNAL_METADATA_FILE_LOCATION.catalogConfig(),
+                        "true")
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -67,7 +67,7 @@ If set to true, allow credential vending for external catalogs.
 
 ##### `polaris.features."ALLOW_EXTERNAL_METADATA_FILE_LOCATION"`
 
-If set to true, Polaris allows metadata files to be located outside the table's default metadata directory. This relaxes the normal check that metadata stays under the table location and should only be used when metadata is intentionally stored in separately controlled locations.
+If set to true, Polaris allows metadata files to be located outside the table's default metadata directory. This relaxes the normal check that metadata stays under the table location and should only be used when metadata is intentionally stored in separately controlled locations. Use this instead of deprecated ALLOW_EXTERNAL_TABLE_LOCATION.
 
 - **Type:** `Boolean`
 - **Default:** `false`
@@ -77,7 +77,7 @@ If set to true, Polaris allows metadata files to be located outside the table's 
 
 ##### `polaris.features."ALLOW_EXTERNAL_TABLE_LOCATION"`
 
-If set to true, Polaris treats table locations as externally managed instead of assuming the default managed structure. Allowed-location validation still applies, but metadata location checks are relaxed, so operators should keep allowed locations narrow and specific. This setting is typically used together with ALLOW_UNSTRUCTURED_TABLE_LOCATION.
+Deprecated. Use ALLOW_EXTERNAL_METADATA_FILE_LOCATION instead. When enabled, this legacy compatibility flag relaxes metadata location checks; it does not control whether table locations may escape the structured namespace layout. Use ALLOW_UNSTRUCTURED_TABLE_LOCATION for that behavior.
 
 - **Type:** `Boolean`
 - **Default:** `false`

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -67,7 +67,7 @@ If set to true, allow credential vending for external catalogs.
 
 ##### `polaris.features."ALLOW_EXTERNAL_METADATA_FILE_LOCATION"`
 
-If set to true, Polaris allows metadata files to be located outside the table's default metadata directory. This relaxes the normal check that metadata stays under the table location and should only be used when metadata is intentionally stored in separately controlled locations. Use this instead of deprecated ALLOW_EXTERNAL_TABLE_LOCATION.
+If set to true, Polaris allows metadata files to be located outside the table's default metadata directory. This relaxes the normal check that metadata stays under the table location and should only be used when metadata is intentionally stored in separately controlled locations.
 
 - **Type:** `Boolean`
 - **Default:** `false`

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/_index.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/_index.md
@@ -224,10 +224,11 @@ Leave out `FILE` to prevent its use. Only include the storage types your setup n
 ### Review Location Compatibility Flags
 
 Treat non-default location compatibility flags as part of your production deployment review.
-`ALLOW_UNSTRUCTURED_TABLE_LOCATION`, `ALLOW_EXTERNAL_TABLE_LOCATION`,
-`ALLOW_EXTERNAL_METADATA_FILE_LOCATION`, `ALLOW_TABLE_LOCATION_OVERLAP`, and wildcard allowed
-locations all relax the default storage boundary model and should only be enabled for specific
-interoperability or migration requirements. `OPTIMIZED_SIBLING_CHECK` is not a bypass mode, but it
+`ALLOW_UNSTRUCTURED_TABLE_LOCATION`, `ALLOW_EXTERNAL_METADATA_FILE_LOCATION`,
+`ALLOW_TABLE_LOCATION_OVERLAP`, and wildcard allowed locations all relax the default storage
+boundary model and should only be enabled for specific interoperability or migration requirements.
+`ALLOW_EXTERNAL_TABLE_LOCATION` is a deprecated compatibility alias for
+`ALLOW_EXTERNAL_METADATA_FILE_LOCATION`. `OPTIMIZED_SIBLING_CHECK` is not a bypass mode, but it
 changes how overlap detection is performed and should only be enabled when the required index and
 backfill state is known to be correct.
 


### PR DESCRIPTION
## Summary

Deprecates `ALLOW_EXTERNAL_TABLE_LOCATION` as a legacy compatibility alias for external metadata file locations.

The current runtime behavior uses this flag to relax metadata file location checks, which overlaps with `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` and makes it easy to confuse with `ALLOW_UNSTRUCTURED_TABLE_LOCATION`. This PR keeps behavior unchanged, but points users to:

- `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for metadata files outside the table location
- `ALLOW_UNSTRUCTURED_TABLE_LOCATION` for table/view locations outside the structured namespace layout

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed above; no linked issue.
- [x] 🧪 Manually tested with the commands above.
- [x] 💡 No complex logic added.
- [x] 🧾 Updated `CHANGELOG.md`.
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased`.

Prepared with AI assistance; I reviewed and own the changes.
