### PR TITLE
CLi: handle null/blank catalog type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - `ManifestFileCleanupTaskHandler` now handles Iceberg v2 delete manifests in addition to data manifests. Previously, `DROP TABLE PURGE` on a v2 table that had been updated via merge-on-read DML left position-delete files and their manifests as orphans in object storage; the cleanup task failed silently because `ManifestFiles.read()` rejects delete manifests.
 - OPA authorizer now includes the realm identifier in the authorization context sent to OPA (`input.context.realm`). This ensures OPA policies can enforce tenant isolation across realms, preventing potential collisions if identical principal or resource names exist in different realms.
 - Management API delete operations for principals, principal roles, catalog roles, and catalogs now return error messages that match the actual failure reason (for example, concurrent modification no longer reports a misleading protected-entity message).
+- Python CLI `setup apply` now defaults to an `INTERNAL` catalog type when the `type` field is left blank or null in the setup config, instead of crashing with `AttributeError`
 
 ## [1.6.0]
 

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -891,8 +891,8 @@ class SetupCommand(Command):
                     command_args = {
                         "catalogs_subcommand": Subcommands.CREATE,
                         "catalog_name": catalog_name,
-                        "catalog_type": catalog_data.get(
-                            "type", CatalogType.INTERNAL.value
+                        "catalog_type": (
+                            catalog_data.get("type") or CatalogType.INTERNAL.value
                         ).lower(),
                     }
                     command_args.update(self._map_storage_properties(catalog_data))

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -290,3 +290,31 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_catalogs.assert_called()
         mock_client.list_catalog_roles.assert_called_with("my_catalog")
         mock_client.get_catalog.assert_called_with("my_catalog")
+
+    @patch("apache_polaris.cli.command.setup.os.path.isfile")
+    def test_setup_apply_treats_null_type_as_internal(
+        self, mock_isfile: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_isfile.return_value = True
+        mock_client.list_principals.side_effect = RuntimeError("listing unavailable")
+        setup_yaml = (
+            "catalogs:\n"
+            "  - name: my_catalog\n"
+            "    type: null\n"
+            "    storage_type: file\n"
+            "    default_base_location: file:///path"
+        )
+
+        with (
+            patch(
+                "apache_polaris.cli.command.setup.open",
+                mock_open(read_data=setup_yaml),
+            ),
+        ):
+            self.mock_execute(
+                mock_client,
+                ["setup", "apply", "config.yaml"]
+            )
+        call_args = mock_client.create_catalog.call_args[0][0]
+        self.assertEqual(call_args.catalog.type, "INTERNAL")


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently if an user provides `type` for catalog but left it blank or set to null, it would trigger AttributeError as `lower()` would be called on the `None`.

Here is a sample input and error:
```
# input
➜  polaris git:(hanlde_null_catalog_type) ✗ cat test_null_type.yaml
principal_roles:
  - test_role
catalogs:
  - name: null_type_catalog
    type: null
    storage_type: file
    default_base_location: file:///tmp/polaris-test2

# output
➜  polaris git:(main) ✗ ./polaris --profile dev setup apply test_null_type.yaml

┌─[DEPRECATED]────────────────────────────────┐
│ This script is deprecated. Use pip instead: │
│                                             │
│   pip install apache-polaris                │
└─────────────────────────────────────────────┘
2026-07-25 15:17:24,529 INFO === Starting Setup Apply Process ===
2026-07-25 15:17:24,530 INFO --- Processing principal roles ---
2026-07-25 15:17:24,604 INFO Creating principal role: test_role
2026-07-25 15:17:24,626 INFO Principal role 'test_role' created successfully.
2026-07-25 15:17:24,626 INFO --- Finished processing principal roles ---
2026-07-25 15:17:24,626 INFO --- Processing principals ---
2026-07-25 15:17:24,626 INFO --- Finished processing principals ---
2026-07-25 15:17:24,626 INFO --- Processing catalog: null_type_catalog ---
2026-07-25 15:17:24,626 INFO --- Processing catalogs ---
2026-07-25 15:17:24,649 INFO Creating catalog: null_type_catalog
2026-07-25 15:17:24,649 ERROR Failed to create catalog 'null_type_catalog'
Traceback (most recent call last):
  File "/Users/yong/Desktop/GitHome/polaris/client/python/apache_polaris/cli/command/setup.py", line 896, in _create_catalogs
    ).lower(),
      ^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
2026-07-25 15:17:24,650 INFO --- Finished processing catalogs ---
2026-07-25 15:17:24,650 WARNING Skipping further processing for catalog 'null_type_catalog' due to creation failure.
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
