### PR TITLE
fix(cache): add configurable refresh buffer to StorageCredentialCache

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -467,21 +467,20 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(30 * 60) // 30 minutes
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Integer>
-      STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS =
-          PolarisConfiguration.<Integer>builder()
-              .key("STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS")
-              .description(
-                  "Minimum remaining validity (in seconds) that a cached storage credential must "
-                      + "have before it is considered stale and evicted. When non-zero, credentials "
-                      + "are removed from the cache this many seconds before they expire, ensuring "
-                      + "clients always receive credentials with at least this much validity left. "
-                      + "When zero (the default), credentials are kept for half of their remaining "
-                      + "lifetime, which is the legacy behavior. Must be less than "
-                      + STORAGE_CREDENTIAL_DURATION_SECONDS.key()
-                      + ".")
-              .defaultValue(0)
-              .buildFeatureConfiguration();
+  public static final FeatureConfiguration<Integer> STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS =
+      PolarisConfiguration.<Integer>builder()
+          .key("STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS")
+          .description(
+              "Minimum remaining validity (in seconds) that a cached storage credential must "
+                  + "have before it is considered stale and evicted. When non-zero, credentials "
+                  + "are removed from the cache this many seconds before they expire, ensuring "
+                  + "clients always receive credentials with at least this much validity left. "
+                  + "When zero (the default), credentials are kept for half of their remaining "
+                  + "lifetime, which is the legacy behavior. Must be less than "
+                  + STORAGE_CREDENTIAL_DURATION_SECONDS.key()
+                  + ".")
+          .defaultValue(0)
+          .buildFeatureConfiguration();
 
   public static final FeatureConfiguration<Integer> MAX_METADATA_REFRESH_RETRIES =
       PolarisConfiguration.<Integer>builder()

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -467,6 +467,22 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(30 * 60) // 30 minutes
           .buildFeatureConfiguration();
 
+  public static final FeatureConfiguration<Integer>
+      STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS =
+          PolarisConfiguration.<Integer>builder()
+              .key("STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS")
+              .description(
+                  "Minimum remaining validity (in seconds) that a cached storage credential must "
+                      + "have before it is considered stale and evicted. When non-zero, credentials "
+                      + "are removed from the cache this many seconds before they expire, ensuring "
+                      + "clients always receive credentials with at least this much validity left. "
+                      + "When zero (the default), credentials are kept for half of their remaining "
+                      + "lifetime, which is the legacy behavior. Must be less than "
+                      + STORAGE_CREDENTIAL_DURATION_SECONDS.key()
+                      + ".")
+              .defaultValue(0)
+              .buildFeatureConfiguration();
+
   public static final FeatureConfiguration<Integer> MAX_METADATA_REFRESH_RETRIES =
       PolarisConfiguration.<Integer>builder()
           .key("MAX_METADATA_REFRESH_RETRIES")

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -52,12 +52,13 @@ public class StorageCredentialCache {
             .expireAfter(
                 Expiry.creating(
                     (StorageCredentialCacheKey key, StorageCredentialCacheEntry entry) -> {
+                      long remainingMs =
+                          entry.getExpirationTime() - System.currentTimeMillis();
+                      long bufferMs = entry.refreshBufferMs();
+                      long effectiveTtl =
+                          bufferMs > 0 ? remainingMs - bufferMs : remainingMs / 2;
                       long expireAfterMillis =
-                          Math.max(
-                              0,
-                              Math.min(
-                                  (entry.getExpirationTime() - System.currentTimeMillis()) / 2,
-                                  entry.maxCacheDurationMs()));
+                          Math.max(0, Math.min(effectiveTtl, entry.maxCacheDurationMs()));
                       return Duration.ofMillis(expireAfterMillis);
                     }))
             .build(
@@ -65,7 +66,9 @@ public class StorageCredentialCache {
                   LOGGER.atDebug().log("StorageCredentialCache::load");
                   StorageAccessConfig accessConfig = key.load();
                   return new StorageCredentialCacheEntry(
-                      accessConfig, maxCacheDurationMs(key.realmConfig()));
+                      accessConfig,
+                      maxCacheDurationMs(key.realmConfig()),
+                      refreshBufferMs(key.realmConfig()));
                 });
   }
 
@@ -84,6 +87,12 @@ public class StorageCredentialCache {
     } else {
       return cacheDurationSeconds * 1000L;
     }
