### PR TITLE
Remove schema version option from admin bootstrap command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   - `polaris.event-listener.executor.queue-size` configures the queue size for pending events when all threads are busy.
 
 ### Breaking changes
+- Removed the `--schema-version` (`-v`) option from the admin tool's `bootstrap` command. New realms
+  are now always bootstrapped with the latest available schema version.
 - The `MaintenanceService.performMaintenance()` signature now requires an explicit `OptionalLong overrideRunId` argument to supersede the latest unfinished maintenance run.
 - Admin grant APIs now reject table-like privilege targets with an empty namespace. A table-like target without a namespace is considered invalid input.
 - The REST layer now enforces stricter validation for entity names (including namespaces, tables, views, and generic tables). Requests containing invalid names will be rejected with an HTTP 400 error. Existing clients should verify and rename entities before upgrading if their names fall into the following forbidden categories:

--- a/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
+++ b/runtime/admin/src/main/java/org/apache/polaris/admintool/BootstrapCommand.java
@@ -25,7 +25,6 @@ import org.apache.polaris.core.persistence.bootstrap.BootstrapOptions;
 import org.apache.polaris.core.persistence.bootstrap.ImmutableBootstrapOptions;
 import org.apache.polaris.core.persistence.bootstrap.ImmutableSchemaOptions;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
-import org.apache.polaris.core.persistence.bootstrap.SchemaOptions;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
 import picocli.CommandLine;
 
@@ -42,9 +41,6 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
     // This ArgGroup enforces the mandatory, exclusive choice.
     @CommandLine.ArgGroup(multiplicity = "1")
     RootCredentialsOptions rootCredentialsOptions;
-
-    // This @Mixin provides independent, optional schema flags.
-    @CommandLine.Mixin SchemaInputOptions schemaInputOptions = new SchemaInputOptions();
 
     // This static inner class encapsulates the mutually exclusive choices.
     static class RootCredentialsOptions {
@@ -86,15 +82,6 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
           description = "A file containing root principal credentials to bootstrap.")
       Path file;
     }
-
-    static class SchemaInputOptions {
-      @CommandLine.Option(
-          names = {"-v", "--schema-version"},
-          paramLabel = "<schema version>",
-          description =
-              "The version of the schema to load. The set of valid values depends on the backend type. If omitted the latest schema version will be used.")
-      Integer schemaVersion;
-    }
   }
 
   @Override
@@ -129,24 +116,11 @@ public class BootstrapCommand extends BaseMetaStoreCommand {
         }
       }
 
-      final SchemaOptions schemaOptions;
-      if (inputOptions.schemaInputOptions != null) {
-        ImmutableSchemaOptions.Builder builder = ImmutableSchemaOptions.builder();
-
-        if (inputOptions.schemaInputOptions.schemaVersion != null) {
-          builder.schemaVersion(inputOptions.schemaInputOptions.schemaVersion);
-        }
-
-        schemaOptions = builder.build();
-      } else {
-        schemaOptions = ImmutableSchemaOptions.builder().build();
-      }
-
       BootstrapOptions bootstrapOptions =
           ImmutableBootstrapOptions.builder()
               .realms(realms)
               .rootCredentialsSet(rootCredentialsSet)
-              .schemaOptions(schemaOptions)
+              .schemaOptions(ImmutableSchemaOptions.builder().build())
               .build();
 
       // Execute the bootstrap

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/BootstrapCommandTest.java
@@ -92,4 +92,16 @@ class BootstrapCommandTest {
     assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_USAGE);
     assertThat(err.toString()).contains("Unknown option: '--not-real-arg'").contains("Usage:");
   }
+
+  @Test
+  void testBootstrapSchemaVersionIsRejected() {
+    CommandLine commandLine = new CommandLine(new BootstrapCommand());
+    StringWriter err = new StringWriter();
+    commandLine.setErr(new PrintWriter(err));
+
+    int exitCode = commandLine.execute("--schema-version=1", "-r", "realm1", "--print-credentials");
+
+    assertThat(exitCode).isEqualTo(BaseCommand.EXIT_CODE_USAGE);
+    assertThat(err.toString()).contains("Unknown option: '--schema-version=1'").contains("Usage:");
+  }
 }

--- a/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
+++ b/runtime/admin/src/test/java/org/apache/polaris/admintool/relational/jdbc/RelationalJdbcBootstrapCommandTest.java
@@ -29,15 +29,6 @@ import org.junit.jupiter.api.Test;
 
 @TestProfile(AdminProfiles.RelationalJdbc.class)
 public class RelationalJdbcBootstrapCommandTest extends BootstrapCommandTestBase {
-
-  @Test
-  public void testBootstrapWithExplicitSchemaVersion(QuarkusMainLauncher launcher) {
-    LaunchResult result1 =
-        launcher.launch("bootstrap", "-v", "4", "-r", "realm1", "-c", "realm1,root,s3cr3t");
-    assertThat(result1.exitCode()).isEqualTo(0);
-    assertThat(result1.getOutput()).contains("Bootstrap completed successfully.");
-  }
-
   @Test
   public void testBootstrap(QuarkusMainLauncher launcher) {
     // Test that bootstrap command works successfully.

--- a/site/content/in-dev/unreleased/admin-tool.md
+++ b/site/content/in-dev/unreleased/admin-tool.md
@@ -102,16 +102,11 @@ docker run apache/polaris-admin-tool:latest bootstrap --help
 The basic usage of the `bootstrap` command is outlined below:
 
 ```
-Usage: polaris-admin-tool.jar bootstrap [-hV] [-v=<schema version>]
-                                        ([-r=<realm> [-r=<realm>]... [-c=<realm,
-                                        clientId,clientSecret>]... [-p]] |
-                                        [[-f=<file>]])
+Usage: polaris-admin-tool.jar bootstrap [-hV] ([-r=<realm> [-r=<realm>]...
+                                        [-c=<realm,clientId,clientSecret>]...
+                                        [-p]] | [[-f=<file>]])
 Bootstraps realms and root principal credentials.
   -h, --help                Show this help message and exit.
-  -v, --schema-version=<schema version>
-                            The version of the schema to load. The set of valid
-                              values depends on the backend type. If omitted the
-                              latest schema version will be used.
   -V, --version             Print version information and exit.
 Standard Input Options:
   -c, --credential=<realm,clientId,clientSecret>


### PR DESCRIPTION
## Summary

- Remove the `--schema-version` (`-v`) option from the admin tool's `bootstrap` command.
- Always let bootstrap select the latest available schema version for new realms.
- Update the command test, generated-help documentation, and unreleased changelog entry.

## Rationale

The project is moving toward shipping only the latest schema version in each release. Allowing users to bootstrap a realm with a historical schema is inconsistent with that direction and adds complexity for configurations where newer features cannot work against the selected historical schema.

This is a breaking CLI change: invocations that pass `--schema-version` or `-v` now fail with a usage error. Lower-level schema-version detection remains unchanged so Polaris can still interpret existing installations correctly.

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (no new complex logic)
- [x] 🧾 Updated `CHANGELOG.md`
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased`
