### PR TITLE
Fix setup apply failure exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations, including catalog config `polaris.config.allow.external.metadata.file.location`.
 
 ### Fixes
-- Python CLI `setup apply` now exits with an error after any provisioning operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
+- Python CLI `setup apply` now exits with an error after any setup operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
 - Python CLI `tables list`, `tables get`, and `tables delete` commands now exit with status 1 when catalog API requests fail. Previously, these commands printed an error but exited successfully.
 - Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations, including catalog config `polaris.config.allow.external.metadata.file.location`.
 
 ### Fixes
+- Python CLI `setup apply` now exits with an error after any provisioning operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
 - Python CLI `tables list`, `tables get`, and `tables delete` commands now exit with status 1 when catalog API requests fail. Previously, these commands printed an error but exited successfully.
 - Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.
 - Async task execution (table cleanup, manifest and batch file cleanup) now retries when a handler returns false on transient errors (e.g. IO or delete failures). Previously `false` was swallowed with only a warning log and the task was never retried via the existing retry mechanism.

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -20,11 +20,11 @@ import os
 import logging
 import yaml
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Optional, List, Any, Set
 
 from apache_polaris.cli.command import Command
-from apache_polaris.cli.exceptions import CliError
+from apache_polaris.cli.exceptions import CliError, CLI_ERROR_EXIT_CODE
 from apache_polaris.cli.constants import (
     PrincipalType,
     Subcommands,
@@ -76,6 +76,7 @@ class SetupCommand(Command):
     _existing_catalogs: Optional[Set[str]] = None
     _existing_principals: Optional[Set[str]] = None
     _catalog_api: Optional[Any] = None
+    _failure_count: int = field(default=0, init=False, repr=False)
 
     def _get_catalog_api(self, api: PolarisDefaultApi) -> Any:
         """Get or create and cache the IcebergCatalogAPI client."""
@@ -524,6 +525,7 @@ class SetupCommand(Command):
     def execute(self, api: PolarisDefaultApi) -> None:
         """Execute the setup command based on the subcommand (apply or export)."""
         if self.setup_subcommand == Subcommands.APPLY:
+            self._failure_count = 0
             if self.dry_run:
                 logger.info("=== Starting Setup Dry-Run ===")
             else:
@@ -574,6 +576,11 @@ class SetupCommand(Command):
                 logger.info(f"--- Finished processing catalog: {catalog_name} ---")
             if self.dry_run:
                 logger.info("=== Dry-Run Finished ===")
+            elif self._failure_count:
+                raise CliError(
+                    f"Setup apply failed; provisioning errors: {self._failure_count}",
+                    exit_code=CLI_ERROR_EXIT_CODE,
+                )
             else:
                 logger.info("=== Setup Apply Process Completed Successfully ===")
         elif self.setup_subcommand == Subcommands.EXPORT:
@@ -600,6 +607,10 @@ class SetupCommand(Command):
                 details_str = yaml.dump(details_copy, indent=2, sort_keys=False).strip()
                 message += f" with details:\n{details_str}"
         logger.info(message)
+
+    def _record_failure(self, message: str) -> None:
+        self._failure_count += 1
+        logger.exception(message)
 
     def _create_principals(
         self,
@@ -640,7 +651,7 @@ class SetupCommand(Command):
                         )
                         existing_principals.add(principal_name)
                     except Exception:
-                        logger.exception(
+                        self._record_failure(
                             f"Failed to create principal '{principal_name}'"
                         )
             # Assign roles
@@ -681,7 +692,7 @@ class SetupCommand(Command):
                             f"Assigned principal '{principal_name}' to role '{role_name}' successfully."
                         )
                     except Exception:
-                        logger.exception(
+                        self._record_failure(
                             f"Failed to assign principal '{principal_name}' to role '{role_name}'"
                         )
         logger.info("--- Finished processing principals ---")
@@ -722,7 +733,9 @@ class SetupCommand(Command):
                     if self._existing_principal_roles is not None:
                         self._existing_principal_roles.add(role_name)
                 except Exception:
-                    logger.exception(f"Failed to create principal role '{role_name}'")
+                    self._record_failure(
+                        f"Failed to create principal role '{role_name}'"
+                    )
         logger.info("--- Finished processing principal roles ---")
 
     def _map_storage_properties(self, catalog_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -954,7 +967,7 @@ class SetupCommand(Command):
                     logger.info(f"Catalog '{catalog_name}' created successfully.")
                     existing_catalogs.add(catalog_name)
                 except Exception:
-                    logger.exception(f"Failed to create catalog '{catalog_name}'")
+                    self._record_failure(f"Failed to create catalog '{catalog_name}'")
                     overall_success = False
         logger.info("--- Finished processing catalogs ---")
         return overall_success
@@ -1001,7 +1014,7 @@ class SetupCommand(Command):
                         # Update the cache with the newly created role
                         existing_roles_in_catalog.add(role_name)
                     except Exception:
-                        logger.exception(
+                        self._record_failure(
                             f"Failed to create catalog role '{role_name}' in catalog '{catalog_name}'"
                         )
                         continue
@@ -1040,7 +1053,7 @@ class SetupCommand(Command):
                             f"Assigned catalog role '{role_name}' to principal role '{principal_role_name}' successfully."
                         )
                     except Exception:
-                        logger.exception(
+                        self._record_failure(
                             f"Failed to assign catalog role '{role_name}' to principal role '{principal_role_name}'"
                         )
             # Grant privileges
@@ -1115,7 +1128,7 @@ class SetupCommand(Command):
             cmd.execute(api)
             logger.info(f"Successfully granted {log_message}")
         except Exception:
-            logger.exception(f"Failed to grant {log_message}")
+            self._record_failure(f"Failed to grant {log_message}")
 
     def _create_namespaces(
         self,
@@ -1216,7 +1229,7 @@ class SetupCommand(Command):
                     )
                     existing_namespaces.add(ns_name)
                 except Exception:
-                    logger.exception(
+                    self._record_failure(
                         f"Failed to create namespace '{ns_name}' in catalog '{catalog_name}'"
                     )
         logger.info(
@@ -1314,7 +1327,7 @@ class SetupCommand(Command):
                         )
                         logger.info(f"Policy '{policy_name}' created successfully.")
                     except Exception:
-                        logger.exception(f"Failed to create policy '{policy_name}'")
+                        self._record_failure(f"Failed to create policy '{policy_name}'")
                         continue
             # Attachments
             attachments = policy_data.get("attach", [])
@@ -1355,7 +1368,7 @@ class SetupCommand(Command):
                         cmd.execute(api)
                         logger.info(f"Successfully attached policy '{policy_name}'")
                     except Exception:
-                        logger.exception(f"Failed to attach policy '{policy_name}'")
+                        self._record_failure(f"Failed to attach policy '{policy_name}'")
         logger.info(f"--- Finished processing policies for catalog: {catalog_name} ---")
 
     def _validate_entity(

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -1281,6 +1281,7 @@ class SetupCommand(Command):
             except NotFoundException:
                 policy_exists = False
             except Exception:
+                # A real apply's create attempt determines whether this failure is terminal.
                 if dry_run:
                     self._record_failure(
                         f"Could not verify existence of policy '{policy_name}'"

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -671,6 +671,7 @@ class SetupCommand(Command):
                     logger.warning(
                         f"Skipping assignment for non-existing principal role '{role_name}' for principal '{principal_name}'"
                     )
+                    self._failure_count += 1
                     continue
 
                 if dry_run:
@@ -1041,6 +1042,7 @@ class SetupCommand(Command):
                     logger.warning(
                         f"Skipping assignment of catalog role '{role_name}' to non-existing principal role '{principal_role_name}'"
                     )
+                    self._failure_count += 1
                     continue
                 if dry_run:
                     self._log_dry_run(

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -902,6 +902,7 @@ class SetupCommand(Command):
                             logger.warning(
                                 f"External catalog '{catalog_name}' is missing the required 'connection' info block."
                             )
+                            self._failure_count += 1
                             overall_success = False
                             continue
                         command_args.update(conn_args)
@@ -1279,8 +1280,8 @@ class SetupCommand(Command):
             except NotFoundException:
                 policy_exists = False
             except Exception:
-                logger.warning(
-                    f"Could not verify existence of policy '{policy_name}', attempting creation."
+                self._record_failure(
+                    f"Could not verify existence of policy '{policy_name}'"
                 )
                 policy_exists = False
             if policy_exists:

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -92,7 +92,7 @@ class SetupCommand(Command):
                     p.name for p in api.list_principals().principals
                 }
             except Exception:
-                logger.exception("Failed to fetch existing principals")
+                self._record_failure("Failed to fetch existing principals")
                 self._existing_principals = set()
         return self._existing_principals
 
@@ -104,7 +104,7 @@ class SetupCommand(Command):
                     role.name for role in api.list_principal_roles().roles
                 }
             except Exception:
-                logger.exception("Failed to fetch existing principal roles")
+                self._record_failure("Failed to fetch existing principal roles")
                 self._existing_principal_roles = set()
         return self._existing_principal_roles
 
@@ -126,8 +126,8 @@ class SetupCommand(Command):
                     # In dry-run, a 404 is expected if the catalog doesn't exist yet
                     is_404 = getattr(e, "status", None) == 404 or "(404)" in str(e)
                     if not (self.dry_run and is_404):
-                        logger.warning(
-                            f"Failed to fetch catalog roles for catalog '{catalog_name}': {e}"
+                        self._record_failure(
+                            f"Failed to fetch catalog roles for catalog '{catalog_name}'"
                         )
                     self._existing_catalog_roles[catalog_name] = set()
             return self._existing_catalog_roles[catalog_name]
@@ -139,7 +139,7 @@ class SetupCommand(Command):
             try:
                 self._existing_catalogs = {c.name for c in api.list_catalogs().catalogs}
             except Exception:
-                logger.exception("Failed to fetch existing catalogs")
+                self._record_failure("Failed to fetch existing catalogs")
                 self._existing_catalogs = set()
         return self._existing_catalogs
 
@@ -574,13 +574,13 @@ class SetupCommand(Command):
                     dry_run=self.dry_run,
                 )
                 logger.info(f"--- Finished processing catalog: {catalog_name} ---")
-            if self.dry_run:
-                logger.info("=== Dry-Run Finished ===")
-            elif self._failure_count:
+            if self._failure_count:
                 raise CliError(
-                    f"Setup apply failed; provisioning errors: {self._failure_count}",
+                    f"Setup apply failed; setup errors: {self._failure_count}",
                     exit_code=CLI_ERROR_EXIT_CODE,
                 )
+            elif self.dry_run:
+                logger.info("=== Dry-Run Finished ===")
             else:
                 logger.info("=== Setup Apply Process Completed Successfully ===")
         elif self.setup_subcommand == Subcommands.EXPORT:
@@ -620,6 +620,9 @@ class SetupCommand(Command):
     ) -> None:
         """Create principals and assign them to principal roles."""
         logger.info("--- Processing principals ---")
+        if not principals_config:
+            logger.info("--- Finished processing principals ---")
+            return
         existing_principals = self._get_existing_principals(api)
         for principal_name, principal_data in principals_config.items():
             if principal_name in existing_principals:
@@ -705,6 +708,9 @@ class SetupCommand(Command):
     ) -> None:
         """Create principal roles."""
         logger.info("--- Processing principal roles ---")
+        if not principal_roles_config:
+            logger.info("--- Finished processing principal roles ---")
+            return
         self._get_existing_principal_roles(api)
 
         for role_name in principal_roles_config:
@@ -981,8 +987,14 @@ class SetupCommand(Command):
     ) -> None:
         """Create catalog roles, assign them to principal roles, and grant privileges."""
         logger.info(f"--- Processing catalog roles for catalog: {catalog_name} ---")
+        if not roles_config:
+            logger.info(
+                f"--- Finished processing catalog roles for catalog: {catalog_name} ---"
+            )
+            return
         existing_roles_in_catalog = self._get_existing_catalog_roles(api, catalog_name)
-        self._get_existing_principal_roles(api)
+        if any(role_data.get("assign_to") for role_data in roles_config.values()):
+            self._get_existing_principal_roles(api)
         for role_name, role_data in roles_config.items():
             if role_name in existing_roles_in_catalog:
                 logger.info(
@@ -1189,7 +1201,7 @@ class SetupCommand(Command):
                             existing_namespaces.add(".".join(ns))
                             listed_parents.add(parent_ns)
                     except Exception:
-                        logger.exception(
+                        self._record_failure(
                             f"Failed to list sub-namespaces for '{parent_ns}'"
                         )
 

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -525,7 +525,6 @@ class SetupCommand(Command):
     def execute(self, api: PolarisDefaultApi) -> None:
         """Execute the setup command based on the subcommand (apply or export)."""
         if self.setup_subcommand == Subcommands.APPLY:
-            self._failure_count = 0
             if self.dry_run:
                 logger.info("=== Starting Setup Dry-Run ===")
             else:
@@ -1282,9 +1281,15 @@ class SetupCommand(Command):
             except NotFoundException:
                 policy_exists = False
             except Exception:
-                self._record_failure(
-                    f"Could not verify existence of policy '{policy_name}'"
-                )
+                if dry_run:
+                    self._record_failure(
+                        f"Could not verify existence of policy '{policy_name}'"
+                    )
+                else:
+                    logger.warning(
+                        f"Could not verify existence of policy '{policy_name}', attempting creation.",
+                        exc_info=True,
+                    )
                 policy_exists = False
             if policy_exists:
                 logger.info(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -149,6 +149,35 @@ class TestSetupCommand(CLITestBase):
 
         self.assertEqual(command._failure_count, 1)
 
+    @patch("apache_polaris.cli.command.setup.PolicyAPI")
+    def test_setup_apply_recovers_policy_lookup_failure(
+        self, mock_policy_api: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_policy_api.return_value.load_policy.side_effect = RuntimeError(
+            "listing unavailable"
+        )
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            dry_run=False,
+        )
+
+        command._create_policies_and_attachments(
+            mock_client,
+            "catalog",
+            {
+                "policy": {
+                    "namespace": "namespace",
+                    "type": "data-compaction",
+                    "content": {},
+                }
+            },
+            dry_run=False,
+        )
+
+        self.assertEqual(command._failure_count, 0)
+        mock_policy_api.return_value.create_policy.assert_called_once()
+
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_s3_optional_fields(self, mock_isfile: MagicMock) -> None:
         mock_client = self.build_mock_client()

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -91,6 +91,34 @@ class TestSetupCommand(CLITestBase):
         )
         self.assertEqual(command._failure_count, 0)
 
+    @patch("apache_polaris.cli.command.setup.PolicyAPI")
+    def test_setup_dry_run_reports_policy_lookup_failures(
+        self, mock_policy_api: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_policy_api.return_value.load_policy.side_effect = RuntimeError(
+            "listing unavailable"
+        )
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            dry_run=True,
+        )
+
+        command._create_policies_and_attachments(
+            mock_client,
+            "catalog",
+            {
+                "policy": {
+                    "namespace": "namespace",
+                    "type": "data-compaction",
+                    "content": {},
+                }
+            },
+            dry_run=True,
+        )
+
+        self.assertEqual(command._failure_count, 1)
+
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_s3_optional_fields(self, mock_isfile: MagicMock) -> None:
         mock_client = self.build_mock_client()
@@ -109,6 +137,27 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_principals.assert_not_called()
         mock_client.list_principal_roles.assert_not_called()
         mock_client.list_catalog_roles.assert_not_called()
+
+    @patch("apache_polaris.cli.command.setup.os.path.isfile")
+    def test_setup_apply_reports_missing_external_catalog_connection(
+        self, mock_isfile: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_isfile.return_value = True
+        setup_yaml = "catalogs:\n  - name: broken\n    type: external"
+
+        with (
+            patch(
+                "apache_polaris.cli.command.setup.open",
+                mock_open(read_data=setup_yaml),
+            ),
+            self.assertRaises(CliError) as cm,
+        ):
+            self.mock_execute(mock_client, ["setup", "apply", "config.yaml"])
+
+        self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+        self.assertIn("setup errors: 1", str(cm.exception))
+        mock_client.create_catalog.assert_not_called()
 
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_reports_provisioning_failures(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -42,7 +42,14 @@ class TestSetupCommand(CLITestBase):
     @patch(
         "apache_polaris.cli.command.setup.open",
         new_callable=mock_open,
-        read_data="principals:\n  quickstart_user:\n    roles:\n      - quickstart_user_role",
+        read_data=(
+            "principal_roles:\n"
+            "  - quickstart_user_role\n"
+            "principals:\n"
+            "  quickstart_user:\n"
+            "    roles:\n"
+            "      - quickstart_user_role"
+        ),
     )
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_dry_run(
@@ -77,6 +84,29 @@ class TestSetupCommand(CLITestBase):
         self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
         self.assertIn("setup errors: 1", str(cm.exception))
         mock_client.create_principal.assert_not_called()
+
+    @patch("apache_polaris.cli.command.setup.os.path.isfile")
+    def test_setup_dry_run_reports_missing_role_assignments(
+        self, mock_isfile: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_isfile.return_value = True
+        setup_yaml = "principals:\n  user:\n    roles:\n      - missing-role"
+
+        with (
+            patch(
+                "apache_polaris.cli.command.setup.open",
+                mock_open(read_data=setup_yaml),
+            ),
+            self.assertRaises(CliError) as cm,
+        ):
+            self.mock_execute(
+                mock_client,
+                ["setup", "apply", "config.yaml", "--dry-run"],
+            )
+
+        self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+        self.assertIn("setup errors: 1", str(cm.exception))
 
     def test_setup_dry_run_ignores_missing_catalog_roles(self) -> None:
         mock_client = self.build_mock_client()

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -20,6 +20,8 @@
 import io
 from unittest.mock import patch, MagicMock, mock_open
 from cli_test_utils import CLITestBase, INVALID_ARGS
+from apache_polaris.cli.command.setup import SetupCommand
+from apache_polaris.cli.constants import Subcommands
 from apache_polaris.cli.exceptions import CliError, CLI_ERROR_EXIT_CODE
 from apache_polaris.sdk.management import (
     PolarisCatalog,
@@ -52,6 +54,44 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_principals.assert_called()
 
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
+    def test_setup_dry_run_reports_lookup_failures(
+        self, mock_isfile: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_isfile.return_value = True
+        mock_client.list_principals.side_effect = RuntimeError("listing unavailable")
+        setup_yaml = "principals:\n  quickstart_user: {}"
+
+        with (
+            patch(
+                "apache_polaris.cli.command.setup.open",
+                mock_open(read_data=setup_yaml),
+            ),
+            self.assertRaises(CliError) as cm,
+        ):
+            self.mock_execute(
+                mock_client,
+                ["setup", "apply", "config.yaml", "--dry-run"],
+            )
+
+        self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+        self.assertIn("setup errors: 1", str(cm.exception))
+        mock_client.create_principal.assert_not_called()
+
+    def test_setup_dry_run_ignores_missing_catalog_roles(self) -> None:
+        mock_client = self.build_mock_client()
+        mock_client.list_catalog_roles.side_effect = RuntimeError("(404)")
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            dry_run=True,
+        )
+
+        self.assertEqual(
+            command._get_existing_catalog_roles(mock_client, "new-catalog"), set()
+        )
+        self.assertEqual(command._failure_count, 0)
+
+    @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_s3_optional_fields(self, mock_isfile: MagicMock) -> None:
         mock_client = self.build_mock_client()
         mock_isfile.return_value = True
@@ -66,6 +106,9 @@ class TestSetupCommand(CLITestBase):
         # role_arn should be None, NOT an empty string
         self.assertIsNone(call_args.catalog.storage_config_info.role_arn)
         self.assertEqual(call_args.catalog.name, "s3-catalog")
+        mock_client.list_principals.assert_not_called()
+        mock_client.list_principal_roles.assert_not_called()
+        mock_client.list_catalog_roles.assert_not_called()
 
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_reports_provisioning_failures(
@@ -73,7 +116,9 @@ class TestSetupCommand(CLITestBase):
     ) -> None:
         mock_client = self.build_mock_client()
         mock_isfile.return_value = True
-        mock_client.list_principal_roles.return_value.roles = []
+        mock_client.list_principal_roles.side_effect = RuntimeError(
+            "listing unavailable"
+        )
         mock_client.create_principal_role.side_effect = [
             RuntimeError("backend unavailable"),
             None,
@@ -90,7 +135,7 @@ class TestSetupCommand(CLITestBase):
             self.mock_execute(mock_client, ["setup", "apply", "config.yaml"])
 
         self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
-        self.assertIn("provisioning errors: 1", str(cm.exception))
+        self.assertIn("setup errors: 2", str(cm.exception))
         self.assertEqual(mock_client.create_principal_role.call_count, 2)
 
     @patch(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -20,6 +20,7 @@
 import io
 from unittest.mock import patch, MagicMock, mock_open
 from cli_test_utils import CLITestBase, INVALID_ARGS
+from apache_polaris.cli.exceptions import CliError, CLI_ERROR_EXIT_CODE
 from apache_polaris.sdk.management import (
     PolarisCatalog,
     CatalogProperties,
@@ -65,6 +66,32 @@ class TestSetupCommand(CLITestBase):
         # role_arn should be None, NOT an empty string
         self.assertIsNone(call_args.catalog.storage_config_info.role_arn)
         self.assertEqual(call_args.catalog.name, "s3-catalog")
+
+    @patch("apache_polaris.cli.command.setup.os.path.isfile")
+    def test_setup_apply_reports_provisioning_failures(
+        self, mock_isfile: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_isfile.return_value = True
+        mock_client.list_principal_roles.return_value.roles = []
+        mock_client.create_principal_role.side_effect = [
+            RuntimeError("backend unavailable"),
+            None,
+        ]
+        setup_yaml = "principal_roles:\n  - failed-role\n  - successful-role"
+
+        with (
+            patch(
+                "apache_polaris.cli.command.setup.open",
+                mock_open(read_data=setup_yaml),
+            ),
+            self.assertRaises(CliError) as cm,
+        ):
+            self.mock_execute(mock_client, ["setup", "apply", "config.yaml"])
+
+        self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+        self.assertIn("provisioning errors: 1", str(cm.exception))
+        self.assertEqual(mock_client.create_principal_role.call_count, 2)
 
     @patch(
         "apache_polaris.cli.command.setup.open", new_callable=mock_open, read_data="{}"

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -60,6 +60,20 @@ class TestSetupCommand(CLITestBase):
         self.mock_execute(mock_client, ["setup", "apply", "config.yaml", "--dry-run"])
         mock_client.list_principals.assert_called()
 
+    def test_setup_apply_succeeds_without_failures(self) -> None:
+        mock_client = self.build_mock_client()
+        mock_client.list_principal_roles.return_value.roles = []
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            setup_config="config.yaml",
+            _config_cache={"principal_roles": ["successful-role"]},
+        )
+
+        command.execute(mock_client)
+
+        self.assertEqual(command._failure_count, 0)
+        mock_client.create_principal_role.assert_called_once()
+
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_dry_run_reports_lookup_failures(
         self, mock_isfile: MagicMock


### PR DESCRIPTION
## Summary

- Track terminal setup failures, including discovery/list operations, during `setup apply`.
- Preserve best-effort processing so later resources are still attempted.
- Exit with the standard CLI error status instead of logging a false success.

## Why

`setup apply` catches setup API exceptions to continue applying the rest of a
configuration. Previously, those caught failures were never reflected in the
command result, so automation received exit status 0 and a success message even
when one or more requested resources were not provisioned. Discovery failures
could also be cached as empty results, causing later work to be skipped without
failing the command.

The command now counts those failures and raises a `CliError` after processing
the configuration. Regression tests verify the nonzero result, best-effort
continuation, discovery-failure handling (including policy lookups), invalid
external-catalog configuration, unresolved role assignments, and the expected
dry-run 404 behavior.

Fixes #5097

## Testing

- `make client-unit-test` (159 tests passed on Python 3.14.6)
- `PRE_COMMIT_HOME=/tmp/polaris-pre-commit make client-lint` (all format, Ruff, and mypy hooks passed)
- `make client-license-check` (passed)
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew format compileAll` (build successful)
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew check` (attempted; unrelated Docker-backed `polaris-admin` and Azurite tests could not start because Docker is not installed locally)
- The exact CI Gradle command (`check sourceTarball distTar distZip publishToMavenLocal -x :polaris-runtime-service:test -x :polaris-admin:test -PnoIntegrationTests --continue`) completed all 1,887 tasks except the Docker-backed `:polaris-relational-jdbc:test`, whose Testcontainers PostgreSQL initialization could not start without a local Docker socket.

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5097
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (no complex logic added)
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; CLI syntax and configuration are unchanged)
