### PR TITLE
Fix SPDX expression for python license

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -24,7 +24,7 @@ description = "Apache Polaris"
 authors = [{ name = "Apache Software Foundation", email = "dev@polaris.apache.org" }]
 requires-python = ">=3.10,<3.15"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 keywords = [
     "Apache Polaris",


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Somehow we switched back to deprecated license SPDX expression from commit https://github.com/apache/polaris/commit/88b416bd2340457f1cadbfc6685d5706322b5dc0 

Using `license = {text = "Apache-2.0"}` is deprecated and not recommanded per https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files:
_A previous PEP had specified license to be a table with a file or a text key, this format is now deprecated. Most [build backends](https://packaging.python.org/en/latest/glossary/#term-Build-Backend) now support the new format as shown in the following table._

As it is no longer a valid SPDX expression (https://packaging.python.org/en/latest/glossary/#term-SPDX-Expression), this PR fixes this problem with using a proper SPDX license expression.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
