### PR TITLE
Align token exchange scope handling

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
@@ -25,6 +25,7 @@ import com.auth0.jwt.interfaces.JWTVerifier;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.polaris.core.PolarisCallContext;
@@ -123,12 +124,26 @@ public class JWTBroker implements TokenBroker {
     if (principalLookup.isEmpty()) {
       return TokenResponse.of(OAuthError.unauthorized_client);
     }
+    String tokenScope = decodedToken.getScope();
+    if (scope != null) {
+      TokenRequestValidator validator = new TokenRequestValidator();
+      Optional<OAuthError> validationError = validator.validateScope(scope);
+      if (validationError.isPresent()) {
+        return TokenResponse.of(validationError.get());
+      }
+      Set<String> requestedScopes = validator.parseScopes(scope);
+      if (!decodedToken.getPrincipalRoles().contains(DefaultAuthenticator.PRINCIPAL_ROLE_ALL)
+          && !decodedToken.getPrincipalRoles().containsAll(requestedScopes)) {
+        return TokenResponse.of(OAuthError.invalid_scope);
+      }
+      tokenScope = scope;
+    }
     String tokenString =
         generateTokenString(
             decodedToken.getPrincipalName(),
             decodedToken.getPrincipalId(),
             decodedToken.getClientId(),
-            decodedToken.getScope());
+            tokenScope);
     return TokenResponse.of(
         tokenString, TokenType.ACCESS_TOKEN.getValue(), maxTokenGenerationInSeconds);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidator.java
