### PR TITLE
Clean up and document vended credential properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   now accepts a Quarkus `SecurityIdentity` instead of a `PolarisCredential`, and throws
   `AuthenticationFailedException` (mapped to HTTP 401) instead of Iceberg's
   `NotAuthorizedException`.
+- Polaris does not include the `expiration-time` property anymore when vending credentials. This 
+  property is not consumed by any known client and duplicates the properties specific to each
+  storage provider, such as `s3.session-token-expires-at-ms` for S3.
 
 ### New Features
 - Added GCS principal attribution for vended credentials (the GCP counterpart of AWS STS session tags). Set `GCS_PRINCIPAL_ATTRIBUTION_ENABLED=true` to activate; the feature flags `GCS_PRINCIPAL_ATTRIBUTION_WIF_AUDIENCE`, `GCS_PRINCIPAL_ATTRIBUTION_TOKEN_ISSUER`, and `GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_FILE` are then required (a missing value is a fatal configuration error). Also requires a `gcpServiceAccount` on the catalog StorageConfiguration. When enabled, credential vending chains a catalog-signed JWT through a Workload Identity Federation token exchange and service-account impersonation, so the Polaris principal appears in GCS Data Access audit logs (`serviceAccountDelegationInfo.principalSubject`) for any client. `GCS_PRINCIPAL_ATTRIBUTION_SIGNING_KEY_ID` sets the JWT `kid` for JWKS key rotation. Attribution is keyed per-principal in the credential cache; when disabled (default), GCP vending behaviour is unchanged.

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageAccessProperty.java
@@ -21,6 +21,7 @@ package org.apache.polaris.core.storage;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A subset of Iceberg catalog properties recognized by Polaris.
@@ -29,97 +30,186 @@ import org.apache.iceberg.gcp.GCPProperties;
  * storage.
  */
 public enum StorageAccessProperty {
-  AWS_KEY_ID(String.class, "s3.access-key-id", "the aws access key id", true),
-  AWS_SECRET_KEY(String.class, "s3.secret-access-key", "the aws access key secret", true),
-  AWS_TOKEN(String.class, "s3.session-token", "the aws scoped access token", true),
+  AWS_KEY_ID(
+      String.class,
+      "s3.access-key-id",
+      "AWS access key ID from the STS session",
+      true,
+      StorageType.AWS),
+  AWS_SECRET_KEY(
+      String.class,
+      "s3.secret-access-key",
+      "AWS secret access key from the STS session",
+      true,
+      StorageType.AWS),
+  AWS_TOKEN(
+      String.class,
+      "s3.session-token",
+      "AWS session token from the STS session",
+      true,
+      StorageType.AWS),
   AWS_SESSION_TOKEN_EXPIRES_AT_MS(
       String.class,
       "s3.session-token-expires-at-ms",
-      "the time the aws session token expires, in milliseconds",
+      "expiration time of the session token, in milliseconds since the Unix epoch",
       true,
-      true),
-  AWS_ENDPOINT(String.class, "s3.endpoint", "the S3 endpoint to use for requests", false),
+      true,
+      StorageType.AWS),
+  AWS_ENDPOINT(
+      String.class,
+      "s3.endpoint",
+      "custom S3 endpoint URL; emitted for S3-compatible stores such as MinIO or Ozone, absent for native AWS S3",
+      false,
+      StorageType.AWS),
   AWS_PATH_STYLE_ACCESS(
-      Boolean.class, "s3.path-style-access", "whether to use S3 path style access", false),
+      Boolean.class,
+      "s3.path-style-access",
+      "set to true when path-style addressing is required; emitted for S3-compatible stores, absent for native AWS S3",
+      false,
+      StorageType.AWS),
   CLIENT_REGION(
       String.class,
       "client.region",
-      "region to configure client for making requests to AWS",
-      false),
+      "AWS region to use for S3 and STS requests",
+      false,
+      StorageType.AWS),
   AWS_REFRESH_CREDENTIALS_ENDPOINT(
       String.class,
       AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT,
-      "the endpoint to load vended credentials for a table from the catalog",
+      "catalog endpoint the client can call to refresh vended credentials before they expire",
       false,
-      false),
+      false,
+      StorageType.AWS),
 
-  GCS_ACCESS_TOKEN(String.class, "gcs.oauth2.token", "the gcs scoped access token", true),
-  GCS_ACCESS_TOKEN_EXPIRES_AT(
+  GCS_ACCESS_TOKEN(
+      String.class, "gcs.oauth2.token", "downscoped OAuth2 access token", true, StorageType.GCS),
+  GCS_ACCESS_TOKEN_EXPIRES_AT_MS(
       String.class,
       "gcs.oauth2.token-expires-at",
-      "the time the gcs access token expires, in milliseconds",
+      "expiration time of the access token, in milliseconds since the Unix epoch",
       true,
-      true),
+      true,
+      StorageType.GCS),
   GCS_REFRESH_CREDENTIALS_ENDPOINT(
       String.class,
       GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT,
-      "the endpoint to load vended credentials for a table from the catalog",
+      "catalog endpoint the client can call to refresh vended credentials before they expire",
       false,
-      false),
+      false,
+      StorageType.GCS),
 
