### PR TITLE
fix(catalog): preserve metadata location when using snapshots=refs

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -25,6 +25,7 @@ import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CRE
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.alreadyExistsExceptionForTableLikeEntity;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import io.smallrye.common.annotation.Identifier;
@@ -44,13 +45,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -1704,20 +1703,25 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     catalogHandlerUtils().renameView(viewCatalog, request);
   }
 
-  private @NonNull LoadTableResponse filterResponseToSnapshots(
+  @VisibleForTesting
+  @NonNull LoadTableResponse filterResponseToSnapshots(
       LoadTableResponse loadTableResponse, String snapshots) {
     if (snapshots == null || snapshots.equalsIgnoreCase(SNAPSHOTS_ALL)) {
       return loadTableResponse;
     } else if (snapshots.equalsIgnoreCase(SNAPSHOTS_REFS)) {
       TableMetadata metadata = loadTableResponse.tableMetadata();
 
-      Set<Long> referencedSnapshotIds =
-          metadata.refs().values().stream()
-              .map(SnapshotRef::snapshotId)
-              .collect(Collectors.toSet());
-
+      // suppressHistoricalSnapshots() drops snapshots not referenced by any branch/tag without
+      // recording a MetadataUpdate, so metadataLocation() survives the filter. This mirrors
+      // org.apache.iceberg.rest.CatalogHandlers#loadTable's REFS case in Iceberg core; using
+      // removeSnapshotsIf() here instead would record a change and force metadataLocation() to
+      // null (TableMetadata requires an empty change list to claim a persisted location), even
+      // though nothing was actually written to disk.
       TableMetadata filteredMetadata =
-          metadata.removeSnapshotsIf(s -> !referencedSnapshotIds.contains(s.snapshotId()));
+          TableMetadata.buildFrom(metadata)
+              .withMetadataLocation(metadata.metadataFileLocation())
+              .suppressHistoricalSnapshots()
+              .build();
 
       return LoadTableResponse.builder()
           .withTableMetadata(filteredMetadata)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1711,11 +1711,8 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     } else if (snapshots.equalsIgnoreCase(SNAPSHOTS_REFS)) {
       TableMetadata metadata = loadTableResponse.tableMetadata();
 
-      // suppressHistoricalSnapshots() removes snapshots not referenced by any branch/tag without
-      // recording a MetadataUpdate. TableMetadata only allows a non-null metadataLocation when
-      // its change list is empty, so this keeps the filtered response pointing at the same
-      // persisted metadata file a snapshots=all request would return. Matches
-      // org.apache.iceberg.rest.CatalogHandlers#loadTable's REFS case in Iceberg core.
+      // suppressHistoricalSnapshots() preserves metadataLocation() while dropping unreferenced
+      // snapshots, matching org.apache.iceberg.rest.CatalogHandlers#loadTable's REFS case.
       TableMetadata filteredMetadata =
           TableMetadata.buildFrom(metadata)
               .withMetadataLocation(metadata.metadataFileLocation())

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -1711,12 +1711,11 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     } else if (snapshots.equalsIgnoreCase(SNAPSHOTS_REFS)) {
       TableMetadata metadata = loadTableResponse.tableMetadata();
 
-      // suppressHistoricalSnapshots() drops snapshots not referenced by any branch/tag without
-      // recording a MetadataUpdate, so metadataLocation() survives the filter. This mirrors
-      // org.apache.iceberg.rest.CatalogHandlers#loadTable's REFS case in Iceberg core; using
-      // removeSnapshotsIf() here instead would record a change and force metadataLocation() to
-      // null (TableMetadata requires an empty change list to claim a persisted location), even
-      // though nothing was actually written to disk.
+      // suppressHistoricalSnapshots() removes snapshots not referenced by any branch/tag without
+      // recording a MetadataUpdate. TableMetadata only allows a non-null metadataLocation when
+      // its change list is empty, so this keeps the filtered response pointing at the same
+      // persisted metadata file a snapshots=all request would return. Matches
+      // org.apache.iceberg.rest.CatalogHandlers#loadTable's REFS case in Iceberg core.
       TableMetadata filteredMetadata =
           TableMetadata.buildFrom(metadata)
               .withMetadataLocation(metadata.metadataFileLocation())

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -40,6 +40,9 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
@@ -52,6 +55,7 @@ import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
@@ -588,5 +592,77 @@ class IcebergCatalogHandlerTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("credential vending disabled");
     verify(icebergCatalog, never()).loadTable(any());
+  }
+
+  /**
+   * Builds a two-snapshot {@link TableMetadata} with only the latest snapshot referenced by the
+   * "main" branch, then re-stamps a metadata-location onto it and clears its change log, mimicking
+   * what a real catalog load hands to {@code filterResponseToSnapshots} (a clean object, no pending
+   * changes, non-null location).
+   */
+  private TableMetadata loadedTwoSnapshotTableMetadata() {
+    Snapshot historicalSnapshot = mock(Snapshot.class);
+    when(historicalSnapshot.snapshotId()).thenReturn(1L);
+    when(historicalSnapshot.sequenceNumber()).thenReturn(1L);
+
+    Snapshot currentSnapshot = mock(Snapshot.class);
+    when(currentSnapshot.snapshotId()).thenReturn(2L);
+    when(currentSnapshot.sequenceNumber()).thenReturn(2L);
+
+    TableMetadata uncommitted =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get())),
+                    PartitionSpec.unpartitioned(),
+                    TABLE_LOCATION,
+                    Map.of()))
+            .addSnapshot(historicalSnapshot)
+            // setBranchSnapshot() adds currentSnapshot itself, no separate addSnapshot() call.
+            .setBranchSnapshot(currentSnapshot, "main")
+            .build();
+
+    return TableMetadata.buildFrom(uncommitted)
+        .withMetadataLocation(TABLE_LOCATION + "/metadata/00002-fake.metadata.json")
+        .discardChanges()
+        .build();
+  }
+
+  @Test
+  void filterResponseToSnapshotsRefsPreservesMetadataLocation() {
+    TableMetadata metadata = loadedTwoSnapshotTableMetadata();
+    assertThat(metadata.snapshots()).hasSize(2);
+
+    LoadTableResponse response = LoadTableResponse.builder().withTableMetadata(metadata).build();
+    String metadataLocation = response.metadataLocation();
+    assertThat(metadataLocation)
+        .as("precondition: the unfiltered (snapshots=all) response carries a metadata-location")
+        .isNotNull();
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+    LoadTableResponse filtered = handler.filterResponseToSnapshots(response, "refs");
+
+    assertThat(filtered.tableMetadata().snapshots())
+        .as("snapshots=refs must still drop the historical (non-ref) snapshot")
+        .hasSize(1);
+    assertThat(filtered.metadataLocation())
+        .as("metadata-location must be preserved when filtering snapshots=refs")
+        .isEqualTo(metadataLocation);
+  }
+
+  @Test
+  void filterResponseToSnapshotsAllAndNullReturnResponseUnchanged() {
+    TableMetadata metadata = loadedTwoSnapshotTableMetadata();
+    LoadTableResponse response = LoadTableResponse.builder().withTableMetadata(metadata).build();
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThat(handler.filterResponseToSnapshots(response, "all"))
+        .as("snapshots=all must be a pure passthrough")
+        .isSameAs(response);
+    assertThat(handler.filterResponseToSnapshots(response, null))
+        .as("no snapshots param must be a pure passthrough, same as snapshots=all")
+        .isSameAs(response);
   }
 }


### PR DESCRIPTION
Use TableMetadata.Builder#suppressHistoricalSnapshots() instead of removeSnapshotsIf(), matching org.apache.iceberg.rest.CatalogHandlers's reference implementation for snapshots=refs. suppress=true does not record a MetadataUpdate, so metadataLocation() survives without a separate discardChanges() rebuild.

Fixes #4656. Supersedes #4724 (stale, author unreachable).

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
