### PR TITLE
Clarify principal role selection semantics

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisPrincipal.java
@@ -30,80 +30,263 @@ import org.immutables.value.Value;
 @PolarisImmutable
 public interface PolarisPrincipal extends Principal {
 
+  /** Indicates how principal roles should be selected during role resolution. */
+  enum RoleSelection {
+    /** Resolve the specific role names returned by {@link PolarisPrincipal#getRoles()}. */
+    SELECTED_ROLES,
+
+    /** Resolve all roles currently granted to the principal. */
+    ALL_ROLES
+  }
+
   /**
    * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity} and
-   * roles.
+   * selected role names.
+   *
+   * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
+   * properties will be derived from the internal properties of the entity. Role resolution will be
+   * limited to the given {@code roles}; an empty set means no principal roles are selected.
+   *
+   * @param principalEntity the principal entity representing the user or service
+   * @param roles the selected principal role names
+   */
+  static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
+    return of(principalEntity, roles, RoleSelection.SELECTED_ROLES);
+  }
+
+  /**
+   * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity},
+   * selected role names, and role selection mode.
    *
    * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
    * properties will be derived from the internal properties of the entity.
    *
    * @param principalEntity the principal entity representing the user or service
-   * @param roles the set of roles associated with the principal
+   * @param roles the selected principal role names
+   * @param roleSelection how principal roles should be selected during role resolution
    */
