### PR TITLE
Python CLI: support --no-sts and --no-kms in catalogs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Added an OpenTelemetry event listener for emitting Polaris audit events as OpenTelemetry log records.
 - Added optional `sessionPolicy` field to `SigV4AuthenticationParameters` for catalog federation. When set, the IAM session policy JSON is attached to the STS AssumeRole request, allowing administrators to restrict vended credentials to only the required AWS services and actions (Principle of Least Privilege).
 - Python CLI: added `--scheme` to specify URL scheme
+- Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Added opt-in idempotency for `createTable` and `updateTable` in the Iceberg REST catalog. When enabled via `polaris.idempotency.enabled=true` (default `false`), a client-supplied `Idempotency-Key` header is embedded into the table entity and committed in the same transaction as the operation; a retry carrying the same key within the TTL window (`polaris.idempotency.ttl`, default `PT5M`) replays the original success instead of failing — with `AlreadyExists` for `createTable`, or with `CommitFailedException` for `updateTable` when the request's requirements no longer match the already-advanced table. When idempotency is enabled, the reuse window is advertised to clients through the `idempotency-key-lifetime` field of the `GET /v1/config` response.
 
 ### Changes

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -267,6 +267,8 @@ class CatalogsCommand(Command):
             or self.current_kms_key
             or self.allowed_kms_keys
             or self.path_style_access
+            or self.sts_unavailable
+            or self.kms_unavailable
         )
 
     def _has_azure_storage_info(self) -> bool:
@@ -509,6 +511,22 @@ class CatalogsCommand(Command):
                             f"--region requires S3 storage_type, got: {storage_type}"
                         )
                     updated_storage_info.region = self.region
+
+                if self.sts_unavailable:
+                    storage_type = updated_storage_info.storage_type
+                    if storage_type.lower() != StorageType.S3.value:
+                        raise CliError(
+                            f"--no-sts requires S3 storage_type, got: {storage_type}"
+                        )
+                    updated_storage_info.sts_unavailable = self.sts_unavailable
+
+                if self.kms_unavailable:
+                    storage_type = updated_storage_info.storage_type
+                    if storage_type.lower() != StorageType.S3.value:
+                        raise CliError(
+                            f"--no-kms requires S3 storage_type, got: {storage_type}"
+                        )
+                    updated_storage_info.kms_unavailable = self.kms_unavailable
 
                 request = UpdateCatalogRequest(
                     current_entity_version=catalog.entity_version,

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -282,6 +282,14 @@ class CatalogsCommand(Command):
     def _has_gcs_storage_info(self) -> bool:
         return bool(self.service_account)
 
+    @staticmethod
+    def _require_s3(storage_info: StorageConfigInfo, flag: str) -> None:
+        # Note: We have to lowercase the returned value because the server enum
+        # is uppercase but we defined the StorageType enums as lowercase.
+        storage_type = storage_info.storage_type
+        if storage_type.lower() != StorageType.S3.value:
+            raise CliError(f"{flag} requires S3 storage_type, got: {storage_type}")
+
     def _build_storage_config_info(self) -> Optional[StorageConfigInfo]:
         config = None
         if self.storage_type == StorageType.S3.value:
@@ -503,29 +511,15 @@ class CatalogsCommand(Command):
                     )
 
                 if self.region:
-                    # Note: We have to lowercase the returned value because the server enum
-                    # is uppercase but we defined the StorageType enums as lowercase.
-                    storage_type = updated_storage_info.storage_type
-                    if storage_type.lower() != StorageType.S3.value:
-                        raise CliError(
-                            f"--region requires S3 storage_type, got: {storage_type}"
-                        )
+                    self._require_s3(updated_storage_info, "--region")
                     updated_storage_info.region = self.region
 
                 if self.sts_unavailable:
-                    storage_type = updated_storage_info.storage_type
-                    if storage_type.lower() != StorageType.S3.value:
-                        raise CliError(
-                            f"--no-sts requires S3 storage_type, got: {storage_type}"
-                        )
+                    self._require_s3(updated_storage_info, "--no-sts")
                     updated_storage_info.sts_unavailable = self.sts_unavailable
 
                 if self.kms_unavailable:
