### PR TITLE
Catalog-level KMS configuration for Iceberg table encryption support

### DIFF
--- a/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
+++ b/api/management-model/src/test/java/org/apache/polaris/core/admin/model/CatalogSerializationTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.core.admin.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,8 @@ public class CatalogSerializationTest {
   private static final String TEST_CATALOG_NAME = "test-catalog";
   private static final String TEST_ROLE_ARN = "arn:aws:iam::123456789012:role/test-role";
   private static final String KMS_KEY = "arn:aws:kms:us-east-1:012345678901:key/allowed-key-1";
+  private static final String TABLE_ENCRYPTION_KMS_ROLE_ARN =
+      "arn:aws:iam::123456789012:role/test-kms-role";
 
   @BeforeEach
   public void setUp() {
@@ -103,6 +106,50 @@ public class CatalogSerializationTest {
                 + "\"pathStyleAccess\":false,"
                 + "\"storageType\":\"S3\","
                 + "\"allowedLocations\":[]"
+                + "}}");
+  }
+
+  @Test
+  public void testJsonFormatWithKmsConfigInfo() throws Exception {
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(TEST_CATALOG_NAME)
+            .setProperties(new CatalogProperties(TEST_LOCATION))
+            .setStorageConfigInfo(
+                AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+                    .setRoleArn(TEST_ROLE_ARN)
+                    .build())
+            .setKmsConfigInfo(
+                AwsKmsConfigInfo.builder(KmsConfigInfo.KmsTypeEnum.AWS)
+                    .setKmsName("my-aws-kms-dev")
+                    .setRoleArn(TABLE_ENCRYPTION_KMS_ROLE_ARN)
+                    .setRegion("us-east-2")
+                    .setAllowedKeyArns(
+                        List.of("arn:aws:kms:us-east-2:123456789012:key/allowed-key"))
+                    .build())
+            .build();
+
+    String json = mapper.writeValueAsString(catalog);
+
+    assertThat(json)
+        .isEqualTo(
+            "{\"type\":\"INTERNAL\","
+                + "\"name\":\"test-catalog\","
+                + "\"properties\":{\"default-base-location\":\"s3://test/\"},"
+                + "\"storageConfigInfo\":{"
+                + "\"roleArn\":\"arn:aws:iam::123456789012:role/test-role\","
+                + "\"allowedKmsKeys\":[],"
+                + "\"pathStyleAccess\":false,"
+                + "\"storageType\":\"S3\","
+                + "\"allowedLocations\":[]"
+                + "},"
+                + "\"kmsConfigInfo\":{"
+                + "\"roleArn\":\"arn:aws:iam::123456789012:role/test-kms-role\","
+                + "\"region\":\"us-east-2\","
+                + "\"allowedKeyArns\":[\"arn:aws:kms:us-east-2:123456789012:key/allowed-key\"],"
+                + "\"kmsType\":\"AWS\","
+                + "\"kmsName\":\"my-aws-kms-dev\""
                 + "}}");
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/ManagementApi.java
@@ -220,7 +220,8 @@ public class ManagementApi extends PolarisRestApi {
                     new UpdateCatalogRequest(
                         catalog.getEntityVersion(),
                         catalogProps,
-                        catalog.getStorageConfigInfo())))) {
+                        catalog.getStorageConfigInfo(),
+                        null)))) {
       assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
     }
   }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -450,7 +450,10 @@ public class PolarisManagementServiceIntegrationTest {
     // default-base-location.
     UpdateCatalogRequest updateRequest =
         new UpdateCatalogRequest(
-            fetchedCatalog.getEntityVersion(), Map.of("foo", "bar"), null /* storageConfigIno */);
+            fetchedCatalog.getEntityVersion(),
+            Map.of("foo", "bar"),
+            null /* storageConfigIno */,
+            null /* kmsConfigInfo */);
 
     // Successfully update
     Catalog updatedCatalog;
@@ -587,7 +590,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "abfss://newcontainer@acct1.dfs.core.windows.net/"),
-            modifiedStorageConfig);
+            modifiedStorageConfig,
+            null);
     try (Response response =
         managementApi.request("v1/catalogs/" + catalogName).put(Entity.json(badUpdateRequest))) {
       assertThat(response)
@@ -604,7 +608,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "abfss://newcontainer@acct1.dfs.core.windows.net/"),
-            storageConfig);
+            storageConfig,
+            null);
 
     // 200 successful update
     try (Response response =
@@ -680,7 +685,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "s3://newbucket/"),
-            invalidModifiedStorageConfig);
+            invalidModifiedStorageConfig,
+            null);
     try (Response response =
         managementApi
             .request("v1/catalogs/{cat}", Map.of("cat", catalogName))
@@ -707,7 +713,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "s3://newbucket/"),
-            validModifiedStorageConfig);
+            validModifiedStorageConfig,
+            null);
 
     // 200 successful update
     try (Response response =
@@ -795,7 +802,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "s3://bucket1/"),
-            differentAccountConfig);
+            differentAccountConfig,
+            null);
 
     try (Response response =
         managementApi
@@ -847,7 +855,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "s3://bucket1/"),
-            updatedConfig);
+            updatedConfig,
+            null);
 
     try (Response response =
         managementApi
@@ -898,7 +907,8 @@ public class PolarisManagementServiceIntegrationTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "s3://bucket1/"),
-            configWithDifferentExternalId);
+            configWithDifferentExternalId,
+            null);
 
     try (Response response =
         managementApi

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.polaris.core.admin.model.AwsKmsConfigInfo;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -38,6 +39,7 @@ import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
 import org.apache.polaris.core.admin.model.ExternalCatalog;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
+import org.apache.polaris.core.admin.model.KmsConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.BehaviorChangeConfiguration;
@@ -45,6 +47,8 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.connection.ConnectionConfigInfoDpo;
 import org.apache.polaris.core.identity.dpo.ServiceIdentityInfoDpo;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
+import org.apache.polaris.core.kms.PolarisKmsConfigurationInfo;
+import org.apache.polaris.core.kms.aws.AwsKmsConfigurationInfo;
 import org.apache.polaris.core.secrets.SecretReference;
 import org.apache.polaris.core.storage.FileStorageConfigurationInfo;
 import org.apache.polaris.core.storage.PolarisStorageConfigurationInfo;
@@ -94,6 +98,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     builder.setInternalProperties(internalProperties);
     builder.setStorageConfigurationInfo(
         realmConfig, catalog.getStorageConfigInfo(), getBaseLocation(catalog));
+    builder.setKmsConfigurationInfo(catalog.getKmsConfigInfo());
     return builder.build();
   }
 
