### PR TITLE
Validate Iceberg metadata locations during table updates

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -56,7 +57,10 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.LocationProviders;
+import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -473,7 +477,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             .setMetadataLocation(metadataFileLocation)
             .build();
 
-    updateTableLike(identifier, updatedEntity);
+    updateTableLike(identifier, updatedEntity, false);
 
     TableOperations ops = newTableOps(identifier);
     return new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());
@@ -1268,8 +1272,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
     Set<String> dataLocations =
         StorageUtil.getLocationsUsedByTable(tableMetadata.location(), tableMetadata.properties());
-    CatalogUtils.validateLocationsForTableLike(
-        realmConfig, tableIdentifier, dataLocations, resolvedStorageEntity);
+    Set<String> locationsToValidate =
+        getLocationsUsedByTableAndDirectMetadataReferences(
+            tableMetadata.location(), tableMetadata.properties(), tableMetadata);
+    validateLocationsForTableLike(tableIdentifier, locationsToValidate, resolvedStorageEntity);
     validateNoLocationsOverlap(
         tableIdentifier,
         dataLocations,
@@ -1306,8 +1312,41 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       TableIdentifier identifier,
       String location,
       PolarisResolvedPathWrapper resolvedStorageEntity) {
-    CatalogUtils.validateLocationsForTableLike(
-        realmConfig, identifier, Set.of(location), resolvedStorageEntity);
+    validateLocationsForTableLike(identifier, Set.of(location), resolvedStorageEntity);
+  }
+
+  private void validateLocationsForTableLike(
+      TableIdentifier identifier,
+      Set<String> locations,
+      PolarisResolvedPathWrapper resolvedStorageEntity) {
+    if (!locations.isEmpty()) {
+      CatalogUtils.validateLocationsForTableLike(
+          realmConfig, identifier, locations, resolvedStorageEntity);
+    }
+  }
+
+  private Set<String> getLocationsUsedByTableAndDirectMetadataReferences(TableMetadata metadata) {
+    return getLocationsUsedByTableAndDirectMetadataReferences(
+        metadata.location(), metadata.properties(), metadata);
+  }
+
+  private Set<String> getLocationsUsedByTableAndDirectMetadataReferences(
+      String tableLocation, Map<String, String> tableProperties, TableMetadata metadata) {
+    Set<String> locations =
+        new HashSet<>(StorageUtil.getLocationsUsedByTable(tableLocation, tableProperties));
+    locations.addAll(getDirectMetadataFileReferences(metadata));
+    return locations;
+  }
+
+  private Set<String> getDirectMetadataFileReferences(TableMetadata metadata) {
+    Set<String> locations = new HashSet<>();
+    metadata.snapshots().stream().map(Snapshot::manifestListLocation).forEach(locations::add);
+    metadata.statisticsFiles().stream().map(StatisticsFile::path).forEach(locations::add);
+    metadata.partitionStatisticsFiles().stream()
+        .map(PartitionStatisticsFile::path)
+        .forEach(locations::add);
+    locations.remove(null);
+    return locations;
   }
 
   private void validateTableMetadataLocations(
@@ -1316,10 +1355,13 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       PolarisResolvedPathWrapper resolvedStorageEntity,
       List<PolarisEntity> resolvedNamespace) {
     // checks throwing ForbiddenException (must come first)
-    Set<String> locations = StorageUtil.getLocationsUsedByTable(metadata);
-    CatalogUtils.validateLocationsForTableLike(
-        realmConfig, identifier, locations, resolvedStorageEntity);
-    validateNoLocationsOverlap(identifier, locations, resolvedStorageEntity, resolvedNamespace);
+    Set<String> tableLocations = StorageUtil.getLocationsUsedByTable(metadata);
+    validateLocationsForTableLike(
+        identifier,
+        getLocationsUsedByTableAndDirectMetadataReferences(metadata),
+        resolvedStorageEntity);
+    validateNoLocationsOverlap(
+        identifier, tableLocations, resolvedStorageEntity, resolvedNamespace);
     // checks throwing BadRequestException (must come after)
     validateMetadataFileInTableDir(identifier, metadata);
   }
@@ -1866,6 +1908,13 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
               : resolvedTableEntities;
 
       Set<String> requestedLocations = StorageUtil.getLocationsUsedByTable(metadata);
+      boolean tableLocationsChanged =
+          base == null || requestedTableLocationsChanged(base, metadata);
+      Set<String> locationsToValidate =
+          tableLocationsChanged
+              ? getLocationsUsedByTableAndDirectMetadataReferences(metadata)
+              : getDirectMetadataFileReferences(metadata);
+      locationsToValidate.add(nextMetadataFileLocation(metadata));
 
       List<PolarisEntity> resolvedNamespace =
           resolvedTableEntities == null
