### PR TITLE
Export nested namespaces in setup CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
+- Python CLI `setup export` now includes nested namespaces and policy definitions from those
+  namespaces. Previously, only top-level namespaces and their policies were exported.
 - Python CLI `setup apply` now exits with an error after any setup operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
 - Python CLI `tables list`, `tables get`, and `tables delete` commands now exit with status 1 when catalog API requests fail. Previously, these commands printed an error but exited successfully.
 - Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -348,14 +348,16 @@ class SetupCommand(Command):
                         self._serialize_connection_info(c.connection_config_info)
                     )
                 # Add nested entities
+                catalog_api = IcebergCatalogAPI(self._get_catalog_api(api))
+                namespaces = self._list_namespaces_recursively(catalog_api, c.name)
                 catalog_info["roles"] = self._export_catalog_roles_for_catalog(
                     api, c.name
                 )
                 catalog_info["namespaces"] = self._export_namespaces_for_catalog(
-                    api, c.name
+                    api, c.name, namespaces
                 )
                 catalog_info["policies"] = self._export_policies_for_catalog(
-                    api, c.name
+                    api, c.name, namespaces
                 )
                 # remove empty sections
                 if not catalog_info.get("roles"):
@@ -437,14 +439,16 @@ class SetupCommand(Command):
         )
 
     def _export_namespaces_for_catalog(
-        self, api: PolarisDefaultApi, catalog_name: str
+        self,
+        api: PolarisDefaultApi,
+        catalog_name: str,
+        namespaces: List[List[str]],
     ) -> List[Any]:
         """Export all namespaces for a given catalog."""
         namespaces_list: List[Any] = []
         catalog_api_client = self._get_catalog_api(api)
         catalog_api = IcebergCatalogAPI(catalog_api_client)
         try:
-            namespaces = self._list_namespaces_recursively(catalog_api, catalog_name)
             for ns in namespaces:
                 ns_name = ".".join(ns)
                 ns_details = catalog_api.load_namespace_metadata(
@@ -466,15 +470,16 @@ class SetupCommand(Command):
         return namespaces_list
 
     def _export_policies_for_catalog(
-        self, api: PolarisDefaultApi, catalog_name: str
+        self,
+        api: PolarisDefaultApi,
+        catalog_name: str,
+        namespaces: List[List[str]],
     ) -> Dict[str, Any]:
         """Export all policies for a given catalog."""
         policies_map: Dict[str, Any] = {}
         catalog_api_client = self._get_catalog_api(api)
-        catalog_api = IcebergCatalogAPI(catalog_api_client)
         try:
             policy_api = PolicyAPI(catalog_api_client)
-            namespaces = self._list_namespaces_recursively(catalog_api, catalog_name)
             for ns in namespaces:
                 ns_name = ".".join(ns)
                 namespace_str = ns_name.replace(".", UNIT_SEPARATOR)

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -35,6 +35,7 @@ from apache_polaris.cli.constants import (
     CatalogConnectionType,
     AuthenticationType,
     ServiceIdentityType,
+    EntityType,
 )
 
 from apache_polaris.sdk.management import PolarisDefaultApi
@@ -49,7 +50,7 @@ from apache_polaris.cli.command.catalog_roles import CatalogRolesCommand
 from apache_polaris.cli.command.namespaces import NamespacesCommand
 from apache_polaris.cli.command.privileges import PrivilegesCommand
 from apache_polaris.cli.command.policies import PoliciesCommand
-from apache_polaris.cli.command.utils import get_catalog_api_client
+from apache_polaris.cli.command.utils import crawl_namespace, get_catalog_api_client
 
 logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -420,6 +421,21 @@ class SetupCommand(Command):
             )
         return roles_map
 
+    def _list_namespaces_recursively(
+        self, catalog_api: IcebergCatalogAPI, catalog_name: str
+    ) -> List[List[str]]:
+        return sorted(
+            namespace
+            for _, namespace in crawl_namespace(
+                catalog_api=catalog_api,
+                catalog_name=catalog_name,
+                on_error=lambda label, _: logger.exception(
+                    "Failed to export %s", label
+                ),
+                entity_type_filter=EntityType.NAMESPACE.value,
+            )
+        )
+
     def _export_namespaces_for_catalog(
         self, api: PolarisDefaultApi, catalog_name: str
     ) -> List[Any]:
