### PR TITLE
Fix setup export failure status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those
   namespaces. Previously, only top-level namespaces and their policies were exported.
+- Python CLI `setup export` now exits with an error without emitting partial YAML if any required
+  API read fails. Previously, individual failures were logged but the command printed incomplete
+  configuration and exited with status 0.
 - Python CLI `setup apply` now exits with an error after any setup operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
 - Python CLI `tables list`, `tables get`, and `tables delete` commands now exit with status 1 when catalog API requests fail. Previously, these commands printed an error but exited successfully.
 - Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -156,6 +156,11 @@ class SetupCommand(Command):
             "principal_roles": self._export_principal_roles(api),
             "catalogs": self._export_catalogs(api),
         }
+        if self._failure_count:
+            raise CliError(
+                f"Setup export failed; export errors: {self._failure_count}",
+                exit_code=CLI_ERROR_EXIT_CODE,
+            )
         print(yaml.safe_dump(config, sort_keys=False, indent=2).rstrip())
         logger.info("--- Finished Exporting Polaris Configuration ---")
 
@@ -173,10 +178,12 @@ class SetupCommand(Command):
                             [r.name for r in assigned_roles]
                         )
                 except Exception:
-                    logger.warning(f"Failed to export roles for principal '{p.name}'")
+                    self._record_failure(
+                        f"Failed to export roles for principal '{p.name}'"
+                    )
                 principals_map[p.name] = principal_info
         except Exception:
-            logger.exception("Failed to export principals")
+            self._record_failure("Failed to export principals")
         return principals_map
 
     def _export_principal_roles(self, api: PolarisDefaultApi) -> List[str]:
@@ -184,7 +191,7 @@ class SetupCommand(Command):
         try:
             return sorted([role.name for role in api.list_principal_roles().roles])
         except Exception:
-            logger.exception("Failed to export principal roles")
+            self._record_failure("Failed to export principal roles")
             return []
 
     def _serialize_authentication_info(self, auth_params: Any) -> Dict[str, Any]:
@@ -370,7 +377,7 @@ class SetupCommand(Command):
                     del catalog_info["properties"]
                 catalogs_list.append(catalog_info)
         except Exception:
