### PR TITLE
making the external authorizers consume the user-defined properties from the entity attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,10 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   root principal already exists. Existing credentials are never returned or altered.
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 - The field `clientSecret` of the Polaris management API type `ResetPrincipalRequest` is now using `format: password`. This does not change the wire format, but code generated from the OpenAPI may require downstream changes.
+- OPA and Ranger authorizers now receive user-defined principal properties from the backing
+  `PrincipalEntity` (exposed via `PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY`), alongside
+  internal properties. Internal properties win on key collision so system-managed values such as
+  `client_id` cannot be shadowed by user input.
 
 ### Deprecations
 - The `currentKmsKey` and `allowedKmsKeys` AWS storage configuration properties are deprecated. Use `encryptionKeys` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Changes
 
+- After authentication, a `SecurityIdentityAugmentor` projects selected principal facts onto
+  namespaced `PolarisPrincipal` attributes. OPA and Ranger consume those derived keys rather than
+  walking `PrincipalEntity`: `polaris.user.*` for user-defined principal properties,
+  `polaris.system.client_id` and `polaris.system.credential-rotation-required` for selected
+  internal facts, and `polaris.auth.*` when an authenticator has asserted them. The raw
+  `PrincipalEntity` is not included in the external PDP payload. A user property cannot shadow a
+  system key because the namespace is part of the attribute name.
 - A metastore failure during authentication now returns a fixed `Service unavailable` message
   instead of naming the lookup that failed; the principal lookup previously returned `Unable to
   fetch principal entity`. The failing lookup is still named in the server log at `ERROR`, which
@@ -186,10 +193,6 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   root principal already exists. Existing credentials are never returned or altered.
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 - The field `clientSecret` of the Polaris management API type `ResetPrincipalRequest` is now using `format: password`. This does not change the wire format, but code generated from the OpenAPI may require downstream changes.
-- OPA and Ranger authorizers now receive user-defined principal properties from the backing
-  `PrincipalEntity` (exposed via `PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY`), alongside
-  internal properties. Internal properties win on key collision so system-managed values such as
-  `client_id` cannot be shadowed by user input.
 
 ### Deprecations
 - The `currentKmsKey` and `allowedKmsKeys` AWS storage configuration properties are deprecated. Use `encryptionKeys` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   root principal already exists. Existing credentials are never returned or altered.
 - Authorization failure messages (HTTP 403 / `ForbiddenException` from `PolarisAuthorizerImpl`) now log the specific missing privilege(s) and the entity each was checked against server-side (at `INFO` level), e.g. `missing TABLE_CREATE on NAMESPACE 'ns1'`. The client-facing 403 response remains a generic message to avoid leaking authorization metadata to untrusted clients. Operators can correlate client errors to server logs using the existing `X-Request-ID` header (present in default log MDC as `requestId`).
 - The field `clientSecret` of the Polaris management API type `ResetPrincipalRequest` is now using `format: password`. This does not change the wire format, but code generated from the OpenAPI may require downstream changes.
+- OPA and Ranger authorizers now receive user-defined principal properties from the backing
+  `PrincipalEntity` (exposed via `PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY`), alongside
+  internal properties. Internal properties win on key collision so system-managed values such as
+  `client_id` cannot be shadowed by user input.
 
 ### Deprecations
 - Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations, including catalog config `polaris.config.allow.external.metadata.file.location`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,12 +66,15 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Changes
 
 - After authentication, a `SecurityIdentityAugmentor` projects selected principal facts onto
-  namespaced `PolarisPrincipal` attributes. OPA and Ranger consume those derived keys rather than
-  walking `PrincipalEntity`: `polaris.user.*` for user-defined principal properties,
+  namespaced `PolarisPrincipal` attributes. External authorizers consume those derived keys rather
+  than walking `PrincipalEntity`: `polaris.user.*` for user-defined principal properties,
   `polaris.system.client_id` and `polaris.system.credential-rotation-required` for selected
-  internal facts, and `polaris.auth.*` when an authenticator has asserted them. The raw
-  `PrincipalEntity` is not included in the external PDP payload. A user property cannot shadow a
-  system key because the namespace is part of the attribute name.
+  internal facts, and `polaris.auth.*` when an authenticator has asserted them. OPA receives the
+  keys as `actor.attributes`. Ranger copies them onto `RangerUserInfo`, but Apache Ranger 2.9.0's
+  embedded plugin evaluates only user name, groups, and roles, so `polaris.user.*` cannot currently
+  change a Ranger policy decision. The raw `PrincipalEntity` is not included in the external PDP
+  payload. A user property cannot shadow a system key because the namespace is part of the
+  attribute name. Empty-string user property values are forwarded as empty attributes, not omitted.
 - A metastore failure during authentication now returns a fixed `Service unavailable` message
   instead of naming the lookup that failed; the principal lookup previously returned `Unable to
   fetch principal entity`. The failing lookup is still named in the server log at `ERROR`, which

--- a/extensions/auth/opa/opa-input-schema.json
+++ b/extensions/auth/opa/opa-input-schema.json
@@ -16,6 +16,12 @@
           "items" : {
             "type" : "string"
           }
+        },
+        "attributes" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         }
       }
     },

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -24,10 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -50,6 +47,7 @@ import org.apache.polaris.core.auth.PathSegment;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
 import org.apache.polaris.core.auth.PolarisSecurable;
 import org.apache.polaris.core.auth.PolicyAttachmentAuthorizationIntent;
 import org.apache.polaris.core.auth.PrivilegeGrantAuthorizationIntent;
@@ -59,7 +57,6 @@ import org.apache.polaris.core.auth.RootPrivilegeGrantAuthorizationIntent;
 import org.apache.polaris.core.auth.SingleTargetAuthorizationIntent;
 import org.apache.polaris.core.auth.TargetlessAuthorizationIntent;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.extension.auth.opa.model.ImmutableActor;
@@ -349,22 +346,8 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
     return ImmutableActor.builder()
         .principal(principal.getName())
         .addAllRoles(principal.getRoles())
-        .putAllAttributes(extractPrincipalAttributes(principal))
+        .putAllAttributes(PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal))
         .build();