-  // Currently not using ACCESS TOKEN as the ResolvingFileIO is using ADLSFileIO for azure case and
-  // it expects for SAS
-  AZURE_ACCESS_TOKEN(String.class, "", "the azure scoped access token", true),
-  AZURE_SAS_TOKEN(String.class, "adls.sas-token.", "an azure shared access signature token", true),
+  AZURE_SAS_TOKEN_ACCOUNT_HOST(
+      String.class,
+      "adls.sas-token",
+      "SAS token keyed by the full storage DNS name (e.g. `adls.sas-token.myaccount.dfs.core.windows.net`); consumed by Spark via Iceberg's ADLSFileIO",
+      true,
+      false,
+      StorageType.AZURE,
+      "account-host"),
+  AZURE_SAS_TOKEN_ACCOUNT_NAME(
+      String.class,
+      "adls.sas-token",
+      "SAS token keyed by the storage account name only (e.g. `adls.sas-token.myaccount`); consumed by Iceberg 1.7.x clients",
+      true,
+      false,
+      StorageType.AZURE,
+      "account-name"),
   AZURE_SAS_TOKEN_BARE(
       String.class,
       "adls.sas-token",
-      "an azure shared access signature token (bare property name, without the <account-host> suffix)",
-      true),
-  AZURE_ACCOUNT_NAME(String.class, "adls.account-name", "the azure storage account name", true),
+      "bare SAS token (no suffix); consumed by PyIceberg via adlfs/fsspec",
+      true,
+      StorageType.AZURE),
+  AZURE_ACCOUNT_NAME(
+      String.class,
+      "adls.account-name",
+      "storage account name; consumed by PyIceberg via adlfs/fsspec",
+      true,
+      StorageType.AZURE),
   AZURE_REFRESH_CREDENTIALS_ENDPOINT(
       String.class,
       AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
-      "the endpoint to load vended credentials for a table from the catalog",
+      "catalog endpoint the client can call to refresh vended credentials before they expire",
       false,
-      false),
-  EXPIRATION_TIME(
+      false,
+      StorageType.AZURE),
+  AZURE_SAS_TOKEN_EXPIRES_AT_MS(
       Long.class,
-      "expiration-time",
-      "the expiration time for the access token, in milliseconds",
+      "adls.sas-token-expires-at-ms",
+      "expiration time of the SAS token keyed by the full storage DNS name, in milliseconds since the Unix epoch",
       true,
-      true),
-  AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX(
-      Long.class,
-      AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX,
-      "The expiration time for the access token, in milliseconds",
       true,
-      true);
+      StorageType.AZURE,
+      "account-host");
 
-  private final Class valueType;
+  /** Groups a {@link StorageAccessProperty} by cloud storage provider. */
+  public enum StorageType {
+    AWS,
+    AZURE,
+    GCS
+  }
+
+  private final Class<?> valueType;
   private final String propertyName;
   private final String description;
   private final boolean isCredential;
   private final boolean isExpirationTimestamp;
+  private final StorageType storageType;
+
+  /**
+   * For prefix properties the actual key is {@code propertyName + "." + runtimeSuffix}. This field
+   * names what that suffix represents (e.g. {@code "account-host"}, {@code "account-name"}) and is
+   * used only for documentation purposes.
+   */
+  private final String suffixLabel;
 
   StorageAccessProperty(
-      Class valueType, String propertyName, String description, boolean isCredential) {
-    this(valueType, propertyName, description, isCredential, false);
-  }
-
-  StorageAccessProperty(
-      Class valueType,
+      Class<?> valueType,
       String propertyName,
       String description,
       boolean isCredential,
-      boolean isExpirationTimestamp) {
+      StorageType storageType) {
+    this(valueType, propertyName, description, isCredential, false, storageType, null);
+  }
+
+  StorageAccessProperty(
+      Class<?> valueType,
+      String propertyName,
+      String description,
+      boolean isCredential,
+      boolean isExpirationTimestamp,
+      StorageType storageType) {
+    this(
+        valueType,
+        propertyName,
+        description,
+        isCredential,
+        isExpirationTimestamp,
+        storageType,
+        null);
+  }
+
+  StorageAccessProperty(
+      Class<?> valueType,
+      String propertyName,
+      String description,
+      boolean isCredential,
+      boolean isExpirationTimestamp,
+      StorageType storageType,
+      String suffixLabel) {
     this.valueType = valueType;
     this.propertyName = propertyName;
     this.description = description;
     this.isCredential = isCredential;
     this.isExpirationTimestamp = isExpirationTimestamp;
+    this.storageType = storageType;
+    this.suffixLabel = suffixLabel;
   }
 