-            logger.exception("Failed to export catalogs")
+            self._record_failure("Failed to export catalogs")
         return catalogs_list
 
     def _export_catalog_roles_for_catalog(
@@ -418,7 +425,7 @@ class SetupCommand(Command):
                         role_info["privileges"] = privileges
                 roles_map[r.name] = role_info
         except Exception:
-            logger.exception(
+            self._record_failure(
                 f"Failed to export catalog roles for catalog '{catalog_name}'"
             )
         return roles_map
@@ -431,8 +438,8 @@ class SetupCommand(Command):
             for _, namespace in crawl_namespace(
                 catalog_api=catalog_api,
                 catalog_name=catalog_name,
-                on_error=lambda label, _: logger.exception(
-                    "Failed to export %s", label
+                on_error=lambda label, _: self._record_failure(
+                    f"Failed to export {label}"
                 ),
                 entity_type_filter=EntityType.NAMESPACE.value,
             )
@@ -464,7 +471,7 @@ class SetupCommand(Command):
                 else:
                     namespaces_list.append(ns_name)
         except Exception:
-            logger.exception(
+            self._record_failure(
                 f"Failed to export namespaces for catalog '{catalog_name}'"
             )
         return namespaces_list
@@ -511,7 +518,9 @@ class SetupCommand(Command):
                         policy_info["description"] = policy_obj.description
                     policies_map[p.name] = policy_info
         except Exception:
-            logger.exception(f"Failed to export policies for catalog '{catalog_name}'")
+            self._record_failure(
+                f"Failed to export policies for catalog '{catalog_name}'"
+            )
         return policies_map
 
     def _load_setup_config(self) -> Dict[str, Any]:

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -285,7 +285,11 @@ class TestSetupCommand(CLITestBase):
             ),
         )
         mock_client.list_catalog_roles.return_value = MagicMock(roles=[])
-        self.mock_execute(mock_client, ["setup", "export"])
+        with patch(
+            "apache_polaris.cli.command.setup.IcebergCatalogAPI"
+        ) as mock_catalog_api:
+            mock_catalog_api.return_value.list_namespaces.return_value.namespaces = []
+            self.mock_execute(mock_client, ["setup", "export"])
         mock_client.list_principals.assert_called()
         mock_client.list_principal_roles.assert_called()
         mock_client.list_catalogs.assert_called()
@@ -339,8 +343,8 @@ class TestSetupCommand(CLITestBase):
         catalog_api.load_namespace_metadata.return_value = object()
 
         policy_api = mock_policy_api_class.return_value
-        policy_api.list_policies.side_effect = (
-            lambda prefix, namespace: SimpleNamespace(
+        policy_api.list_policies.side_effect = lambda prefix, namespace: (
+            SimpleNamespace(
                 identifiers=(
                     [SimpleNamespace(name="child-policy")]
                     if namespace == f"parent{UNIT_SEPARATOR}child"
@@ -364,6 +368,7 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_catalogs.return_value = SimpleNamespace(
             catalogs=[SimpleNamespace(name="catalog")]
         )
+
         mock_client.get_catalog.return_value = PolarisCatalog(
             type="INTERNAL",
             name="catalog",
@@ -412,3 +417,76 @@ class TestSetupCommand(CLITestBase):
                 ),
             ]
         )
+
+    def test_setup_export_reports_top_level_read_failures(self) -> None:
+        for method_name in (
+            "list_principals",
+            "list_principal_roles",
+            "list_catalogs",
+        ):
+            with self.subTest(method_name=method_name):
+                mock_client = self.build_mock_client()
+                mock_client.list_principals.return_value.principals = []
+                mock_client.list_principal_roles.return_value.roles = []
+                mock_client.list_catalogs.return_value.catalogs = []
+                getattr(mock_client, method_name).side_effect = RuntimeError(
+                    "backend unavailable"
+                )
+                command = SetupCommand(setup_subcommand=Subcommands.EXPORT)
+
+                with (
+                    patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+                    self.assertRaises(CliError) as cm,
+                ):
+                    command.execute(mock_client)
+
+                self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+                self.assertIn("export errors: 1", str(cm.exception))
+                self.assertEqual(mock_stdout.getvalue(), "")
+
+    @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
+    def test_setup_export_reports_nested_read_failures(
+        self, mock_catalog_api: MagicMock
+    ) -> None:
+        mock_client = self.build_mock_client()
+        mock_principal = MagicMock()
+        mock_principal.name = "principal"
+        mock_client.list_principals.return_value.principals = [mock_principal]
+        mock_client.list_principal_roles_assigned.side_effect = RuntimeError(
+            "backend unavailable"
+        )
+        mock_client.list_principal_roles.return_value.roles = []
+        mock_catalog = MagicMock()
+        mock_catalog.name = "catalog"
+        mock_client.list_catalogs.return_value.catalogs = [mock_catalog]
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="file:///path",
+                additional_properties={},
+            ),
+            storage_config_info=FileStorageConfigInfo(
+                storage_type="FILE",
+                allowed_locations=["file:///path"],
+            ),
+        )
+        mock_client.list_catalog_roles.side_effect = RuntimeError("backend unavailable")
+        mock_catalog_api.return_value.list_namespaces.side_effect = RuntimeError(
+            "backend unavailable"
+        )
+        command = SetupCommand(
+            setup_subcommand=Subcommands.EXPORT,
+            _catalog_api=MagicMock(),
+        )
+
+        with (
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+            self.assertRaises(CliError) as cm,
+        ):
+            command.execute(mock_client)
+
+        self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
+        self.assertIn("export errors: 3", str(cm.exception))
+        self.assertEqual(mock_stdout.getvalue(), "")


### PR DESCRIPTION
## Summary

- Count every failed API read during `setup export` using the existing setup failure tracker.
- Refuse to print partial YAML and exit with status 1 after all export sections have been attempted.
- Cover top-level and nested export failures while preserving successful export behavior.

Previously, an unavailable management or catalog endpoint could be logged and replaced with an empty section, after which the CLI printed incomplete configuration and exited successfully. This made partial backup output indistinguishable from a complete export.

Fixes #5154

## Validation

- `UV_CACHE_DIR=/tmp/polaris-uv-cache uv run pytest tests/ -q` — 164 passed, 38 subtests passed.
- `PRE_COMMIT_HOME=/tmp/polaris-pre-commit UV_CACHE_DIR=/tmp/polaris-uv-cache uv run pre-commit run --files apache_polaris/cli/command/setup.py tests/test_setup_command.py` — all hooks passed.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew format compileAll` — passed.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home DOCKER_HOST=unix:///Users/mattfaltyn/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock ./gradlew check --max-workers=1` — passed (1,409 tasks).

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5154
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (no complex logic added)
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; no interface or usage change)

## AI assistance

Significant AI assistance was used to investigate the bug, implement the fix, and draft tests and documentation. I reviewed the final changes and take responsibility for them.
