### PR TITLE
Add boolean-return authorization helper for control-flow decisions

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
@@ -396,6 +396,38 @@ public abstract class CatalogHandler {
     initializeCatalog();
   }
 
+  /**
+   * Returns {@code true} if the current principal is authorized for the given operation on the
+   * specified table-like entity that has already been resolved, {@code false} otherwise. Unlike
+   * {@link #authorizeResolvedBasicTableLikeOperationOrThrow}, this method does not throw on
+   * authorization failure, making it suitable for control-flow decisions where a denied operation
+   * should fall through to an alternative check rather than immediately failing the request.
+   *
+   * <p>The caller must have already invoked {@link #resolveBasicTableLikeTargetOrThrow} to resolve
+   * the entity before calling this method. If the entity did not resolve (for example, the table
+   * does not exist), this method throws {@link #notFoundExceptionForTableLikeEntity} rather than
+   * delegating to the authorizer, mirroring {@link
+   * #authorizeResolvedBasicTableLikeOperationOrThrow} so that a missing entity surfaces as a
+   * not-found (404) response instead of a server error.
+   */
+  protected boolean isResolvedBasicTableLikeOperationAuthorized(
+      PolarisAuthorizableOperation op, PolarisEntitySubType subType, TableIdentifier identifier) {
+    PolarisResolvedPathWrapper target =
+        resolutionManifest.getResolvedPath(ResolvedPathKey.ofTableLike(identifier), subType, true);
+    if (target == null) {
+      throw notFoundExceptionForTableLikeEntity(identifier, subType);
+    }
+
+    AuthorizationState authorizationState = new AuthorizationState(resolutionManifest);
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            polarisPrincipal(),
+            List.of(
+                new SingleTargetAuthorizationIntent(
+                    op, PolarisSecurableMapper.tableLike(catalogName(), identifier))));
+    return authorizer().authorize(authorizationState, request).isAllowed();
+  }
+
   protected void resolveAndAuthorizeBasicTableLikeOperationOrThrow(
       PolarisAuthorizableOperation op, PolarisEntitySubType subType, TableIdentifier identifier) {
     resolveBasicTableLikeTargetOrThrow(op, identifier);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1022,12 +1022,12 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
 
     Set<PolarisStorageActions> actionsRequested =
         new HashSet<>(Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
-    try {
-      authorizeResolvedBasicTableLikeOperationOrThrow(
-          write, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
+    if (isResolvedBasicTableLikeOperationAuthorized(
+        write, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier)) {
       actionsRequested.add(PolarisStorageActions.WRITE);
-    } catch (ForbiddenException e) {
-      // Reuse the already-resolved table view for the read-delegation fallback.
+      initializeCatalog();
+    } else {
+      // Fall back to read-delegation authorization. Reuse the already-resolved table view.
       authorizeResolvedBasicTableLikeOperationOrThrow(
           read, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.AuthorizationDecision;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
@@ -120,6 +121,9 @@ class IcebergCatalogHandlerTest {
             .build();
     when(storageAccessConfigProvider.getStorageAccessConfig(any(), any(), any(), any(), any()))
         .thenReturn(storageAccessConfig);
+    // Default: authorize() returns allow. Tests that need a deny override this.
+    when(authorizer.authorize(any(AuthorizationState.class), any(AuthorizationRequest.class)))
+        .thenReturn(AuthorizationDecision.allow());
   }
 
   @SuppressWarnings({"unchecked"})
@@ -319,42 +323,36 @@ class IcebergCatalogHandlerTest {
     when(catalog.loadTable(TABLE2)).thenReturn(table);
     when(accessDelegationModeResolver.resolve(any(), any()))
         .thenReturn(Optional.of(VENDED_CREDENTIALS));
-    doThrow(new ForbiddenException("write delegation denied"))
-        .when(authorizer)
-        .authorizeOrThrow(
-            any(),
-            any(),
-            eq(PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION),
-            nullable(PolarisResolvedPathWrapper.class),
-            nullable(PolarisResolvedPathWrapper.class));
+    // The write-delegation probe now uses authorize(state, request).isAllowed() which does not
+    // throw. Mock it to return a deny decision so the fallback to read-delegation is triggered.
+    when(authorizer.authorize(any(AuthorizationState.class), any(AuthorizationRequest.class)))
+        .thenReturn(AuthorizationDecision.deny("write delegation denied"));
     @SuppressWarnings("unchecked")
     ArgumentCaptor<AuthorizationRequest> requestCaptor =
         ArgumentCaptor.forClass(AuthorizationRequest.class);
     ArgumentCaptor<AuthorizationState> stateCaptor =
         ArgumentCaptor.forClass(AuthorizationState.class);
-    ArgumentCaptor<PolarisAuthorizableOperation> operationCaptor =
-        ArgumentCaptor.forClass(PolarisAuthorizableOperation.class);
 
     @SuppressWarnings("resource")
     IcebergCatalogHandler handler = newHandler();
 
     handler.loadCredentials(TABLE2, Optional.empty());
 
+    // Verify resolve is called once for the write-delegation operation.
     verify(authorizer).resolveAuthorizationInputs(stateCaptor.capture(), requestCaptor.capture());
     assertThat(stateCaptor.getValue().getResolutionManifest()).isSameAs(resolutionManifest);
     assertThat(requestCaptor.getValue().intents().getFirst().getOperation())
         .isEqualTo(PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION);
-    verify(authorizer, org.mockito.Mockito.times(2))
+    // Verify authorize() was called for the write-delegation boolean check.
+    verify(authorizer).authorize(any(AuthorizationState.class), any(AuthorizationRequest.class));
+    // Verify authorizeOrThrow is called once for the read-delegation fallback.
+    verify(authorizer)
         .authorizeOrThrow(
             any(),
             any(),
-            operationCaptor.capture(),
+            eq(PolarisAuthorizableOperation.LOAD_TABLE_WITH_READ_DELEGATION),
             nullable(PolarisResolvedPathWrapper.class),
             nullable(PolarisResolvedPathWrapper.class));
-    assertThat(operationCaptor.getAllValues())
-        .containsExactly(
-            PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION,
-            PolarisAuthorizableOperation.LOAD_TABLE_WITH_READ_DELEGATION);
   }
 
   @Test

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
+import org.apache.polaris.core.auth.AuthorizationDecision;
 import org.apache.polaris.core.auth.AuthorizationState;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
@@ -255,6 +256,11 @@ public record TestServices(
               })
           .when(authorizer)
           .resolveAuthorizationInputs(any(), any());
+      // The mock authorizer authorizes everything: authorizeOrThrow(...) is a no-op (void), and
+      // authorize(state, request) must mirror that by returning an "allow" decision. Without this
+      // stub the mock returns null and decision-native callers (e.g. loadTable's write-delegation
+      // probe) would NPE on AuthorizationDecision.isAllowed().
+      Mockito.when(authorizer.authorize(any(), any())).thenReturn(AuthorizationDecision.allow());
 
       // Application level
       StorageCredentialCacheConfig storageCredentialCacheConfig = () -> 10_000;


### PR DESCRIPTION
## Summary

This PR introduces `isResolvedBasicTableLikeOperationAuthorized()` in `CatalogHandler`—the first service-layer caller of `PolarisAuthorizer.authorize(state, request)` for boolean authorization decisions—and refactors `authorizeLoadTable` to use it.

## Problem

`authorizeLoadTable` currently relies on catching `ForbiddenException` for normal control flow. It first attempts write-delegation authorization and, if that fails, falls back to read-delegation authorization. Using exceptions for expected control flow reduces readability and incurs unnecessary overhead from exception creation and stack trace capture. The code already contains a TODO for this improvement:

> `// TODO: Refactor to have a boolean-return version of the helpers so we can fallthrough easily.`

## Changes

### 1. `CatalogHandler.java`

Added `isResolvedBasicTableLikeOperationAuthorized(op, identifier)`, which uses the decision-native `authorize(AuthorizationState, AuthorizationRequest).isAllowed()` path instead of relying on exceptions. Like `authorizeResolvedBasicTableLikeOperationOrThrow()`, this helper assumes `resolveBasicTableLikeTargetOrThrow()` has already been called.

### 2. `IcebergCatalogHandler.java`

Refactored `authorizeLoadTable` to use the new helper, replacing exception-based control flow with a straightforward conditional.

**Before**

```java
try {
    authorizeResolvedBasicTableLikeOperationOrThrow(
        write, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
    actionsRequested.add(PolarisStorageActions.WRITE);
} catch (ForbiddenException e) {
    authorizeResolvedBasicTableLikeOperationOrThrow(
        read, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
}
```

**After**

```java
if (isResolvedBasicTableLikeOperationAuthorized(write, tableIdentifier)) {
    actionsRequested.add(PolarisStorageActions.WRITE);
    initializeCatalog();
} else {
    authorizeResolvedBasicTableLikeOperationOrThrow(
        read, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
}
```

### 3. `IcebergCatalogHandlerTest.java`

Updated `loadCredentialsFallbackResolvesOnceThenAuthorizesReadDelegation` to mock the decision-native `authorize()` path (returning `AuthorizationDecision.deny()`) instead of configuring `authorizeOrThrow()` to throw. Also added a default `authorize()` mock returning `AuthorizationDecision.allow()` for the remaining tests.

## Scope

This PR only refactors the `authorizeLoadTable` call site. A similar exception-based pattern exists in `authorizeRegisterTable`, but addressing that will require additional boolean-returning helpers for namespace-level and overwrite authorization. That work will be handled in a follow-up PR.

## Testing

Updated the existing test in `IcebergCatalogHandlerTest` to verify the new decision-native authorization flow. All tests in `IcebergCatalogHandlerTest` pass.

## Checklist

- [x] 🛡️ Not a security issue
- [x] 🔗 Resolves the existing TODO in `IcebergCatalogHandler`
- [x] 🧪 Updated existing tests to cover the new `authorize()` path
- [x] 💡 Added Javadoc for the new helper
- [x] 🧾 No CHANGELOG update required (internal refactoring)
- [x] 📚 No documentation update required