### PR TITLE
CLI: Consistent error message during value error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Deprecated `ALLOW_EXTERNAL_TABLE_LOCATION`. Use `ALLOW_EXTERNAL_METADATA_FILE_LOCATION` for external metadata file locations, including catalog config `polaris.config.allow.external.metadata.file.location`.
 
 ### Fixes
+- Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup apply` now exits with an error after any setup operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.
 - Python CLI `tables list`, `tables get`, and `tables delete` commands now exit with status 1 when catalog API requests fail. Previously, these commands printed an error but exited successfully.
 - Default table storage locations with object-storage prefixing enabled are now percent-encoded with UTF-8 instead of the JVM default charset. Previously the persisted location of a table under a non-ASCII namespace or table name depended on the platform default charset, so the same table could resolve to a different (or lossy) location on a non-UTF-8 JVM.

--- a/client/python/apache_polaris/cli/command/repl.py
+++ b/client/python/apache_polaris/cli/command/repl.py
@@ -132,6 +132,8 @@ class PolarisRepl(Cmd):
             sys.stderr.write(f"{e}\n")
         except NotImplementedError as e:
             sys.stderr.write(f"Internal error: {e}\n")
+        except ValueError as e:
+            sys.stderr.write(f"Syntax error: {e}\n")
         except Exception as e:
             sys.stderr.write(f"An unexpected error occurred: {e}\n")
 

--- a/client/python/tests/test_repl_command.py
+++ b/client/python/tests/test_repl_command.py
@@ -188,6 +188,15 @@ class TestReplCommand(CLITestBase):
         self.assertIn("repl", out)
         self.assertIn("exit", out)
 
+    def test_repl_handles_syntax_error(self) -> None:
+        repl = PolarisRepl(self.build_mock_client())
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            repl.default('catalogs create "unclosed')
+        output = mock_stderr.getvalue()
+        self.assertIn("Syntax error", output)
+        self.assertIn("No closing quotation", output)
+        self.assertNotIn("unexpected", output)
+
     def test_help_for_command_delegates_to_argparse(self) -> None:
         repl = PolarisRepl(self.build_mock_client())
         with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Currently if an user causes an value error in the cli REPL mode, we would throw something likes following:
```
polaris@dev> catalogs create "unclosed_quote
An unexpected error occurred: No closing quotation
```

This may be too generic for a value error, thus, we should consider use "Syntax error" for those instead:
```
polaris@dev> catalogs create "unclosed_quote
Syntax error: No closing quotation
```

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