@@ -18,14 +18,17 @@
  */
 package org.apache.polaris.service.auth.internal.broker;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.apache.polaris.service.auth.internal.service.OAuthError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class TokenRequestValidator {
 
-  static final Logger LOGGER = Logger.getLogger(TokenRequestValidator.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenRequestValidator.class);
 
   static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
   static final String CLIENT_CREDENTIALS = "client_credentials";
@@ -57,24 +60,33 @@ final class TokenRequestValidator {
       return Optional.of(OAuthError.invalid_client);
     }
     if (grantType == null || grantType.isEmpty() || !ALLOWED_GRANT_TYPES.contains(grantType)) {
-      LOGGER.info("Invalid grant type: " + grantType);
+      LOGGER.info("Invalid grant type: {}", grantType);
       return Optional.of(OAuthError.invalid_grant);
     }
     if (scope == null || scope.isEmpty()) {
       LOGGER.info("Missing scope in Request Body");
       return Optional.of(OAuthError.invalid_scope);
     }
-    String[] scopes = scope.split(" ");
-    for (String s : scopes) {
-      if (!s.startsWith(POLARIS_ROLE_PREFIX)) {
-        LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
-        return Optional.of(OAuthError.invalid_scope);
-      }
-      if (s.replaceFirst(POLARIS_ROLE_PREFIX, "").isEmpty()) {
-        LOGGER.info("Invalid scope provided. scope=" + s + ", scopes=" + scope);
+    return validateScope(scope);
+  }
+
+  Optional<OAuthError> validateScope(String scope) {
+    var scopes = parseScopes(scope);
+    if (scopes.isEmpty()) {
+      LOGGER.info("Invalid empty scope provided.");
+      return Optional.of(OAuthError.invalid_scope);
+    }
+    for (var s : scopes) {
+      if (!s.startsWith(POLARIS_ROLE_PREFIX) || s.length() == POLARIS_ROLE_PREFIX.length()) {
+        LOGGER.info("Invalid scope '{}' provided. scope={}", s, scope);
         return Optional.of(OAuthError.invalid_scope);
       }
     }
     return Optional.empty();
+  }
+
+  Set<String> parseScopes(String scope) {
+    // Note: Set.of() would throw an IAE on duplicate scopes. This preserves the original behavior.
+    return Arrays.stream(scope.split(" ")).collect(Collectors.toSet());
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/JWTSymmetricKeyGeneratorTest.java
@@ -30,8 +30,11 @@ import org.apache.polaris.core.entity.PolarisPrincipalSecrets;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.PrincipalSecretsResult;
+import org.apache.polaris.service.auth.internal.service.OAuthError;
 import org.apache.polaris.service.types.TokenType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 public class JWTSymmetricKeyGeneratorTest {
@@ -75,5 +78,154 @@ public class JWTSymmetricKeyGeneratorTest {
     assertThat(token.getExpiresIn()).isEqualTo(666);
     assertThat(decodedJWT.getClaim("scope").asString()).isEqualTo("PRINCIPAL_ROLE:TEST");
     assertThat(decodedJWT.getClaim("client_id").asString()).isEqualTo(clientId);
+  }
+
+  @Test
+  public void testGenerateFromTokenUsesRequestedScope() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken =
+        generateToken(generator, "PRINCIPAL_ROLE:TEST PRINCIPAL_ROLE:OTHER");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            "PRINCIPAL_ROLE:TEST",
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isNull();
+    assertThat(decodedScope(token.getAccessToken())).isEqualTo("PRINCIPAL_ROLE:TEST");
+  }
+
+  @Test
+  public void testGenerateFromTokenPreservesScopeWhenScopeIsOmitted() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:TEST");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            null,
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isNull();
+    assertThat(decodedScope(token.getAccessToken())).isEqualTo("PRINCIPAL_ROLE:TEST");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  public void testGenerateFromTokenRejectsBlankRequestedScope(String requestedScope) {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:TEST");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            requestedScope,
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isEqualTo(OAuthError.invalid_scope);
+  }
+
+  @Test
+  public void testGenerateFromTokenRejectsInvalidScope() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:ALL");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            "ALL",
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isEqualTo(OAuthError.invalid_scope);
+  }
+
+  @Test
+  public void testGenerateFromTokenRejectsScopeOutsideSubjectScope() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:TEST");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            "PRINCIPAL_ROLE:ALL",
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isEqualTo(OAuthError.invalid_scope);
+  }
+
+  @Test
+  public void testGenerateFromTokenRejectsPartiallyUnauthorizedRequestedScope() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:TEST");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            "PRINCIPAL_ROLE:TEST PRINCIPAL_ROLE:OTHER",
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isEqualTo(OAuthError.invalid_scope);
+  }
+
+  @Test
+  public void testGenerateFromTokenCanNarrowAllScope() {
+    TokenBroker generator = tokenBroker();
+    TokenResponse subjectToken = generateToken(generator, "PRINCIPAL_ROLE:ALL");
+
+    TokenResponse token =
+        generator.generateFromToken(
+            TokenType.ACCESS_TOKEN,
+            subjectToken.getAccessToken(),
+            TokenRequestValidator.TOKEN_EXCHANGE,
+            "PRINCIPAL_ROLE:TEST",
+            TokenType.ACCESS_TOKEN);
+
+    assertThat(token.getError()).isNull();
+    assertThat(decodedScope(token.getAccessToken())).isEqualTo("PRINCIPAL_ROLE:TEST");
+  }
+
+  private TokenBroker tokenBroker() {
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
+    PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
+    long principalId = 123L;
+    String mainSecret = "test_secret";
+    String clientId = "test_client_id";
+    PolarisPrincipalSecrets principalSecrets =
+        new PolarisPrincipalSecrets(principalId, clientId, mainSecret, "otherSecret");
+    Mockito.when(metastoreManager.loadPrincipalSecrets(polarisCallContext, clientId))
+        .thenReturn(new PrincipalSecretsResult(principalSecrets));
+    PrincipalEntity principal =
+        new PrincipalEntity.Builder().setId(principalId).setName("principal").build();
+    Mockito.when(metastoreManager.findPrincipalById(polarisCallContext, principalId))
+        .thenReturn(Optional.of(principal));
+    Algorithm algorithm = Algorithm.HMAC256("polaris");
+    return new JWTBroker(
+        metastoreManager, polarisCallContext, 666, algorithm, JWTBroker.buildVerifier(algorithm));
+  }
+
+  private TokenResponse generateToken(TokenBroker generator, String scope) {
+    return generator.generateFromClientSecrets(
+        "test_client_id",
+        "test_secret",
+        TokenRequestValidator.CLIENT_CREDENTIALS,
+        scope,
+        TokenType.ACCESS_TOKEN);
+  }
+
+  private String decodedScope(String token) {
+    return JWT.decode(token).getClaim("scope").asString();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/TokenRequestValidatorTest.java
@@ -69,7 +69,20 @@ public class TokenRequestValidatorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"null", "", ",", "ALL", "PRINCIPAL_ROLE:", "PRINCIPAL_ROLE"})
+  @ValueSource(
+      strings = {
+        "null",
+        "",
+        " ",
+        "  ",
+        ",",
+        "ALL",
+        "PRINCIPAL_ROLE:",
+        "PRINCIPAL_ROLE",
+        " PRINCIPAL_ROLE:ALL",
+        "\tPRINCIPAL_ROLE:ALL\t",
+        "PRINCIPAL_ROLE:ONE  PRINCIPAL_ROLE:TWO"
+      })
   public void testValidateForClientCredentialsFlowInvalidScope(String scope) {
     Assertions.assertThat(
             new TokenRequestValidator()
@@ -79,12 +92,18 @@ public class TokenRequestValidatorTest {
         .isEqualTo(OAuthError.invalid_scope);
   }
 
-  @Test
-  public void testValidateForClientCredentialsFlowAllValid() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "PRINCIPAL_ROLE:ALL",
+        "PRINCIPAL_ROLE:ONE PRINCIPAL_ROLE:TWO",
+        "PRINCIPAL_ROLE:ONE PRINCIPAL_ROLE:ONE"
+      })
+  public void testValidateForClientCredentialsFlowValidScope(String scope) {
     Assertions.assertThat(
             new TokenRequestValidator()
                 .validateForClientCredentialsFlow(
-                    "client-id", "client-secret", "client_credentials", "PRINCIPAL_ROLE:ALL"))
+                    "client-id", "client-secret", "client_credentials", scope))
         .isEmpty();
   }
 }


### PR DESCRIPTION
Honor requested scopes when generating tokens from existing access tokens, reuse the shared scope parser for validation and comparison, and preserve the existing token scope when no scope is requested.

Add coverage for token exchange scope selection and scope parser edge cases.