### PR TITLE
CLI: Improve client cleanup in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,13 +143,8 @@ client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist o
 .PHONY: client-cleanup
 client-cleanup: ## Cleanup virtual environment, build artifacts, and generated files
 	@echo "--- Cleaning up client environment and generated files ---"
-	@echo "Removing virtual environment directory: $(VENV_DIR)..."
-	@if [ -n "$(VENV_DIR)" ] && [ -d "$(VENV_DIR)" ]; then \
-		rm -rf "$(VENV_DIR)"; \
-		echo "Virtual environment removed."; \
-	else \
-		echo "Virtual environment directory '$(VENV_DIR)' not found or VENV_DIR is empty. No action taken."; \
-	fi
+	@echo "Removing virtual environment..."
+	@rm -rf "$(VENV_DIR)"
 	@echo "Removing build artifacts..."
 	@rm -rf $(PYTHON_CLIENT_DIR)/dist
 	@echo "Removing copied spec files..."

--- a/Makefile
+++ b/Makefile
@@ -141,19 +141,26 @@ client-build: client-setup-env ## Build client distribution. Pass FORMAT=sdist o
 	@echo "--- Client distribution build complete ---"
 
 .PHONY: client-cleanup
-client-cleanup: ## Cleanup virtual environment and Python cache files
-	@echo "--- Cleaning up virtual environment and Python cache files ---"
-	@echo "Attempting to remove virtual environment directory: $(VENV_DIR)..."
+client-cleanup: ## Cleanup virtual environment, build artifacts, and generated files
+	@echo "--- Cleaning up client environment and generated files ---"
+	@echo "Removing virtual environment directory: $(VENV_DIR)..."
 	@if [ -n "$(VENV_DIR)" ] && [ -d "$(VENV_DIR)" ]; then \
 		rm -rf "$(VENV_DIR)"; \
 		echo "Virtual environment removed."; \
 	else \
 		echo "Virtual environment directory '$(VENV_DIR)' not found or VENV_DIR is empty. No action taken."; \
 	fi
-	@echo "Cleaning up Python cache files..."
-	@find $(PYTHON_CLIENT_DIR) -type f -name "*.pyc" -delete
+	@echo "Removing build artifacts..."
+	@rm -rf $(PYTHON_CLIENT_DIR)/dist
+	@echo "Removing copied spec files..."
+	@rm -rf $(PYTHON_CLIENT_DIR)/spec
+	@echo "Removing pytest cache..."
+	@rm -rf $(PYTHON_CLIENT_DIR)/.pytest_cache
+	@echo "Removing OpenAPI generator cache..."
+	@rm -rf $(PYTHON_CLIENT_DIR)/.openapi-generator
+	@echo "Removing Python cache files..."
 	@find $(PYTHON_CLIENT_DIR) -type d -name "__pycache__" -delete
-	@echo "--- Virtual environment and Python cache cleanup complete ---"
+	@echo "--- Client cleanup complete ---"
 
 .PHONY: client-setup-env
 client-setup-env: $(VENV_DIR) ## Set up Python client environment (venv + dependencies)


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

The existed `client-cleanup` is not completed as it would still left couple temp dirs around and never clean up them if we want a "clean" `client/python` directory that matches to what we have out of box. Here are the changes:
1. Wording changes around what will be clenaup
2. Cleanup `client/python/dist` dir (this got created via `make client-build`
3. Cleanup `client/python/spec` and `client/python/.openapi-generator` dirs (these got created via `make client-regenerate`
4. Cleanup `client/python/.pytest_cache` dir (this got created via `make client-integration-test`)
5. Cleanup `clien/python/**/__pycache__` dirs (these got created via `client-regenerate`)
6. Remove cleanup over `*.pyc` as those are part of `__pycache__` since python3 and it will be cleanup along with item 5.
7. Remove unnecessary conditional check on `VENV_DIR` cleanup to match to the rest of the cleanup.



## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
