### PR TITLE
Prevent unnecessary principal and role resolution for passthrough paths

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -198,7 +198,8 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
     // Run a single-use Resolver for this path.
     Resolver passthroughResolver = resolverFactory.createResolver(principal, catalogName);
     passthroughResolver.addPath(requestedPath);
-    ResolverStatus status = passthroughResolver.resolveAll();
+    ResolverStatus status =
+        passthroughResolver.resolveSelections(Set.of(Resolvable.REQUESTED_PATHS));
 
     if (status.getStatus() != ResolverStatus.StatusEnum.SUCCESS) {
       LOGGER.debug(

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolutionManifestLookupKeyTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/PolarisResolutionManifestLookupKeyTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -32,6 +34,7 @@ import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.Resolvable;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.persistence.resolver.Resolver;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
@@ -70,6 +73,38 @@ public class PolarisResolutionManifestLookupKeyTest {
 
     var byKey = manifest.getResolvedPath(ResolvedPathKey.of(tablePath), false);
     assertThat(byKey.getResolvedFullPath()).containsExactly(referenceCatalog, resolvedLeaf);
+  }
+
+  @Test
+  void passthroughResolvedPathResolvesOnlyRequestedPathsNotFullGraph() {
+    Resolver resolver = Mockito.mock(Resolver.class);
+    ResolverFactory resolverFactory = Mockito.mock(ResolverFactory.class);
+    RealmContext realmContext = Mockito.mock(RealmContext.class);
+    when(resolverFactory.createResolver(any(), anyString())).thenReturn(resolver);
+    when(resolver.resolveSelections(Set.of(Resolvable.REQUESTED_PATHS)))
+        .thenReturn(new ResolverStatus(ResolverStatus.StatusEnum.SUCCESS));
+
+    ResolvedPolarisEntity referenceCatalog = Mockito.mock(ResolvedPolarisEntity.class);
+    ResolvedPolarisEntity resolvedLeaf = Mockito.mock(ResolvedPolarisEntity.class);
+    when(resolver.getResolvedReferenceCatalog()).thenReturn(referenceCatalog);
+    when(resolver.getResolvedPath()).thenReturn(List.of(resolvedLeaf));
+
+    PolarisResolutionManifest manifest =
+        new PolarisResolutionManifest(
+            new PolarisDefaultDiagServiceImpl(),
+            realmContext,
+            resolverFactory,
+            PolarisPrincipal.of("p", Map.of(), Set.of()),
+            "catalog");
+
+    ResolverPath tablePath = new ResolverPath(List.of("ns1", "tbl1"), PolarisEntityType.TABLE_LIKE);
+    manifest.addPassthroughPath(tablePath);
+
+    var resolved = manifest.getPassthroughResolvedPath(ResolvedPathKey.of(tablePath));
+
+    assertThat(resolved.getResolvedFullPath()).containsExactly(referenceCatalog, resolvedLeaf);
+    verify(resolver).resolveSelections(Set.of(Resolvable.REQUESTED_PATHS));
+    verify(resolver, never()).resolveAll();
   }
 
   @Test


### PR DESCRIPTION
`PolarisResolutionManifest.getPassthroughResolvedPath` spins up a single-use `Resolver` for each passthrough lookup and previously called `resolveAll()`, which resolves the caller principal, all of its activated principal roles, and all activated catalog roles in addition to the reference catalog and the requested path. This method only ever consumes the reference catalog and the resolved path, so all of that principal- and role-related work — and the metastore reads backing it — is wasted. This changes the call to `resolveSelections(Set.of(Resolvable.REQUESTED_PATHS))`, which resolves just the requested path (the reference catalog is pulled in automatically, since paths depend on it) and nothing else. Since `getPassthroughResolvedPath` is invoked on hot paths such as table load, create-idempotency replay, and nested-namespace creation (where it runs once per namespace level), this removes a meaningful amount of redundant resolution and metastore load per request.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