+  }
+
+  /** Minimum buffer to keep between credential expiry and cache eviction. */
+  private long refreshBufferMs(RealmConfig realmConfig) {
+    return realmConfig.getConfig(FeatureConfiguration.STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS)
+        * 1000L;
   }
 
   /**

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCache.java
@@ -52,11 +52,9 @@ public class StorageCredentialCache {
             .expireAfter(
                 Expiry.creating(
                     (StorageCredentialCacheKey key, StorageCredentialCacheEntry entry) -> {
-                      long remainingMs =
-                          entry.getExpirationTime() - System.currentTimeMillis();
+                      long remainingMs = entry.getExpirationTime() - System.currentTimeMillis();
                       long bufferMs = entry.refreshBufferMs();
-                      long effectiveTtl =
-                          bufferMs > 0 ? remainingMs - bufferMs : remainingMs / 2;
+                      long effectiveTtl = bufferMs > 0 ? remainingMs - bufferMs : remainingMs / 2;
                       long expireAfterMillis =
                           Math.max(0, Math.min(effectiveTtl, entry.maxCacheDurationMs()));
                       return Duration.ofMillis(expireAfterMillis);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheEntry.java
@@ -25,9 +25,10 @@ import org.apache.polaris.core.storage.StorageAccessConfig;
  * A storage credential cached entry.
  *
  * @param storageAccessConfig The scoped creds map that is fetched from a creds vending service
+ * @param refreshBufferMs Milliseconds before expiry at which the entry is considered stale
  */
 public record StorageCredentialCacheEntry(
-    StorageAccessConfig storageAccessConfig, long maxCacheDurationMs) {
+    StorageAccessConfig storageAccessConfig, long maxCacheDurationMs, long refreshBufferMs) {
 
   /** Get the expiration time in millisecond for the cached entry */
   public long getExpirationTime() {

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -30,13 +30,13 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.config.RealmConfigImpl;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.assertj.core.api.Assertions;
-import org.apache.polaris.core.config.FeatureConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -452,9 +452,7 @@ public class StorageCredentialCacheTest {
         StorageAccessConfig.builder()
             .put(StorageAccessProperty.AWS_KEY_ID, "key")
             .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
-            .put(
-                StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
-                String.valueOf(expiresAt))
+            .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expiresAt))
             .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
             .build();
 
@@ -491,9 +489,7 @@ public class StorageCredentialCacheTest {
         StorageAccessConfig.builder()
             .put(StorageAccessProperty.AWS_KEY_ID, "key")
             .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
-            .put(
-                StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
-                String.valueOf(expiresAt))
+            .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expiresAt))
             .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
             .build();
 

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -36,6 +36,7 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.assertj.core.api.Assertions;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -439,6 +440,74 @@ public class StorageCredentialCacheTest {
               .build());
     }
     return res;