+  /**
+   * Returns the property name base. For prefix properties (see {@link #isPrefixProperty()}) the
+   * actual runtime key is {@code getPropertyName() + "." + runtimeSuffix}.
+   */
   public String getPropertyName() {
     return propertyName;
   }
@@ -130,5 +220,35 @@ public enum StorageAccessProperty {
 
   public boolean isExpirationTimestamp() {
     return isExpirationTimestamp;
+  }
+
+  public StorageType getStorageType() {
+    return storageType;
+  }
+
+  @SuppressWarnings("unused") // consumed by reflection for automatic documentation generation
+  public Class<?> getValueType() {
+    return valueType;
+  }
+
+  @SuppressWarnings("unused") // consumed by reflection for automatic documentation generation
+  public String getDescription() {
+    return description;
+  }
+
+  /** Returns {@code true} when the actual property key is formed by appending a runtime suffix. */
+  @SuppressWarnings("unused") // consumed by reflection for automatic documentation generation
+  public boolean isPrefixProperty() {
+    return suffixLabel != null;
+  }
+
+  /**
+   * For prefix properties, a human-readable label for the suffix (e.g. {@code "account-host"}).
+   * Returns {@code null} for non-prefix properties.
+   */
+  @SuppressWarnings("unused") // consumed by reflection for automatic documentation generation
+  @Nullable
+  public String getSuffixLabel() {
+    return suffixLabel;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -255,13 +255,10 @@ public class AwsCredentialsStorageIntegration
       accessConfig.put(StorageAccessProperty.AWS_TOKEN, response.credentials().sessionToken());
       Optional.ofNullable(response.credentials().expiration())
           .ifPresent(
-              i -> {
-                accessConfig.put(
-                    StorageAccessProperty.EXPIRATION_TIME, String.valueOf(i.toEpochMilli()));
-                accessConfig.put(
-                    StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
-                    String.valueOf(i.toEpochMilli()));
-              });
+              i ->
+                  accessConfig.put(
+                      StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                      String.valueOf(i.toEpochMilli())));
     }
 
     if (region != null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -263,8 +263,7 @@ public class AzureCredentialsStorageIntegration
       Optional<String> refreshCredentialsEndpoint) {
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
     handleAzureCredential(accessConfig, sasToken, location, expiresAt);
-    accessConfig.put(
-        StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt.toEpochMilli()));
+    accessConfig.expiresAt(expiresAt);
     refreshCredentialsEndpoint.ifPresent(
         endpoint -> {
           accessConfig.put(StorageAccessProperty.AZURE_REFRESH_CREDENTIALS_ENDPOINT, endpoint);
@@ -281,9 +280,11 @@ public class AzureCredentialsStorageIntegration
     String accountName = location.getStorageAccount();
 
     config.putCredential(
-        StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + storageDnsName, sasToken);
+        StorageAccessProperty.AZURE_SAS_TOKEN_ACCOUNT_HOST.getPropertyName() + "." + storageDnsName,
+        sasToken);
     config.putCredential(
-        StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS_PREFIX.getPropertyName()
+        StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS.getPropertyName()
+            + "."
             + storageDnsName,
         String.valueOf(expiresAt.toEpochMilli()));
 
@@ -291,12 +292,14 @@ public class AzureCredentialsStorageIntegration
     // Use accountName (from location) for the stripped variant.
     if (location.isAdls()) {
       config.putCredential(
-          StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
+          StorageAccessProperty.AZURE_SAS_TOKEN_ACCOUNT_NAME.getPropertyName() + "." + accountName,
+          sasToken);
     }
 
     if (location.isBlob()) {
       config.putCredential(
-          StorageAccessProperty.AZURE_SAS_TOKEN.getPropertyName() + accountName, sasToken);
+          StorageAccessProperty.AZURE_SAS_TOKEN_ACCOUNT_NAME.getPropertyName() + "." + accountName,
+          sasToken);
     }
 
     // PyIceberg and other clients need bare adls.sas-token and adls.account-name for compatibility

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegration.java
@@ -337,7 +337,7 @@ public class GcpCredentialsStorageIntegration
     StorageAccessConfig.Builder accessConfig = StorageAccessConfig.builder();
     accessConfig.put(StorageAccessProperty.GCS_ACCESS_TOKEN, token.getTokenValue());
     accessConfig.put(
-        StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT,
+        StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT_MS,
         String.valueOf(token.getExpirationTime().getTime()));
 
     key.refreshCredentialsEndpoint()

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageAccessConfigTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageAccessConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.polaris.core.storage;
 import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_ENDPOINT;
 import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_SECRET_KEY;
 import static org.apache.polaris.core.storage.StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS;
