### PR TITLE
CLI: Update pre-commit hooks version

### DIFF
--- a/client/python/.pre-commit-config.yaml
+++ b/client/python/.pre-commit-config.yaml
@@ -17,13 +17,13 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
+    rev: v0.15.22
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -31,7 +31,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Update pre-commit hooks version to latest for `pre-commit-hooks` and `mirrors-mypy` but keep `ruff-pre-commit` one version below the latest due to massive changes in `0.16.0` where ruff enables a default of 413 rules instead of 59 (detail release log in https://github.com/astral-sh/ruff/releases/tag/0.16.0). We can go to the latest one but in a following PR perhaps as it will be noise change with a lot more files formatting.

Validaiton:
```
➜  polaris git:(pre-commit-version) ✗ make client-lint
--- Setting up Python client environment ---
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (26.1.2)
Resolved 64 packages in 24ms
Resolved 64 packages in 3ms
      Built apache-polaris @ file:///Users/yong/Desktop/GitHome/polaris/client/python
Prepared 1 package in 7.19s
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
 ~ apache-polaris==1.6.0 (from file:///Users/yong/Desktop/GitHome/polaris/client/python)
--- Python client environment setup complete ---
--- Running client linting checks ---
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
--- Client linting checks complete ---
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