@@ -428,9 +444,7 @@ class SetupCommand(Command):
         catalog_api_client = self._get_catalog_api(api)
         catalog_api = IcebergCatalogAPI(catalog_api_client)
         try:
-            namespaces = sorted(
-                catalog_api.list_namespaces(prefix=catalog_name).namespaces
-            )
+            namespaces = self._list_namespaces_recursively(catalog_api, catalog_name)
             for ns in namespaces:
                 ns_name = ".".join(ns)
                 ns_details = catalog_api.load_namespace_metadata(
@@ -460,9 +474,7 @@ class SetupCommand(Command):
         catalog_api = IcebergCatalogAPI(catalog_api_client)
         try:
             policy_api = PolicyAPI(catalog_api_client)
-            namespaces = sorted(
-                catalog_api.list_namespaces(prefix=catalog_name).namespaces
-            )
+            namespaces = self._list_namespaces_recursively(catalog_api, catalog_name)
             for ns in namespaces:
                 ns_name = ".".join(ns)
                 namespace_str = ns_name.replace(".", UNIT_SEPARATOR)

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -18,10 +18,11 @@
 #
 
 import io
-from unittest.mock import patch, MagicMock, mock_open
+from types import SimpleNamespace
+from unittest.mock import call, patch, MagicMock, mock_open
 from cli_test_utils import CLITestBase, INVALID_ARGS
 from apache_polaris.cli.command.setup import SetupCommand
-from apache_polaris.cli.constants import Subcommands
+from apache_polaris.cli.constants import Subcommands, UNIT_SEPARATOR
 from apache_polaris.cli.exceptions import CliError, CLI_ERROR_EXIT_CODE
 from apache_polaris.sdk.management import (
     PolarisCatalog,
@@ -318,3 +319,71 @@ class TestSetupCommand(CLITestBase):
             )
         call_args = mock_client.create_catalog.call_args[0][0]
         self.assertEqual(call_args.catalog.type, "INTERNAL")
+
+    @patch("apache_polaris.cli.command.setup.PolicyAPI")
+    @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
+    def test_setup_export_includes_nested_namespaces_and_policies(
+        self,
+        mock_catalog_api_class: MagicMock,
+        mock_policy_api_class: MagicMock,
+    ) -> None:
+        catalog_api = mock_catalog_api_class.return_value
+
+        def list_namespaces(prefix: str, parent: str | None = None) -> SimpleNamespace:
+            self.assertEqual(prefix, "catalog")
+            namespaces = {
+                None: [["parent"]],
+                "parent": [["parent", "child"]],
+                f"parent{UNIT_SEPARATOR}child": [],
+            }
+            return SimpleNamespace(namespaces=namespaces[parent])
+
+        catalog_api.list_namespaces.side_effect = list_namespaces
+        catalog_api.load_namespace_metadata.return_value = object()
+
+        policy_api = mock_policy_api_class.return_value
+        policy_api.list_policies.side_effect = (
+            lambda prefix, namespace: SimpleNamespace(
+                identifiers=(
+                    [SimpleNamespace(name="child-policy")]
+                    if namespace == f"parent{UNIT_SEPARATOR}child"
+                    else []
+                )
+            )
+        )
+        policy_api.load_policy.return_value = SimpleNamespace(
+            policy=SimpleNamespace(
+                content='{"max-age": 7}',
+                policy_type="data-compaction",
+                description=None,
+            )
+        )
+
+        command = SetupCommand(
+            setup_subcommand=Subcommands.EXPORT,
+            _catalog_api=MagicMock(),
+        )
+
+        self.assertEqual(
+            command._export_namespaces_for_catalog(MagicMock(), "catalog"),
+            ["parent", "parent.child"],
+        )
+        self.assertEqual(
+            command._export_policies_for_catalog(MagicMock(), "catalog"),
+            {
+                "child-policy": {
+                    "namespace": "parent.child",
+                    "type": "data-compaction",
+                    "content": '{"max-age":7}',
+                }
+            },
+        )
+        policy_api.list_policies.assert_has_calls(
+            [
+                call(prefix="catalog", namespace="parent"),
+                call(
+                    prefix="catalog",
+                    namespace=f"parent{UNIT_SEPARATOR}child",
+                ),
+            ]
+        )

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -313,10 +313,7 @@ class TestSetupCommand(CLITestBase):
                 mock_open(read_data=setup_yaml),
             ),
         ):