+  }
+
+  @Test
+  public void testRefreshBufferEvictsNearExpiryCredentials() {
+    // Credentials expire in 120 seconds from now.
+    // With a 300-second refresh buffer, effective TTL = 120s - 300s = -180s → clamped to 0.
+    // The entry must be absent immediately after load.
+    long expiresAt = System.currentTimeMillis() + 120_000;
+    StorageAccessConfig nearExpiryConfig =
+        StorageAccessConfig.builder()
+            .put(StorageAccessProperty.AWS_KEY_ID, "key")
+            .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
+            .put(
+                StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                String.valueOf(expiresAt))
+            .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
+            .build();
+
+    // RealmConfig with STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS = 300
+    RealmConfig realmConfigWithBuffer =
+        new RealmConfigImpl(
+            (rc, name) ->
+                FeatureConfiguration.STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS.key().equals(name)
+                    ? 300
+                    : null,
+            realmContext);
+
+    StorageCredentialCacheKey key =
+        new TestKey(
+            realmContext.getRealmIdentifier(),
+            "bufferConfig",
+            true,
+            Set.of("s3://bucket/path"),
+            Set.of(),
+            Optional.empty(),
+            realmConfigWithBuffer,
+            () -> nearExpiryConfig);
+
+    storageCredentialCache.getOrLoad(key);
+    Assertions.assertThat(storageCredentialCache.getIfPresent(key)).isNull();
+  }
+
+  @Test
+  public void testRefreshBufferZeroPreservesHalfLifetimeBehavior() {
+    // Credentials expire in 120 seconds from now.
+    // With buffer = 0 (default), effective TTL = 120s / 2 = 60s > 0 → entry is kept in cache.
+    long expiresAt = System.currentTimeMillis() + 120_000;
+    StorageAccessConfig config =
+        StorageAccessConfig.builder()
+            .put(StorageAccessProperty.AWS_KEY_ID, "key")
+            .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
+            .put(
+                StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS,
+                String.valueOf(expiresAt))
+            .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
+            .build();
+
+    StorageCredentialCacheKey key =
+        buildKey(
+            "bufferZeroConfig",
+            true,
+            Set.of("s3://bucket/path"),
+            Set.of(),
+            Optional.empty(),
+            () -> config);
+
+    storageCredentialCache.getOrLoad(key);
+    Assertions.assertThat(storageCredentialCache.getIfPresent(key)).isNotNull();
   }
 
   private static List<String> getStorageConfigStrings() {

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -445,7 +445,7 @@ public class StorageCredentialCacheTest {
   @Test
   public void testRefreshBufferEvictsNearExpiryCredentials() {
     // Credentials expire in 120 seconds from now.
-    // With a 300-second refresh buffer, effective TTL = 120s - 300s = -180s → clamped to 0.
+    // With a 300-second refresh buffer, effective TTL = 120s - 300s = -180s -> clamped to 0.
     // The entry must be absent immediately after load.
     long expiresAt = System.currentTimeMillis() + 120_000;
     StorageAccessConfig nearExpiryConfig =
@@ -453,7 +453,6 @@ public class StorageCredentialCacheTest {
             .put(StorageAccessProperty.AWS_KEY_ID, "key")
             .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
             .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expiresAt))
-            .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
             .build();
 
     // RealmConfig with STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS = 300
@@ -481,16 +480,15 @@ public class StorageCredentialCacheTest {
   }
 
   @Test
-  public void testRefreshBufferZeroPreservesHalfLifetimeBehavior() {
+  public void testRefreshBufferZeroKeepsEntryInCache() {
     // Credentials expire in 120 seconds from now.
-    // With buffer = 0 (default), effective TTL = 120s / 2 = 60s > 0 → entry is kept in cache.
+    // With buffer = 0 (default), effective TTL = 120s / 2 = 60s > 0 -> entry is kept in cache.
     long expiresAt = System.currentTimeMillis() + 120_000;
     StorageAccessConfig config =
         StorageAccessConfig.builder()
             .put(StorageAccessProperty.AWS_KEY_ID, "key")
             .put(StorageAccessProperty.AWS_SECRET_KEY, "secret")
             .put(StorageAccessProperty.AWS_SESSION_TOKEN_EXPIRES_AT_MS, String.valueOf(expiresAt))
-            .put(StorageAccessProperty.EXPIRATION_TIME, String.valueOf(expiresAt))
             .build();
 
     StorageCredentialCacheKey key =

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -540,6 +540,15 @@ The duration of time that vended storage credentials are valid for. Support for 
 
 ---
 
+##### `polaris.features."STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS"`
+
+Minimum remaining validity (in seconds) that a cached storage credential must have before it is considered stale and evicted. When non-zero, credentials are removed from the cache this many seconds before they expire, ensuring clients always receive credentials with at least this much validity left. When zero (the default), credentials are kept for half of their remaining lifetime, which is the legacy behavior. Must be less than STORAGE_CREDENTIAL_DURATION_SECONDS.
+
+- **Type:** `Integer`
+- **Default:** `0`
+
+---
+
 ##### `polaris.features."SUPPORTED_CATALOG_CONNECTION_TYPES"`
 
 The list of supported catalog connection types for federation


### PR DESCRIPTION
Closes #2046

The cache currently evicts credentials after half their remaining
lifetime. That works, but there's no way to tune it -- if your storage
provider returns short-lived tokens, you can end up serving credentials
that are nearly expired by the time the client uses them.

This adds STORAGE_CREDENTIAL_REFRESH_BUFFER_SECONDS (default 0). When
set to a positive value, credentials are evicted from the cache once
their remaining validity drops below that threshold. With the default of
0, behavior is unchanged -- the cache still uses the half-lifetime
approach.

Changes:
- New FeatureConfiguration constant with a clear description and a safe
  default
- StorageCredentialCacheEntry carries the buffer alongside
  maxCacheDurationMs so the Caffeine expiry function can use both
- Two new unit tests: one verifying near-expiry credentials are evicted
  with a 300s buffer, one confirming the zero-buffer path preserves the
  existing behavior