### PR TITLE
Eliminate redundant metastore lookups when resolving principal roles

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -22,6 +22,8 @@ import com.google.common.base.Throwables;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -32,12 +34,14 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.CallContext;
+import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
-import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,17 +171,13 @@ public class DefaultAuthenticator implements Authenticator {
     Predicate<String> includeRoleFilter =
         requestedRoles == ALL_ROLES_REQUESTED ? role -> true : requestedRoles::contains;
 
+    Map<Long, PolarisBaseEntity> entitiesById = loadGrantsResult.getEntitiesAsMap();
+
     Set<String> activeRoles =
         loadGrantsResult.getGrantRecords().stream()
-            .map(
-                gr ->
-                    metaStoreManager.loadEntity(
-                        callContext.getPolarisCallContext(),
-                        gr.getSecurableCatalogId(),
-                        gr.getSecurableId(),
-                        PolarisEntityType.PRINCIPAL_ROLE))
-            .filter(EntityResult::isSuccess)
-            .map(EntityResult::getEntity)
+            .map(gr -> loadSecurableEntity(gr, entitiesById))
+            .filter(Objects::nonNull)
+            .filter(entity -> entity.getType() == PolarisEntityType.PRINCIPAL_ROLE)
             .map(PrincipalRoleEntity::of)
             .map(PrincipalRoleEntity::getName)
             .filter(includeRoleFilter)
@@ -248,5 +248,24 @@ public class DefaultAuthenticator implements Authenticator {
       throw new NotAuthorizedException("Unable to authenticate");
     }
     return principalGrantResults;
+  }
+
+  /**
+   * Resolves the securable entity for a grant record, using preloaded entities when available and
+   * falling back to {@link PolarisMetaStoreManager#loadEntity} only when the metastore did not
+   * populate {@link LoadGrantsResult#getEntities()}.
+   */
+  private @Nullable PolarisBaseEntity loadSecurableEntity(
+      PolarisGrantRecord grant, @Nullable Map<Long, PolarisBaseEntity> entitiesById) {
+    if (entitiesById != null) {
+      return entitiesById.get(grant.getSecurableId());
+    }
+    return metaStoreManager
+        .loadEntity(
+            callContext.getPolarisCallContext(),
+            grant.getSecurableCatalogId(),
+            grant.getSecurableId(),
+            PolarisEntityType.PRINCIPAL_ROLE)
+        .getEntity();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -21,6 +21,10 @@ package org.apache.polaris.service.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.quarkus.security.identity.CurrentIdentityAssociation;
@@ -31,6 +35,7 @@ import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
@@ -41,6 +46,7 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.service.admin.PolarisAdminService;
@@ -72,6 +78,7 @@ public class DefaultAuthenticatorTest {
   @Inject RealmContextHolder realmContextHolder;
   @Inject PolarisMetaStoreManager metaStoreManager;
   @Inject CallContext callContext;
+  @Inject PolarisDiagnostics diagnostics;
   @Inject ResolutionManifestFactory resolutionManifestFactory;
   @Inject UserSecretsManager userSecretsManager;
   @Inject ServiceIdentityProvider serviceIdentityProvider;
@@ -297,6 +304,73 @@ public class DefaultAuthenticatorTest {
 
     // Then: should return principal with empty roles set
     assertPrincipal(result, principalEntity);
+  }
+
+  @Test
+  void testResolvePrincipalRolesUsesEntitiesFromLoadGrantsResult() {
+    LoadGrantsResult grantsResult =
+        metaStoreManager.loadGrantsToGrantee(callContext.getPolarisCallContext(), principalEntity);
+    assertThat(grantsResult.getEntities())
+        .as("loadGrantsToGrantee must populate securable entities")
+        .isNotEmpty()
+        .allMatch(e -> e.getType() == PolarisEntityType.PRINCIPAL_ROLE);
+
+    // Build a standalone DefaultAuthenticator wired to a spied metaStoreManager so we
+    // can verify call counts. Going through the CDI-managed authenticator would give
+    // us a client proxy, and field writes on that proxy do not propagate to the
+    // per-request instance the authenticator actually uses.
+    PolarisMetaStoreManager metaStoreManagerSpy = Mockito.spy(metaStoreManager);
+    DefaultAuthenticator standaloneAuthenticator = new DefaultAuthenticator();
+    standaloneAuthenticator.metaStoreManager = metaStoreManagerSpy;
+    standaloneAuthenticator.callContext = callContext;
+    standaloneAuthenticator.diagnostics = diagnostics;
+
+    PolarisCredential credentials =
+        PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    PolarisPrincipal result = standaloneAuthenticator.authenticate(credentials);
+
+    assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
+
+    // The role entities must have been served from LoadGrantsResult.getEntities(),
+    // not re-fetched via loadEntity(..., PRINCIPAL_ROLE) per grant record.
+    verify(metaStoreManagerSpy, never())
+        .loadEntity(any(), anyLong(), anyLong(), Mockito.eq(PolarisEntityType.PRINCIPAL_ROLE));
+  }
+
+  @Test
+  void testResolvePrincipalRolesFallsBackToLoadEntityWhenEntitiesNotPreloaded() {
+    // Backward-compatibility: older metastore backends may not serialize the entities
+    // list on LoadGrantsResult (see the JSON constructor comment in LoadGrantsResult).
+    // When getEntities() returns null, the authenticator must fall back to per-record
+    // loadEntity so those deployments continue to resolve roles correctly.
+    LoadGrantsResult grants =
+        metaStoreManager.loadGrantsToGrantee(callContext.getPolarisCallContext(), principalEntity);
+    LoadGrantsResult grantsWithoutEntities =
+        new LoadGrantsResult(grants.getGrantsVersion(), grants.getGrantRecords(), null);
+    assertThat(grantsWithoutEntities.getEntitiesAsMap()).isNull();
+
+    PolarisMetaStoreManager metaStoreManagerSpy = Mockito.spy(metaStoreManager);
+    Mockito.doReturn(grantsWithoutEntities)
+        .when(metaStoreManagerSpy)
+        .loadGrantsToGrantee(
+            any(), Mockito.argThat(p -> p != null && p.getId() == principalEntity.getId()));
+
+    DefaultAuthenticator standaloneAuthenticator = new DefaultAuthenticator();
+    standaloneAuthenticator.metaStoreManager = metaStoreManagerSpy;
+    standaloneAuthenticator.callContext = callContext;
+    standaloneAuthenticator.diagnostics = diagnostics;
+
+    PolarisCredential credentials =
+        PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    PolarisPrincipal result = standaloneAuthenticator.authenticate(credentials);
+
+    // Roles should still resolve — the fallback path must produce the same result.
+    assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
+
+    verify(metaStoreManagerSpy, Mockito.times(2))
+        .loadEntity(any(), anyLong(), anyLong(), Mockito.eq(PolarisEntityType.PRINCIPAL_ROLE));
   }
 
   @Test


### PR DESCRIPTION
`DefaultAuthenticator.resolvePrincipalRoles` runs on every authenticated request and already calls `loadGrantsToGrantee`, which returns both grant records and the resolved securable entities in a single bulk metastore read. The authenticator was ignoring those pre-loaded entities and calling `loadEntity` once per grant record, so a principal with `N` roles caused `1+N` metastore reads per auth instead of one. This change resolves role names from `LoadGrantsResult.getEntitiesAsMap()`, matching the pattern already used in `PolarisAdminService`, while preserving existing behavior: missing entities and non-PRINCIPAL_ROLE securables are still filtered out, and requested-role filtering is unchanged. 

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
