### PR TITLE
Avoid fetching full entity rows in lookupEntityGrantRecordsVersion

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -629,26 +629,10 @@ public class JdbcBasePersistenceImpl
   @Override
   public int lookupEntityGrantRecordsVersion(
       @NonNull PolarisCallContext callCtx, long catalogId, long entityId) {
-    Map<String, Object> params =
-        Map.of("catalog_id", catalogId, "id", entityId, "realm_id", realmId);
-    PreparedQuery query =
-        QueryGenerator.generateSelectQuery(
-            ModelEntity.VERSION_COLUMNS, ModelEntity.TABLE_NAME, params);
-    try {
-      var results = datasourceOperations.executeSelect(query, new EntityVersionConverter());
-      if (results.isEmpty()) {
-        return 0;
-      } else if (results.size() > 1) {
-        throw new IllegalStateException(
-            String.format(
-                "More than one(%s) entities were found for catalogId=%s, entityId=%s",
-                results.size(), catalogId, entityId));
-      }
-      return results.getFirst().versions().grantRecordsVersion();
-    } catch (SQLException e) {
-      throw new RuntimeException(
-          String.format("Failed to retrieve grant records version due to %s", e.getMessage()), e);
-    }
+    List<PolarisChangeTrackingVersions> versions =
+        lookupEntityVersions(callCtx, List.of(new PolarisEntityId(catalogId, entityId)));
+    PolarisChangeTrackingVersions version = versions.getFirst();
+    return version == null ? 0 : version.grantRecordsVersion();
   }
 
   @Override

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -629,14 +629,26 @@ public class JdbcBasePersistenceImpl
   @Override
   public int lookupEntityGrantRecordsVersion(
       @NonNull PolarisCallContext callCtx, long catalogId, long entityId) {
-
     Map<String, Object> params =
         Map.of("catalog_id", catalogId, "id", entityId, "realm_id", realmId);
-    PolarisBaseEntity b =
-        getPolarisBaseEntity(
-            QueryGenerator.generateSelectQuery(
-                ModelEntity.getAllColumnNames(schemaVersion), ModelEntity.TABLE_NAME, params));
-    return b == null ? 0 : b.getGrantRecordsVersion();
+    PreparedQuery query =
+        QueryGenerator.generateSelectQuery(
+            ModelEntity.VERSION_COLUMNS, ModelEntity.TABLE_NAME, params);
+    try {
+      var results = datasourceOperations.executeSelect(query, new EntityVersionConverter());
+      if (results.isEmpty()) {
+        return 0;
+      } else if (results.size() > 1) {
+        throw new IllegalStateException(
+            String.format(
+                "More than one(%s) entities were found for catalogId=%s, entityId=%s",
+                results.size(), catalogId, entityId));
+      }
+      return results.getFirst().versions().grantRecordsVersion();
+    } catch (SQLException e) {
+      throw new RuntimeException(
+          String.format("Failed to retrieve grant records version due to %s", e.getMessage()), e);
+    }
   }
 
   @Override

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
@@ -256,6 +256,76 @@ class JdbcBasePersistenceImplTest {
     assertThat(sql).doesNotContain("internal_properties");
   }
 
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void lookupEntityGrantRecordsVersionReturnsVersionOrZeroForMissing(int schemaVersion)
+      throws SQLException, IOException {
+    JdbcConnectionPool dataSource =
+        JdbcConnectionPool.create(
+            "jdbc:h2:mem:lookup_grant_version_v"
+                + schemaVersion
+                + "_"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1",
+            "sa",
+            "");
+    DatasourceOperations real = new DatasourceOperations(dataSource, new TestJdbcConfiguration());
+    try (InputStream script = DatabaseType.H2.openInitScriptResource(schemaVersion)) {
+      real.executeScript(script);
+    }
+    // Spy so we can assert on the SQL actually issued, without blocking the real call.
+    DatasourceOperations spy = Mockito.spy(real);
+    doCallRealMethod().when(spy).executeSelect(any(), any());
+
+    JdbcBasePersistenceImpl impl =
+        new JdbcBasePersistenceImpl(
+            new PolarisDefaultDiagServiceImpl(),
+            spy,
+            RANDOM_SECRETS,
+            REALM_CONTEXT.getRealmIdentifier(),
+            schemaVersion);
+    PolarisCallContext callCtx = new PolarisCallContext(REALM_CONTEXT, impl);
+
+    PolarisBaseEntity e1 =
+        new PolarisBaseEntity.Builder()
+            .id(201L)
+            .catalogId(0L)
+            .parentId(0L)
+            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .name("e1")
+            .entityVersion(1)
+            .grantRecordsVersion(5)
+            .createTimestamp(System.currentTimeMillis())
+            .build();
+    PolarisBaseEntity e2 =
+        new PolarisBaseEntity.Builder()
+            .id(202L)
+            .catalogId(0L)
+            .parentId(0L)
+            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .name("e2")
+            .entityVersion(1)
+            .grantRecordsVersion(9)
+            .createTimestamp(System.currentTimeMillis())
+            .build();
+    impl.writeEntity(callCtx, e1, false, null);
+    impl.writeEntity(callCtx, e2, false, null);
+
+    // Behavioural: returns the stored version per entity, 0 for a missing entity.
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 201L)).isEqualTo(5);
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 202L)).isEqualTo(9);
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 999L)).isEqualTo(0);
+
+    // Perf: the SQL that actually executed must not fetch the large JSON property columns.
+    ArgumentCaptor<QueryGenerator.PreparedQuery> captor =
+        ArgumentCaptor.forClass(QueryGenerator.PreparedQuery.class);
+    verify(spy, Mockito.atLeastOnce()).executeSelect(captor.capture(), any());
+    assertThat(captor.getAllValues())
+        .allSatisfy(q -> assertThat(q.sql()).doesNotContain("properties"));
+  }
+
   private static final class TestJdbcConfiguration implements RelationalJdbcConfiguration {
     @Override
     public Optional<Integer> maxRetries() {

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
@@ -143,56 +143,16 @@ class JdbcBasePersistenceImplTest {
   @ValueSource(ints = {1, 2})
   void lookupEntityVersionsPreservesOrderAndNullsForMissing(int schemaVersion)
       throws SQLException, IOException {
-    JdbcConnectionPool dataSource =
-        JdbcConnectionPool.create(
-            "jdbc:h2:mem:lookup_versions_v"
-                + schemaVersion
-                + "_"
-                + System.nanoTime()
-                + ";DB_CLOSE_DELAY=-1",
-            "sa",
-            "");
-    DatasourceOperations real = new DatasourceOperations(dataSource, new TestJdbcConfiguration());
-    try (InputStream script = DatabaseType.H2.openInitScriptResource(schemaVersion)) {
-      real.executeScript(script);
-    }
+    DatasourceOperations real = newH2DatasourceOperations("lookup_versions_v", schemaVersion);
     // Spy so we can assert on the SQL actually issued, without blocking the real call.
     DatasourceOperations spy = Mockito.spy(real);
     doCallRealMethod().when(spy).executeSelect(any(), any());
+    TestPersistence tp = newTestPersistence(spy, schemaVersion);
+    JdbcBasePersistenceImpl impl = tp.impl();
+    PolarisCallContext callCtx = tp.callCtx();
 
-    JdbcBasePersistenceImpl impl =
-        new JdbcBasePersistenceImpl(
-            new PolarisDefaultDiagServiceImpl(),
-            spy,
-            RANDOM_SECRETS,
-            REALM_CONTEXT.getRealmIdentifier(),
-            schemaVersion);
-    PolarisCallContext callCtx = new PolarisCallContext(REALM_CONTEXT, impl);
-
-    PolarisBaseEntity e1 =
-        new PolarisBaseEntity.Builder()
-            .id(101L)
-            .catalogId(0L)
-            .parentId(0L)
-            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
-            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-            .name("e1")
-            .entityVersion(1)
-            .grantRecordsVersion(2)
-            .createTimestamp(System.currentTimeMillis())
-            .build();
-    PolarisBaseEntity e2 =
-        new PolarisBaseEntity.Builder()
-            .id(102L)
-            .catalogId(0L)
-            .parentId(0L)
-            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
-            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-            .name("e2")
-            .entityVersion(3)
-            .grantRecordsVersion(4)
-            .createTimestamp(System.currentTimeMillis())
-            .build();
+    PolarisBaseEntity e1 = newTestEntity(101L, "e1", 1, 2);
+    PolarisBaseEntity e2 = newTestEntity(102L, "e2", 3, 4);
     impl.writeEntity(callCtx, e1, false, null);
     impl.writeEntity(callCtx, e2, false, null);
 
@@ -258,72 +218,75 @@ class JdbcBasePersistenceImplTest {
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2})
-  void lookupEntityGrantRecordsVersionReturnsVersionOrZeroForMissing(int schemaVersion)
+  void lookupEntityGrantRecordsVersionDelegatesToLookupEntityVersions(int schemaVersion)
       throws SQLException, IOException {
+    // lookupEntityGrantRecordsVersion delegates to lookupEntityVersions, whose SQL shape (and the
+    // exclusion of large property columns) is already covered by the test above; this test only
+    // needs to check the delegation's own behavioural contract.
+    DatasourceOperations datasourceOperations =
+        newH2DatasourceOperations("lookup_grant_version_v", schemaVersion);
+    TestPersistence tp = newTestPersistence(datasourceOperations, schemaVersion);
+    JdbcBasePersistenceImpl impl = tp.impl();
+    PolarisCallContext callCtx = tp.callCtx();
+
+    PolarisBaseEntity e1 = newTestEntity(201L, "e1", 1, 5);
+    PolarisBaseEntity e2 = newTestEntity(202L, "e2", 1, 9);
+    impl.writeEntity(callCtx, e1, false, null);
+    impl.writeEntity(callCtx, e2, false, null);
+
+    // Behavioural: returns the stored grant-records version per entity, 0 for a missing entity.
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 201L)).isEqualTo(5);
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 202L)).isEqualTo(9);
+    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 999L)).isEqualTo(0);
+  }
+
+  private static DatasourceOperations newH2DatasourceOperations(
+      String dbNamePrefix, int schemaVersion) throws SQLException, IOException {
     JdbcConnectionPool dataSource =
         JdbcConnectionPool.create(
-            "jdbc:h2:mem:lookup_grant_version_v"
+            "jdbc:h2:mem:"
+                + dbNamePrefix
                 + schemaVersion
                 + "_"
                 + System.nanoTime()
                 + ";DB_CLOSE_DELAY=-1",
             "sa",
             "");
-    DatasourceOperations real = new DatasourceOperations(dataSource, new TestJdbcConfiguration());
+    DatasourceOperations operations =
+        new DatasourceOperations(dataSource, new TestJdbcConfiguration());
     try (InputStream script = DatabaseType.H2.openInitScriptResource(schemaVersion)) {
-      real.executeScript(script);
+      operations.executeScript(script);
     }
-    // Spy so we can assert on the SQL actually issued, without blocking the real call.
-    DatasourceOperations spy = Mockito.spy(real);
-    doCallRealMethod().when(spy).executeSelect(any(), any());
+    return operations;
+  }
 