-                    storage_type = updated_storage_info.storage_type
-                    if storage_type.lower() != StorageType.S3.value:
-                        raise CliError(
-                            f"--no-kms requires S3 storage_type, got: {storage_type}"
-                        )
+                    self._require_s3(updated_storage_info, "--no-kms")
                     updated_storage_info.kms_unavailable = self.kms_unavailable
 
                 request = UpdateCatalogRequest(

--- a/client/python/apache_polaris/cli/options/option_tree.py
+++ b/client/python/apache_polaris/cli/options/option_tree.py
@@ -399,6 +399,18 @@ class OptionTree:
                             group="AWS S3 Storage Options",
                         ),
                         Argument(
+                            Arguments.STS_UNAVAILABLE,
+                            bool,
+                            Hints.S3_STS_UNAVAILABLE,
+                            group="AWS S3 Storage Options",
+                        ),
+                        Argument(
+                            Arguments.KMS_UNAVAILABLE,
+                            bool,
+                            Hints.S3_KMS_UNAVAILABLE,
+                            group="AWS S3 Storage Options",
+                        ),
+                        Argument(
                             Arguments.SET_PROPERTY,
                             str,
                             Hints.CATALOG_SET_PROPERTY,

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -25,6 +25,7 @@ from apache_polaris.sdk.management import (
     PolarisCatalog,
     CatalogProperties,
     AwsStorageConfigInfo,
+    StorageConfigInfo,
 )
 
 
@@ -463,6 +464,66 @@ class TestCatalogsCommand(CLITestBase):
         mock_client.get_catalog.assert_called_with("foo")
         self.mock_execute(mock_client, ["catalogs", "get", "foo"])
         mock_client.get_catalog.assert_called_with("foo")
+
+    def test_catalog_update_s3_options(self) -> None:
+        mock_client = self.build_mock_client()
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="s3-catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="s3://bucket/path", additional_properties={}
+            ),
+            storage_config_info=AwsStorageConfigInfo(
+                storage_type="S3", allowed_locations=[]
+            ),
+        )
+        self.mock_execute(
+            mock_client,
+            ["catalogs", "update", "s3-catalog", "--no-sts", "--no-kms"],
+        )
+        call_args = mock_client.update_catalog.call_args[0][1]
+        self.assertTrue(call_args.storage_config_info.sts_unavailable)
+        self.assertTrue(call_args.storage_config_info.kms_unavailable)
+
+        # --no-kms alone (without any other AWS storage option) must still be applied
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="s3-catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="s3://bucket/path", additional_properties={}
+            ),
+            storage_config_info=AwsStorageConfigInfo(
+                storage_type="S3", allowed_locations=[]
+            ),
+        )
+        self.mock_execute(
+            mock_client,
+            ["catalogs", "update", "s3-catalog", "--no-kms"],
+        )
+        call_args = mock_client.update_catalog.call_args[0][1]
+        self.assertTrue(call_args.storage_config_info.kms_unavailable)
+
+        # --no-kms against a non-S3 catalog should raise
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="gcs-catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="gs://bucket/path", additional_properties={}
+            ),
+            storage_config_info=StorageConfigInfo(
+                storage_type="GCS", allowed_locations=[]
+            ),
+        )
+        self.check_exception(
+            lambda: self.mock_execute(
+                mock_client,
+                ["catalogs", "update", "gcs-catalog", "--no-kms"],
+            ),
+            "--no-kms requires S3 storage_type",
+        )
 
     def test_catalog_list(self) -> None:
         mock_client = self.build_mock_client()

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -351,6 +351,8 @@ Command Options:
 
 AWS S3 Storage Options:
   --region REGION                                The region to use when connecting to S3
+  --no-sts                                       Indicates that Polaris should not use STS (e.g. if STS is not available)
+  --no-kms                                       Indicates that Polaris should not use KMS (e.g. if KMS is not available)
 ```
 
 ##### Examples
@@ -359,6 +361,8 @@ AWS S3 Storage Options:
 polaris catalogs update --set-property tag=new_value my_catalog
 
 polaris catalogs update --default-base-location s3://new-bucket/my_data my_catalog
+
+polaris catalogs update --no-kms my_catalog
 ```
 
 ### Principals


### PR DESCRIPTION
## Summary
- `polaris catalogs update` previously only exposed `--default-base-location`, `--allowed-location`, `--set-property`, `--remove-property`, and `--region` for S3 catalogs. There was no way to toggle `stsUnavailable` / `kmsUnavailable` on an existing catalog — both were only settable at `catalogs create` time via `--no-sts` / `--no-kms` (added in #3501).
- This left no CLI path to mark an already-created S3-compatible catalog (MinIO, Ceph RGW, VAST, etc.) as not supporting KMS/STS after the fact, short of hitting the management API directly.
- Adds `--no-sts` and `--no-kms` to `catalogs update`, reusing the existing `AwsStorageConfigInfo.sts_unavailable` / `kms_unavailable` fields already returned by `catalogs get`.

## Changes
- `client/python/apache_polaris/cli/options/option_tree.py`: register `--no-sts` / `--no-kms` under the `update` subcommand's "AWS S3 Storage Options" group (same `Hints` used by `create`).
- `client/python/apache_polaris/cli/command/catalogs.py`:
  - `_has_aws_storage_info()` now also considers `sts_unavailable` / `kms_unavailable`, so passing only `--no-kms` (with no other AWS option) still triggers the storage-config update path.
  - `execute()`'s `UPDATE` branch applies `sts_unavailable` / `kms_unavailable` onto the existing `storage_config_info` fetched from `get_catalog`, guarded by the same S3-only `storage_type` check used for `--region`.
  - These are one-directional flags (consistent with `create`): passing `--no-kms` sets it `True`; omitting it leaves the existing value untouched (there's no `--kms-available` to explicitly clear it, mirroring current `create` semantics).
- `client/python/tests/test_catalogs_command.py`: added `test_catalog_update_s3_options` covering combined `--no-sts --no-kms`, `--no-kms` alone (regression test for the `_has_aws_storage_info` gap), and rejection when the target catalog isn't S3.
- `site/content/in-dev/unreleased/command-line-interface.md` / `CHANGELOG.md`: documented the new flags.

## Test plan
- [x] `pytest tests/` — 165 passed, 0 failed (full Python client suite, no regressions)
- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy` on `catalogs.py` — same 12 pre-existing errors as on `main` (all unrelated, in `_build_storage_config_info`/`_build_connection_config_info`); no new errors introduced
- [x] Manually verified `polaris catalogs update --help` now lists `--no-sts` and `--no-kms` under "AWS S3 Storage Options"