### PR TITLE
Improve Makefile for pre-commit by including config doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,13 @@ build-spark-plugin-4.0-2.13: check-dependencies ## Build Spark plugin v4.0 with 
 		:polaris-spark-4.0_2.13:assemble
 	@echo "--- Spark plugin v4.0 with Scala v2.13 build complete ---"
 
+config-doc-generate: DEPENDENCIES := java21
+.PHONY: config-doc-generate
+config-doc-generate: check-dependencies ## Generate configuration reference documentation
+	@echo "--- Generating configuration reference documentation ---"
+	@./gradlew :polaris-config-docs-site:copyConfigSectionsToSite
+	@echo "--- Configuration reference documentation generated ---"
+
 spotless-apply: DEPENDENCIES := java21
 .PHONY: spotless-apply
 spotless-apply: check-dependencies ## Apply code formatting using Spotless Gradle plugin.
@@ -415,7 +422,7 @@ regtest-cleanup: check-dependencies ## Stop and remove regression test container
 ##@ Pre-commit
 
 .PHONY: pre-commit
-pre-commit: spotless-apply helm-doc-generate client-lint ## Run tasks for pre-commit
+pre-commit: spotless-apply helm-doc-generate config-doc-generate client-lint ## Run tasks for pre-commit
 
 ##@ Dependencies
 


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR adds a new Makefile target for polaris server config doc generation and adds it as part of `make pre-commit`. This step is needed when devs are add/remove/modify polaris server configs but not documented anywhere.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