+  private static TestPersistence newTestPersistence(
+      DatasourceOperations datasourceOperations, int schemaVersion) {
     JdbcBasePersistenceImpl impl =
         new JdbcBasePersistenceImpl(
             new PolarisDefaultDiagServiceImpl(),
-            spy,
+            datasourceOperations,
             RANDOM_SECRETS,
             REALM_CONTEXT.getRealmIdentifier(),
             schemaVersion);
-    PolarisCallContext callCtx = new PolarisCallContext(REALM_CONTEXT, impl);
+    return new TestPersistence(impl, new PolarisCallContext(REALM_CONTEXT, impl));
+  }
 
-    PolarisBaseEntity e1 =
-        new PolarisBaseEntity.Builder()
-            .id(201L)
-            .catalogId(0L)
-            .parentId(0L)
-            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
-            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-            .name("e1")
-            .entityVersion(1)
-            .grantRecordsVersion(5)
-            .createTimestamp(System.currentTimeMillis())
-            .build();
-    PolarisBaseEntity e2 =
-        new PolarisBaseEntity.Builder()
-            .id(202L)
-            .catalogId(0L)
-            .parentId(0L)
-            .typeCode(PolarisEntityType.PRINCIPAL.getCode())
-            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
-            .name("e2")
-            .entityVersion(1)
-            .grantRecordsVersion(9)
-            .createTimestamp(System.currentTimeMillis())
-            .build();
-    impl.writeEntity(callCtx, e1, false, null);
-    impl.writeEntity(callCtx, e2, false, null);
+  private record TestPersistence(JdbcBasePersistenceImpl impl, PolarisCallContext callCtx) {}
 