-import static org.apache.polaris.core.storage.StorageAccessProperty.EXPIRATION_TIME;
-import static org.apache.polaris.core.storage.StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT;
+import static org.apache.polaris.core.storage.StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS;
+import static org.apache.polaris.core.storage.StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT_MS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -81,11 +81,11 @@ public class StorageAccessConfigTest {
   public void testExpiresAt() {
     StorageAccessConfig.Builder b = StorageAccessConfig.builder();
     assertThat(b.build().expiresAt()).isEmpty();
-    b.put(GCS_ACCESS_TOKEN_EXPIRES_AT, "111");
+    b.put(GCS_ACCESS_TOKEN_EXPIRES_AT_MS, "111");
     assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(111));
     b.put(AWS_SESSION_TOKEN_EXPIRES_AT_MS, "222");
     assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(222));
-    b.put(EXPIRATION_TIME, "333");
+    b.put(AZURE_SAS_TOKEN_EXPIRES_AT_MS, "333");
     assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(333));
     b.expiresAt(Instant.ofEpochMilli(444));
     assertThat(b.build().expiresAt()).hasValue(Instant.ofEpochMilli(444));

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -128,7 +128,7 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
             /* allowedWriteLoc= */ new ArrayList<>(),
             allowListAction);
     Assertions.assertThat(storageAccessConfig.credentials()).hasSize(2);
-    String sasToken = storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN);
+    String sasToken = storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE);
     Assertions.assertThat(sasToken).isNotNull();
     String serviceEndpoint =
         String.format("https://icebergdfsstorageacct.%s.core.windows.net", service);
@@ -201,7 +201,7 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
 
     BlobClient blobClient =
         createBlobClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             "https://icebergdfsstorageacct.dfs.core.windows.net",
             "container",
             allowedPrefix);
@@ -232,7 +232,7 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
     // read fail because container is blocked
     BlobClient blobClientReadFail =
         createBlobClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             String.format("https://icebergdfsstorageacct.%s.core.windows.net", service),
             "regtest",
             blockedPrefix);
@@ -272,13 +272,13 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
         String.format("https://icebergdfsstorageacct.%s.core.windows.net", service);
     BlobClient blobClient =
         createBlobClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             serviceEndpoint,
             "container",
             allowedPrefix + "metadata/00000-65ffa17b-fe64-4c38-bcb9-06f9bd12aa2a.metadata.json");
     DataLakeFileClient fileClient =
         createDatalakeFileClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             serviceEndpoint,
             "container",
             "polaris-test/scopedcreds/metadata",
@@ -313,13 +313,13 @@ public class AzureCredentialStorageIntegrationTest extends BaseStorageIntegratio
     String blockedContainer = "regtest";
     BlobClient blobClientWriteFail =
         createBlobClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             serviceEndpoint,
             blockedContainer,
             blockedPrefix);
     DataLakeFileClient fileClientFail =
         createDatalakeFileClient(
-            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN),
+            storageAccessConfig.get(StorageAccessProperty.AZURE_SAS_TOKEN_BARE),
             serviceEndpoint,
             blockedContainer,
             "polaris-test/scopedcreds/metadata",

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -41,7 +41,7 @@ public class AzureCredentialsStorageIntegrationTest {
     // ADLS location without refresh credentials endpoint.
     StorageAccessConfig adlsNoRefreshResult =
         toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.empty());
-    Assertions.assertThat(adlsNoRefreshResult.credentials()).hasSize(6);
+    Assertions.assertThat(adlsNoRefreshResult.credentials()).hasSize(5);
     Assertions.assertThat(adlsNoRefreshResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.ADLS_ENDPOINT);
     Assertions.assertThat(adlsNoRefreshResult.credentials())