-  }
-
-  private static Map<String, String> extractPrincipalAttributes(PolarisPrincipal principal) {
-    return principal
-        .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
-        .map(
-            entity -> {
-              Map<String, String> attributes = new HashMap<>(entity.getPropertiesAsMap());
-              // Internal properties win on collision so system-managed values cannot be shadowed
-              // by user-supplied properties.
-              attributes.putAll(entity.getInternalPropertiesAsMap());
-              return attributes;
-            })
-        .orElse(Collections.emptyMap());
   }
 
   private ImmutableContext buildContext() {

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -24,7 +24,10 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -56,6 +59,7 @@ import org.apache.polaris.core.auth.RootPrivilegeGrantAuthorizationIntent;
 import org.apache.polaris.core.auth.SingleTargetAuthorizationIntent;
 import org.apache.polaris.core.auth.TargetlessAuthorizationIntent;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
+import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.extension.auth.opa.model.ImmutableActor;
@@ -345,7 +349,22 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
     return ImmutableActor.builder()
         .principal(principal.getName())
         .addAllRoles(principal.getRoles())
+        .putAllAttributes(extractPrincipalAttributes(principal))
         .build();
+  }
+
+  private static Map<String, String> extractPrincipalAttributes(PolarisPrincipal principal) {
+    return principal
+        .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
+        .map(
+            entity -> {
+              Map<String, String> attributes = new HashMap<>(entity.getPropertiesAsMap());
+              // Internal properties win on collision so system-managed values cannot be shadowed
+              // by user-supplied properties.
+              attributes.putAll(entity.getInternalPropertiesAsMap());
+              return attributes;
+            })
+        .orElse(Collections.emptyMap());
   }
 
   private ImmutableContext buildContext() {

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/model/Actor.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/model/Actor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import java.util.Map;
 import org.apache.polaris.immutables.PolarisImmutable;
 
 /**
@@ -40,4 +41,10 @@ public interface Actor {
 
   /** The list of roles associated with the principal. */
   List<String> roles();
+
+  /**
+   * Optional attributes associated with the principal, such as user-defined properties from the
+   * backing {@link org.apache.polaris.core.entity.PrincipalEntity}.
+   */
+  Map<String, String> attributes();
 }

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/model/Actor.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/model/Actor.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.Map;
 import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
 
 /**
  * Represents the actor (principal) making an authorization request.
@@ -43,8 +44,11 @@ public interface Actor {
   List<String> roles();
 
   /**
-   * Optional attributes associated with the principal, such as user-defined properties from the
-   * backing {@link org.apache.polaris.core.entity.PrincipalEntity}.
+   * Provenance-namespaced principal attributes projected after authentication ({@code
+   * polaris.auth.*}, {@code polaris.system.*}, {@code polaris.user.*}).
    */
-  Map<String, String> attributes();
+  @Value.Default
+  default Map<String, String> attributes() {
+    return Map.of();
+  }
 }

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
@@ -1354,6 +1354,58 @@ public class OpaPolarisAuthorizerTest {
   }
 
   @Test