-  static PolarisPrincipal of(PrincipalEntity principalEntity, Set<String> roles) {
+  static PolarisPrincipal of(
+      PrincipalEntity principalEntity, Set<String> roles, RoleSelection roleSelection) {
     return of(
         principalEntity.getName(),
         principalEntity.getInternalPropertiesAsMap(),
         roles,
+        roleSelection,
         Optional.empty());
   }
 
   /**
    * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity} and
-   * roles.
+   * selected role names.
+   *
+   * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
+   * properties will be derived from the internal properties of the entity. Role resolution will be
+   * limited to the given {@code roles}; an empty set means no principal roles are selected.
+   *
+   * @param principalEntity the principal entity representing the user or service
+   * @param roles the selected principal role names
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal of(
+      PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
+    return of(principalEntity, roles, RoleSelection.SELECTED_ROLES, token);
+  }
+
+  /**
+   * Creates a new instance of {@link PolarisPrincipal} from the given {@link PrincipalEntity},
+   * selected role names, role selection mode, and token.
    *
    * <p>The created principal will have the same ID and name as the {@link PrincipalEntity}, and its
    * properties will be derived from the internal properties of the entity.
    *
    * @param principalEntity the principal entity representing the user or service
-   * @param roles the set of roles associated with the principal
+   * @param roles the selected principal role names
+   * @param roleSelection how principal roles should be selected during role resolution
    * @param token the access token of the current user
    */
   static PolarisPrincipal of(
-      PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
+      PrincipalEntity principalEntity,
+      Set<String> roles,
+      RoleSelection roleSelection,
+      Optional<String> token) {
     return of(
-        principalEntity.getName(), principalEntity.getInternalPropertiesAsMap(), roles, token);
+        principalEntity.getName(),
+        principalEntity.getInternalPropertiesAsMap(),
+        roles,
+        roleSelection,
+        token);
   }
 
   /**
-   * Creates a new instance of {@link PolarisPrincipal} with the specified ID, name, roles, and
-   * properties.
+   * Creates a new instance of {@link PolarisPrincipal} with the specified name, properties, and
+   * selected role names.
+   *
+   * <p>Role resolution will be limited to the given {@code roles}; an empty set means no principal
+   * roles are selected.
    *
    * @param name the name of the principal
    * @param properties additional properties associated with the principal
-   * @param roles the set of roles associated with the principal
+   * @param roles the selected principal role names
    */
   static PolarisPrincipal of(String name, Map<String, String> properties, Set<String> roles) {
-    return of(name, properties, roles, Optional.empty());
+    return of(name, properties, roles, RoleSelection.SELECTED_ROLES);
   }
 
   /**
-   * Creates a new instance of {@link PolarisPrincipal} with the specified ID, name, roles, and
-   * properties.
+   * Creates a new instance of {@link PolarisPrincipal} with the specified name, properties,
+   * selected role names, and role selection mode.
    *
    * @param name the name of the principal
    * @param properties additional properties associated with the principal
-   * @param roles the set of roles associated with the principal
+   * @param roles the selected principal role names
+   * @param roleSelection how principal roles should be selected during role resolution
+   */
+  static PolarisPrincipal of(
+      String name, Map<String, String> properties, Set<String> roles, RoleSelection roleSelection) {
+    return of(name, properties, roles, roleSelection, Optional.empty());
+  }
+
+  /**
+   * Creates a new instance of {@link PolarisPrincipal} with the specified name, properties,
+   * selected role names, and token.
+   *
+   * <p>Role resolution will be limited to the given {@code roles}; an empty set means no principal
+   * roles are selected.
+   *
+   * @param name the name of the principal
+   * @param properties additional properties associated with the principal
+   * @param roles the selected principal role names
    * @param token the access token of the current user
    */
   static PolarisPrincipal of(
       String name, Map<String, String> properties, Set<String> roles, Optional<String> token) {
+    return of(name, properties, roles, RoleSelection.SELECTED_ROLES, token);
+  }
+
+  /**
+   * Creates a principal whose role selection should include all roles currently granted to the
+   * principal.
+   *
+   * <p>The returned principal does not carry a role-name snapshot. Callers that need a materialized
+   * list for downstream context should use an overload that accepts {@code roles}.
+   *
+   * @param principalEntity the principal entity representing the user or service
+   */
+  static PolarisPrincipal ofAllRoles(PrincipalEntity principalEntity) {
+    return ofAllRoles(principalEntity, Optional.empty());
+  }
+
+  /**
+   * Creates a principal whose role selection should include all roles currently granted to the
+   * principal.
+   *
+   * <p>The returned principal does not carry a role-name snapshot. Callers that need a materialized
+   * list for downstream context should use an overload that accepts {@code roles}.
+   *
+   * @param principalEntity the principal entity representing the user or service
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal ofAllRoles(PrincipalEntity principalEntity, Optional<String> token) {
+    return ofAllRoles(principalEntity, Set.of(), token);
+  }
+
+  /**
+   * Creates a principal whose role selection should include all roles currently granted to the
+   * principal.
+   *
+   * <p>The returned principal does not carry a role-name snapshot. Callers that need a materialized
+   * list for downstream context should use an overload that accepts {@code roles}.
+   *
+   * @param name the name of the principal
+   * @param properties additional properties associated with the principal
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal ofAllRoles(
+      String name, Map<String, String> properties, Optional<String> token) {
+    return ofAllRoles(name, properties, Set.of(), token);
+  }
+
+  /**
+   * Creates a principal whose role selection should include all roles currently granted to the
+   * principal.
+   *
+   * <p>The {@code roles} argument is a materialized snapshot of activated role names, as captured
+   * or supplied when the principal was created, for downstream context such as request identity
+   * roles, diagnostics, events, and credential vending context. It does not limit role resolution
+   * when {@link #getRoleSelection()} is {@link RoleSelection#ALL_ROLES}.
+   *
+   * @param principalEntity the principal entity representing the user or service
+   * @param roles materialized activated role names, if already known
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal ofAllRoles(
+      PrincipalEntity principalEntity, Set<String> roles, Optional<String> token) {
+    return of(principalEntity, roles, RoleSelection.ALL_ROLES, token);
+  }
+
+  /**
+   * Creates a principal whose role selection should include all roles currently granted to the
+   * principal.
+   *
+   * <p>The {@code roles} argument is a materialized snapshot of activated role names, as captured
+   * or supplied when the principal was created, for downstream context such as request identity
+   * roles, diagnostics, events, and credential vending context. It does not limit role resolution
+   * when {@link #getRoleSelection()} is {@link RoleSelection#ALL_ROLES}.
+   *
+   * @param name the name of the principal
+   * @param properties additional properties associated with the principal
+   * @param roles materialized activated role names, if already known
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal ofAllRoles(
+      String name, Map<String, String> properties, Set<String> roles, Optional<String> token) {
+    return of(name, properties, roles, RoleSelection.ALL_ROLES, token);
+  }
+
+  /**
+   * Creates a new instance of {@link PolarisPrincipal} with the specified name, properties,
+   * selected role names, role selection mode, and token.
+   *
+   * <p>When {@code roleSelection} is {@link RoleSelection#SELECTED_ROLES}, role resolution will be
+   * limited to the given {@code roles}; an empty set means no principal roles are selected. When
+   * {@code roleSelection} is {@link RoleSelection#ALL_ROLES}, role resolution is based on the
+   * principal's current grants rather than the role names returned by {@link #getRoles()}.
+   *
+   * @param name the name of the principal
+   * @param properties additional properties associated with the principal
+   * @param roles the selected principal role names or materialized role-name snapshot
+   * @param roleSelection how principal roles should be selected during role resolution
+   * @param token the access token of the current user
+   */
+  static PolarisPrincipal of(
+      String name,
+      Map<String, String> properties,
+      Set<String> roles,
+      RoleSelection roleSelection,
+      Optional<String> token) {
     return ImmutablePolarisPrincipal.builder()
         .name(name)
         .properties(properties)
         .token(token)
         .roles(roles)
+        .roleSelection(roleSelection)
         .build();
   }
 
   /**
    * Returns the set of activated principal role names.
    *
-   * <p>Activated role names are the roles that were explicitly requested by the client when
-   * authenticating, through JWT claims or other means. It may be a subset of the roles that the
-   * principal has in the system.
+   * <p>When {@link #getRoleSelection()} is {@link RoleSelection#SELECTED_ROLES}, this set is the
+   * selected role set used for role resolution. An empty set means no principal roles are selected.
+   *
+   * <p>When {@link #getRoleSelection()} is {@link RoleSelection#ALL_ROLES}, this set is only a
+   * materialized snapshot of activated role names, as captured or supplied when the principal was
+   * created, for downstream context. It does not limit role resolution.
    */
   Set<String> getRoles();
