### PR TITLE
bootstrap: skip existing realms instead of failing

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthBootstrapUtil.java
@@ -32,6 +32,7 @@ import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.dao.entity.GenerateEntityIdResult;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
@@ -57,8 +58,9 @@ public class AuthBootstrapUtil {
       String overrideMessage =
           "It appears this metastore manager has already been bootstrapped. "
               + "To continue bootstrapping, please first purge the metastore with the `purge` command.";
-      LOGGER.error("\n\n {} \n\n", overrideMessage);
-      throw new IllegalArgumentException(overrideMessage);
+      LOGGER.warn("{}", overrideMessage);
+      return new PrincipalSecretsResult(
+          BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, overrideMessage);
     }
 
     // Create a root container entity that can represent the securable for any top-level grants.

--- a/runtime/admin/build.gradle.kts
+++ b/runtime/admin/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
   compileOnly("com.fasterxml.jackson.core:jackson-databind")
 
   testImplementation(project(":polaris-runtime-test-common"))
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.junit.jupiter)
   testFixturesApi(project(":polaris-core"))
   testFixturesImplementation(project(":polaris-runtime-test-common"))
 

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -46,6 +46,12 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
     // This @Mixin provides independent, optional schema flags.
     @CommandLine.Mixin SchemaInputOptions schemaInputOptions = new SchemaInputOptions();
 
+    @CommandLine.Option(
+        names = {"--ignore-existing"},
+        description =
+            "If a realm is already bootstrapped, emit a warning and continue instead of failing.")
+    boolean ignoreExisting;
+
     // This static inner class encapsulates the mutually exclusive choices.
     static class RootCredentialsOptions {
 
@@ -169,6 +175,11 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
                     result.getValue().getPrincipalSecrets().getMainSecret());
             spec.commandLine().getOut().println(msg);
           }
+        } else if (result.getValue().alreadyExists() && inputOptions.ignoreExisting) {
+          String realm = result.getKey();
+          spec.commandLine()
+              .getErr()
+              .printf("Realm '%s' is already bootstrapped, skipping.%n", realm);
         } else {
           String realm = result.getKey();
           spec.commandLine()

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -19,13 +19,71 @@
 package org.apache.polaris.admintool;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Map;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.bootstrap.BootstrapOptions;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import picocli.CommandLine;
 
+@ExtendWith(MockitoExtension.class)
 class BootstrapCommandTest {
+
+  @Mock private MetaStoreManagerFactory factory;
+
+  @Test
+  void testIgnoreExistingSucceedsOnAlreadyBootstrappedRealm() {
+    when(factory.bootstrapRealms(any(BootstrapOptions.class)))
+        .thenReturn(
+            Map.of(
+                "realm1",
+                new PrincipalSecretsResult(
+                    BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, "realm already bootstrapped")));
+
+    BootstrapCommand cmd = new BootstrapCommand();
+    cmd.metaStoreManagerFactory = factory;
+    CommandLine cli = new CommandLine(cmd);
+    StringWriter out = new StringWriter();
+    StringWriter err = new StringWriter();
+    cli.setOut(new PrintWriter(out, true));
+    cli.setErr(new PrintWriter(err, true));
+
+    int exitCode = cli.execute("-r", "realm1", "-c", "realm1,root,s3cr3t", "--ignore-existing");
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(err.toString()).contains("realm1").contains("already bootstrapped");
+    assertThat(out.toString()).contains("Bootstrap completed successfully.");
+  }
+
+  @Test
+  void testAlreadyBootstrappedWithoutFlagFails() {
+    when(factory.bootstrapRealms(any(BootstrapOptions.class)))
+        .thenReturn(
+            Map.of(
+                "realm1",
+                new PrincipalSecretsResult(
+                    BaseResult.ReturnStatus.ENTITY_ALREADY_EXISTS, "realm already bootstrapped")));
+
+    BootstrapCommand cmd = new BootstrapCommand();
+    cmd.metaStoreManagerFactory = factory;
+    CommandLine cli = new CommandLine(cmd);
+    StringWriter err = new StringWriter();
+    cli.setErr(new PrintWriter(err, true));
+
+    int exitCode = cli.execute("-r", "realm1", "-c", "realm1,root,s3cr3t");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_BOOTSTRAP_ERROR);
+    assertThat(err.toString()).contains("Bootstrap encountered errors during operation.");
+  }
 
   @Test
   void testBootstrapInvalidCredentials() {

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
@@ -48,4 +48,29 @@ public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase
         .contains("Realm 'realm1' successfully bootstrapped.")
         .contains("Bootstrap completed successfully.");
   }
+
+  @Test
+  public void testIgnoreExistingSucceedsOnAlreadyBootstrappedRealm(
+      QuarkusMainLauncher launcher) {
+    launcher.launch("bootstrap", "-r", "realm-dup", "-c", "realm-dup,root,s3cr3t");
+
+    LaunchResult result =
+        launcher.launch(
+            "bootstrap", "-r", "realm-dup", "-c", "realm-dup,root,s3cr3t", "--ignore-existing");
+
+    assertThat(result.exitCode()).isEqualTo(0);
+    assertThat(result.getErrorOutput()).contains("Realm 'realm-dup' is already bootstrapped");
+    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
+  }
+
+  @Test
+  public void testAlreadyBootstrappedWithoutFlagFails(QuarkusMainLauncher launcher) {
+    launcher.launch("bootstrap", "-r", "realm-dup2", "-c", "realm-dup2,root,s3cr3t");
+
+    LaunchResult result =
+        launcher.launch("bootstrap", "-r", "realm-dup2", "-c", "realm-dup2,root,s3cr3t");
+
+    assertThat(result.exitCode()).isNotEqualTo(0);
+    assertThat(result.getErrorOutput()).contains("Bootstrap encountered errors during operation.");
+  }
 }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