-    // Behavioural: returns the stored version per entity, 0 for a missing entity.
-    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 201L)).isEqualTo(5);
-    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 202L)).isEqualTo(9);
-    assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 999L)).isEqualTo(0);
-
-    // Perf: the SQL that actually executed must not fetch the large JSON property columns.
-    ArgumentCaptor<QueryGenerator.PreparedQuery> captor =
-        ArgumentCaptor.forClass(QueryGenerator.PreparedQuery.class);
-    verify(spy, Mockito.atLeastOnce()).executeSelect(captor.capture(), any());
-    assertThat(captor.getAllValues())
-        .allSatisfy(q -> assertThat(q.sql()).doesNotContain("properties"));
+  private static PolarisBaseEntity newTestEntity(
+      long id, String name, int entityVersion, int grantRecordsVersion) {
+    return new PolarisBaseEntity.Builder()
+        .id(id)
+        .catalogId(0L)
+        .parentId(0L)
+        .typeCode(PolarisEntityType.PRINCIPAL.getCode())
+        .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+        .name(name)
+        .entityVersion(entityVersion)
+        .grantRecordsVersion(grantRecordsVersion)
+        .createTimestamp(System.currentTimeMillis())
+        .build();
   }
 
   private static final class TestJdbcConfiguration implements RelationalJdbcConfiguration {


### PR DESCRIPTION
Follow up on https://github.com/apache/polaris/pull/5038 improvement, same patch idea

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