+  void actorAttributesPreserveEmptyUserPropertyValues() throws Exception {
+    final String[] capturedRequestBody = new String[1];
+
+    HttpServer server = createServerWithRequestCapture(capturedRequestBody);
+    try {
+      URI policyUri =
+          URI.create(
+              "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
+      OpaPolarisAuthorizer authorizer =
+          new OpaPolarisAuthorizer(
+              policyUri,
+              HttpClients.createDefault(),
+              JsonMapper.builder().build(),
+              null,
+              null,
+              "test-realm");
+
+      PolarisPrincipal principal =
+          PolarisPrincipal.of(
+              "eve",
+              Map.of(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", ""),
+              Set.of("auditor"));
+
+      PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
+      PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
+
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  authorizer.authorizeOrThrow(
+                      principal,
+                      Set.of(),
+                      PolarisAuthorizableOperation.LOAD_VIEW,
+                      target,
+                      secondary));
+
+      ObjectMapper mapper = JsonMapper.builder().build();
+      JsonNode root = mapper.readTree(capturedRequestBody[0]);
+      JsonNode attributes = root.path("input").path("actor").path("attributes");
+      assertThat(attributes.has(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department"))
+          .isTrue();
+      assertThat(
+              attributes
+                  .path(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department")
+                  .asText())
+          .isEqualTo("");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
   void actorAttributesDoNotWalkPrincipalEntity() throws Exception {
     final String[] capturedRequestBody = new String[1];
 

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
@@ -63,6 +63,7 @@ import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
@@ -96,7 +97,7 @@ public class OpaPolarisAuthorizerTest {
               "test-realm");
 
       PolarisPrincipal principal =
-          PolarisPrincipal.of("eve", Map.of("department", "finance"), Set.of("auditor"));
+          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
 
       Set<PolarisBaseEntity> entities = Set.of();
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
@@ -125,6 +126,11 @@ public class OpaPolarisAuthorizerTest {
       // Verify realm is included for tenant isolation
       assertThat(input.get("context").has("realm")).as("context should contain realm").isTrue();
       assertThat(input.get("context").get("realm").asText()).isEqualTo("test-realm");
+
+      // Verify user-defined principal properties are forwarded as actor attributes
+      var actor = input.get("actor");
+      assertThat(actor.has("attributes")).as("Actor should have 'attributes' field").isTrue();
+      assertThat(actor.get("attributes").get("department").asText()).isEqualTo("finance");
     } finally {
       server.stop(0);
     }
@@ -1215,7 +1221,7 @@ public class OpaPolarisAuthorizerTest {
               "test-realm");
 
       PolarisPrincipal principal =
-          PolarisPrincipal.of("eve", Map.of("department", "finance"), Set.of("auditor"));
+          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
       PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
 
@@ -1256,7 +1262,7 @@ public class OpaPolarisAuthorizerTest {
               "test-realm");
 
       PolarisPrincipal principal =
-          PolarisPrincipal.of("eve", Map.of("department", "finance"), Set.of("auditor"));
+          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
       PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
 
@@ -1274,6 +1280,69 @@ public class OpaPolarisAuthorizerTest {
       JsonNode root = mapper.readTree(capturedRequestBody[0]);
       String requestId = root.at("/input/context/request_id").asText();
       assertThatNoException().isThrownBy(() -> UUID.fromString(requestId));
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void actorAttributesIncludeUserDefinedPropertiesAndInternalWinsOnCollision() throws Exception {
+    final String[] capturedRequestBody = new String[1];
+
+    HttpServer server = createServerWithRequestCapture(capturedRequestBody);
+    try {
+      URI policyUri =
+          URI.create(
+              "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
+      OpaPolarisAuthorizer authorizer =
+          new OpaPolarisAuthorizer(
+              policyUri,
+              HttpClients.createDefault(),
+              JsonMapper.builder().build(),
+              null,
+              null,
+              "test-realm");
+
+      PrincipalEntity entity =
+          new PrincipalEntity.Builder()
+              .setName("eve")
+              .setProperties(
+                  Map.of(
+                      "department",
+                      "finance",
+                      PolarisEntityConstants.getClientIdPropertyName(),
+                      "user-client-id"))
+              .setClientId("internal-client-id")
+              .build();
+      PolarisPrincipal principal =
+          PolarisPrincipal.of(
+              "eve",
+              Map.of(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, entity),
+              Set.of("auditor"));
+
+      PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
+      PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
+
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  authorizer.authorizeOrThrow(
+                      principal,
+                      Set.of(),
+                      PolarisAuthorizableOperation.LOAD_VIEW,
+                      target,
+                      secondary));
+
+      ObjectMapper mapper = JsonMapper.builder().build();
+      JsonNode root = mapper.readTree(capturedRequestBody[0]);
+      var actor = root.path("input").path("actor");
+      assertThat(actor.path("attributes").path("department").asText()).isEqualTo("finance");
+      assertThat(
+              actor
+                  .path("attributes")
+                  .path(PolarisEntityConstants.getClientIdPropertyName())
+                  .asText())
+          .isEqualTo("internal-client-id");
     } finally {
       server.stop(0);
     }
@@ -1372,5 +1441,15 @@ public class OpaPolarisAuthorizerTest {
           .as("Authorization header should not be present when token provider returns null")
           .isFalse();
     }
+  }
+
+  private static PolarisPrincipal principalWithUserAttributes(
+      String name, Map<String, String> userAttributes, Set<String> roles) {
+    return PolarisPrincipal.of(
+        name,
+        Map.of(
+            PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
+            new PrincipalEntity.Builder().setName(name).setProperties(userAttributes).build()),
+        roles);
   }
 }

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
@@ -56,6 +56,7 @@ import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PathSegment;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
 import org.apache.polaris.core.auth.PolarisSecurable;
 import org.apache.polaris.core.auth.RenameAuthorizationIntent;
 import org.apache.polaris.core.auth.SingleTargetAuthorizationIntent;
@@ -97,7 +98,10 @@ public class OpaPolarisAuthorizerTest {
               "test-realm");
 
       PolarisPrincipal principal =
-          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
+          PolarisPrincipal.of(
+              "eve",
+              Map.of(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "finance"),
+              Set.of("auditor"));
 
       Set<PolarisBaseEntity> entities = Set.of();
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
@@ -130,7 +134,12 @@ public class OpaPolarisAuthorizerTest {
       // Verify user-defined principal properties are forwarded as actor attributes
       var actor = input.get("actor");
       assertThat(actor.has("attributes")).as("Actor should have 'attributes' field").isTrue();
-      assertThat(actor.get("attributes").get("department").asText()).isEqualTo("finance");
+      assertThat(
+              actor
+                  .get("attributes")
+                  .get(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department")
+                  .asText())
+          .isEqualTo("finance");
     } finally {
       server.stop(0);
     }
@@ -1220,8 +1229,7 @@ public class OpaPolarisAuthorizerTest {
               "test-id",
               "test-realm");
 
-      PolarisPrincipal principal =
-          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
+      PolarisPrincipal principal = PolarisPrincipal.of("eve", Map.of(), Set.of("auditor"));
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
       PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
 
@@ -1261,8 +1269,7 @@ public class OpaPolarisAuthorizerTest {
               null,
               "test-realm");
 
-      PolarisPrincipal principal =
-          principalWithUserAttributes("eve", Map.of("department", "finance"), Set.of("auditor"));
+      PolarisPrincipal principal = PolarisPrincipal.of("eve", Map.of(), Set.of("auditor"));
       PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
       PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
 
@@ -1286,7 +1293,68 @@ public class OpaPolarisAuthorizerTest {
   }
 
   @Test
-  void actorAttributesIncludeUserDefinedPropertiesAndInternalWinsOnCollision() throws Exception {
+  void actorAttributesIncludeDerivedNamespacedKeys() throws Exception {
+    final String[] capturedRequestBody = new String[1];
+
+    HttpServer server = createServerWithRequestCapture(capturedRequestBody);
+    try {
+      URI policyUri =
+          URI.create(
+              "http://localhost:" + server.getAddress().getPort() + "/v1/data/polaris/allow");
+      OpaPolarisAuthorizer authorizer =
+          new OpaPolarisAuthorizer(
+              policyUri,
+              HttpClients.createDefault(),
+              JsonMapper.builder().build(),
+              null,
+              null,
+              "test-realm");
+
+      PolarisPrincipal principal =
+          PolarisPrincipal.of(
+              "eve",
+              Map.of(
+                  PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department",
+                  "finance",
+                  PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID,
+                  "internal-client-id",
+                  PolarisPrincipalAttributeNamespaces.USER_PREFIX
+                      + PolarisEntityConstants.getClientIdPropertyName(),
+                  "user-client-id"),
+              Set.of("auditor"));
+
+      PolarisResolvedPathWrapper target = new PolarisResolvedPathWrapper(List.of());
+      PolarisResolvedPathWrapper secondary = new PolarisResolvedPathWrapper(List.of());
+
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  authorizer.authorizeOrThrow(
+                      principal,
+                      Set.of(),
+                      PolarisAuthorizableOperation.LOAD_VIEW,
+                      target,
+                      secondary));
+
+      ObjectMapper mapper = JsonMapper.builder().build();
+      JsonNode root = mapper.readTree(capturedRequestBody[0]);
+      var attributes = root.path("input").path("actor").path("attributes");
+      assertThat(
+              attributes
+                  .path(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department")
+                  .asText())
+          .isEqualTo("finance");
+      assertThat(attributes.path(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID).asText())
+          .isEqualTo("internal-client-id");
+      assertThat(attributes.path(PolarisEntityConstants.getClientIdPropertyName()).isMissingNode())
+          .isTrue();
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void actorAttributesDoNotWalkPrincipalEntity() throws Exception {
     final String[] capturedRequestBody = new String[1];
 
     HttpServer server = createServerWithRequestCapture(capturedRequestBody);
@@ -1306,12 +1374,7 @@ public class OpaPolarisAuthorizerTest {
       PrincipalEntity entity =
           new PrincipalEntity.Builder()
               .setName("eve")
-              .setProperties(
-                  Map.of(
-                      "department",
-                      "finance",
-                      PolarisEntityConstants.getClientIdPropertyName(),
-                      "user-client-id"))
+              .setProperties(Map.of("department", "finance"))
               .setClientId("internal-client-id")
               .build();
       PolarisPrincipal principal =
@@ -1335,14 +1398,9 @@ public class OpaPolarisAuthorizerTest {
 
       ObjectMapper mapper = JsonMapper.builder().build();
       JsonNode root = mapper.readTree(capturedRequestBody[0]);
-      var actor = root.path("input").path("actor");
-      assertThat(actor.path("attributes").path("department").asText()).isEqualTo("finance");
-      assertThat(
-              actor
-                  .path("attributes")
-                  .path(PolarisEntityConstants.getClientIdPropertyName())
-                  .asText())
-          .isEqualTo("internal-client-id");
+      JsonNode attributes = root.path("input").path("actor").path("attributes");
+      assertThat(attributes.isObject()).isTrue();
+      assertThat(attributes.size()).isZero();
     } finally {
       server.stop(0);
     }
@@ -1441,15 +1499,5 @@ public class OpaPolarisAuthorizerTest {
           .as("Authorization header should not be present when token provider returns null")
           .isFalse();
     }
-  }
-
-  private static PolarisPrincipal principalWithUserAttributes(
-      String name, Map<String, String> userAttributes, Set<String> roles) {
-    return PolarisPrincipal.of(
-        name,
-        Map.of(
-            PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
-            new PrincipalEntity.Builder().setName(name).setProperties(userAttributes).build()),
-        roles);
   }
 }

--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
@@ -28,9 +28,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.ranger.authz.model.RangerAccessInfo;
@@ -128,19 +128,8 @@ public class RangerUtils {
   }
 
   private static Map<String, Object> getUserAttributes(PolarisPrincipal principal) {
-    Map<String, String> properties =
-        principal
-            .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
-            .map(
-                entity -> {
-                  Map<String, String> merged = new HashMap<>(entity.getPropertiesAsMap());
-                  // Internal properties win on collision so system-managed values cannot be
-                  // shadowed by user-supplied properties.
-                  merged.putAll(entity.getInternalPropertiesAsMap());
-                  return merged;
-                })
-            .orElse(Collections.emptyMap());
-
-    return properties.isEmpty() ? Collections.emptyMap() : new HashMap<>(properties);
+    Map<String, String> derived =
+        PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal);
+    return derived.isEmpty() ? Collections.emptyMap() : new HashMap<>(derived);
   }
 }

--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
@@ -52,6 +52,14 @@ public class RangerUtils {
     };
   }
 
+  /**
+   * Builds the Ranger authz-api user DTO, including derived namespaced principal attributes.
+   *
+   * <p>Apache Ranger 2.9.0's embedded authorizer constructs {@code RangerAccessRequestImpl} from
+   * the user name, groups, and roles only and does not copy {@link RangerUserInfo#getAttributes()}
+   * onto the request that policy evaluation uses. These attributes are still populated so the DTO
+   * matches the authz-api contract; they cannot currently change a Ranger policy decision.
+   */
   public static RangerUserInfo toUserInfo(PolarisPrincipal principal) {
     return new RangerUserInfo(
         principal.getName(), getUserAttributes(principal), null, principal.getRoles());

--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtils.java
@@ -131,7 +131,14 @@ public class RangerUtils {
     Map<String, String> properties =
         principal
             .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
-            .map(PrincipalEntity::getInternalPropertiesAsMap)
+            .map(
+                entity -> {
+                  Map<String, String> merged = new HashMap<>(entity.getPropertiesAsMap());
+                  // Internal properties win on collision so system-managed values cannot be
+                  // shadowed by user-supplied properties.
+                  merged.putAll(entity.getInternalPropertiesAsMap());
+                  return merged;
+                })
             .orElse(Collections.emptyMap());
 
     return properties.isEmpty() ? Collections.emptyMap() : new HashMap<>(properties);

--- a/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
+++ b/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.extension.auth.ranger.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.ranger.authz.model.RangerUserInfo;
+import org.junit.jupiter.api.Test;
+
+public class RangerUtilsTest {
+
+  @Test
+  void toUserInfoIncludesUserDefinedPrincipalProperties() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "alice",
+            Map.of(
+                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
+                new PrincipalEntity.Builder()
+                    .setName("alice")
+                    .setProperties(Map.of("department", "finance"))
+                    .setClientId("client-id-123")
+                    .build()),
+            Set.of("admin"));
+
+    RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
+
+    assertThat(userInfo.getName()).isEqualTo("alice");
+    assertThat(userInfo.getRoles()).containsExactly("admin");
+    assertThat(userInfo.getAttributes()).containsEntry("department", "finance");
+    assertThat(userInfo.getAttributes())
+        .containsEntry(PolarisEntityConstants.getClientIdPropertyName(), "client-id-123");
+  }
+
+  @Test
+  void toUserInfoPrefersInternalPropertiesOnCollision() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "alice",
+            Map.of(
+                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
+                new PrincipalEntity.Builder()
+                    .setName("alice")
+                    .setProperties(
+                        Map.of(PolarisEntityConstants.getClientIdPropertyName(), "user-value"))
+                    .setClientId("internal-value")
+                    .build()),
+            Set.of("admin"));
+
+    RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
+
+    assertThat(userInfo.getAttributes())
+        .containsEntry(PolarisEntityConstants.getClientIdPropertyName(), "internal-value");
+  }
+}

--- a/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
+++ b/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
@@ -49,10 +49,27 @@ public class RangerUtilsTest {
 
     assertThat(userInfo.getName()).isEqualTo("alice");
     assertThat(userInfo.getRoles()).containsExactly("admin");
+    // Ranger 2.9.0's embedded plugin does not copy these attributes onto the access request
+    // it evaluates, so this asserts the DTO contract only. An authorization-level test that
+    // depends on polaris.user.* cannot pass until Ranger copies RangerUserInfo.attributes.
     assertThat(userInfo.getAttributes())
         .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "finance")
         .containsEntry(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID, "client-id-123")
         .containsEntry(PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "region", "us-west");
+  }
+
+  @Test
+  void toUserInfoPreservesEmptyUserPropertyValues() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "alice",
+            Map.of(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", ""),
+            Set.of("admin"));
+
+    RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
+
+    assertThat(userInfo.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "");
   }
 
   @Test

--- a/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
+++ b/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/utils/RangerUtilsTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.ranger.authz.model.RangerUserInfo;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,31 @@ import org.junit.jupiter.api.Test;
 public class RangerUtilsTest {
 
   @Test
-  void toUserInfoIncludesUserDefinedPrincipalProperties() {
+  void toUserInfoIncludesDerivedNamespacedAttributes() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "alice",
+            Map.of(
+                PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department",
+                "finance",
+                PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID,
+                "client-id-123",
+                PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "region",
+                "us-west"),
+            Set.of("admin"));
+
+    RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
+
+    assertThat(userInfo.getName()).isEqualTo("alice");
+    assertThat(userInfo.getRoles()).containsExactly("admin");
+    assertThat(userInfo.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "finance")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID, "client-id-123")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "region", "us-west");
+  }
+
+  @Test
+  void toUserInfoDoesNotWalkPrincipalEntity() {
     PolarisPrincipal principal =
         PolarisPrincipal.of(
             "alice",
@@ -47,31 +71,20 @@ public class RangerUtilsTest {
 
     RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
 
-    assertThat(userInfo.getName()).isEqualTo("alice");
-    assertThat(userInfo.getRoles()).containsExactly("admin");
-    assertThat(userInfo.getAttributes()).containsEntry("department", "finance");
-    assertThat(userInfo.getAttributes())
-        .containsEntry(PolarisEntityConstants.getClientIdPropertyName(), "client-id-123");
+    assertThat(userInfo.getAttributes()).isEmpty();
   }
 
   @Test
-  void toUserInfoPrefersInternalPropertiesOnCollision() {
+  void toUserInfoOmitsUnnamespacedAttributes() {
     PolarisPrincipal principal =
         PolarisPrincipal.of(
             "alice",
             Map.of(
-                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
-                new PrincipalEntity.Builder()
-                    .setName("alice")
-                    .setProperties(
-                        Map.of(PolarisEntityConstants.getClientIdPropertyName(), "user-value"))
-                    .setClientId("internal-value")
-                    .build()),
+                "department", "finance", PolarisPrincipal.PRINCIPAL_ROLE_ALL_ATTRIBUTE_KEY, true),
             Set.of("admin"));
 
     RangerUserInfo userInfo = RangerUtils.toUserInfo(principal);
 
-    assertThat(userInfo.getAttributes())
-        .containsEntry(PolarisEntityConstants.getClientIdPropertyName(), "internal-value");
+    assertThat(userInfo.getAttributes()).isEmpty();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespaces.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespaces.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Provenance namespaces for authorizer-facing attributes on {@link PolarisPrincipal}.
+ *
+ * <p>Authenticators set primary attributes such as {@link
+ * PolarisPrincipal#PRINCIPAL_ENTITY_ATTRIBUTE_KEY}. A post-auth augmentor then projects selected
+ * values onto these namespaced keys. External authorizers should consume the derived keys rather
+ * than walking {@code PrincipalEntity}.
+ */
+public final class PolarisPrincipalAttributeNamespaces {
+
+  /** Prefix for attributes asserted by an authenticator or identity provider. */
+  public static final String AUTH_PREFIX = "polaris.auth.";
+
+  /** Prefix for selected Polaris-managed / internal principal facts. */
+  public static final String SYSTEM_PREFIX = "polaris.system.";
+
+  /** Prefix for free-form user-defined principal properties. */
+  public static final String USER_PREFIX = "polaris.user.";
+
+  /** Derived client id from {@code PrincipalEntity} internal properties. */
+  public static final String SYSTEM_CLIENT_ID = SYSTEM_PREFIX + "client_id";
+
+  /** Derived credential-rotation flag from {@code PrincipalEntity} internal properties. */
+  public static final String SYSTEM_CREDENTIAL_ROTATION_REQUIRED =
+      SYSTEM_PREFIX + "credential-rotation-required";
+
+  private PolarisPrincipalAttributeNamespaces() {}
+
+  /** Returns whether {@code key} is a derived, namespaced principal attribute. */
+  public static boolean isDerivedAttributeKey(String key) {
+    return key != null
+        && (key.startsWith(AUTH_PREFIX)
+            || key.startsWith(SYSTEM_PREFIX)
+            || key.startsWith(USER_PREFIX));
+  }
+
+  /**
+   * Returns the derived string attributes from {@code principal} for external authorizers.
+   *
+   * <p>Non-string values and keys outside the provenance namespaces (including {@link
+   * PolarisPrincipal#PRINCIPAL_ENTITY_ATTRIBUTE_KEY}) are omitted.
+   */
+  public static Map<String, String> derivedStringAttributes(PolarisPrincipal principal) {
+    return derivedStringAttributes(principal.getAttributes());
+  }
+
+  private static Map<String, String> derivedStringAttributes(Map<String, Object> attributes) {
+    if (attributes == null || attributes.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> derived = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+      if (isDerivedAttributeKey(entry.getKey()) && entry.getValue() instanceof String value) {
+        derived.put(entry.getKey(), value);
+      }
+    }
+    return Map.copyOf(derived);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespacesTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespacesTest.java
@@ -73,6 +73,18 @@ public class PolarisPrincipalAttributeNamespacesTest {
   }
 
   @Test
+  void derivedStringAttributesPreservesEmptyStringValues() {
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve",
+            Map.of(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", ""),
+            Set.of());
+
+    assertThat(PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal))
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "");
+  }
+
+  @Test
   void derivedStringAttributesEmptyWhenNoneProjected() {
     PolarisPrincipal principal = PolarisPrincipal.of("eve", Map.of(), Set.of());
     assertThat(PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal)).isEmpty();

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespacesTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisPrincipalAttributeNamespacesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class PolarisPrincipalAttributeNamespacesTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "polaris.auth.department,true",
+    "polaris.system.client_id,true",
+    "polaris.user.department,true",
+    "department,false",
+    "client_id,false",
+    "org.apache.polaris.core.auth.PRINCIPAL_ENTITY,false"
+  })
+  void isDerivedAttributeKey(String key, boolean expected) {
+    assertThat(PolarisPrincipalAttributeNamespaces.isDerivedAttributeKey(key)).isEqualTo(expected);
+  }
+
+  @Test
+  void derivedStringAttributesOmitsPrimaryAndNonStringValues() {
+    PrincipalEntity entity = new PrincipalEntity.Builder().setName("eve").build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve",
+            Map.of(
+                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
+                entity,
+                PolarisPrincipal.PRINCIPAL_ROLE_ALL_ATTRIBUTE_KEY,
+                true,
+                PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department",
+                "finance",
+                PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID,
+                "client-1",
+                PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "region",
+                "us-west"),
+            Set.of("auditor"));
+
+    assertThat(PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal))
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department",
+                "finance",
+                PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID,
+                "client-1",
+                PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "region",
+                "us-west"));
+  }
+
+  @Test
+  void derivedStringAttributesEmptyWhenNoneProjected() {
+    PolarisPrincipal principal = PolarisPrincipal.of("eve", Map.of(), Set.of());
+    assertThat(PolarisPrincipalAttributeNamespaces.derivedStringAttributes(principal)).isEmpty();
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentor.java
@@ -92,9 +92,11 @@ public class PrincipalAttributeAugmentor implements SecurityIdentityAugmentor {
         internal.get(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE));
     for (Map.Entry<String, String> property : entity.getPropertiesAsMap().entrySet()) {
       String key = property.getKey();
-      if (key != null && !key.isBlank()) {
-        putIfPresent(
-            derived, PolarisPrincipalAttributeNamespaces.USER_PREFIX + key, property.getValue());
+      String value = property.getValue();
+      // Keep non-null stored values, including empty strings. The Principal API does not
+      // reject blank property values, so dropping them here would hide them from authorizers.
+      if (key != null && !key.isBlank() && value != null) {
+        derived.put(PolarisPrincipalAttributeNamespaces.USER_PREFIX + key, value);
       }
     }
     return derived;

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentor.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PrincipalEntity;
+
+/**
+ * A {@link SecurityIdentityAugmentor} that runs after {@link AuthenticatingAugmentor} and projects
+ * selected {@link PrincipalEntity} fields onto namespaced {@link PolarisPrincipal} attributes.
+ *
+ * <p>User-defined properties become {@code polaris.user.*}. Selected internal properties become
+ * {@code polaris.system.*}. If the principal has no {@code PRINCIPAL_ENTITY} attribute (federated
+ * or detached principals), this augmentor is a no-op.
+ */
+@ApplicationScoped
+public class PrincipalAttributeAugmentor implements SecurityIdentityAugmentor {
+
+  /** Must run after {@link AuthenticatingAugmentor}. */
+  public static final int PRIORITY = AuthenticatingAugmentor.PRIORITY - 100;
+
+  @Override
+  public int priority() {
+    return PRIORITY;
+  }
+
+  @Override
+  public Uni<SecurityIdentity> augment(
+      SecurityIdentity identity, AuthenticationRequestContext context) {
+    if (identity.isAnonymous() || !(identity.getPrincipal() instanceof PolarisPrincipal)) {
+      return Uni.createFrom().item(identity);
+    }
+    return Uni.createFrom().item(enrich(identity));
+  }
+
+  static SecurityIdentity enrich(SecurityIdentity identity) {
+    PolarisPrincipal principal = (PolarisPrincipal) identity.getPrincipal();
+    PrincipalEntity entity =
+        principal
+            .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
+            .orElse(null);
+    if (entity == null) {
+      return identity;
+    }
+    Map<String, Object> derived = deriveFromEntity(entity);
+    if (derived.isEmpty()) {
+      return identity;
+    }
+    Map<String, Object> attributes = new LinkedHashMap<>(principal.getAttributes());
+    attributes.putAll(derived);
+    PolarisPrincipal enriched =
+        PolarisPrincipal.of(principal.getName(), attributes, principal.getRoles());
+    return QuarkusSecurityIdentity.builder(identity).setPrincipal(enriched).build();
+  }
+
+  static Map<String, Object> deriveFromEntity(PrincipalEntity entity) {
+    Map<String, Object> derived = new LinkedHashMap<>();
+    Map<String, String> internal = entity.getInternalPropertiesAsMap();
+    putIfPresent(
+        derived,
+        PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID,
+        internal.get(PolarisEntityConstants.getClientIdPropertyName()));
+    putIfPresent(
+        derived,
+        PolarisPrincipalAttributeNamespaces.SYSTEM_CREDENTIAL_ROTATION_REQUIRED,
+        internal.get(PolarisEntityConstants.PRINCIPAL_CREDENTIAL_ROTATION_REQUIRED_STATE));
+    for (Map.Entry<String, String> property : entity.getPropertiesAsMap().entrySet()) {
+      String key = property.getKey();
+      if (key != null && !key.isBlank()) {
+        putIfPresent(
+            derived, PolarisPrincipalAttributeNamespaces.USER_PREFIX + key, property.getValue());
+      }
+    }
+    return derived;
+  }
+
+  private static void putIfPresent(Map<String, Object> derived, String key, String value) {
+    if (value != null && !value.isBlank()) {
+      derived.put(key, value);
+    }
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -500,11 +500,37 @@ public class DefaultAuthenticatorTest {
     assertThat(result.getAttribute("custom-key", String.class)).isEmpty();
   }
 
+  @Test
+  void testPrincipalEntityAttributeContainsUserProperties() {
+    // Given: a principal with user-defined properties
+    PrincipalEntity entity =
+        createPrincipal("principal-with-properties", Map.of("department", "finance"));
+    PolarisCredential credentials =
+        PolarisCredential.of(
+            null, entity.getName(), Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    // When: authenticating the principal
+    PolarisPrincipal result = authenticator.authenticate(identityFor(credentials));
+
+    // Then: the principal entity attribute must include the user-defined properties
+    PrincipalEntity entityAttr =
+        result
+            .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
+            .orElseThrow();
+    assertThat(entityAttr.getPropertiesAsMap()).containsEntry("department", "finance");
+  }
+
   private PrincipalEntity createPrincipal(String name, String... roles) {
+    return createPrincipal(name, Map.of(), roles);
+  }
+
+  private PrincipalEntity createPrincipal(
+      String name, Map<String, String> properties, String... roles) {
 
     PrincipalWithCredentialsCredentials credentials =
         newAdminService()
-            .createPrincipal(new PrincipalEntity.Builder().setName(name).build())
+            .createPrincipal(
+                new PrincipalEntity.Builder().setName(name).setProperties(properties).build())
             .getCredentials();
 
     metaStoreManager.rotatePrincipalSecrets(

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -40,6 +40,7 @@ import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -512,12 +513,16 @@ public class DefaultAuthenticatorTest {
     // When: authenticating the principal
     PolarisPrincipal result = authenticator.authenticate(identityFor(credentials));
 
-    // Then: the principal entity attribute must include the user-defined properties
+    // Then: the principal entity attribute must include the user-defined properties, but
+    // DefaultAuthenticator does not project authorizer-facing namespaced keys.
     PrincipalEntity entityAttr =
         result
             .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
             .orElseThrow();
     assertThat(entityAttr.getPropertiesAsMap()).containsEntry("department", "finance");
+    assertThat(result.getAttributes())
+        .doesNotContainKey(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department")
+        .doesNotContainKey("department");
   }
 
   private PrincipalEntity createPrincipal(String name, String... roles) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -438,11 +438,37 @@ public class DefaultAuthenticatorTest {
     assertThat(result.getAttribute("custom-key", String.class)).hasValue("custom-value");
   }
 
+  @Test
+  void testPrincipalEntityAttributeContainsUserProperties() {
+    // Given: a principal with user-defined properties
+    PrincipalEntity entity =
+        createPrincipal("principal-with-properties", Map.of("department", "finance"));
+    PolarisCredential credentials =
+        PolarisCredential.of(
+            null, entity.getName(), Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    // When: authenticating the principal
+    PolarisPrincipal result = authenticator.authenticate(identityFor(credentials));
+
+    // Then: the principal entity attribute must include the user-defined properties
+    PrincipalEntity entityAttr =
+        result
+            .getAttribute(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class)
+            .orElseThrow();
+    assertThat(entityAttr.getPropertiesAsMap()).containsEntry("department", "finance");
+  }
+
   private PrincipalEntity createPrincipal(String name, String... roles) {
+    return createPrincipal(name, Map.of(), roles);
+  }
+
+  private PrincipalEntity createPrincipal(
+      String name, Map<String, String> properties, String... roles) {
 
     PrincipalWithCredentialsCredentials credentials =
         newAdminService()
-            .createPrincipal(new PrincipalEntity.Builder().setName(name).build())
+            .createPrincipal(
+                new PrincipalEntity.Builder().setName(name).setProperties(properties).build())
             .getCredentials();
 
     metaStoreManager.rotatePrincipalSecrets(

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentorTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
+import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipalAttributeNamespaces;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PrincipalEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class PrincipalAttributeAugmentorTest {
+
+  private PrincipalAttributeAugmentor augmentor;
+
+  @BeforeEach
+  public void setup() {
+    augmentor = new PrincipalAttributeAugmentor();
+  }
+
+  @Test
+  public void testPriorityRunsAfterAuthenticatingAugmentor() {
+    assertThat(augmentor.priority()).isLessThan(AuthenticatingAugmentor.PRIORITY);
+  }
+
+  @Test
+  public void testAugmentAnonymousIdentity() {
+    SecurityIdentity anonymous = QuarkusSecurityIdentity.builder().setAnonymous(true).build();
+    assertThat(augmentor.augment(anonymous, null).await().indefinitely()).isSameAs(anonymous);
+  }
+
+  @Test
+  public void testAugmentNonPolarisPrincipal() {
+    Principal other = Mockito.mock(Principal.class);
+    SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(other).build();
+    assertThat(augmentor.augment(identity, Uni.createFrom()::item).await().indefinitely())
+        .isSameAs(identity);
+  }
+
+  @Test
+  public void testAugmentWithoutPrincipalEntity() {
+    PolarisPrincipal principal = PolarisPrincipal.of("eve", Map.of(), Set.of("auditor"));
+    SecurityIdentity identity = identityFor(principal);
+    assertThat(augmentor.augment(identity, Uni.createFrom()::item).await().indefinitely())
+        .isSameAs(identity);
+  }
+
+  @Test
+  public void testDerivesUserAndSelectedSystemAttributes() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setProperties(Map.of("department", "finance"))
+            .setClientId("client-1")
+            .setCredentialRotationRequiredState()
+            .build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve",
+            Map.of(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, entity),
+            Set.of("auditor"));
+
+    SecurityIdentity result =
+        augmentor.augment(identityFor(principal), Uni.createFrom()::item).await().indefinitely();
+    PolarisPrincipal enriched = (PolarisPrincipal) result.getPrincipal();
+
+    assertThat(enriched.getName()).isEqualTo("eve");
+    assertThat(enriched.getRoles()).containsExactly("auditor");
+    assertThat(
+            enriched.getAttribute(
+                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, PrincipalEntity.class))
+        .contains(entity);
+    assertThat(enriched.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "finance")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID, "client-1")
+        .containsEntry(
+            PolarisPrincipalAttributeNamespaces.SYSTEM_CREDENTIAL_ROTATION_REQUIRED, "true");
+  }
+
+  @Test
+  public void testUserPropertyCannotShadowSystemClientId() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setProperties(
+                Map.of(PolarisEntityConstants.getClientIdPropertyName(), "user-client-id"))
+            .setClientId("internal-client-id")
+            .build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve", Map.of(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, entity), Set.of());
+
+    PolarisPrincipal enriched =
+        (PolarisPrincipal)
+            augmentor
+                .augment(identityFor(principal), Uni.createFrom()::item)
+                .await()
+                .indefinitely()
+                .getPrincipal();
+
+    assertThat(enriched.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID, "internal-client-id")
+        .containsEntry(
+            PolarisPrincipalAttributeNamespaces.USER_PREFIX
+                + PolarisEntityConstants.getClientIdPropertyName(),
+            "user-client-id")
+        .doesNotContainKey(PolarisEntityConstants.getClientIdPropertyName());
+  }
+
+  @Test
+  public void testPreservesExistingAuthAttributes() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setProperties(Map.of("department", "finance"))
+            .build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve",
+            Map.of(
+                PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY,
+                entity,
+                PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "department",
+                "idp-finance"),
+            Set.of());
+
+    PolarisPrincipal enriched =
+        (PolarisPrincipal)
+            augmentor
+                .augment(identityFor(principal), Uni.createFrom()::item)
+                .await()
+                .indefinitely()
+                .getPrincipal();
+
+    assertThat(enriched.getAttributes())
+        .containsEntry(
+            PolarisPrincipalAttributeNamespaces.AUTH_PREFIX + "department", "idp-finance")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "finance");
+  }
+
+  @Test
+  public void testDoesNotDumpUnselectedInternalProperties() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setClientId("client-1")
+            .addInternalProperty("unrelated_internal", "secret")
+            .build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve", Map.of(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, entity), Set.of());
+
+    PolarisPrincipal enriched =
+        (PolarisPrincipal)
+            augmentor
+                .augment(identityFor(principal), Uni.createFrom()::item)
+                .await()
+                .indefinitely()
+                .getPrincipal();
+
+    assertThat(enriched.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.SYSTEM_CLIENT_ID, "client-1")
+        .doesNotContainKey(PolarisPrincipalAttributeNamespaces.SYSTEM_PREFIX + "unrelated_internal")
+        .doesNotContainKey("unrelated_internal");
+  }
+
+  private static SecurityIdentity identityFor(PolarisPrincipal principal) {
+    return QuarkusSecurityIdentity.builder()
+        .setAnonymous(false)
+        .setPrincipal(principal)
+        .addRoles(principal.getRoles())
+        .build();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/PrincipalAttributeAugmentorTest.java
@@ -164,6 +164,31 @@ public class PrincipalAttributeAugmentorTest {
   }
 
   @Test
+  public void testPreservesEmptyAndWhitespaceUserPropertyValues() {
+    PrincipalEntity entity =
+        new PrincipalEntity.Builder()
+            .setName("eve")
+            .setProperties(Map.of("department", "", "team", "   ", "region", "us-west"))
+            .build();
+    PolarisPrincipal principal =
+        PolarisPrincipal.of(
+            "eve", Map.of(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, entity), Set.of());
+
+    PolarisPrincipal enriched =
+        (PolarisPrincipal)
+            augmentor
+                .augment(identityFor(principal), Uni.createFrom()::item)
+                .await()
+                .indefinitely()
+                .getPrincipal();
+
+    assertThat(enriched.getAttributes())
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "department", "")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "team", "   ")
+        .containsEntry(PolarisPrincipalAttributeNamespaces.USER_PREFIX + "region", "us-west");
+  }
+
+  @Test
   public void testDoesNotDumpUnselectedInternalProperties() {
     PrincipalEntity entity =
         new PrincipalEntity.Builder()

--- a/site/content/in-dev/unreleased/managing-security/access-control.md
+++ b/site/content/in-dev/unreleased/managing-security/access-control.md
@@ -180,7 +180,7 @@ keys, or other secrets in table or view properties.
 | Privilege | Description |
 | --------- | ----------- |
 | PRINCIPAL_READ_PROPERTIES | Enables reading principal properties. |
-| PRINCIPAL_WRITE_PROPERTIES | Enables configuring principal properties. When user-defined principal properties are forwarded to external authorizers as `polaris.user.*` attributes, this privilege allows modifying user-supplied ABAC attributes. |
+| PRINCIPAL_WRITE_PROPERTIES | Enables configuring principal properties. User-defined principal properties are projected as `polaris.user.*` attributes after authentication. OPA receives those keys as `actor.attributes` and can use them for ABAC. Ranger copies the same keys onto `RangerUserInfo`, but Apache Ranger 2.9.0's embedded authorizer evaluates only user name, groups, and roles, so these attributes cannot currently change a Ranger policy decision. |
 
 ## RBAC example
 

--- a/site/content/in-dev/unreleased/managing-security/access-control.md
+++ b/site/content/in-dev/unreleased/managing-security/access-control.md
@@ -175,6 +175,13 @@ keys, or other secrets in table or view properties.
 | POLICY_ATTACH | Enables policy to be attached to entities. |
 | POLICY_DETACH | Enables policy to be detached from entities. |
 
+### Principal privileges
+
+| Privilege | Description |
+| --------- | ----------- |
+| PRINCIPAL_READ_PROPERTIES | Enables reading principal properties. |
+| PRINCIPAL_WRITE_PROPERTIES | Enables configuring principal properties. When user-defined principal properties are forwarded to external authorizers as `polaris.user.*` attributes, this privilege allows modifying user-supplied ABAC attributes. |
+
 ## RBAC example
 
 The following diagram illustrates how RBAC works in Polaris and

--- a/site/content/in-dev/unreleased/managing-security/external-pdp/opa.md
+++ b/site/content/in-dev/unreleased/managing-security/external-pdp/opa.md
@@ -185,7 +185,11 @@ Polaris sends the following input structure to OPA:
 {
   "actor": {
     "principal": "user@example.com",
-    "roles": ["role1", "role2"]
+    "roles": ["role1", "role2"],
+    "attributes": {
+      "polaris.user.department": "finance",
+      "polaris.system.client_id": "abc123"
+    }
   },
   "action": "LOAD_TABLE_WITH_READ_DELEGATION",
   "resource": {
@@ -219,6 +223,7 @@ Polaris sends the following input structure to OPA:
 |-------|------|-------------|
 | `principal` | string | The principal identifier (e.g., username, service account) |
 | `roles` | array | Array of role names assigned to the principal |
+| `attributes` | object | Provenance-namespaced string attributes projected after authentication. Keys use `polaris.user.*` for user-defined principal properties, `polaris.system.*` for selected Polaris-managed facts (for example `polaris.system.client_id`), and `polaris.auth.*` for authenticator/IdP assertions. The raw `PrincipalEntity` is not included. |
 
 #### Action Field
 

--- a/site/content/in-dev/unreleased/managing-security/external-pdp/opa.md
+++ b/site/content/in-dev/unreleased/managing-security/external-pdp/opa.md
@@ -223,7 +223,7 @@ Polaris sends the following input structure to OPA:
 |-------|------|-------------|
 | `principal` | string | The principal identifier (e.g., username, service account) |
 | `roles` | array | Array of role names assigned to the principal |
-| `attributes` | object | Provenance-namespaced string attributes projected after authentication. Keys use `polaris.user.*` for user-defined principal properties, `polaris.system.*` for selected Polaris-managed facts (for example `polaris.system.client_id`), and `polaris.auth.*` for authenticator/IdP assertions. The raw `PrincipalEntity` is not included. |
+| `attributes` | object | Provenance-namespaced string attributes projected after authentication. Keys use `polaris.user.*` for user-defined principal properties, `polaris.system.*` for selected Polaris-managed facts (for example `polaris.system.client_id`), and `polaris.auth.*` for authenticator/IdP assertions. The raw `PrincipalEntity` is not included. Stored user-property values are forwarded as-is, including empty strings; a missing key means the property was not set (or was null), not that it was stored as `""`. |
 
 #### Action Field
 


### PR DESCRIPTION
follow-up Dmitri mentioned in #5085: after the `PolarisPrincipal` generic-attributes refactor, forward **user-defined principal properties** to OPA and Ranger authorizers so the behavior from the earlier #5032 approach is preserved without merging properties into `PolarisPrincipal` itself.

PR #4405 originally proposed merging user-defined properties directly into `PolarisPrincipal`. The dev-list discussion concluded that `PolarisPrincipal` should stay decoupled from `PrincipalEntity`, and PR #5085 introduced generic attributes to expose the entity as an optional attribute. This PR completes that direction by making the external authorizers consume the user-defined properties from the entity attribute.