+
+  /** Returns how principal roles should be selected during role resolution. */
+  RoleSelection getRoleSelection();
 
   /**
    * Returns the properties of this principal.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/Resolver.java
@@ -793,9 +793,11 @@ public class Resolver {
     // activate all principal roles specified in the authenticated principal
     if (resolvePrincipalRoles) {
       resolvedCallerPrincipalRoles =
-          this.polarisPrincipal.getRoles().isEmpty()
-              ? resolveAllPrincipalRoles(toValidate, resolvedCallerPrincipal)
-              : resolvePrincipalRolesByName(toValidate, this.polarisPrincipal.getRoles());
+          switch (this.polarisPrincipal.getRoleSelection()) {
+            case ALL_ROLES -> resolveAllPrincipalRoles(toValidate, resolvedCallerPrincipal);
+            case SELECTED_ROLES ->
+                resolvePrincipalRolesByName(toValidate, this.polarisPrincipal.getRoles());
+          };
     } else {
       resolvedCallerPrincipalRoles = new ArrayList<>();
     }

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BaseResolverTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.auth.PolarisPrincipal;
@@ -36,7 +35,6 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.entity.PrincipalEntity;
-import org.apache.polaris.core.entity.PrincipalRoleEntity;
 import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.apache.polaris.core.persistence.resolver.Resolver;
@@ -421,21 +419,10 @@ public abstract class BaseResolverTest {
       this.cache =
           new InMemoryEntityCache(diagServices, callCtx().getRealmConfig(), metaStoreManager());
     }
-    boolean allRoles = principalRolesScope == null;
-    Optional<List<PrincipalRoleEntity>> roleEntities =
-        Optional.ofNullable(principalRolesScope)
-            .map(
-                scopes ->
-                    scopes.stream()
-                        .map(
-                            roleName ->
-                                metaStoreManager().findPrincipalRoleByName(callCtx(), roleName))
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(Collectors.toList()));
     PolarisPrincipal authenticatedPrincipal =
-        PolarisPrincipal.of(
-            PrincipalEntity.of(P1), Optional.ofNullable(principalRolesScope).orElse(Set.of()));
+        principalRolesScope == null
+            ? PolarisPrincipal.ofAllRoles(PrincipalEntity.of(P1))
+            : PolarisPrincipal.of(PrincipalEntity.of(P1), principalRolesScope);
     return new Resolver(
         diagServices,
         callCtx(),

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -26,13 +26,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipal.RoleSelection;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -86,8 +86,6 @@ public class DefaultAuthenticator implements Authenticator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticator.class);
 
-  private static final Set<String> ALL_ROLES_REQUESTED = Set.of();
-
   @Inject PolarisMetaStoreManager metaStoreManager;
   @Inject CallContext callContext;
   @Inject PolarisDiagnostics diagnostics;
@@ -98,10 +96,15 @@ public class DefaultAuthenticator implements Authenticator {
     LOGGER.debug("Resolving principal for credentials: {}", credentials);
 
     PrincipalEntity principalEntity = resolvePrincipalEntity(credentials);
-    Set<String> principalRoles = resolvePrincipalRoles(credentials, principalEntity);
+    PrincipalRoleSelection principalRoles = resolvePrincipalRoles(credentials, principalEntity);
     PolarisPrincipal polarisPrincipal =
         PolarisPrincipal.of(
-            principalEntity, principalRoles, Optional.ofNullable(credentials.getToken()));
+            principalEntity,
+            principalRoles.roles(),
+            principalRoles.allRolesRequested()
+                ? RoleSelection.ALL_ROLES
+                : RoleSelection.SELECTED_ROLES,
+            Optional.ofNullable(credentials.getToken()));
 
     LOGGER.debug("Resolved principal: {}", polarisPrincipal);
     return polarisPrincipal;
@@ -162,14 +165,11 @@ public class DefaultAuthenticator implements Authenticator {
    * roles they have been granted in the system, and all such roles will be included in the returned
    * set.
    */