@@ -127,6 +132,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setLastUpdateTimestamp(getLastUpdateTimestamp())
             .setEntityVersion(getEntityVersion())
             .setStorageConfigInfo(getStorageInfo(internalProperties))
+            .setKmsConfigInfo(getKmsInfo(internalProperties))
             .setConnectionConfigInfo(getConnectionInfo(internalProperties, serviceIdentityProvider))
             .build()
         : PolarisCatalog.builder()
@@ -137,6 +143,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
             .setLastUpdateTimestamp(getLastUpdateTimestamp())
             .setEntityVersion(getEntityVersion())
             .setStorageConfigInfo(getStorageInfo(internalProperties))
+            .setKmsConfigInfo(getKmsInfo(internalProperties))
             .build();
   }
 
@@ -193,6 +200,27 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     return null;
   }
 
+  private KmsConfigInfo getKmsInfo(Map<String, String> internalProperties) {
+    if (internalProperties.containsKey(PolarisEntityConstants.getKmsConfigInfoPropertyName())) {
+      PolarisKmsConfigurationInfo configInfo = getKmsConfigurationInfo();
+      if (configInfo instanceof AwsKmsConfigurationInfo awsConfig) {
+        return AwsKmsConfigInfo.builder()
+            .setKmsType(KmsConfigInfo.KmsTypeEnum.AWS)
+            .setKmsName(awsConfig.getKmsName())
+            .setRoleArn(awsConfig.getRoleArn())
+            .setExternalId(awsConfig.getExternalId())
+            .setRegion(awsConfig.getRegion())
+            .setEndpoint(awsConfig.getEndpoint())
+            .setEndpointInternal(awsConfig.getEndpointInternal())
+            .setStsEndpoint(awsConfig.getStsEndpoint())
+            .setAllowedKeyArns(awsConfig.getAllowedKeyArns())
+            .build();
+      }
+      return null;
+    }
+    return null;
+  }
+
   private ConnectionConfigInfo getConnectionInfo(
       Map<String, String> internalProperties, ServiceIdentityProvider serviceIdentityProvider) {
     if (internalProperties.containsKey(
@@ -213,6 +241,15 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
         getInternalPropertiesAsMap().get(PolarisEntityConstants.getStorageConfigInfoPropertyName());
     if (configStr != null) {
       return PolarisStorageConfigurationInfo.deserialize(configStr);
+    }
+    return null;
+  }
+
+  public @Nullable PolarisKmsConfigurationInfo getKmsConfigurationInfo() {
+    String configStr =
+        getInternalPropertiesAsMap().get(PolarisEntityConstants.getKmsConfigInfoPropertyName());
+    if (configStr != null) {
+      return PolarisKmsConfigurationInfo.deserialize(configStr);
     }
     return null;
   }
@@ -299,6 +336,33 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     public Builder setDefaultBaseLocation(String defaultBaseLocation) {
       // Note that this member lives in the main 'properties' map rather than internalProperties.
       properties.put(DEFAULT_BASE_LOCATION_KEY, defaultBaseLocation);
+      return this;
+    }
+
+    public Builder setKmsConfigurationInfo(KmsConfigInfo kmsConfigModel) {
+      if (kmsConfigModel != null) {
+        PolarisKmsConfigurationInfo config;
+        switch (kmsConfigModel.getKmsType()) {
+          case AWS:
+            AwsKmsConfigInfo awsConfigModel = (AwsKmsConfigInfo) kmsConfigModel;
+            config =
+                AwsKmsConfigurationInfo.builder()
+                    .kmsName(kmsConfigModel.getKmsName())
+                    .roleArn(awsConfigModel.getRoleArn())
+                    .externalId(awsConfigModel.getExternalId())
+                    .region(awsConfigModel.getRegion())
+                    .endpoint(awsConfigModel.getEndpoint())
+                    .endpointInternal(awsConfigModel.getEndpointInternal())
+                    .stsEndpoint(awsConfigModel.getStsEndpoint())
+                    .allowedKeyArns(awsConfigModel.getAllowedKeyArns())
+                    .build();
+            break;
+          default:
+            throw new IllegalStateException("Unsupported KMS type: " + kmsConfigModel.getKmsType());
+        }
+        internalProperties.put(
+            PolarisEntityConstants.getKmsConfigInfoPropertyName(), config.serialize());
+      }
       return this;
     }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/PolarisEntityConstants.java
@@ -49,6 +49,8 @@ public class PolarisEntityConstants {
   private static final String STORAGE_CONFIGURATION_INFO_PROPERTY_NAME =
       "storage_configuration_info";
 
+  private static final String KMS_CONFIGURATION_INFO_PROPERTY_NAME = "kms_configuration_info";
+
   private static final String STORAGE_INTEGRATION_IDENTIFIER_PROPERTY_NAME =
       "storage_integration_identifier";
 
@@ -105,6 +107,10 @@ public class PolarisEntityConstants {
 
   public static String getStorageConfigInfoPropertyName() {
     return STORAGE_CONFIGURATION_INFO_PROPERTY_NAME;
+  }
+
+  public static String getKmsConfigInfoPropertyName() {
+    return KMS_CONFIGURATION_INFO_PROPERTY_NAME;
   }
 
   public static String getConnectionConfigInfoPropertyName() {

--- a/polaris-core/src/main/java/org/apache/polaris/core/kms/PolarisKmsConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/kms/PolarisKmsConfigurationInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.kms;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.apache.polaris.core.kms.aws.AwsKmsConfigurationInfo;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Polaris KMS configuration information persisted with catalog metadata.
+ *
+ * <p>This configuration describes how Polaris should access a key-management service. Runtime
+ * credentials produced from this configuration belong in KMS access config objects, not here.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes({@JsonSubTypes.Type(value = AwsKmsConfigurationInfo.class)})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class PolarisKmsConfigurationInfo {
+
+  private static final ObjectMapper DEFAULT_MAPPER;
+
+  static {
+    DEFAULT_MAPPER =
+        JsonMapper.builder()
+            .defaultPropertyInclusion(
+                JsonInclude.Value.construct(
+                    JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+  }
+
+  /** Optional logical name for resolving service-local KMS credentials. */
+  @Nullable
+  public abstract String getKmsName();
+
+  public abstract KmsType getKmsType();
+
+  public String serialize() {
+    try {
+      return DEFAULT_MAPPER.writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("serialize failed: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Deserialize a json string into a Polaris KMS configuration object.
+   *
+   * @param jsonStr a json string
+   * @return the Polaris KMS configuration object
+   */
+  public static PolarisKmsConfigurationInfo deserialize(final @NonNull String jsonStr) {
+    try {
+      return DEFAULT_MAPPER.readValue(jsonStr, PolarisKmsConfigurationInfo.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("deserialize failed: " + e.getMessage(), e);
+    }
+  }
+
+  public enum KmsType {
+    AWS
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/kms/aws/AwsKmsConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/kms/aws/AwsKmsConfigurationInfo.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.kms.aws;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.net.URI;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.polaris.core.kms.PolarisKmsConfigurationInfo;
+import org.apache.polaris.immutables.PolarisImmutable;
+import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
+
+/** AWS KMS configuration information. */
+@PolarisImmutable
+@JsonSerialize(as = ImmutableAwsKmsConfigurationInfo.class)
+@JsonDeserialize(as = ImmutableAwsKmsConfigurationInfo.class)
+@JsonTypeName("AwsKmsConfigurationInfo")
+public abstract class AwsKmsConfigurationInfo extends PolarisKmsConfigurationInfo {
+
+  private static final Pattern ROLE_ARN_PATTERN_COMPILED =
+      Pattern.compile("^.+:(.*):.+:.*:(.*):.+$");
+
+  public static ImmutableAwsKmsConfigurationInfo.Builder builder() {
+    return ImmutableAwsKmsConfigurationInfo.builder();
+  }
+
+  @Override
+  public KmsType getKmsType() {
+    return KmsType.AWS;
+  }
+
+  /** AWS role ARN used by Polaris to access AWS KMS, optional when using node identity. */
+  @Nullable
+  public abstract String getRoleArn();
+
+  /** AWS external ID, optional. */
+  @Nullable
+  public abstract String getExternalId();
+
+  /** AWS region used by AWS KMS clients. */
+  @Nullable
+  public abstract String getRegion();
+
+  /** AWS KMS endpoint URI, optional. */
+  @Nullable
+  public abstract String getEndpoint();
+
+  /** AWS KMS endpoint URI for Polaris server-side access, optional. */
+  @Nullable
+  public abstract String getEndpointInternal();
+
+  /** AWS STS endpoint URI, optional. */
+  @Nullable
+  public abstract String getStsEndpoint();
+
+  /** KMS key ARNs this catalog is allowed to use for Iceberg table encryption. */
+  public abstract List<String> getAllowedKeyArns();
+
+  @JsonIgnore
+  @Nullable
+  public URI getEndpointUri() {
+    return getEndpoint() == null ? null : URI.create(getEndpoint());
+  }
+
+  @JsonIgnore
+  @Nullable
+  public URI getInternalEndpointUri() {
+    return getEndpointInternal() == null ? getEndpointUri() : URI.create(getEndpointInternal());
+  }
+
+  /** Returns the STS endpoint if set, defaulting to the internal KMS endpoint otherwise. */
+  @JsonIgnore
+  @Nullable
+  public URI getStsEndpointUri() {
+    return getStsEndpoint() == null ? getInternalEndpointUri() : URI.create(getStsEndpoint());
+  }
+
+  @JsonIgnore
+  @Nullable
+  public String getAwsAccountId() {
+    String arn = getRoleArn();
+    if (arn != null) {
+      Matcher matcher = ROLE_ARN_PATTERN_COMPILED.matcher(arn);
+      checkState(matcher.matches());
+      return matcher.group(2);
+    }
+    return null;
+  }
+
+  @JsonIgnore
+  @Nullable
+  public String getAwsPartition() {
+    String arn = getRoleArn();
+    if (arn != null) {
+      Matcher matcher = ROLE_ARN_PATTERN_COMPILED.matcher(arn);
+      checkState(matcher.matches());
+      return matcher.group(1);
+    }
+    return null;
+  }
+
+  @Value.Check
+  protected void check() {
+    String arn = getRoleArn();
+    validateRoleArn(arn);
+    if (arn != null) {
+      Matcher matcher = ROLE_ARN_PATTERN_COMPILED.matcher(arn);
+      if (!matcher.matches()) {
+        throw new IllegalArgumentException("ARN does not match the expected role ARN pattern");
+      }
+    }
+  }
+
+  public static void validateRoleArn(String arn) {
+    if (arn == null) {
+      return;
+    }
+    if (arn.isEmpty()) {
+      throw new IllegalArgumentException("ARN must not be empty");
+    }
+    checkArgument(
+        ROLE_ARN_PATTERN_COMPILED.matcher(arn).matches(), "Invalid role ARN format: %s", arn);
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/kms/PolarisKmsConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/kms/PolarisKmsConfigurationInfoTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.kms;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.util.stream.Stream;
+import org.apache.polaris.core.kms.aws.AwsKmsConfigurationInfo;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class PolarisKmsConfigurationInfoTest {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  private static ObjectMapper mapper;
+
+  @BeforeAll
+  public static void setup() {
+    mapper = JsonMapper.builder().build();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void reserialization(PolarisKmsConfigurationInfo configInfo, String serialized)
+      throws Exception {
+    var jsonStr = configInfo.serialize();
+
+    var asJsonNode = mapper.readValue(jsonStr, JsonNode.class);
+    var serializedJsonNode = mapper.readValue(serialized, JsonNode.class);
+    soft.assertThat(asJsonNode).isEqualTo(serializedJsonNode);
+
+    var deserialized = mapper.readValue(serialized, PolarisKmsConfigurationInfo.class);
+    soft.assertThat(deserialized).isEqualTo(configInfo);
+
+    var reserialized = mapper.readValue(jsonStr, PolarisKmsConfigurationInfo.class);
+    soft.assertThat(reserialized).isEqualTo(configInfo);
+  }
+
+  static Stream<Arguments> reserialization() {
+    return Stream.of(
+        arguments(
+            AwsKmsConfigurationInfo.builder()
+                .kmsName("aws-kms")
+                .roleArn("arn:aws:iam::123456789012:role/polaris-kms")
+                .region("us-east-2")
+                .endpoint("https://kms.us-east-2.amazonaws.com")
+                .stsEndpoint("https://sts.us-east-2.amazonaws.com")
+                .addAllowedKeyArn("arn:aws:kms:us-east-2:123456789012:key/read-key")
+                .build(),
+            "{\"@type\":\"AwsKmsConfigurationInfo\",\"kmsName\":\"aws-kms\",\"kmsType\":\"AWS\",\"roleArn\":\"arn:aws:iam::123456789012:role/polaris-kms\",\"region\":\"us-east-2\",\"endpoint\":\"https://kms.us-east-2.amazonaws.com\",\"stsEndpoint\":\"https://sts.us-east-2.amazonaws.com\",\"allowedKeyArns\":[\"arn:aws:kms:us-east-2:123456789012:key/read-key\"]}"));
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/kms/aws/AwsKmsConfigurationInfoTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/kms/aws/AwsKmsConfigurationInfoTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.polaris.core.kms.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AwsKmsConfigurationInfoTest {
+
+  @Test
+  public void testStsEndpoint() {
+    assertThat(newBuilder().build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri, AwsKmsConfigurationInfo::getStsEndpointUri)
+        .containsExactly(null, null);
+    assertThat(newBuilder().stsEndpoint("http://sts.example.com").build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri, AwsKmsConfigurationInfo::getStsEndpointUri)
+        .containsExactly(null, URI.create("http://sts.example.com"));
+    assertThat(newBuilder().endpoint("http://kms.example.com").build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri, AwsKmsConfigurationInfo::getStsEndpointUri)
+        .containsExactly(
+            URI.create("http://kms.example.com"), URI.create("http://kms.example.com"));
+    assertThat(
+            newBuilder()
+                .endpoint("http://kms.example.com")
+                .stsEndpoint("http://sts.example.com")
+                .build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri, AwsKmsConfigurationInfo::getStsEndpointUri)
+        .containsExactly(
+            URI.create("http://kms.example.com"), URI.create("http://sts.example.com"));
+    assertThat(
+            newBuilder()
+                .endpoint("http://kms.example.com")
+                .endpointInternal("http://int.example.com")
+                .build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getStsEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(
+            URI.create("http://kms.example.com"),
+            URI.create("http://int.example.com"),
+            URI.create("http://int.example.com"));
+  }
+
+  @Test
+  public void testInternalEndpoint() {
+    assertThat(newBuilder().build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(null, null);
+    assertThat(newBuilder().stsEndpoint("http://sts.example.com").build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(null, null);
+    assertThat(newBuilder().endpoint("http://kms.example.com").build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(
+            URI.create("http://kms.example.com"), URI.create("http://kms.example.com"));
+    assertThat(
+            newBuilder()
+                .endpoint("http://kms.example.com")
+                .stsEndpoint("http://sts.example.com")
+                .endpointInternal("http://int.example.com")
+                .build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(
+            URI.create("http://kms.example.com"), URI.create("http://int.example.com"));
+    assertThat(
+            newBuilder()
+                .stsEndpoint("http://sts.example.com")
+                .endpointInternal("http://int.example.com")
+                .build())
+        .extracting(
+            AwsKmsConfigurationInfo::getEndpointUri,
+            AwsKmsConfigurationInfo::getInternalEndpointUri)
+        .containsExactly(null, URI.create("http://int.example.com"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void testRoleArnParsing(
+      String roleArn, String expectedAccountId, String expectedPartition) {
+    AwsKmsConfigurationInfo awsConfig =
+        AwsKmsConfigurationInfo.builder().roleArn(roleArn).region("us-east-2").build();
+
+    Assertions.assertThat(awsConfig)
+        .extracting(
+            AwsKmsConfigurationInfo::getRoleArn,
+            AwsKmsConfigurationInfo::getAwsAccountId,
+            AwsKmsConfigurationInfo::getAwsPartition)
+        .containsExactly(roleArn, expectedAccountId, expectedPartition);
+  }
+
+  static Stream<Arguments> testRoleArnParsing() {
+    return Stream.of(
+        Arguments.of("arn:aws:iam::012345678901:role/jdoe", "012345678901", "aws"),
+        Arguments.of("arn:aws-us-gov:iam::012345678901:role/jdoe", "012345678901", "aws-us-gov"),
+        Arguments.of("arn:aws-cn:iam::012345678901:role/jdoe", "012345678901", "aws-cn"));
+  }
+
+  private static ImmutableAwsKmsConfigurationInfo.Builder newBuilder() {
+    return AwsKmsConfigurationInfo.builder().roleArn("arn:aws:iam::123456789012:role/polaris-test");
+  }
+}

--- a/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/GcpCatalogFederationIntegrationIT.java
+++ b/runtime/service/src/cloudTest/java/org/apache/polaris/service/it/GcpCatalogFederationIntegrationIT.java
@@ -193,7 +193,8 @@ public class GcpCatalogFederationIntegrationIT {
                 .setGcsServiceAccount(SERVICE_ACCOUNT)
                 .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
                 .setAllowedLocations(List.of(BASE_LOCATION))
-                .build());
+                .build(),
+            null);
 
     managementApi.createCatalog(catalog);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1042,6 +1042,9 @@ public class PolarisAdminService {
       updateBuilder.setStorageConfigurationInfo(
           realmConfig, updateRequest.getStorageConfigInfo(), defaultBaseLocation);
     }
+    if (updateRequest.getKmsConfigInfo() != null) {
+      updateBuilder.setKmsConfigurationInfo(updateRequest.getKmsConfigInfo());
+    }
     CatalogEntity updatedEntity = updateBuilder.build();
 
     validateUpdateCatalogDiffOrThrow(currentCatalogEntity, updatedEntity);

--- a/runtime/service/src/main/java/org/apache/polaris/service/kms/KmsConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/kms/KmsConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.kms;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
+import jakarta.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.polaris.docs.ConfigDocs;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
+/** Server-local KMS credentials configuration. */
+@ConfigMapping(prefix = "polaris.kms")
+public interface KmsConfiguration {
+
+  static KmsConfiguration empty() {
+    return () ->
+        new AwsKmsConfig() {
+          @Override
+          public Optional<String> accessKey() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<String> secretKey() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Map<String, AwsKmsCredentialsConfig> keyManagementServices() {
+            return Map.of();
+          }
+        };
+  }
+
+  @WithName("aws")
+  AwsKmsConfig aws();
+
+  interface AwsKmsConfig {
+    /**
+     * The AWS access key to use for KMS authentication. If not present, the default credentials
+     * provider chain will be used.
+     */
+    @WithName("access-key")
+    Optional<String> accessKey();
+
+    /**
+     * The AWS secret key to use for KMS authentication. If not present, the default credentials
+     * provider chain will be used.
+     */
+    @WithName("secret-key")
+    Optional<String> secretKey();
+
+    @WithParentName
+    @ConfigDocs.ConfigPropertyName("kms")
+    Map<String, AwsKmsCredentialsConfig> keyManagementServices();
+  }
+
+  interface AwsKmsCredentialsConfig {
+    /** The AWS access key to use for KMS authentication when using named KMS configurations. */
+    @WithName("access-key")
+    String accessKey();
+
+    /** The AWS secret key to use for KMS authentication when using named KMS configurations. */
+    @WithName("secret-key")
+    String secretKey();
+  }
+
+  default Optional<AwsCredentials> awsCredentials(@Nullable String kmsName) {
+    if (kmsName != null) {
+      if (!aws().keyManagementServices().containsKey(kmsName)) {
+        throw new IllegalArgumentException(
+            "KMS name '" + kmsName + "' is not configured on the server");
+      }
+      AwsKmsCredentialsConfig kmsConfig = aws().keyManagementServices().get(kmsName);
+      return Optional.of(awsCredentials(kmsConfig.accessKey(), kmsConfig.secretKey()));
+    }
+
+    if (aws().accessKey().isPresent() && aws().secretKey().isPresent()) {
+      return Optional.of(awsCredentials(aws().accessKey().get(), aws().secretKey().get()));
+    }
+
+    return Optional.empty();
+  }
+
+  private static AwsCredentials awsCredentials(String accessKey, String secretKey) {
+    return AwsBasicCredentials.create(accessKey, secretKey);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/ManagementServiceTest.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
+import org.apache.polaris.core.admin.model.AwsKmsConfigInfo;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogProperties;
@@ -39,6 +40,7 @@ import org.apache.polaris.core.admin.model.CreateCatalogRequest;
 import org.apache.polaris.core.admin.model.ExternalCatalog;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.IcebergRestConnectionConfigInfo;
+import org.apache.polaris.core.admin.model.KmsConfigInfo;
 import org.apache.polaris.core.admin.model.OAuthClientCredentialsParameters;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -212,7 +214,8 @@ public class ManagementServiceTest {
         new UpdateCatalogRequest(
             fetchedCatalog.getEntityVersion(),
             Map.of("default-base-location", "file:///tmp/path/to/data/"),
-            fileStorage);
+            fileStorage,
+            null);
 
     // failure to update
     assertThatThrownBy(
@@ -235,7 +238,8 @@ public class ManagementServiceTest {
                 .setAllowedLocations(List.of("s3://bucket/path/to/data"))
                 .setRoleArn("arn:aws:iam::123456789012:role/my-role")
                 .setEndpoint("http://example.com")
-                .build());
+                .build(),
+            null);
     assertThatThrownBy(
             () ->
                 services
@@ -475,6 +479,70 @@ public class ManagementServiceTest {
   }
 
   @Test
+  public void testCreateAndUpdateCatalogWithKmsConfigInfo() {
+    StorageConfigInfo storageConfig =
+        AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
+            .setRoleArn("arn:aws:iam::123456789011:role/role1")
+            .build();
+    AwsKmsConfigInfo kmsConfig =
+        AwsKmsConfigInfo.builder(KmsConfigInfo.KmsTypeEnum.AWS)
+            .setKmsName("my-aws-kms-dev")
+            .setRoleArn("arn:aws:iam::123456789011:role/kms-role")
+            .setRegion("us-east-2")
+            .setAllowedKeyArns(List.of("arn:aws:kms:us-east-2:123456789011:key/allowed-key"))
+            .build();
+    String catalogName = "catalog_with_kms";
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName(catalogName)
+            .setStorageConfigInfo(storageConfig)
+            .setKmsConfigInfo(kmsConfig)
+            .setProperties(new CatalogProperties("s3://bucket1/"))
+            .build();
+
+    try (Response response =
+        services
+            .catalogsApi()
+            .createCatalog(
+                new CreateCatalogRequest(catalog),
+                services.realmContext(),
+                services.securityContext())) {
+      assertThat(response).returns(Response.Status.CREATED.getStatusCode(), Response::getStatus);
+    }
+
+    Catalog fetchedCatalog;
+    try (Response response =
+        services
+            .catalogsApi()
+            .getCatalog(catalogName, services.realmContext(), services.securityContext())) {
+      assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+      fetchedCatalog = (Catalog) response.getEntity();
+      assertThat(fetchedCatalog.getKmsConfigInfo()).isEqualTo(kmsConfig);
+    }
+
+    AwsKmsConfigInfo updatedKmsConfig =
+        AwsKmsConfigInfo.builder(KmsConfigInfo.KmsTypeEnum.AWS)
+            .setKmsName("my-updated-aws-kms-dev")
+            .setRoleArn("arn:aws:iam::123456789011:role/updated-kms-role")
+            .setRegion("us-east-1")
+            .setAllowedKeyArns(List.of("arn:aws:kms:us-east-1:123456789011:key/allowed-key"))
+            .build();
+    UpdateCatalogRequest updateRequest =
+        new UpdateCatalogRequest(fetchedCatalog.getEntityVersion(), null, null, updatedKmsConfig);
+
+    try (Response response =
+        services
+            .catalogsApi()
+            .updateCatalog(
+                catalogName, updateRequest, services.realmContext(), services.securityContext())) {
+      assertThat(response).returns(Response.Status.OK.getStatusCode(), Response::getStatus);
+      Catalog updatedCatalog = (Catalog) response.getEntity();
+      assertThat(updatedCatalog.getKmsConfigInfo()).isEqualTo(updatedKmsConfig);
+    }
+  }
+
+  @Test
   public void testUpdateCatalogChangeAwsAccountIdBlockedByDefault() {
     AwsStorageConfigInfo awsConfigModel =
         AwsStorageConfigInfo.builder()
@@ -516,7 +584,8 @@ public class ManagementServiceTest {
             AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
                 .setAllowedLocations(List.of("s3://bucket/path/to/data"))
                 .setRoleArn("arn:aws:iam::999999999999:role/other-role")
-                .build());
+                .build(),
+            null);
     assertThatThrownBy(
             () ->
                 services
@@ -572,7 +641,8 @@ public class ManagementServiceTest {
             AwsStorageConfigInfo.builder(StorageConfigInfo.StorageTypeEnum.S3)
                 .setAllowedLocations(List.of("s3://bucket/path/to/data"))
                 .setRoleArn("arn:aws:iam::123456789012:role/other-role")
-                .build());
+                .build(),
+            null);
     try (Response response =
         services
             .catalogsApi()
@@ -626,7 +696,8 @@ public class ManagementServiceTest {
                 .setAllowedLocations(List.of("s3://bucket/path/to/data"))
                 .setRoleArn("arn:aws:iam::123456789012:role/my-role")
                 .setExternalId("different-external-id")
-                .build());
+                .build(),
+            null);
     assertThatThrownBy(
             () ->
                 services
@@ -697,7 +768,8 @@ public class ManagementServiceTest {
                 .setAllowedLocations(List.of("s3://bucket/path/to/data"))
                 .setRoleArn("arn:aws:iam::999999999999:role/other-role")
                 .setExternalId("different-external-id")
-                .build());
+                .build(),
+            null);
     try (Response response =
         flagEnabledServices
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisOverlappingCatalogTest.java
@@ -94,7 +94,8 @@ public class PolarisOverlappingCatalogTest {
             System.currentTimeMillis(),
             System.currentTimeMillis(),
             1,
-            config);
+            config,
+            null);
     return services
         .catalogsApi()
         .createCatalog(

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisS3InteroperabilityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisS3InteroperabilityTest.java
@@ -106,7 +106,8 @@ public class PolarisS3InteroperabilityTest {
             1725487592064L,
             1725487592064L,
             1,
-            config);
+            config,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionEventTest.java
@@ -167,7 +167,7 @@ public class CommitTransactionEventTest {
             .build();
     Catalog catalogObject =
         new Catalog(
-            Catalog.TypeEnum.INTERNAL, catalog, propertiesBuilder.build(), 0L, 0L, 1, config);
+            Catalog.TypeEnum.INTERNAL, catalog, propertiesBuilder.build(), 0L, 0L, 1, config, null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionMetadataCleanupTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionMetadataCleanupTest.java
@@ -163,14 +163,7 @@ public class CommitTransactionMetadataCleanupTest {
             .build();
     Catalog catalogObject =
         new Catalog(
-            Catalog.TypeEnum.INTERNAL,
-            catalog,
-            propertiesBuilder.build(),
-            0L,
-            0L,
-            1,
-            config,
-            null);
+            Catalog.TypeEnum.INTERNAL, catalog, propertiesBuilder.build(), 0L, 0L, 1, config, null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionMetadataCleanupTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitTransactionMetadataCleanupTest.java
@@ -163,7 +163,14 @@ public class CommitTransactionMetadataCleanupTest {
             .build();
     Catalog catalogObject =
         new Catalog(
-            Catalog.TypeEnum.INTERNAL, catalog, propertiesBuilder.build(), 0L, 0L, 1, config);
+            Catalog.TypeEnum.INTERNAL,
+            catalog,
+            propertiesBuilder.build(),
+            0L,
+            0L,
+            1,
+            config,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/EntityIdempotencyUpdateTableTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/EntityIdempotencyUpdateTableTest.java
@@ -202,7 +202,8 @@ public class EntityIdempotencyUpdateTableTest {
             1725487592064L,
             1725487592064L,
             1,
-            storageConfig);
+            storageConfig,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -697,7 +697,8 @@ public class IcebergAllowedLocationTest {
             1725487592064L,
             1725487592064L,
             1,
-            config);
+            config,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergOverlappingTableTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergOverlappingTableTest.java
@@ -186,7 +186,8 @@ public class IcebergOverlappingTableTest {
             1725487592064L,
             1725487592064L,
             1,
-            config);
+            config,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergTableLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergTableLocationTest.java
@@ -114,7 +114,8 @@ public class IcebergTableLocationTest {
             1725487592064L,
             1725487592064L,
             1,
-            config);
+            config,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -23,12 +23,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
 import org.apache.polaris.core.admin.model.AwsIamServiceIdentityInfo;
+import org.apache.polaris.core.admin.model.AwsKmsConfigInfo;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.Catalog;
@@ -37,6 +39,7 @@ import org.apache.polaris.core.admin.model.ConnectionConfigInfo;
 import org.apache.polaris.core.admin.model.ExternalCatalog;
 import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.IcebergRestConnectionConfigInfo;
+import org.apache.polaris.core.admin.model.KmsConfigInfo;
 import org.apache.polaris.core.admin.model.PolarisCatalog;
 import org.apache.polaris.core.admin.model.ServiceIdentityInfo;
 import org.apache.polaris.core.admin.model.SigV4AuthenticationParameters;
@@ -494,6 +497,43 @@ public class CatalogEntityTest {
     Catalog catalog = catalogEntity.asCatalog(serviceIdentityProvider);
     assertThat(catalog.getStorageConfigInfo()).isEqualTo(config);
     assertThat(MAPPER.writeValueAsString(catalog.getStorageConfigInfo())).isEqualTo(configStr);
+  }
+
+  @Test
+  public void testKmsConfigRoundTrip() throws JsonProcessingException {
+    String baseLocation = "s3://test-bucket/path";
+    AwsStorageConfigInfo storageConfigModel =
+        AwsStorageConfigInfo.builder()
+            .setRoleArn("arn:aws:iam::012345678901:role/test-role")
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
+            .setAllowedLocations(List.of(baseLocation))
+            .build();
+    AwsKmsConfigInfo kmsConfigModel =
+        AwsKmsConfigInfo.builder(KmsConfigInfo.KmsTypeEnum.AWS)
+            .setKmsName("my-aws-kms-dev")
+            .setRoleArn("arn:aws:iam::012345678901:role/test-kms-role")
+            .setExternalId("externalId")
+            .setRegion("us-east-2")
+            .setEndpoint("https://kms.us-east-2.amazonaws.com")
+            .setEndpointInternal("https://kms.internal.example.com")
+            .setStsEndpoint("https://sts.us-east-2.amazonaws.com")
+            .setAllowedKeyArns(List.of("arn:aws:kms:us-east-2:012345678901:key/allowed-key"))
+            .build();
+    String configStr = MAPPER.writeValueAsString(kmsConfigModel);
+
+    Catalog catalog =
+        PolarisCatalog.builder()
+            .setType(Catalog.TypeEnum.INTERNAL)
+            .setName("test-kms-config-round-trip")
+            .setProperties(new CatalogProperties(baseLocation))
+            .setStorageConfigInfo(storageConfigModel)
+            .setKmsConfigInfo(MAPPER.readValue(configStr, KmsConfigInfo.class))
+            .build();
+    CatalogEntity catalogEntity = CatalogEntity.fromCatalog(realmConfig, catalog);
+
+    Catalog roundTripped = catalogEntity.asCatalog(serviceIdentityProvider);
+    assertThat(roundTripped.getKmsConfigInfo()).isEqualTo(kmsConfigModel);
+    assertThat(MAPPER.writeValueAsString(roundTripped.getKmsConfigInfo())).isEqualTo(configStr);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyCreateTableTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/idempotency/EntityIdempotencyCreateTableTest.java
@@ -188,7 +188,8 @@ public class EntityIdempotencyCreateTableTest {
             1725487592064L,
             1725487592064L,
             1,
-            storageConfig);
+            storageConfig,
+            null);
     try (Response response =
         services
             .catalogsApi()

--- a/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_kms.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_kms.md
@@ -1,0 +1,33 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: smallrye-polaris_kms
+build:
+  list: never
+  render: never
+---
+
+Server-local KMS credentials configuration.
+
+| Property | Default Value | Type | Description |
+|----------|---------------|------|-------------|
+| `polaris.kms.aws.access-key` |  | `string` | The AWS access key to use for KMS authentication. If not present, the default credentials  provider chain will be used.  |
+| `polaris.kms.aws.secret-key` |  | `string` | The AWS secret key to use for KMS authentication. If not present, the default credentials  provider chain will be used.  |
+| `polaris.kms.aws.`_`<kms>`_`.access-key` |  | `string` | The AWS access key to use for KMS authentication when using named KMS configurations.  |
+| `polaris.kms.aws.`_`<kms>`_`.secret-key` |  | `string` | The AWS secret key to use for KMS authentication when using named KMS configurations.  |

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -879,6 +879,8 @@ components:
           description: The version of the catalog object used to determine if the catalog metadata has changed
         storageConfigInfo:
           $ref: "#/components/schemas/StorageConfigInfo"
+        kmsConfigInfo:
+          $ref: "#/components/schemas/KmsConfigInfo"
       required:
         - name
         - type
@@ -1234,6 +1236,62 @@ components:
       allOf:
         - $ref: '#/components/schemas/StorageConfigInfo'
 
+    KmsConfigInfo:
+      type: object
+      description: A KMS configuration used by catalogs for Iceberg table encryption
+      properties:
+        kmsType:
+          type: string
+          enum:
+            - AWS
+          description: The key-management service provider type
+        kmsName:
+          type: string
+          description: An optional name referencing a server-side KMS configuration
+      required:
+        - kmsType
+      discriminator:
+        propertyName: kmsType
+        mapping:
+          AWS: "#/components/schemas/AwsKmsConfigInfo"
+
+    AwsKmsConfigInfo:
+      type: object
+      description: AWS KMS configuration info for Iceberg table encryption
+      allOf:
+        - $ref: '#/components/schemas/KmsConfigInfo'
+        - type: object
+          properties:
+            roleArn:
+              type: string
+              description: AWS role ARN used by Polaris to access AWS KMS. Optional when using node or pod identity.
+              example: "arn:aws:iam::123456789001:role/polaris-kms-role"
+            externalId:
+              type: string
+              description: An optional external ID used to establish a trust relationship with AWS in the trust policy
+            region:
+              type: string
+              description: AWS region used by AWS KMS clients
+              example: "us-east-2"
+            endpoint:
+              type: string
+              description: AWS KMS endpoint URI. Clients always see this value if it is set.
+              example: "https://kms.us-east-2.amazonaws.com"
+            endpointInternal:
+              type: string
+              description: AWS KMS endpoint URI used by Polaris server-side access. If not set, defaults to `endpoint`.
+              example: "https://kms.internal.example.com"
+            stsEndpoint:
+              type: string
+              description: AWS STS endpoint URI used by Polaris server-side access.
+              example: "https://sts.us-east-2.amazonaws.com"
+            allowedKeyArns:
+              type: array
+              description: KMS key ARNs this catalog is allowed to use for Iceberg table encryption
+              items:
+                type: string
+              example: ["arn:aws:kms:us-east-2:123456789001:key/allowed-key"]
+
     ServiceIdentityInfo:
       type: object
       description: Identity metadata for the Polaris service used to access external resources.
@@ -1277,6 +1335,8 @@ components:
             type: string
         storageConfigInfo:
           $ref: "#/components/schemas/StorageConfigInfo"
+        kmsConfigInfo:
+          $ref: "#/components/schemas/KmsConfigInfo"
 
     Principals:
       description: A list of Principals


### PR DESCRIPTION
## Summary

Adds catalog-level KMS configuration metadata for future Iceberg table encryption support.

This introduces a Polaris-managed KMS configuration surface that is separate from storage configuration. Storage configuration continues to describe where table data lives and how Polaris accesses that storage. KMS configuration describes which key-management service a catalog is allowed to use for Iceberg table encryption.

See proposal document at: https://docs.google.com/document/d/1Ui5bYVci7BtEkTITxjgW7Pp9SjrTyq8pW2Z7lVt4TQA

## Motivation

Iceberg table encryption is a table-format concern, not a storage-layer encryption setting like S3 SSE-KMS. A Polaris catalog may need to work with encrypted Iceberg tables whose table encryption KMS does not necessarily match the storage backend. For example, an Iceberg table stored in S3 could theoretically use a different KMS provider, or a specific AWS KMS configuration independent of the catalog's S3 storage configuration.

To support this cleanly, Polaris needs catalog-level KMS metadata before wiring that configuration into encrypted Iceberg table operations.

## Changes

- Adds `KmsConfigInfo` and `AwsKmsConfigInfo` to the management API.
- Adds optional `kmsConfigInfo` to catalog create/update/read models.
- Persists catalog KMS configuration in catalog internal properties.
- Adds internal `PolarisKmsConfigurationInfo` and `AwsKmsConfigurationInfo` model classes.
- Adds server-local `polaris.kms.*` runtime configuration for default and named AWS KMS credentials.
- Adds tests for API serialization, internal KMS config serialization, and catalog round trips.
- Adds generated configuration documentation for `polaris.kms.*`.

This PR does not wire KMS configuration into `LocalIcebergCatalog` or encrypted Iceberg FileIO behavior yet. That runtime usage is intended as a follow-up once the catalog configuration contract is agreed.

## Testing

Added coverage for:

- Catalog JSON serialization with `kmsConfigInfo`
- Internal KMS configuration serialization/deserialization
- AWS KMS configuration endpoint handling
- AWS KMS role ARN parsing
- Catalog create/update/read round trip with KMS config
- Catalog entity round trip from management model to persisted internal properties and back

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to the dev list discussion on Iceberg table encryption KMS configuration
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated CHANGELOG.md (if needed)
- [x] 📚 Updated documentation in site/content/in-dev/unreleased (if needed)