@@ -61,7 +61,7 @@ public class AzureCredentialsStorageIntegrationTest {
     // ADLS location with refresh credentials endpoint.
     StorageAccessConfig adlsWithRefreshResult =
         toAccessConfig("sasToken", adlsLocation, expiresAt, Optional.of("endpoint/credentials"));
-    Assertions.assertThat(adlsWithRefreshResult.credentials()).hasSize(6);
+    Assertions.assertThat(adlsWithRefreshResult.credentials()).hasSize(5);
     Assertions.assertThat(adlsWithRefreshResult.credentials())
         .containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(adlsWithRefreshResult.credentials())
@@ -81,7 +81,7 @@ public class AzureCredentialsStorageIntegrationTest {
     // Blob location.
     StorageAccessConfig blobResult =
         toAccessConfig("sasToken", blobLocation, expiresAt, Optional.empty());
-    Assertions.assertThat(blobResult.credentials()).hasSize(6);
+    Assertions.assertThat(blobResult.credentials()).hasSize(5);
     Assertions.assertThat(blobResult.credentials()).containsKey("adls.sas-token.myaccount");
     Assertions.assertThat(blobResult.credentials())
         .containsKey("adls.sas-token.myaccount." + AzureLocation.BLOB_ENDPOINT);

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -424,19 +424,18 @@ public class StorageCredentialCacheTest {
               .put(StorageAccessProperty.AWS_KEY_ID, "key_id_" + finalI)
               .put(StorageAccessProperty.AWS_SECRET_KEY, "key_secret_" + finalI)
               .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, expireTime)
-              .put(StorageAccessProperty.EXPIRATION_TIME, expireTime)
               .build());
       if (res.size() == number) return res;
       res.add(
           StorageAccessConfig.builder()
-              .put(StorageAccessProperty.AZURE_SAS_TOKEN, "sas_token_" + finalI)
-              .put(StorageAccessProperty.EXPIRATION_TIME, expireTime)
+              .put(StorageAccessProperty.AZURE_SAS_TOKEN_BARE, "sas_token_" + finalI)
+              .put(StorageAccessProperty.AZURE_SAS_TOKEN_EXPIRES_AT_MS, expireTime)
               .build());
       if (res.size() == number) return res;
       res.add(
           StorageAccessConfig.builder()
               .put(StorageAccessProperty.GCS_ACCESS_TOKEN, "gcs_token_" + finalI)
-              .put(StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT, expireTime)
+              .put(StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT_MS, expireTime)
               .build());
     }
     return res;

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -200,7 +200,8 @@ class GcpCredentialsStorageIntegrationTest extends BaseStorageIntegrationTest {
             storageAccessConfig.get(StorageAccessProperty.GCS_ACCESS_TOKEN),
             new Date(
                 Long.parseLong(
-                    storageAccessConfig.get(StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT))));
+                    storageAccessConfig.get(
+                        StorageAccessProperty.GCS_ACCESS_TOKEN_EXPIRES_AT_MS))));
     return StorageOptions.newBuilder()
         .setCredentials(GoogleCredentials.create(accessToken))
         .build()

--- a/site/content/in-dev/unreleased/configuration/config-sections/storage-aws.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/storage-aws.md
@@ -1,0 +1,36 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: storage-aws
+build:
+  list: never
+  render: never
+---
+
+| Property | Type | Kind | Description |
+|----------|------|------|-------------|
+| `s3.access-key-id` | `String` | credential | AWS access key ID from the STS session |
+| `s3.secret-access-key` | `String` | credential | AWS secret access key from the STS session |
+| `s3.session-token` | `String` | credential | AWS session token from the STS session |
+| `s3.session-token-expires-at-ms` | `String` | credential | Expiration time of the session token, in milliseconds since the Unix epoch |
+| `s3.endpoint` | `String` | config | Custom S3 endpoint URL; emitted for S3-compatible stores such as MinIO or Ozone, absent for native AWS S3 |
+| `s3.path-style-access` | `Boolean` | config | Set to true when path-style addressing is required; emitted for S3-compatible stores, absent for native AWS S3 |
+| `client.region` | `String` | config | AWS region to use for S3 and STS requests |
+| `client.refresh-credentials-endpoint` | `String` | config | Catalog endpoint the client can call to refresh vended credentials before they expire |
+

--- a/site/content/in-dev/unreleased/configuration/config-sections/storage-azure.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/storage-azure.md
@@ -1,0 +1,34 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: storage-azure
+build:
+  list: never
+  render: never
+---
+
+| Property | Type | Kind | Description |
+|----------|------|------|-------------|
+| `adls.sas-token.<account-host>` | `String` | credential | SAS token keyed by the full storage DNS name (e.g. `adls.sas-token.myaccount.dfs.core.windows.net`); consumed by Spark via Iceberg's ADLSFileIO |
+| `adls.sas-token.<account-name>` | `String` | credential | SAS token keyed by the storage account name only (e.g. `adls.sas-token.myaccount`); consumed by Iceberg 1.7.x clients |
+| `adls.sas-token` | `String` | credential | Bare SAS token (no suffix); consumed by PyIceberg via adlfs/fsspec |
+| `adls.account-name` | `String` | credential | Storage account name; consumed by PyIceberg via adlfs/fsspec |
+| `adls.refresh-credentials-endpoint` | `String` | config | Catalog endpoint the client can call to refresh vended credentials before they expire |
+| `adls.sas-token-expires-at-ms.<account-host>` | `Long` | credential | Expiration time of the SAS token keyed by the full storage DNS name, in milliseconds since the Unix epoch |
+

