### PR TITLE
test: wait for async refresh events in testEventsAreEmitted

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.catalog.iceberg;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -45,6 +46,7 @@ import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -3087,11 +3089,24 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     catalog.createNamespace(TestData.NAMESPACE);
     Table table = catalog.buildTable(TestData.TABLE, TestData.SCHEMA).create();
 
+    // Clear after setup so we only observe refresh events from the property commits below.
+    // Events are published asynchronously via the Vert.x event bus + listener executor
+    // (see PolarisServiceBusEventDispatcher / PolarisEventListeners), so the test must wait
+    // for delivery rather than asserting immediately after commit.
+    testPolarisEventListener.clear();
+
     String key = "foo";
     String valOld = "bar1";
     String valNew = "bar2";
     table.updateProperties().set(key, valOld).commit();
     table.updateProperties().set(key, valNew).commit();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .until(
+            () ->
+                testPolarisEventListener.hasEvent(PolarisEventType.BEFORE_REFRESH_TABLE)
+                    && testPolarisEventListener.hasEvent(PolarisEventType.AFTER_REFRESH_TABLE));
 
     PolarisEvent beforeRefreshEvent =
         testPolarisEventListener.getLatest(PolarisEventType.BEFORE_REFRESH_TABLE);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.awaitility.Awaitility.await;
+
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusMock;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -245,11 +248,21 @@ public abstract class AbstractLocalIcebergCatalogViewTest
             .withQuery("a", "b")
             .create();
 
+    // Clear after setup; refresh events are delivered asynchronously via Vert.x.
+    testPolarisEventListener.clear();
+
     String key = "foo";
     String valOld = "bar1";
     String valNew = "bar2";
     view.updateProperties().set(key, valOld).commit();
     view.updateProperties().set(key, valNew).commit();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .until(
+            () ->
+                testPolarisEventListener.hasEvent(PolarisEventType.BEFORE_REFRESH_VIEW)
+                    && testPolarisEventListener.hasEvent(PolarisEventType.AFTER_REFRESH_VIEW));
 
     PolarisEvent beforeRefreshEvent =
         testPolarisEventListener.getLatest(PolarisEventType.BEFORE_REFRESH_VIEW);

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/events/listeners/TestPolarisEventListener.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/events/listeners/TestPolarisEventListener.java
@@ -36,6 +36,11 @@ public class TestPolarisEventListener implements PolarisEventListener {
     latestEvents.clear();
   }
 
+  /** Returns whether an event of the given type has been recorded. */
+  public boolean hasEvent(PolarisEventType type) {
+    return latestEvents.containsKey(type);
+  }
+
   public PolarisEvent getLatest(PolarisEventType type) {
     var latest = latestEvents.get(type);
     if (latest == null) {


### PR DESCRIPTION
Fixes #5019.

`LocalIcebergCatalogRelationalTest.testEventsAreEmitted` was flaking with:

```
No event of type AFTER_REFRESH_TABLE recorded
```

Refresh events are published over the Vert.x event bus and delivered on a listener executor, so they can land after the test already called `getLatest`. That race showed up in CI (including on #5003).