### PR TITLE
Fix ManifestFileCleanupTaskHandlerTest

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/ManifestFileCleanupTaskHandlerTest.java
@@ -192,7 +192,7 @@ class ManifestFileCleanupTaskHandlerTest {
             .build();
     task = addTaskLocation(task);
     assertThatPredicate(handler::canHandleTask).accepts(task);
-    assertThat(handler.handleTask(task, polarisCallContext)).isTrue();
+    handler.handleTask(task, polarisCallContext);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(deleteFile1Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(deleteFile2Path);
     assertThatPredicate((String f) -> TaskUtils.exists(f, fileIO)).rejects(manifestFile.path());


### PR DESCRIPTION
Fix compilation error caused by overlapped merges of #4941 and #4962

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