@@ -1874,11 +1923,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                   .getRawFullPath()
               : resolvedTableEntities.getRawParentPath();
 
-      if (base == null || requestedTableLocationsChanged(base, metadata)) {
-        // If location is changing then we must validate that the requested location is valid
-        // for the storage configuration inherited under this entity's path.
-        CatalogUtils.validateLocationsForTableLike(
-            realmConfig, tableIdentifier, requestedLocations, resolvedStorageEntity);
+      validateLocationsForTableLike(tableIdentifier, locationsToValidate, resolvedStorageEntity);
+
+      if (tableLocationsChanged) {
+        // Also validate that the table location doesn't overlap an existing table.
         validateNoLocationsOverlap(
             tableIdentifier, requestedLocations, resolvedStorageEntity, resolvedNamespace);
         // and that the metadata file points to a location within the table's directory structure
@@ -1967,9 +2015,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         }
 
         if (null == existingLocation) {
-          createTableLike(tableIdentifier, entity);
+          createTableLike(tableIdentifier, entity, false);
         } else {
-          updateTableLike(tableIdentifier, entity);
+          updateTableLike(tableIdentifier, entity, false);
         }
         // We diverge from `BaseMetastoreTableOperations`: only update the in-memory state after
         // the metastore persistence succeeds. If we updated it before and persistence threw,
@@ -2395,9 +2443,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
               identifier, oldLocation, newLocation, existingLocation);
         }
         if (null == existingLocation) {
-          createTableLike(identifier, entity);
+          createTableLike(identifier, entity, true);
         } else {
-          updateTableLike(identifier, entity);
+          updateTableLike(identifier, entity, true);
         }
         writeSucceeded = true;
       } finally {
@@ -2723,7 +2771,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
    * duplicate the logic to try to resolve parentIds before constructing the proposed entity. This
    * method will fill in the parentId if needed upon resolution.
    */
-  private void createTableLike(TableIdentifier identifier, PolarisEntity entity) {
+  private void createTableLike(
+      TableIdentifier identifier, PolarisEntity entity, boolean validateMetadataLocation) {
     PolarisResolvedPathWrapper resolvedParent =
         resolvedEntityView.getResolvedPath(ResolvedPathKey.ofNamespace(identifier.namespace()));
     if (resolvedParent == null) {
@@ -2732,11 +2781,14 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           String.format("Failed to fetch resolved parent for TableIdentifier '%s'", identifier));
     }
 
-    createTableLike(identifier, entity, resolvedParent);
+    createTableLike(identifier, entity, resolvedParent, validateMetadataLocation);
   }
 
   private void createTableLike(
-      TableIdentifier identifier, PolarisEntity entity, PolarisResolvedPathWrapper resolvedParent) {
+      TableIdentifier identifier,
+      PolarisEntity entity,
+      PolarisResolvedPathWrapper resolvedParent,
+      boolean validateMetadataLocation) {
     IcebergTableLikeEntity icebergTableLikeEntity = IcebergTableLikeEntity.of(entity);
     // Set / suffix
     boolean requireTrailingSlash =
@@ -2752,7 +2804,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
     // Make sure the metadata file is valid for our allowed locations.
     String metadataLocation = icebergTableLikeEntity.getMetadataLocation();
-    validateLocationForTableLike(identifier, metadataLocation, resolvedParent);
+    if (validateMetadataLocation) {
+      validateLocationForTableLike(identifier, metadataLocation, resolvedParent);
+    }
 
     List<PolarisEntity> catalogPath = resolvedParent.getRawFullPath();
 
@@ -2793,7 +2847,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     LOGGER.debug("Created TableLike entity {} with TableIdentifier {}", resultEntity, identifier);
   }
 
-  private void updateTableLike(TableIdentifier identifier, PolarisEntity entity) {
+  private void updateTableLike(
+      TableIdentifier identifier, PolarisEntity entity, boolean validateMetadataLocation) {
     PolarisResolvedPathWrapper resolvedEntities =
         resolvedEntityView.getResolvedPath(
             ResolvedPathKey.ofTableLike(identifier), entity.getSubType());
@@ -2818,7 +2873,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
     // Make sure the metadata file is valid for our allowed locations.
     String metadataLocation = icebergTableLikeEntity.getMetadataLocation();
-    validateLocationForTableLike(identifier, metadataLocation, resolvedEntities);
+    if (validateMetadataLocation) {
+      validateLocationForTableLike(identifier, metadataLocation, resolvedEntities);
+    }
 
     List<PolarisEntity> catalogPath = resolvedEntities.getRawParentPath();
     EntityResult res =
@@ -3010,8 +3067,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                   PolarisStorageActions.LIST));
       TableMetadata tableMetadata = TableMetadataParser.read(fileIO, newLocation);
 
-      // then validate that it points to a valid location for this table
-      validateLocationForTableLike(tableIdentifier, tableMetadata.location());
+      // then validate that the metadata points to valid locations for this table
+      validateLocationsForTableLike(
+          tableIdentifier,
+          getLocationsUsedByTableAndDirectMetadataReferences(tableMetadata),
+          resolvedParent);
 
       // finally, validate that the metadata file is within the table directory
       validateMetadataFileInTableDir(tableIdentifier, tableMetadata);
@@ -3022,14 +3082,14 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             "Creating table {} for notification with metadataLocation {}",
             tableIdentifier,
             newLocation);