--- a/site/content/in-dev/unreleased/configuration/config-sections/storage-gcs.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/storage-gcs.md
@@ -1,0 +1,31 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: storage-gcs
+build:
+  list: never
+  render: never
+---
+
+| Property | Type | Kind | Description |
+|----------|------|------|-------------|
+| `gcs.oauth2.token` | `String` | credential | Downscoped OAuth2 access token |
+| `gcs.oauth2.token-expires-at` | `String` | credential | Expiration time of the access token, in milliseconds since the Unix epoch |
+| `gcs.oauth2.refresh-credentials-endpoint` | `String` | config | Catalog endpoint the client can call to refresh vended credentials before they expire |
+

--- a/site/content/in-dev/unreleased/vended-credentials.md
+++ b/site/content/in-dev/unreleased/vended-credentials.md
@@ -1,0 +1,96 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: Vended Credentials Reference
+linkTitle: Vended Credentials Reference
+type: docs
+weight: 460
+---
+
+When an Iceberg client (Spark, Trino, PyIceberg, etc.) loads a table or view, Polaris can be
+configured to return short-lived, scoped credentials that the client uses to access cloud storage
+directly. These credentials are returned as key-value properties in the Iceberg REST API response
+(see `LoadTableResult` and `LoadViewResult` in the [Iceberg REST
+spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml)).
+
+Properties with kind `credential` carry sensitive material and are returned in the `credentials`
+map of the API response (never logged). Properties with kind `config` carry non-sensitive
+configuration and are returned in the `config` map.
+
+There is no standard that defines common property names for vended credentials. The names Polaris
+uses match what the Iceberg SDK expects for each storage type. This page documents the exact
+property names Polaris emits so that client authors and operators can diagnose authentication
+failures and understand client compatibility.
+
+## AWS S3
+
+Polaris calls [AWS STS `AssumeRole`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+with an inline session policy scoped to the specific table locations and operations (read, list,
+write) the caller is authorized to perform. The resulting temporary credentials are returned to the
+client.
+
+{{% include-config-section "storage-aws" %}}
+
+## Azure ADLS
+
+Polaris generates a
+[User Delegation SAS token](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-user-delegation-sas-create-dotnet)
+scoped to the container and path prefix the caller is authorized to access. Azure limits the
+maximum validity of a User Delegation SAS token to **seven days**.
+
+{{% include-config-section "storage-azure" %}}
+
+{{< alert note >}}
+The suffixed key forms (`adls.sas-token.<account-host>` and `adls.sas-token.<account-name>`) always
+carry the same SAS token. Polaris emits all forms simultaneously so that different clients can each
+find the key they expect without any client-specific configuration.
+{{< /alert >}}
+
+## Google Cloud Storage (GCS)
+
+Polaris obtains a downscoped OAuth2 access token via Google's
+[Credential Access Boundary](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials)
+mechanism. The token is scoped to the specific GCS buckets and path prefixes the caller is
+authorized to access and supports optional service account impersonation.
+
+{{% include-config-section "storage-gcs" %}}
+
+## Credential refresh
+
+When a client requests vended credentials by setting the `X-Iceberg-Access-Delegation` header to
+`vended-credentials` on a table load or create request, Polaris also returns a credential-refresh
+endpoint URL in the properties listed above (one per storage type). Iceberg clients that support
+the Iceberg REST credential-refresh protocol can call this endpoint to obtain fresh credentials
+before the current ones expire, avoiding the need to re-load the table.
+
+## Client compatibility summary
+
+The table below summarizes which property forms are required by common clients, based on the
+Iceberg SDK each client uses.
+
+| Client                             | Storage type | Required properties                                            |
+|------------------------------------|--------------|----------------------------------------------------------------|
+| Apache Spark (Iceberg ≥ 1.8)       | S3           | `s3.access-key-id`, `s3.secret-access-key`, `s3.session-token` |
+| Apache Spark (Iceberg ≥ 1.8)       | ADLS / Blob  | `adls.sas-token.<account-host>`                                |
+| Apache Spark (Iceberg 1.7.x)       | ADLS / Blob  | `adls.sas-token.<account-name>`                                |
+| PyIceberg (via `adlfs` / `fsspec`) | ADLS / Blob  | `adls.sas-token`, `adls.account-name`                          |
+| Apache Spark / PyIceberg           | GCS          | `gcs.oauth2.token`                                             |
+
+Polaris emits **all applicable forms simultaneously**, so no client-specific Polaris configuration
+is required to switch between the clients listed above.

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/DocGenDoclet.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/DocGenDoclet.java
@@ -83,12 +83,14 @@ public class DocGenDoclet implements Doclet {
     var propertiesConfigs = new PropertiesConfigs(environment);
     var smallryeConfigs = new SmallRyeConfigs(environment);
     var polarisConfigs = new PolarisConfigurationConfigs(environment);
+    var storageAccessPropertyConfigs = new StorageAccessPropertyConfigs(environment);
 
     for (var includedElement : environment.getIncludedElements()) {
       try {
         includedElement.accept(propertiesConfigs.visitor(), null);
         includedElement.accept(smallryeConfigs.visitor(), null);
         includedElement.accept(polarisConfigs.visitor(), null);
+        includedElement.accept(storageAccessPropertyConfigs.visitor(), null);
       } catch (RuntimeException ex) {
         throw new RuntimeException("Failure processing included element " + includedElement, ex);
       }
@@ -99,6 +101,8 @@ public class DocGenDoclet implements Doclet {
     smallryeConfigPages(environment, smallryeConfigs);
 
     polarisConfigPages(polarisConfigs);
+
+    storageAccessPropertyPages(storageAccessPropertyConfigs);
 
     return true;
   }
@@ -344,6 +348,28 @@ public class DocGenDoclet implements Doclet {
       String propertyNamePrefix, String propertyName, String propertySuffix) {
     var r = concatWithDot(propertyNamePrefix, propertyName);
     return propertySuffix.isEmpty() ? r : concatWithDot(r, "`_`<" + propertySuffix + ">`_`");
+  }
+
+  private void storageAccessPropertyPages(
+      StorageAccessPropertyConfigs storageAccessPropertyConfigs) {
+    var byStorageType = storageAccessPropertyConfigs.byStorageType();
+    if (byStorageType.isEmpty()) {
+      return;
+    }
+    System.out.println("... generating storage access property pages");
+    for (var entry : byStorageType.entrySet()) {
+      var storageType = entry.getKey();
+      var properties = entry.getValue();
+      System.out.printf("... generating storage access property page for %s%n", storageType);
+      var page = new StorageAccessPropertySectionPage(properties);
+      var file = outputDirectory.resolve("storage-" + storageType.toLowerCase(Locale.ROOT) + ".md");
+      try (var pw =
+          new PrintWriter(Files.newBufferedWriter(file, UTF_8, CREATE, TRUNCATE_EXISTING))) {
+        page.writeTo(pw);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   private String safeFileName(String str) {

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertyConfigs.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertyConfigs.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.docs.generator;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.AbstractElementVisitor8;
+import javax.tools.StandardLocation;
+import jdk.javadoc.doclet.DocletEnvironment;
+
+/**
+ * Processes the {@code StorageAccessProperty} enum to extract vended-credentials documentation,
+ * grouped by storage type.
+ */
+public class StorageAccessPropertyConfigs {
+  private static final String CLASS_NAME = "org.apache.polaris.core.storage.StorageAccessProperty";
+
+  private final ClassLoader classLoader;
+
+  /** Maps storageType.name() → ordered list of property infos for that storage type. */
+  private final Map<String, List<StorageAccessPropertyInfo>> byStorageType = new LinkedHashMap<>();
+
+  public StorageAccessPropertyConfigs(DocletEnvironment env) {
+    this.classLoader = env.getJavaFileManager().getClassLoader(StandardLocation.CLASS_PATH);
+  }
+
+  /** Returns properties grouped by storage type, in declaration order per group. */
+  public Map<String, List<StorageAccessPropertyInfo>> byStorageType() {
+    return byStorageType;
+  }
+
+  ElementVisitor<Void, Void> visitor() {
+    return new AbstractElementVisitor8<>() {
+
+      @Override
+      public Void visitPackage(PackageElement e, Void ignore) {
+        return null;
+      }
+
+      @Override
+      public Void visitType(TypeElement e, Void ignore) {
+        if (!e.getQualifiedName().toString().equals(CLASS_NAME)) {
+          return null;
+        }
+        try {
+          Class<?> clazz = Class.forName(CLASS_NAME, true, classLoader);
+          processEnum(clazz);
+        } catch (ClassNotFoundException ex) {
+          System.err.println("Warning: Could not load class " + CLASS_NAME + ": " + ex);
+        }
+        return null;
+      }
+
+      @SuppressWarnings("unchecked")
+      private void processEnum(Class<?> clazz) throws ClassNotFoundException {
+        if (!clazz.isEnum()) {
+          return;
+        }
+        Method getPropertyName;
+        Method getDescription;
+        Method getValueType;
+        Method isCredential;
+        Method getStorageType;
+        Method getSuffixLabel;
+        try {
+          getPropertyName = clazz.getMethod("getPropertyName");
+          getDescription = clazz.getMethod("getDescription");
+          getValueType = clazz.getMethod("getValueType");
+          isCredential = clazz.getMethod("isCredential");
+          getStorageType = clazz.getMethod("getStorageType");
+          getSuffixLabel = clazz.getMethod("getSuffixLabel");
+        } catch (NoSuchMethodException ex) {
+          System.err.println("Warning: Missing expected method on " + CLASS_NAME + ": " + ex);
+          return;
+        }
+
+        for (Object constant : clazz.getEnumConstants()) {
+          try {
+            String propertyName = (String) getPropertyName.invoke(constant);
+            if (propertyName == null || propertyName.isEmpty()) {
+              continue;
+            }
+            String description = (String) getDescription.invoke(constant);
+            Class<?> valueType = (Class<?>) getValueType.invoke(constant);
+            String typeName = valueType.getSimpleName();
+            boolean credential = (boolean) isCredential.invoke(constant);
+            Object storageTypeEnum = getStorageType.invoke(constant);
+            String storageType = storageTypeEnum.toString();
+            String suffixLabel = (String) getSuffixLabel.invoke(constant);
+
+            var info =
+                new StorageAccessPropertyInfo(
+                    propertyName, description, typeName, credential, storageType, suffixLabel);
+            byStorageType.computeIfAbsent(storageType, k -> new ArrayList<>()).add(info);
+          } catch (Exception ex) {
+            System.err.println("Warning: Error processing constant " + constant + ": " + ex);
+          }
+        }
+      }
+
+      @Override
+      public Void visitVariable(VariableElement e, Void ignore) {
+        return null;
+      }
+
+      @Override
+      public Void visitExecutable(ExecutableElement e, Void ignore) {
+        return null;
+      }
+
+      @Override
+      public Void visitTypeParameter(TypeParameterElement e, Void ignore) {
+        return null;
+      }
+    };
+  }
+}

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertyInfo.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertyInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.docs.generator;
+
+/**
+ * Holds information about a {@code StorageAccessProperty} enum constant.
+ *
+ * <p>When {@code suffixLabel} is non-null the property is a prefix property: the actual runtime key
+ * is {@code propertyName + "." + runtimeSuffix}, and {@code suffixLabel} names what that suffix
+ * represents (e.g. {@code "account-host"}).
+ */
+public record StorageAccessPropertyInfo(
+    String propertyName,
+    String description,
+    String valueType,
+    boolean isCredential,
+    String storageType,
+    String suffixLabel) {
+
+  public boolean isPrefixProperty() {
+    return suffixLabel != null;
+  }
+}

--- a/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertySectionPage.java
+++ b/tools/config-docs/generator/src/main/java/org/apache/polaris/docs/generator/StorageAccessPropertySectionPage.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.docs.generator;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+/** Generates a markdown table for a group of {@link StorageAccessPropertyInfo} entries. */
+public class StorageAccessPropertySectionPage {
+
+  private final List<StorageAccessPropertyInfo> properties;
+
+  public StorageAccessPropertySectionPage(List<StorageAccessPropertyInfo> properties) {
+    this.properties = properties;
+  }
+
+  public void writeTo(PrintWriter pw) {
+    pw.println("| Property | Type | Kind | Description |");
+    pw.println("|----------|------|------|-------------|");
+    for (var info : properties) {
+      String kind = info.isCredential() ? "credential" : "config";
+      String displayName =
+          info.isPrefixProperty()
+              ? info.propertyName() + ".<" + info.suffixLabel() + ">"
+              : info.propertyName();
+      // Capitalize first letter of description for consistency
+      String desc = info.description();
+      if (!desc.isEmpty()) {
+        desc = Character.toUpperCase(desc.charAt(0)) + desc.substring(1);
+      }
+      pw.printf("| `%s` | `%s` | %s | %s |%n", displayName, info.valueType(), kind, desc);
+    }
+    pw.println();
+  }
+}

--- a/tools/config-docs/site/build.gradle.kts
+++ b/tools/config-docs/site/build.gradle.kts
@@ -160,6 +160,7 @@ abstract class CopyConfigSectionsToSite : DefaultTask() {
       .matching {
         include("smallrye-*.md")
         include("flags-*.md")
+        include("storage-*.md")
       }
       .files
       .forEach { file ->


### PR DESCRIPTION
This change introduces a new "Vended Credentials Reference" page in Polaris website, automatically generated from the authoritative `StorageAccessProperty` enum constants.

Other changes:

- Removed unused `AZURE_ACCESS_TOKEN` enum constant
- Removed redundant `EXPIRATION_TIME` enum constant (no client consumes such a property)
- Reworked and renamed Azure's prefixed properties for clarity.
- Renamed expiration time properties for better naming alignment.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
