### PR TITLE
Fix view grants on federated catalogs

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -2351,7 +2351,7 @@ public class PolarisAdminService {
     if (completePathWrapper == null
         || leafEntity == null
         || !(leafEntity.getType() == PolarisEntityType.TABLE_LIKE
-            && leafEntity.getSubType() == PolarisEntitySubType.ICEBERG_TABLE
+            && subTypes.contains(leafEntity.getSubType())
             && Objects.equals(leafEntity.getName(), identifier.name()))) {
       throw new RuntimeException(
           String.format(

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceTest.java
@@ -667,6 +667,71 @@ public class PolarisAdminServiceTest {
   }
 
   @Test
+  void testGrantPrivilegeOnViewLikeToRole_PassthroughFacade() throws Exception {
+    String catalogName = "test-catalog";
+    String catalogRoleName = "test-role";
+    Namespace namespace = Namespace.of("ns1");
+    TableIdentifier identifier = TableIdentifier.of(namespace, "test-view");
+    PolarisPrivilege privilege = PolarisPrivilege.VIEW_WRITE_PROPERTIES;
+
+    PolarisEntity catalogEntity = createEntity(catalogName, PolarisEntityType.CATALOG);
+    when(resolutionManifest.getResolvedCatalogEntity()).thenReturn(CatalogEntity.of(catalogEntity));
+    when(resolutionManifest.getIsPassthroughFacade()).thenReturn(true);
+
+    PolarisResolvedPathWrapper catalogRoleWrapper = mock(PolarisResolvedPathWrapper.class);
+    PolarisEntity catalogRoleEntity = createEntity(catalogRoleName, PolarisEntityType.CATALOG_ROLE);
+    when(catalogRoleWrapper.getRawLeafEntity()).thenReturn(catalogRoleEntity);
+    when(resolutionManifest.getResolvedPath(
+            eq(ResolvedPathKey.of(List.of(catalogRoleName), PolarisEntityType.CATALOG_ROLE))))
+        .thenReturn(catalogRoleWrapper);
+
+    PolarisEntity nsEntity = createNamespaceEntity(namespace, 2L, 1L);
+
+    // The view is not yet resolved as a table-like entity, so the pre-existing path stops at the
+    // namespace (leaf subtype is not ICEBERG_VIEW). This forces the synthetic-creation branch.
+    PolarisResolvedPathWrapper existingPathWrapper = mock(PolarisResolvedPathWrapper.class);
+    when(existingPathWrapper.getRawFullPath()).thenReturn(List.of(catalogEntity, nsEntity));
+    when(existingPathWrapper.getRawLeafEntity()).thenReturn(nsEntity);
+    when(resolutionManifest.getResolvedPath(
+            eq(ResolvedPathKey.ofTableLike(identifier)), eq(PolarisEntitySubType.ANY_SUBTYPE)))
+        .thenReturn(existingPathWrapper);
+
+    // The single-level namespace already exists, so no synthetic namespace is created.
+    PolarisResolvedPathWrapper nsWrapper = mock(PolarisResolvedPathWrapper.class);
+    when(nsWrapper.getRawFullPath()).thenReturn(List.of(catalogEntity, nsEntity));
+    when(nsWrapper.getRawLeafEntity()).thenReturn(nsEntity);
+    when(nsWrapper.isFullyResolvedNamespace(eq(catalogName), eq(namespace))).thenReturn(true);
+    when(resolutionManifest.getPassthroughResolvedPath(eq(ResolvedPathKey.ofNamespace(namespace))))
+        .thenReturn(nsWrapper);
+
+    GenerateEntityIdResult idResult = mock(GenerateEntityIdResult.class);
+    when(idResult.getId()).thenReturn(6L);
+    when(metaStoreManager.generateNewEntityId(any())).thenReturn(idResult);
+    EntityResult createResult = mock(EntityResult.class);
+    when(createResult.isSuccess()).thenReturn(true);
+    when(metaStoreManager.createEntityIfNotExists(any(), any(), any())).thenReturn(createResult);
+
+    // After creation, the synthetic leaf re-resolves as an ICEBERG_VIEW (via selectEntitySubType).
+    PolarisEntity viewEntity =
+        createTableEntity(identifier, PolarisEntitySubType.ICEBERG_VIEW, 6L, 2L);
+    PolarisResolvedPathWrapper viewPathWrapper = mock(PolarisResolvedPathWrapper.class);
+    when(viewPathWrapper.getRawLeafEntity()).thenReturn(viewEntity);
+    when(viewPathWrapper.getRawParentPath()).thenReturn(List.of(catalogEntity, nsEntity));
+    when(resolutionManifest.getPassthroughResolvedPath(eq(ResolvedPathKey.ofTableLike(identifier))))
+        .thenReturn(viewPathWrapper);
+
+    PrivilegeResult successResult = mock(PrivilegeResult.class);
+    when(successResult.isSuccess()).thenReturn(true);
+    when(metaStoreManager.grantPrivilegeOnSecurableToRole(any(), any(), any(), any(), any()))
+        .thenReturn(successResult);
+
+    PrivilegeResult result =
+        adminService.grantPrivilegeOnViewToRole(
+            catalogName, catalogRoleName, identifier, privilege);
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
   void testGrantPrivilegeOnTableLikeToRole_PassthroughFacade_FeatureDisabled() throws Exception {
     String catalogName = "test-catalog";
     String catalogRoleName = "test-role";


### PR DESCRIPTION
Granting or revoking a privilege on a view in a federated (passthrough) catalog always failed with Failed to create or find table entity '<name>' in federated catalog '<catalog>', while the same operation on a table worked fine. 
The cause is in `PolarisAdminService`.`createSyntheticTableLikeEntities`: it synthesizes the entity with the caller's intended `subtype` via `selectEntitySubType(subTypes)` (which is `ICEBERG_VIEW` for a `view`), but the post-creation validation of the re-resolved leaf was hard-coded to accept only `ICEBERG_TABLE`, so a correctly-created view leaf failed the check and the method threw. 
This changes that check to `subTypes.contains(leafEntity.getSubType())`, validating against the `subtypes` the caller actually requested and consistent with how the synthetic entity was created.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
