### PR TITLE
Follow-up polish to the `createTable`/`updateTable` idempotency work.

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -53,25 +52,15 @@ import java.util.UUID;
  * evolve the encoding later without ambiguity.
  *
  * <p>For {@code createTable} this window holds a single entry, but the shape generalizes to a
- * bounded per-entity window for repeated mutations (e.g. {@code updateTable}). Expired keys are
- * dropped inline whenever the entity is rewritten ({@link #recordKey}); expiry is also honored at
- * read time ({@link #hasLiveKey}) so a stale-but-not-yet-purged key is treated as absent.
+ * per-entity window for repeated mutations (e.g. {@code updateTable}). The window is bounded only
+ * by expiry (TTL): expired keys are dropped inline whenever the entity is rewritten ({@link
+ * #recordKey}), and expiry is also honored at read time ({@link #hasLiveKey}) so a
+ * stale-but-not-yet-purged key is treated as absent. Live keys are never evicted by count.
  */
 public final class EntityIdempotency {
 
   /** Internal-properties key under which the per-entity idempotency key window is stored. */
   public static final String IDEMPOTENCY_KEYS_PROPERTY = "polaris-idempotency-keys";
-
-  /**
-   * Live-key window size at the {@link #BASELINE_TTL}; the effective cap scales with the key TTL.
-   */
-  private static final int BASELINE_WINDOW_SIZE = 64;
-
-  /** TTL that {@link #BASELINE_WINDOW_SIZE} is calibrated for. */
-  private static final Duration BASELINE_TTL = Duration.ofMinutes(5);
-
-  /** Absolute ceiling on live keys per entity, to bound entity size for large TTLs. */
-  private static final int MAX_WINDOW_CEILING = 1024;
 
   /** Magic prefix for the version 1 SMILE window ({@code IS1} + base64url bytes). */
   private static final String FORMAT_SMILE_V1 = "IS1";
@@ -102,8 +91,12 @@ public final class EntityIdempotency {
    * Returns a copy of {@code internalProperties} with {@code key} recorded (expiring at {@code
    * expiry}) and any keys already expired as of {@code now} dropped. This is the inline
    * purge-on-write step: it runs within the same transaction that persists the entity, so no
-   * separate maintenance pass is required to bound the window. The window is capped at a size
-   * derived from this key's TTL ({@code expiry - now}); see {@link #maxWindowSize(Duration)}.
+   * separate maintenance pass is required.
+   *
+   * <p>The window is bounded only by expiry (TTL), never by a fixed count: a live key is never
+   * evicted to make room. Evicting a still-live key would silently disable idempotency for it and
+   * reintroduce the corruption failure mode (a retry would re-run and could 409), so under a high
+   * write rate we accept a larger window rather than dropping keys that could still be retried.
    */
   public static Map<String, String> recordKey(
       Map<String, String> internalProperties, UUID key, Instant expiry, Instant now) {
@@ -120,14 +113,6 @@ public final class EntityIdempotency {
       }
     }
 
-    // Bounded window, sized from this key's TTL. Drop the earliest-expiring entries (front of the
-    // sorted list) *before* inserting so the key just recorded is always retained. This matters
-    // when entries share an expiry (e.g. a burst of writes) and expiry order can't rank recency.
-    int maxWindowSize = maxWindowSize(Duration.between(now, expiry));
-    while (window.size() >= maxWindowSize) {
-      window.remove(0);
-    }
-
     KeyEntry newEntry = new KeyEntry(keyString, expiry.toEpochMilli());
     int insertionPoint = Collections.binarySearch(window, newEntry, BY_EXPIRY);
     if (insertionPoint < 0) {
@@ -138,16 +123,6 @@ public final class EntityIdempotency {
     Map<String, String> updated = new HashMap<>(internalProperties);
     updated.put(IDEMPOTENCY_KEYS_PROPERTY, encode(window));
     return updated;
-  }
-
-  /**
-   * Effective cap on the live-key window, scaled linearly from {@link #BASELINE_WINDOW_SIZE} at
-   * {@link #BASELINE_TTL} (e.g. 5m -> 64, 10m -> 128), floored at 1 and clamped by {@link
-   * #MAX_WINDOW_CEILING} so a large TTL can't grow the per-entity window without bound.
-   */
-  private static int maxWindowSize(Duration ttl) {
-    long scaled = (long) BASELINE_WINDOW_SIZE * ttl.toSeconds() / BASELINE_TTL.toSeconds();
-    return (int) Math.max(1, Math.min(MAX_WINDOW_CEILING, scaled));
   }
 
   private static List<KeyEntry> decode(String raw) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -34,6 +35,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.exceptions.ServiceUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper for the entity-property idempotency model (single-transaction / "embedded key" approach).
@@ -55,15 +59,29 @@ import java.util.UUID;
  * per-entity window for repeated mutations (e.g. {@code updateTable}). The window is bounded only
  * by expiry (TTL): expired keys are dropped inline whenever the entity is rewritten ({@link
  * #recordKey}), and expiry is also honored at read time ({@link #hasLiveKey}) so a
- * stale-but-not-yet-purged key is treated as absent. Live keys are never evicted by count.
+ * stale-but-not-yet-purged key is treated as absent. Live keys are never evicted by count; a large
+ * safety ceiling ({@link #MAX_LIVE_KEYS}) bounds the window by failing the write rather than
+ * dropping a still-live key.
  */
 public final class EntityIdempotency {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EntityIdempotency.class);
 
   /** Internal-properties key under which the per-entity idempotency key window is stored. */
   public static final String IDEMPOTENCY_KEYS_PROPERTY = "polaris-idempotency-keys";
 
   /** Magic prefix for the version 1 SMILE window ({@code IS1} + base64url bytes). */
   private static final String FORMAT_SMILE_V1 = "IS1";
+
+  /**
+   * Safety ceiling on the number of live keys retained on a single entity. Unlike a count-based
+   * eviction cap, this never drops a live key: when the window is full the write fails instead, so
+   * a key that could still be retried is never silently discarded. The limit is deliberately high —
+   * reaching it requires this many successful commits to one table within the key TTL — so
+   * legitimate workloads never hit it, while still bounding stored idempotency data against
+   * unbounded growth (a DoS guardrail).
+   */
+  private static final int MAX_LIVE_KEYS = 10_000;
 
   private static final ObjectMapper SMILE_MAPPER = SmileMapper.builder().build();
 
@@ -93,13 +111,31 @@ public final class EntityIdempotency {
    * purge-on-write step: it runs within the same transaction that persists the entity, so no
    * separate maintenance pass is required.
    *
-   * <p>The window is bounded only by expiry (TTL), never by a fixed count: a live key is never
-   * evicted to make room. Evicting a still-live key would silently disable idempotency for it and
-   * reintroduce the corruption failure mode (a retry would re-run and could 409), so under a high
-   * write rate we accept a larger window rather than dropping keys that could still be retried.
+   * <p>The window is bounded only by expiry (TTL), never by a count-based eviction: a live key is
+   * never evicted to make room. Evicting a still-live key would silently disable idempotency for it
+   * and reintroduce the corruption failure mode (a retry would re-run and could 409), so under a
+   * high write rate we accept a larger window rather than dropping keys that could still be
+   * retried. A large safety ceiling ({@link #MAX_LIVE_KEYS}) still bounds the window: when it is
+   * reached the write fails with a retryable {@link ServiceUnavailableException} (HTTP 503) instead
+   * of dropping a key.
    */
   public static Map<String, String> recordKey(
       Map<String, String> internalProperties, UUID key, Instant expiry, Instant now) {
+    return recordKey(internalProperties, key, expiry, now, MAX_LIVE_KEYS);
+  }
+
+  /**
+   * Overload that takes an explicit ceiling so tests can exercise the guardrail without recording
+   * {@link #MAX_LIVE_KEYS} keys. Production always calls the public overload with {@link
+   * #MAX_LIVE_KEYS}.
+   */
+  @VisibleForTesting
+  static Map<String, String> recordKey(
+      Map<String, String> internalProperties,
+      UUID key,
+      Instant expiry,
+      Instant now,
+      int maxLiveKeys) {
     long nowMillis = now.toEpochMilli();
     String keyString = key.toString();
 
@@ -111,6 +147,16 @@ public final class EntityIdempotency {
       if (entry.expiryMillis > nowMillis && !entry.key.equals(keyString)) {
         window.add(entry);
       }
+    }
+
+    // Fail rather than evict a live key: dropping one would silently disable idempotency for it.
+    // 503 (retryable) is apt: once some of the live keys expire the write can succeed.
+    if (window.size() >= maxLiveKeys) {
+      throw new ServiceUnavailableException(
+          "Idempotency key window for this entity is full (%d live keys); refusing to record "
+              + "another to bound entity size. This indicates an abnormally high rate of "
+              + "idempotent writes to a single table within the key TTL.",
+          maxLiveKeys);
     }
 
     KeyEntry newEntry = new KeyEntry(keyString, expiry.toEpochMilli());
@@ -136,6 +182,13 @@ public final class EntityIdempotency {
       byte[] smile = Base64.getUrlDecoder().decode(raw.substring(FORMAT_SMILE_V1.length()));
       return SMILE_MAPPER.readValue(smile, new TypeReference<List<KeyEntry>>() {});
     } catch (IllegalArgumentException | IOException e) {
+      // Server-written data, so a decode failure means corruption or a tampered property; surface
+      // it. Only WARN (not ERROR) because it self-heals: the operation proceeds as if no keys were
+      // recorded and the next write overwrites the property with a valid window.
+      LOGGER.warn(
+          "Ignoring unreadable idempotency key window in property '{}'; treating as no live keys.",
+          IDEMPOTENCY_KEYS_PROPERTY,
+          e);
       return List.of();
     }
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.iceberg.exceptions.ServiceUnavailableException;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +116,8 @@ public final class EntityIdempotency {
    * and reintroduce the corruption failure mode (a retry would re-run and could 409), so under a
    * high write rate we accept a larger window rather than dropping keys that could still be
    * retried. A large safety ceiling ({@link #MAX_LIVE_KEYS}) still bounds the window: when it is
-   * reached the write fails with a retryable {@link ServiceUnavailableException} (HTTP 503) instead
-   * of dropping a key.
+   * reached the write fails with a retryable {@link PolarisServiceUnavailableException} (HTTP 503
+   * with a {@code Retry-After}) instead of dropping a key.
    */
   public static Map<String, String> recordKey(
       Map<String, String> internalProperties, UUID key, Instant expiry, Instant now) {
@@ -150,9 +150,12 @@ public final class EntityIdempotency {
     }
 
     // Fail rather than evict a live key: dropping one would silently disable idempotency for it.
-    // 503 (retryable) is apt: once some of the live keys expire the write can succeed.
+    // The window is sorted by expiry, so its first entry expires soonest; a slot frees (and the
+    // write can succeed) once it does, so advertise that as the Retry-After on the 503.
     if (window.size() >= maxLiveKeys) {
-      throw new ServiceUnavailableException(
+      long retryAfterSeconds = Math.max(1, (window.get(0).expiryMillis - nowMillis + 999) / 1000);
+      throw new PolarisServiceUnavailableException(
+          (int) retryAfterSeconds,
           "Idempotency key window for this entity is full (%d live keys); refusing to record "
               + "another to bound entity size. This indicates an abnormally high rate of "
               + "idempotent writes to a single table within the key TTL.",

--- a/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/idempotency/EntityIdempotency.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -61,11 +62,19 @@ public final class EntityIdempotency {
   /** Internal-properties key under which the per-entity idempotency key window is stored. */
   public static final String IDEMPOTENCY_KEYS_PROPERTY = "polaris-idempotency-keys";
 
-  /** Upper bound on live idempotency keys stored on a single entity. */
-  public static final int MAX_WINDOW_SIZE = 64;
+  /**
+   * Live-key window size at the {@link #BASELINE_TTL}; the effective cap scales with the key TTL.
+   */
+  private static final int BASELINE_WINDOW_SIZE = 64;
+
+  /** TTL that {@link #BASELINE_WINDOW_SIZE} is calibrated for. */
+  private static final Duration BASELINE_TTL = Duration.ofMinutes(5);
+
+  /** Absolute ceiling on live keys per entity, to bound entity size for large TTLs. */
+  private static final int MAX_WINDOW_CEILING = 1024;
 
   /** Magic prefix for the version 1 SMILE window ({@code IS1} + base64url bytes). */
-  private static final String WINDOW_FORMAT_SMILE_V1 = "IS1";
+  private static final String FORMAT_SMILE_V1 = "IS1";
 
   private static final ObjectMapper SMILE_MAPPER = SmileMapper.builder().build();
 
@@ -93,7 +102,8 @@ public final class EntityIdempotency {
    * Returns a copy of {@code internalProperties} with {@code key} recorded (expiring at {@code
    * expiry}) and any keys already expired as of {@code now} dropped. This is the inline
    * purge-on-write step: it runs within the same transaction that persists the entity, so no
-   * separate maintenance pass is required to bound the window. Capped at {@link #MAX_WINDOW_SIZE}.
+   * separate maintenance pass is required to bound the window. The window is capped at a size
+   * derived from this key's TTL ({@code expiry - now}); see {@link #maxWindowSize(Duration)}.
    */
   public static Map<String, String> recordKey(
       Map<String, String> internalProperties, UUID key, Instant expiry, Instant now) {
@@ -110,10 +120,11 @@ public final class EntityIdempotency {
       }
     }
 
-    // Bounded window: drop the earliest-expiring entries (front of the sorted list) to make room
-    // *before* inserting, so the key just recorded is always retained even when every entry shares
-    // the same expiry (e.g. a burst of writes at one instant) and expiry order can't rank recency.
-    while (window.size() >= MAX_WINDOW_SIZE) {
+    // Bounded window, sized from this key's TTL. Drop the earliest-expiring entries (front of the
+    // sorted list) *before* inserting so the key just recorded is always retained. This matters
+    // when entries share an expiry (e.g. a burst of writes) and expiry order can't rank recency.
+    int maxWindowSize = maxWindowSize(Duration.between(now, expiry));
+    while (window.size() >= maxWindowSize) {
       window.remove(0);
     }
 
@@ -129,25 +140,35 @@ public final class EntityIdempotency {
     return updated;
   }
 
+  /**
+   * Effective cap on the live-key window, scaled linearly from {@link #BASELINE_WINDOW_SIZE} at
+   * {@link #BASELINE_TTL} (e.g. 5m -> 64, 10m -> 128), floored at 1 and clamped by {@link
+   * #MAX_WINDOW_CEILING} so a large TTL can't grow the per-entity window without bound.
+   */
+  private static int maxWindowSize(Duration ttl) {
+    long scaled = (long) BASELINE_WINDOW_SIZE * ttl.toSeconds() / BASELINE_TTL.toSeconds();
+    return (int) Math.max(1, Math.min(MAX_WINDOW_CEILING, scaled));
+  }
+
   private static List<KeyEntry> decode(String raw) {
-    if (raw == null || raw.isEmpty()) {
+    if (raw == null || !raw.startsWith(FORMAT_SMILE_V1)) {
       return List.of();
     }
-    if (!raw.startsWith(WINDOW_FORMAT_SMILE_V1)) {
-      throw new IllegalArgumentException("Unrecognized idempotency key window format");
-    }
-    byte[] smile = Base64.getUrlDecoder().decode(raw.substring(WINDOW_FORMAT_SMILE_V1.length()));
+    // An unreadable window (bad base64 or SMILE decode failure) is treated as no live keys rather
+    // than failing the operation: a corrupt property degrades to normal behavior and the next
+    // recordKey overwrites it.
     try {
+      byte[] smile = Base64.getUrlDecoder().decode(raw.substring(FORMAT_SMILE_V1.length()));
       return SMILE_MAPPER.readValue(smile, new TypeReference<List<KeyEntry>>() {});
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to decode idempotency key window", e);
+    } catch (IllegalArgumentException | IOException e) {
+      return List.of();
     }
   }
 
   private static String encode(Collection<KeyEntry> window) {
     try {
       byte[] smile = SMILE_MAPPER.writeValueAsBytes(window);
-      return WINDOW_FORMAT_SMILE_V1 + Base64.getUrlEncoder().withoutPadding().encodeToString(smile);
+      return FORMAT_SMILE_V1 + Base64.getUrlEncoder().withoutPadding().encodeToString(smile);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to encode idempotency key window", e);
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.idempotency;
 import static org.apache.polaris.service.idempotency.EntityIdempotency.IDEMPOTENCY_KEYS_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -105,29 +106,70 @@ public class EntityIdempotencyTest {
 
   @Test
   public void recordKeyEvictsEarliestWhenFull() {
-    // Fill the window to capacity with strictly increasing expiries, so the earliest-expiring key
-    // (the first one recorded) is the well-defined eviction target.
+    // The cap scales with the key TTL. At the 5-minute baseline the window holds 64 keys.
+    // Expiries are spaced by milliseconds so they stay distinct but share one TTL bucket,
+    // giving a well-defined earliest-expiring eviction target.
+    Instant base = NOW.plus(Duration.ofMinutes(5));
+    int baselineCap = 64;
+
     UUID earliest = UUID.randomUUID();
-    UUID secondEarliest = UUID.randomUUID();
     Map<String, String> internal =
-        EntityIdempotency.recordKey(Map.of(), earliest, NOW.plusSeconds(1), NOW);
-    internal = EntityIdempotency.recordKey(internal, secondEarliest, NOW.plusSeconds(2), NOW);
-    for (int i = 3; i <= EntityIdempotency.MAX_WINDOW_SIZE; i++) {
-      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), NOW.plusSeconds(i), NOW);
+        EntityIdempotency.recordKey(Map.of(), earliest, base.plusMillis(1), NOW);
+    UUID secondEarliest = UUID.randomUUID();
+    internal = EntityIdempotency.recordKey(internal, secondEarliest, base.plusMillis(2), NOW);
+    for (int i = 3; i <= baselineCap; i++) {
+      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), base.plusMillis(i), NOW);
     }
 
     // One more write past capacity must evict only the earliest-expiring key while retaining the
     // key just recorded (trim-before-insert: the new key is never the one dropped).
     UUID newest = UUID.randomUUID();
     internal =
-        EntityIdempotency.recordKey(
-            internal, newest, NOW.plusSeconds(EntityIdempotency.MAX_WINDOW_SIZE + 1L), NOW);
+        EntityIdempotency.recordKey(internal, newest, base.plusMillis(baselineCap + 1L), NOW);
 
     // Read at NOW, when every recorded key would still be live if present, so absence == eviction.
     // Only the single earliest key is dropped: the new key and the next-earliest survive.
     assertThat(EntityIdempotency.hasLiveKey(internal, newest, NOW)).isTrue();
     assertThat(EntityIdempotency.hasLiveKey(internal, secondEarliest, NOW)).isTrue();
     assertThat(EntityIdempotency.hasLiveKey(internal, earliest, NOW)).isFalse();
+  }
+
+  @Test
+  public void windowCapScalesWithTtl() {
+    // A 10-minute TTL doubles the baseline cap to 128, so 65 keys (which would evict the earliest
+    // at
+    // the 5-minute baseline) all fit and none is evicted.
+    Instant base = NOW.plus(Duration.ofMinutes(10));
+    UUID earliest = UUID.randomUUID();
+    Map<String, String> internal =
+        EntityIdempotency.recordKey(Map.of(), earliest, base.plusMillis(1), NOW);
+    for (int i = 2; i <= 65; i++) {
+      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), base.plusMillis(i), NOW);
+    }
+
+    assertThat(EntityIdempotency.hasLiveKey(internal, earliest, NOW)).isTrue();
+  }
+
+  @Test
+  public void malformedWindowIsTreatedAsNoLiveKeys() {
+    // A corrupt/unrecognized window must degrade to "no live keys" rather than throwing: an unknown
+    // format prefix, and a valid prefix followed by non-base64 bytes.
+    Map<String, String> unknownPrefix = Map.of(IDEMPOTENCY_KEYS_PROPERTY, "XYZgarbage");
+    Map<String, String> badBase64 = Map.of(IDEMPOTENCY_KEYS_PROPERTY, "IS1@@@not-base64@@@");
+
+    assertThat(EntityIdempotency.hasLiveKey(unknownPrefix, UUID.randomUUID(), NOW)).isFalse();
+    assertThat(EntityIdempotency.hasLiveKey(badBase64, UUID.randomUUID(), NOW)).isFalse();
+  }
+
+  @Test
+  public void recordKeyOverwritesMalformedWindow() {
+    UUID key = UUID.randomUUID();
+    Map<String, String> corrupt = Map.of(IDEMPOTENCY_KEYS_PROPERTY, "IS1@@@not-base64@@@");
+
+    Map<String, String> updated = EntityIdempotency.recordKey(corrupt, key, LATER, NOW);
+
+    assertThat(updated.get(IDEMPOTENCY_KEYS_PROPERTY)).startsWith("IS1");
+    assertThat(EntityIdempotency.hasLiveKey(updated, key, NOW)).isTrue();
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.iceberg.exceptions.ServiceUnavailableException;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -137,7 +137,7 @@ public class EntityIdempotencyTest {
     Map<String, String> full = internal;
     assertThatThrownBy(
             () -> EntityIdempotency.recordKey(full, UUID.randomUUID(), LATER, NOW, ceiling))
-        .isInstanceOf(ServiceUnavailableException.class)
+        .isInstanceOf(PolarisServiceUnavailableException.class)
         .hasMessageContaining("full");
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.idempotency;
 import static org.apache.polaris.service.idempotency.EntityIdempotency.IDEMPOTENCY_KEYS_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -105,49 +104,21 @@ public class EntityIdempotencyTest {
   }
 
   @Test
-  public void recordKeyEvictsEarliestWhenFull() {
-    // The cap scales with the key TTL. At the 5-minute baseline the window holds 64 keys.
-    // Expiries are spaced by milliseconds so they stay distinct but share one TTL bucket,
-    // giving a well-defined earliest-expiring eviction target.
-    Instant base = NOW.plus(Duration.ofMinutes(5));
-    int baselineCap = 64;
-
-    UUID earliest = UUID.randomUUID();
-    Map<String, String> internal =
-        EntityIdempotency.recordKey(Map.of(), earliest, base.plusMillis(1), NOW);
-    UUID secondEarliest = UUID.randomUUID();
-    internal = EntityIdempotency.recordKey(internal, secondEarliest, base.plusMillis(2), NOW);
-    for (int i = 3; i <= baselineCap; i++) {
-      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), base.plusMillis(i), NOW);
+  public void recordKeyRetainsAllLiveKeysWithoutCountCap() {
+    // The window is bounded only by expiry, never by a fixed count: recording many still-live keys
+    // must retain every one. Evicting a live key would silently disable idempotency for it and
+    // could reintroduce the corruption failure mode idempotency exists to prevent.
+    int numberOfKeys = 500;
+    UUID[] keys = new UUID[numberOfKeys];
+    Map<String, String> internal = Map.of();
+    for (int i = 0; i < numberOfKeys; i++) {
+      keys[i] = UUID.randomUUID();
+      internal = EntityIdempotency.recordKey(internal, keys[i], LATER, NOW);
     }
 
-    // One more write past capacity must evict only the earliest-expiring key while retaining the
-    // key just recorded (trim-before-insert: the new key is never the one dropped).
-    UUID newest = UUID.randomUUID();
-    internal =
-        EntityIdempotency.recordKey(internal, newest, base.plusMillis(baselineCap + 1L), NOW);
-
-    // Read at NOW, when every recorded key would still be live if present, so absence == eviction.
-    // Only the single earliest key is dropped: the new key and the next-earliest survive.
-    assertThat(EntityIdempotency.hasLiveKey(internal, newest, NOW)).isTrue();
-    assertThat(EntityIdempotency.hasLiveKey(internal, secondEarliest, NOW)).isTrue();
-    assertThat(EntityIdempotency.hasLiveKey(internal, earliest, NOW)).isFalse();
-  }
-
-  @Test
-  public void windowCapScalesWithTtl() {
-    // A 10-minute TTL doubles the baseline cap to 128, so 65 keys (which would evict the earliest
-    // at
-    // the 5-minute baseline) all fit and none is evicted.
-    Instant base = NOW.plus(Duration.ofMinutes(10));
-    UUID earliest = UUID.randomUUID();
-    Map<String, String> internal =
-        EntityIdempotency.recordKey(Map.of(), earliest, base.plusMillis(1), NOW);
-    for (int i = 2; i <= 65; i++) {
-      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), base.plusMillis(i), NOW);
+    for (UUID key : keys) {
+      assertThat(EntityIdempotency.hasLiveKey(internal, key, NOW)).isTrue();
     }
-
-    assertThat(EntityIdempotency.hasLiveKey(internal, earliest, NOW)).isTrue();
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyTest.java
@@ -20,10 +20,12 @@ package org.apache.polaris.service.idempotency;
 
 import static org.apache.polaris.service.idempotency.EntityIdempotency.IDEMPOTENCY_KEYS_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -119,6 +121,24 @@ public class EntityIdempotencyTest {
     for (UUID key : keys) {
       assertThat(EntityIdempotency.hasLiveKey(internal, key, NOW)).isTrue();
     }
+  }
+
+  @Test
+  public void recordKeyFailsRatherThanEvictWhenSafetyCeilingReached() {
+    // At the safety ceiling the write fails instead of evicting a live key. Fill the window to the
+    // (small, test-only) ceiling, then a further live key must throw rather than drop an existing
+    // one. Expired entries are still purged, so a full window of live keys is required to trip it.
+    int ceiling = 3;
+    Map<String, String> internal = Map.of();
+    for (int i = 0; i < ceiling; i++) {
+      internal = EntityIdempotency.recordKey(internal, UUID.randomUUID(), LATER, NOW, ceiling);
+    }
+
+    Map<String, String> full = internal;
+    assertThatThrownBy(
+            () -> EntityIdempotency.recordKey(full, UUID.randomUUID(), LATER, NOW, ceiling))
+        .isInstanceOf(ServiceUnavailableException.class)
+        .hasMessageContaining("full");
   }
 
   @Test


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Follow-up polish to the entity-property idempotency feature:

1. **Remove the fixed key-window cap.** The per-entity live-key window was capped
   at a hardcoded `MAX_WINDOW_SIZE = 64`, evicting the earliest-expiring key on
   overflow. This cap is removed entirely: a count-based cap can drop a still-live
   key, which silently disables idempotency for it and reintroduces the corruption
   failure mode this feature prevents. The window is now bounded solely by expiry
   (TTL) — expired keys are still purged inline on each write — so a live key is
   never evicted to make room.

2. **Graceful decode.** A corrupt or unrecognized key window (unknown format
   prefix, invalid base64, or unreadable SMILE) is now treated as "no live keys"
   instead of throwing. This keeps a malformed property from failing the whole
   create/update; the next write overwrites it with a valid window (self-healing).

3. **Rename.** Private constant `WINDOW_FORMAT_SMILE_V1` -> `FORMAT_SMILE_V1`
   (wire value `IS1` unchanged).




## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