@@ -48,29 +48,4 @@ public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase
         .contains("Realm 'realm1' successfully bootstrapped.")
         .contains("Bootstrap completed successfully.");
   }
-
-  @Test
-  public void testIgnoreExistingSucceedsOnAlreadyBootstrappedRealm(
-      QuarkusMainLauncher launcher) {
-    launcher.launch("bootstrap", "-r", "realm-dup", "-c", "realm-dup,root,s3cr3t");
-
-    LaunchResult result =
-        launcher.launch(
-            "bootstrap", "-r", "realm-dup", "-c", "realm-dup,root,s3cr3t", "--ignore-existing");
-
-    assertThat(result.exitCode()).isEqualTo(0);
-    assertThat(result.getErrorOutput()).contains("Realm 'realm-dup' is already bootstrapped");
-    assertThat(result.getOutput()).contains("Bootstrap completed successfully.");
-  }
-
-  @Test
-  public void testAlreadyBootstrappedWithoutFlagFails(QuarkusMainLauncher launcher) {
-    launcher.launch("bootstrap", "-r", "realm-dup2", "-c", "realm-dup2,root,s3cr3t");
-
-    LaunchResult result =
-        launcher.launch("bootstrap", "-r", "realm-dup2", "-c", "realm-dup2,root,s3cr3t");
-
-    assertThat(result.exitCode()).isNotEqualTo(0);
-    assertThat(result.getErrorOutput()).contains("Bootstrap encountered errors during operation.");
-  }
 }


### PR DESCRIPTION
Running bootstrap more than once on the same realm currently crashes with
an IllegalArgumentException and a non-zero exit. This makes it hard to
script (e.g. a k8s init job that runs on every upgrade).

Two changes:

1. AuthBootstrapUtil returns a structured ENTITY_ALREADY_EXISTS result
   instead of throwing, so callers can handle it explicitly.

2. BootstrapCommand gets --ignore-existing. Without it, behavior is
   unchanged (already-bootstrapped realm still fails). With it, the
   realm is skipped with a warning and the command exits 0.

Tests cover both cases against the JDBC backend.