-            self.mock_execute(
-                mock_client,
-                ["setup", "apply", "config.yaml"]
-            )
+            self.mock_execute(mock_client, ["setup", "apply", "config.yaml"])
         call_args = mock_client.create_catalog.call_args[0][0]
         self.assertEqual(call_args.catalog.type, "INTERNAL")
 
@@ -363,13 +360,30 @@ class TestSetupCommand(CLITestBase):
             setup_subcommand=Subcommands.EXPORT,
             _catalog_api=MagicMock(),
         )
-
-        self.assertEqual(
-            command._export_namespaces_for_catalog(MagicMock(), "catalog"),
-            ["parent", "parent.child"],
+        mock_client = MagicMock()
+        mock_client.list_catalogs.return_value = SimpleNamespace(
+            catalogs=[SimpleNamespace(name="catalog")]
         )
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="file:///path",
+                additional_properties={},
+            ),
+            storage_config_info=FileStorageConfigInfo(
+                storage_type="FILE",
+                allowed_locations=["file:///path"],
+            ),
+        )
+        mock_client.list_catalog_roles.return_value = SimpleNamespace(roles=[])
+
+        catalog = command._export_catalogs(mock_client)[0]
+
+        self.assertEqual(catalog["namespaces"], ["parent", "parent.child"])
         self.assertEqual(
-            command._export_policies_for_catalog(MagicMock(), "catalog"),
+            catalog["policies"],
             {
                 "child-policy": {
                     "namespace": "parent.child",
@@ -377,6 +391,17 @@ class TestSetupCommand(CLITestBase):
                     "content": '{"max-age":7}',
                 }
             },
+        )
+        self.assertEqual(
+            catalog_api.list_namespaces.call_args_list,
+            [
+                call(prefix="catalog"),
+                call(prefix="catalog", parent="parent"),
+                call(
+                    prefix="catalog",
+                    parent=f"parent{UNIT_SEPARATOR}child",
+                ),
+            ],
         )
         policy_api.list_policies.assert_has_calls(
             [


### PR DESCRIPTION
## Summary

`setup export` previously called `list_namespaces` only at the catalog root, so its output omitted every nested namespace and every policy definition stored below the top level. This made successful exports incomplete and prevented an export/apply round trip from reconstructing the full setup.

This change:

- reuses the existing namespace-only `crawl_namespace` traversal for both namespace and policy export;
- adds regression coverage for a child namespace and a policy defined within it;
- records the user-visible fix in the changelog.

Policy attachments remain outside the scope of export, as documented by the existing CLI warning.

Fixes #5146

## Validation

- `uv run pytest tests/ -q` — 163 tests and 35 subtests passed
- `uv run pre-commit run --files apache_polaris/cli/command/setup.py tests/test_setup_command.py` — all hooks passed
- `uv run pytest integration_tests/` against a freshly built local `apache/polaris:latest` image — 15 tests passed
- `./gradlew check sourceTarball distTar distZip publishToMavenLocal -x :polaris-runtime-service:test -x :polaris-admin:test -PnoIntegrationTests --continue` — 1,904 tasks, build successful
- `./gradlew :polaris-runtime-service:intTest` — build successful
- `./gradlew :polaris-relational-jdbc:test` — build successful
- `./gradlew :polaris-floci-aws-testcontainer:intTest` — build successful
- `./gradlew format compileAll` — 976 tasks, build successful
- `uv build --clear` — source distribution and wheel built successfully

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5146
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (no new complex logic)
- [x] 🧾 Updated `CHANGELOG.md`
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; behavior now matches the complete-export contract)

## AI assistance

Significant AI assistance was used to investigate, implement, and validate this change. I reviewed and own the final result.