-  protected Set<String> resolvePrincipalRoles(
+  protected PrincipalRoleSelection resolvePrincipalRoles(
       PolarisCredential credentials, PrincipalEntity principal) {
 
-    Set<String> requestedRoles = extractRequestedRoles(credentials);
+    PrincipalRoleSelection requestedRoles = extractRequestedRoles(credentials);
     LoadGrantsResult loadGrantsResult = loadPrincipalGrants(principal);
-
-    Predicate<String> includeRoleFilter =
-        requestedRoles == ALL_ROLES_REQUESTED ? role -> true : requestedRoles::contains;
 
     Map<Long, PolarisBaseEntity> entitiesById = loadGrantsResult.getEntitiesAsMap();
 
@@ -180,19 +180,21 @@ public class DefaultAuthenticator implements Authenticator {
             .filter(entity -> entity.getType() == PolarisEntityType.PRINCIPAL_ROLE)
             .map(PrincipalRoleEntity::of)
             .map(PrincipalRoleEntity::getName)
-            .filter(includeRoleFilter)
+            .filter(
+                role -> requestedRoles.allRolesRequested() || requestedRoles.roles().contains(role))
             .collect(Collectors.toSet());
 
-    if (requestedRoles != ALL_ROLES_REQUESTED && !activeRoles.containsAll(requestedRoles)) {
+    if (!requestedRoles.allRolesRequested() && !activeRoles.containsAll(requestedRoles.roles())) {
       LOGGER
           .atWarn()
           .addKeyValue("principal", principal.getName())
           .addKeyValue("credentials", credentials)
           .addKeyValue("roles", activeRoles)
           .log("Some principal roles were not found in the principal's grants");
+      throw new NotAuthorizedException("Unable to authenticate");
     }
 
-    return activeRoles;
+    return new PrincipalRoleSelection(activeRoles, requestedRoles.allRolesRequested());
   }
 
   /**
@@ -204,10 +206,10 @@ public class DefaultAuthenticator implements Authenticator {
    * <p>Otherwise, it filters the roles that start with the {@link #PRINCIPAL_ROLE_PREFIX} and
    * returns the set of roles without the prefix.
    */
-  protected Set<String> extractRequestedRoles(PolarisCredential credentials) {
+  protected PrincipalRoleSelection extractRequestedRoles(PolarisCredential credentials) {
     Set<String> credentialsRoles = credentials.getPrincipalRoles();
     if (credentialsRoles.contains(PRINCIPAL_ROLE_ALL)) {
-      return ALL_ROLES_REQUESTED;
+      return new PrincipalRoleSelection(Set.of(), true);
     }
     if (credentialsRoles.stream().anyMatch(s -> !s.startsWith(PRINCIPAL_ROLE_PREFIX))) {
       LOGGER
@@ -219,10 +221,12 @@ public class DefaultAuthenticator implements Authenticator {
                   + "These roles will be ignored during authentication.",
               PRINCIPAL_ROLE_PREFIX);
     }
-    return credentialsRoles.stream()
-        .filter(s -> s.startsWith(PRINCIPAL_ROLE_PREFIX))
-        .map(s -> s.substring(PRINCIPAL_ROLE_PREFIX.length()))
-        .collect(Collectors.toSet());
+    return new PrincipalRoleSelection(
+        credentialsRoles.stream()
+            .filter(s -> s.startsWith(PRINCIPAL_ROLE_PREFIX))
+            .map(s -> s.substring(PRINCIPAL_ROLE_PREFIX.length()))
+            .collect(Collectors.toSet()),
+        false);
   }
 
   /**
@@ -268,4 +272,6 @@ public class DefaultAuthenticator implements Authenticator {
             PolarisEntityType.PRINCIPAL_ROLE)
         .getEntity();
   }
+
+  protected record PrincipalRoleSelection(Set<String> roles, boolean allRolesRequested) {}
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAdminServiceAuthzTest.java
@@ -42,7 +42,16 @@ import org.junit.jupiter.api.TestFactory;
 @TestProfile(Profiles.PolarisAuthzBaseProfile.class)
 public class PolarisAdminServiceAuthzTest extends PolarisAuthzTestBase {
   private PolarisAdminService newTestAdminService() {
-    return newTestAdminService(Set.of());
+    final PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.ofAllRoles(principalEntity);
+    return new PolarisAdminService(
+        callContext,
+        resolutionManifestFactory,
+        metaStoreManager,
+        userSecretsManager,
+        serviceIdentityProvider,
+        authenticatedPrincipal,
+        polarisAuthorizer,
+        reservedProperties);
   }
 
   private PolarisAdminService newTestAdminService(Set<String> activatedPrincipalRoles) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -33,7 +33,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
@@ -219,7 +218,7 @@ public abstract class PolarisAuthzTestBase {
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
-    this.authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
+    this.authenticatedRoot = PolarisPrincipal.ofAllRoles(rootPrincipal);
     QuarkusMock.installMockForType(authenticatedRoot, PolarisPrincipal.class);
 
     this.adminService =

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -33,12 +33,14 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.PrincipalWithCredentialsCredentials;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisPrincipal.RoleSelection;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -92,10 +94,11 @@ public class DefaultAuthenticatorTest {
   @BeforeEach
   public void setup(TestInfo testInfo) {
     realmContextHolder.set(() -> testInfo.getTestMethod().orElseThrow().getName());
-    authenticatedRoot =
-        PolarisPrincipal.of(PolarisEntityConstants.getRootPrincipalName(), Map.of(), Set.of());
-    identityAssociation.setIdentity(
-        QuarkusSecurityIdentity.builder().setPrincipal(authenticatedRoot).build());
+    PolarisPrincipal root =
+        PolarisPrincipal.ofAllRoles(
+            PolarisEntityConstants.getRootPrincipalName(), Map.of(), Set.of(), Optional.empty());
+    authenticatedRoot = root;
+    identityAssociation.setIdentity(QuarkusSecurityIdentity.builder().setPrincipal(root).build());
     principalEntity = createPrincipal(PRINCIPAL_NAME, PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
     principalEntityNoRoles = createPrincipal(PRINCIPAL_NAME_NO_ROLES);
   }
@@ -185,6 +188,7 @@ public class DefaultAuthenticatorTest {
 
     // Then: should return principal with all assigned roles
     assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
+    assertThat(result.getRoleSelection()).isEqualTo(RoleSelection.ALL_ROLES);
   }
 
   @Test
@@ -201,6 +205,7 @@ public class DefaultAuthenticatorTest {
 
     // Then: should return principal with only the requested role
     assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1);
+    assertThat(result.getRoleSelection()).isEqualTo(RoleSelection.SELECTED_ROLES);
   }
 
   @Test
@@ -244,11 +249,8 @@ public class DefaultAuthenticatorTest {
             PRINCIPAL_NAME,
             Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + "non-existent-role"));
 
-    // When: authenticating the principal
-    PolarisPrincipal result = authenticator.authenticate(credentials);
-
-    // Then: should return principal with empty roles set (non-existent roles are filtered out)
-    assertPrincipal(result, principalEntity);
+    // When/Then: authentication should fail with NotAuthorizedException
+    assertUnauthorized(credentials);
   }
 
   @Test
@@ -260,15 +262,10 @@ public class DefaultAuthenticatorTest {
             PRINCIPAL_NAME,
             Set.of(
                 DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1,
-                DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX
-                    + "non-existent-role" // This should be ignored
-                ));
+                DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + "non-existent-role"));
 
-    // When: authenticating the principal
-    PolarisPrincipal result = authenticator.authenticate(credentials);
-
-    // Then: should return principal with only the valid role
-    assertPrincipal(result, principalEntity, PRINCIPAL_ROLE1);
+    // When/Then: authentication should fail with NotAuthorizedException
+    assertUnauthorized(credentials);
   }
 
   @Test
@@ -304,6 +301,7 @@ public class DefaultAuthenticatorTest {
 
     // Then: should return principal with empty roles set
     assertPrincipal(result, principalEntity);
+    assertThat(result.getRoleSelection()).isEqualTo(RoleSelection.SELECTED_ROLES);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
@@ -151,7 +150,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
-    authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
+    authenticatedRoot = PolarisPrincipal.ofAllRoles(rootPrincipal);
     polarisPrincipalHolder.set(authenticatedRoot);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalogHandlerAuthzTest.java
@@ -46,19 +46,16 @@ public class PolarisGenericTableCatalogHandlerAuthzTest extends PolarisAuthzTest
   @jakarta.inject.Inject @Any Instance<FederatedCatalogFactory> federatedCatalogFactories;
 
   private GenericTableCatalogHandler newWrapper() {
-    return newWrapper(Set.of());
+    return newWrapper(PolarisPrincipal.ofAllRoles(principalEntity));
   }
 
   private GenericTableCatalogHandler newWrapper(Set<String> activatedPrincipalRoles) {
-    return newWrapper(activatedPrincipalRoles, CATALOG_NAME);
+    return newWrapper(PolarisPrincipal.of(principalEntity, activatedPrincipalRoles));
   }
 
-  private GenericTableCatalogHandler newWrapper(
-      Set<String> activatedPrincipalRoles, String catalogName) {
-    PolarisPrincipal authenticatedPrincipal =
-        PolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
+  private GenericTableCatalogHandler newWrapper(PolarisPrincipal authenticatedPrincipal) {
     return ImmutableGenericTableCatalogHandler.builder()
-        .catalogName(catalogName)
+        .catalogName(PolarisAuthzTestBase.CATALOG_NAME)
         .polarisPrincipal(authenticatedPrincipal)
         .callContext(callContext)
         .resolutionManifestFactory(resolutionManifestFactory)

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -122,7 +122,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
   @Inject IcebergCatalogHandlerFactory icebergCatalogHandlerFactory;
 
   protected IcebergCatalogHandler newHandler() {
-    return newHandler(Set.of());
+    PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.ofAllRoles(principalEntity);
+    return icebergCatalogHandlerFactory.createHandler(CATALOG_NAME, authenticatedPrincipal);
   }
 
   private IcebergCatalogHandler newHandler(Set<String> activatedPrincipalRoles) {
@@ -1165,7 +1166,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
    * behavior to coarse-grained authorization.
    */
   private IcebergCatalogHandler newHandlerWithFineGrainedAuthzDisabled() {
-    PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.of(principalEntity, Set.of());
+    PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.ofAllRoles(principalEntity);
 
     // Create a custom CallContext that returns a custom RealmConfig
     CallContext mockCallContext = Mockito.mock(CallContext.class);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
@@ -167,7 +167,7 @@ public abstract class AbstractLocalIcebergCatalogViewTest
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
-    authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
+    authenticatedRoot = PolarisPrincipal.ofAllRoles(rootPrincipal);
 
     authorizer = new PolarisAuthorizerImpl(realmConfig);
     reservedProperties = ReservedProperties.NONE;

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerFineGrainedDisabledTest.java
@@ -24,7 +24,6 @@ import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
@@ -48,7 +47,7 @@ public class IcebergCatalogHandlerFineGrainedDisabledTest extends PolarisAuthzTe
   @Inject IcebergCatalogHandlerFactory icebergCatalogHandlerFactory;
 
   private IcebergCatalogHandler newHandler() {
-    PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.of(principalEntity, Set.of());
+    PolarisPrincipal authenticatedPrincipal = PolarisPrincipal.ofAllRoles(principalEntity);
     IcebergCatalogHandler handler =
         icebergCatalogHandlerFactory.createHandler(CATALOG_NAME, authenticatedPrincipal);
     return ImmutableIcebergCatalogHandler.builder().from(handler).build();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
@@ -172,7 +171,7 @@ public abstract class AbstractPolicyCatalogTest {
 
     PrincipalEntity rootPrincipal =
         metaStoreManager.findRootPrincipal(polarisContext).orElseThrow();
-    authenticatedRoot = PolarisPrincipal.of(rootPrincipal, Set.of());
+    authenticatedRoot = PolarisPrincipal.ofAllRoles(rootPrincipal);
     polarisPrincipalHolder.set(authenticatedRoot);
 
     PolarisAuthorizer authorizer = new PolarisAuthorizerImpl(realmConfig);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogHandlerAuthzTest.java
@@ -43,12 +43,14 @@ import org.junit.jupiter.api.TestFactory;
 public class PolicyCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
 
   private PolicyCatalogHandler newHandler() {
-    return newHandler(Set.of());
+    return newHandler(PolarisPrincipal.ofAllRoles(principalEntity));
   }
 
   private PolicyCatalogHandler newHandler(Set<String> activatedPrincipalRoles) {
-    PolarisPrincipal authenticatedPrincipal =
-        PolarisPrincipal.of(principalEntity, activatedPrincipalRoles);
+    return newHandler(PolarisPrincipal.of(principalEntity, activatedPrincipalRoles));
+  }
+
+  private PolicyCatalogHandler newHandler(PolarisPrincipal authenticatedPrincipal) {
     return ImmutablePolicyCatalogHandler.builder()
         .catalogName(CATALOG_NAME)
         .polarisPrincipal(authenticatedPrincipal)

--- a/site/content/guides/assets/keycloak/iceberg-realm.json
+++ b/site/content/guides/assets/keycloak/iceberg-realm.json
@@ -420,7 +420,7 @@
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "principal_roles",
-            "claim.value": "[\"service_admin\", \"catalog_admin\"]",
+            "claim.value": "[\"service_admin\"]",
             "jsonType.label": "JSON"
           }
         },

--- a/site/content/guides/keycloak/index.md
+++ b/site/content/guides/keycloak/index.md
@@ -42,8 +42,7 @@ fixed claims:
 
 - `principal_id`: the principal ID of the user. It is always set to zero (0) in this example.
 - `principal_name`: the principal name of the user. It is always set to "root" in this example.
-- `principal_roles`: the principal roles of the user. It is always set to `["server_admin", "catalog_admin"]` in this 
-  example.
+- `principal_roles`: the principal roles of the user. It is always set to `["server_admin"]` in this example.
 
 This is obviously not a realistic configuration. In a real-world scenario, you would configure Keycloak to return the
 actual principal ID, name and roles of the user. Note that principals and principal roles must have been created in


### PR DESCRIPTION
Introduce an explicit marker for principals that should activate all currently granted roles, while preserving empty role sets as an explicit empty selection.

Update authentication and resolver handling to distinguish all-role activation from named-role activation, and align tests and fixtures with the clarified semantics.