### PR TITLE
CLI: Fix dead code

### DIFF
--- a/client/python/apache_polaris/cli/command/find.py
+++ b/client/python/apache_polaris/cli/command/find.py
@@ -96,8 +96,6 @@ class FindCommand(Command):
                     )
             elif self.catalog_name:
                 print("No catalogs found to search.")
-        else:
-            catalogs_to_search = []
 
         # Summary
         total_results = sum(self._type_counts.values())

--- a/client/python/tests/test_parser_basic.py
+++ b/client/python/tests/test_parser_basic.py
@@ -73,7 +73,7 @@ class TestParserBasic(CLITestBase):
                     "gone",
                 ]
             )  # remote-url deprecated
-            self.assertEqual(cm.exception.code, INVALID_ARGS)
+        self.assertEqual(cm.exception.code, INVALID_ARGS)
 
         with self.assertRaises(SystemExit) as cm:
             Parser.parse(["principals", "create", "name", "--type", "bad"])


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR fixes following dead code:
1.  in `find.py` where `catalogs_to_search = []` is not necessary in the else clause as this is never called if not in the if statement. 
2. Wrong indentation in `test_parser_basic.py` caused a line to never get execute.

This PR cleanups a dead code in `find.py` where `catalogs_to_search = []` is not necessary in the else clause as this is never called if not in the if statement. 

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