-        createTableLike(tableIdentifier, entity, resolvedParent);
+        createTableLike(tableIdentifier, entity, resolvedParent, false);
       } else {
         LOGGER.debug(
             "Updating table {} for notification with metadataLocation {}",
             tableIdentifier,
             newLocation);
 
-        updateTableLike(tableIdentifier, entity);
+        updateTableLike(tableIdentifier, entity, false);
       }
     }
     return true;

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -815,6 +815,7 @@ public class IcebergAllowedLocationTest {
         .hasMessageContaining("outside the catalog's current allowed locations");
   }
 
+  @SuppressWarnings({"deprecation", "RedundantSuppression"})
   private record TestSnapshot(
       long sequenceNumber,
       long snapshotId,

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -29,21 +29,38 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.ImmutableGenericPartitionStatisticsFile;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
+import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
@@ -54,6 +71,7 @@ import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.admin.model.UpdateCatalogRequest;
 import org.apache.polaris.service.TestServices;
+import org.apache.polaris.service.catalog.AccessDelegationMode;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -495,6 +513,166 @@ public class IcebergAllowedLocationTest {
         .containsEntry("write.data.path", writeDataPath);
   }
 
+  @Test
+  void testUpdateTableRejectsManifestListOutsideAllowedLocations(@TempDir Path tmpDir) {
+    var tableName = getTableName();
+    var tableId = TableIdentifier.of(namespace, tableName);
+
+    var services = createTableUnderAllowedCatalogLocation(tmpDir, tableName);
+
+    var outsideLocation = tmpDir.resolve("outside").toAbsolutePath().toUri().toString();
+    var snapshot =
+        new TestSnapshot(1L, 1L, null, System.currentTimeMillis(), outsideLocation + "snap.avro");
+
+    var updateRequest =
+        UpdateTableRequest.create(
+            tableId, List.of(), List.of(new MetadataUpdate.AddSnapshot(snapshot)));
+
+    assertThatThrownBy(
+            () ->
+                services
+                    .catalogAdapter()
+                    .newHandler(services.securityContext(), catalog)
+                    .updateTable(tableId, updateRequest))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Invalid locations");
+  }
+
+  @Test
+  void testUpdateTableRejectsStatisticsFileOutsideAllowedLocations(@TempDir Path tmpDir) {
+    var tableName = getTableName();
+    var tableId = TableIdentifier.of(namespace, tableName);
+
+    var services = createTableUnderAllowedCatalogLocation(tmpDir, tableName);
+
+    var outsideLocation = tmpDir.resolve("outside").toAbsolutePath().toUri().toString();
+    StatisticsFile statisticsFile =
+        new GenericStatisticsFile(1L, outsideLocation + "stats.puffin", 1L, 1L, List.of());
+
+    var updateRequest =
+        UpdateTableRequest.create(
+            tableId, List.of(), List.of(new MetadataUpdate.SetStatistics(statisticsFile)));
+
+    assertThatThrownBy(
+            () ->
+                services
+                    .catalogAdapter()
+                    .newHandler(services.securityContext(), catalog)
+                    .updateTable(tableId, updateRequest))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Invalid locations");
+  }
+
+  @Test
+  void testUpdateTableRejectsPartitionStatisticsFileOutsideAllowedLocations(@TempDir Path tmpDir) {
+    var tableName = getTableName();
+    var tableId = TableIdentifier.of(namespace, tableName);
+
+    var services = createTableUnderAllowedCatalogLocation(tmpDir, tableName);
+
+    var outsideLocation = tmpDir.resolve("outside").toAbsolutePath().toUri().toString();
+    PartitionStatisticsFile partitionStatisticsFile =
+        ImmutableGenericPartitionStatisticsFile.builder()
+            .snapshotId(1L)
+            .path(outsideLocation + "partition-stats.puffin")
+            .fileSizeInBytes(1L)
+            .build();
+
+    var updateRequest =
+        UpdateTableRequest.create(
+            tableId,
+            List.of(),
+            List.of(new MetadataUpdate.SetPartitionStatistics(partitionStatisticsFile)));
+
+    assertThatThrownBy(
+            () ->
+                services
+                    .catalogAdapter()
+                    .newHandler(services.securityContext(), catalog)
+                    .updateTable(tableId, updateRequest))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Invalid locations");
+  }
+
+  private TestServices createTableUnderAllowedCatalogLocation(Path tmpDir, String tableName) {
+    var services = getTestServices();
+    var catalogLocation = tmpDir.resolve(catalog).toAbsolutePath().toUri().toString();
+    var namespaceLocation = catalogLocation + "/" + namespace;
+
+    createCatalog(services, Map.of(), catalogLocation, List.of(catalogLocation));
+    createNamespace(services, namespaceLocation);
+
+    var createTableRequest =
+        CreateTableRequest.builder().withName(tableName).withSchema(SCHEMA).build();
+
+    var createResponse =
+        services
+            .restApi()
+            .createTable(
+                catalog,
+                namespace,
+                createTableRequest,
+                null,
+                IDEMPOTENCY_KEY,
+                services.realmContext(),
+                services.securityContext());
+    assertThat(createResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    return services;
+  }
+
+  @Test
+  void testRegisterTableRejectsDirectMetadataReferencesOutsideAllowedLocations(@TempDir Path tmpDir)
+      throws IOException {
+    var services = getTestServices();
+    var tableName = getTableName();
+
+    var catalogLocation = tmpDir.resolve(catalog).toAbsolutePath().toUri().toString();
+    var namespaceLocation = catalogLocation + "/" + namespace;
+
+    createCatalog(services, Map.of(), catalogLocation, List.of(catalogLocation));
+    createNamespace(services, namespaceLocation);
+
+    var tableDir = tmpDir.resolve(catalog).resolve(namespace).resolve(tableName);
+    var metadataPath = tableDir.resolve("metadata").resolve("00000.metadata.json");
+    Files.createDirectories(metadataPath.getParent());
+
+    var tableLocation = tableDir.toAbsolutePath().toUri().toString();
+    var outsideLocation = tmpDir.resolve("outside").toAbsolutePath().toUri().toString();
+    var snapshot =
+        new TestSnapshot(1L, 1L, null, System.currentTimeMillis(), outsideLocation + "snap.avro");
+    var metadata =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    SCHEMA,
+                    PartitionSpec.unpartitioned(),
+                    SortOrder.unsorted(),
+                    tableLocation,
+                    Map.of()))
+            .addSnapshot(snapshot)
+            .build();
+
+    Files.writeString(metadataPath, TableMetadataParser.toJson(metadata), StandardCharsets.UTF_8);
+
+    var registerRequest =
+        ImmutableRegisterTableRequest.builder()
+            .name(tableName)
+            .metadataLocation(metadataPath.toAbsolutePath().toUri().toString())
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                services
+                    .catalogAdapter()
+                    .newHandler(services.securityContext(), catalog)
+                    .registerTable(
+                        Namespace.of(namespace),
+                        registerRequest,
+                        EnumSet.noneOf(AccessDelegationMode.class),
+                        Optional.empty()))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Invalid locations");
+  }
+
   private void createCatalog(
       TestServices services,
       Map<String, String> catalogConfig,
@@ -635,5 +813,49 @@ public class IcebergAllowedLocationTest {
     assertThatThrownBy(() -> handler.loadCredentials(tableId, Optional.empty()))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("outside the catalog's current allowed locations");
+  }
+
+  private record TestSnapshot(
+      long sequenceNumber,
+      long snapshotId,
+      Long parentId,
+      long timestampMillis,
+      String manifestListLocation)
+      implements Snapshot {
+
+    @Override
+    public List<ManifestFile> allManifests(FileIO io) {
+      return List.of();
+    }
+
+    @Override
+    public List<ManifestFile> dataManifests(FileIO io) {
+      return List.of();
+    }
+
+    @Override
+    public List<ManifestFile> deleteManifests(FileIO io) {
+      return List.of();
+    }
+
+    @Override
+    public String operation() {
+      return "append";
+    }
+
+    @Override
+    public Map<String, String> summary() {
+      return Map.of("operation", operation());
+    }
+
+    @Override
+    public Iterable<DataFile> addedDataFiles(FileIO io) {
+      return List.of();
+    }
+
+    @Override
+    public Iterable<DataFile> removedDataFiles(FileIO io) {
+      return List.of();
+    }
   }
 }


### PR DESCRIPTION
Include direct metadata file references when validating table metadata locations, and avoid repeated validation when the same locations have already been checked as part of the commit or notification flow.